### PR TITLE
The number of netty IO threads is set according to the number of available cores

### DIFF
--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -86,7 +86,10 @@ public class RssShuffleManager implements ShuffleManager {
           lifecycleManager = new LifecycleManager(appId, celebornConf, driverCores);
           rssShuffleClient =
               ShuffleClient.get(
-                  lifecycleManager.self(), celebornConf, lifecycleManager.getUserIdentifier(), driverCores);
+                  lifecycleManager.self(),
+                  celebornConf,
+                  lifecycleManager.getUserIdentifier(),
+                  driverCores);
         }
       }
     }
@@ -159,7 +162,11 @@ public class RssShuffleManager implements ShuffleManager {
         RssShuffleHandle<K, V, ?> h = ((RssShuffleHandle<K, V, ?>) handle);
         ShuffleClient client =
             ShuffleClient.get(
-                h.rssMetaServiceHost(), h.rssMetaServicePort(), celebornConf, h.userIdentifier(), executorCores);
+                h.rssMetaServiceHost(),
+                h.rssMetaServicePort(),
+                celebornConf,
+                h.userIdentifier(),
+                executorCores);
         if ("sort".equals(celebornConf.shuffleWriterMode())) {
           return new SortBasedShuffleWriter<>(
               h.dependency(), h.newAppId(), h.numMappers(), context, celebornConf, client, metrics);
@@ -225,8 +232,15 @@ public class RssShuffleManager implements ShuffleManager {
       @SuppressWarnings("unchecked")
       RssShuffleHandle<K, ?, C> h = (RssShuffleHandle<K, ?, C>) handle;
       return new RssShuffleReader<>(
-          h, startPartition, endPartition, 0, Integer.MAX_VALUE, context,
-              celebornConf, metrics, executorCores);
+          h,
+          startPartition,
+          endPartition,
+          0,
+          Integer.MAX_VALUE,
+          context,
+          celebornConf,
+          metrics,
+          executorCores);
     }
     return SparkUtils.invokeGetReaderMethod(
         sortShuffleManagerName,

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
@@ -37,7 +37,8 @@ class RssShuffleReader[K, C](
     endMapIndex: Int = Int.MaxValue,
     context: TaskContext,
     conf: CelebornConf,
-    metrics: ShuffleReadMetricsReporter)
+    metrics: ShuffleReadMetricsReporter,
+    numCores: Int)
   extends ShuffleReader[K, C] with Logging {
 
   private val dep = handle.dependency
@@ -45,7 +46,8 @@ class RssShuffleReader[K, C](
     handle.rssMetaServiceHost,
     handle.rssMetaServicePort,
     conf,
-    handle.userIdentifier)
+    handle.userIdentifier,
+    numCores)
 
   override def read(): Iterator[Product2[K, C]] = {
 

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -46,7 +46,7 @@ public abstract class ShuffleClient implements Cloneable {
   protected ShuffleClient() {}
 
   public static ShuffleClient get(
-      RpcEndpointRef driverRef, CelebornConf conf, UserIdentifier userIdentifier) {
+      RpcEndpointRef driverRef, CelebornConf conf, UserIdentifier userIdentifier, int numCores) {
     if (null == _instance || !initFinished) {
       synchronized (ShuffleClient.class) {
         if (null == _instance) {
@@ -55,12 +55,12 @@ public abstract class ShuffleClient implements Cloneable {
           // ShuffleClient is building a singleton, it may cause the MetaServiceEndpoint to not be
           // assigned. An Executor will only construct a ShuffleClient singleton once. At this time,
           // when communicating with MetaService, it will cause a NullPointerException.
-          _instance = new ShuffleClientImpl(conf, userIdentifier);
+          _instance = new ShuffleClientImpl(conf, userIdentifier, numCores);
           _instance.setupMetaServiceRef(driverRef);
           initFinished = true;
         } else if (!initFinished) {
           _instance.shutDown();
-          _instance = new ShuffleClientImpl(conf, userIdentifier);
+          _instance = new ShuffleClientImpl(conf, userIdentifier, numCores);
           _instance.setupMetaServiceRef(driverRef);
           initFinished = true;
         }
@@ -70,7 +70,7 @@ public abstract class ShuffleClient implements Cloneable {
   }
 
   public static ShuffleClient get(
-      String driverHost, int port, CelebornConf conf, UserIdentifier userIdentifier) {
+      String driverHost, int port, CelebornConf conf, UserIdentifier userIdentifier, int numCores) {
     if (null == _instance || !initFinished) {
       synchronized (ShuffleClient.class) {
         if (null == _instance) {
@@ -79,12 +79,12 @@ public abstract class ShuffleClient implements Cloneable {
           // ShuffleClient is building a singleton, it may cause the MetaServiceEndpoint to not be
           // assigned. An Executor will only construct a ShuffleClient singleton once. At this time,
           // when communicating with MetaService, it will cause a NullPointerException.
-          _instance = new ShuffleClientImpl(conf, userIdentifier);
+          _instance = new ShuffleClientImpl(conf, userIdentifier, numCores);
           _instance.setupMetaServiceRef(driverHost, port);
           initFinished = true;
         } else if (!initFinished) {
           _instance.shutDown();
-          _instance = new ShuffleClientImpl(conf, userIdentifier);
+          _instance = new ShuffleClientImpl(conf, userIdentifier, numCores);
           _instance.setupMetaServiceRef(driverHost, port);
           initFinished = true;
         }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -131,7 +131,9 @@ public class ShuffleClientImpl extends ShuffleClient {
     pushBufferMaxSize = conf.pushBufferMaxSize();
 
     // init rpc env and master endpointRef
-    rpcEnv = RpcEnv.create("ShuffleClient", Utils.localHostName(), Utils.localHostName(),0, conf, numCores);
+    rpcEnv =
+        RpcEnv.create(
+            "ShuffleClient", Utils.localHostName(), Utils.localHostName(), 0, conf, numCores);
 
     TransportConf dataTransportConf =
         Utils.fromCelebornConf(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -121,7 +121,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   // key: shuffleId
   private final Map<Integer, ReduceFileGroups> reduceFileGroupsMap = new ConcurrentHashMap<>();
 
-  public ShuffleClientImpl(CelebornConf conf, UserIdentifier userIdentifier) {
+  public ShuffleClientImpl(CelebornConf conf, UserIdentifier userIdentifier, int numCores) {
     super();
     this.conf = conf;
     this.userIdentifier = userIdentifier;
@@ -131,7 +131,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     pushBufferMaxSize = conf.pushBufferMaxSize();
 
     // init rpc env and master endpointRef
-    rpcEnv = RpcEnv.create("ShuffleClient", Utils.localHostName(), 0, conf);
+    rpcEnv = RpcEnv.create("ShuffleClient", Utils.localHostName(), Utils.localHostName(),0, conf, numCores);
 
     TransportConf dataTransportConf =
         Utils.fromCelebornConf(

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -40,7 +40,8 @@ import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc._
 import org.apache.celeborn.common.util.{PbSerDeUtils, ThreadUtils, Utils}
 
-class LifecycleManager(appId: String, val conf: CelebornConf, val numCores: Int) extends RpcEndpoint with Logging {
+class LifecycleManager(appId: String, val conf: CelebornConf, val numCores: Int) extends RpcEndpoint
+  with Logging {
 
   private val lifecycleHost = Utils.localHostName
 

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -40,7 +40,7 @@ import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc._
 import org.apache.celeborn.common.util.{PbSerDeUtils, ThreadUtils, Utils}
 
-class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoint with Logging {
+class LifecycleManager(appId: String, val conf: CelebornConf, val numCores: Int) extends RpcEndpoint with Logging {
 
   private val lifecycleHost = Utils.localHostName
 
@@ -139,8 +139,10 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   override val rpcEnv: RpcEnv = RpcEnv.create(
     RpcNameConstants.RSS_METASERVICE_SYS,
     lifecycleHost,
+    lifecycleHost,
     conf.shuffleManagerPort,
-    conf)
+    conf,
+    numCores)
   rpcEnv.setupEndpoint(RpcNameConstants.RSS_METASERVICE_EP, this)
 
   logInfo(s"Starting LifecycleManager on ${rpcEnv.address}")

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -195,7 +195,7 @@ public class ShuffleClientSuiteJ {
     conf.set("rss.client.compression.codec", codec.name());
     conf.set("celeborn.push.retry.threads", "1");
     conf.set("celeborn.push.buffer.size", "1K");
-    shuffleClient = new ShuffleClientImpl(conf, new UserIdentifier("mock", "mock"));
+    shuffleClient = new ShuffleClientImpl(conf, new UserIdentifier("mock", "mock"), 0);
 
     masterLocation.setPeer(slaveLocation);
     when(endpointRef.askSync(

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
@@ -41,8 +41,8 @@ trait ReadWriteTestBase extends Logging {
       .set("rss.client.compression.codec", codec.name)
       .set("celeborn.push.replicate.enabled", "true")
       .set("celeborn.push.buffer.size", "256K")
-    val lifecycleManager = new LifecycleManager(APP, clientConf)
-    val shuffleClient = new ShuffleClientImpl(clientConf, UserIdentifier("mock", "mock"))
+    val lifecycleManager = new LifecycleManager(APP, clientConf, 0)
+    val shuffleClient = new ShuffleClientImpl(clientConf, UserIdentifier("mock", "mock"), 0)
     shuffleClient.setupMetaServiceRef(lifecycleManager.self)
 
     val STR1 = RandomStringUtils.random(1024)


### PR DESCRIPTION
### What changes were proposed in this pull request?

The number of netty IO threads is set according to the number of available cores.

For example in the case of executorCores=3:

**before**
![image](https://user-images.githubusercontent.com/63445864/198021745-dc39da6f-83e6-42a4-87b7-50f92f186093.png)

**after**
![image2022-10-21 16_39_31](https://user-images.githubusercontent.com/63445864/198021946-8cfbffa2-a264-42f1-81ac-971112ba5ef9.png)




### Why are the changes needed?

Avoid wasting resources

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?

/cc @waitinfuture 