### PR TITLE
[CELEBORN-151][K8S] Celeborn should run as celeborn instead of root in container

### DIFF
--- a/docker/DEPLOY_ON_K8S.md
+++ b/docker/DEPLOY_ON_K8S.md
@@ -1,33 +1,40 @@
-# How to Deploy RSS on Kubernetes
+# How to Deploy Celeborn on Kubernetes
 
 ## Prerequisite
-Celeborn is recommended to be deployed on nodes with local disk. Before starting, please make sure local disks on nodes are mounted to specific path.
+Celeborn is recommended to be deployed on nodes with local disk. Before starting, please make sure
+local disks on nodes are mounted to specific path.
 
 ## [Optional] Build Celeborn docker image
-We have provided a docker image for Celeborn in helm chart. If you want to build your own Celeborn image, run docker build with our Dockerfile.
+We have provided a docker image for Celeborn in helm chart. If you want to build your own Celeborn
+image, run docker build with our Dockerfile.
 
-You should download or build your binary package first, then decompress it, cd decompress directory, use following command to build docker image.
+You should download or build your binary package first, then decompress it, cd decompress directory,
+use following command to build docker image.
 
-`
-docker build -f docker/Dockerfile -t ${your-repo}:${tag} .
-`
+```
+docker build . \
+    --file docker/Dockerfile \
+    --build-arg celeborn_uid=10006 \
+    --tag ${your-repo}:${tag} \
+```
 
 ## Deploy Celeborn with helm
 
 #### Install kubectl and Helm
 
-Please install and config kubectl and Helm first. See [Installing kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [Installing Helm](https://helm.sh/docs/intro/install/).
+Please install and config kubectl and Helm first. See [Installing kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+and [Installing Helm](https://helm.sh/docs/intro/install/).
 
-#### Create namespace on kubernetes
-`
-kubectl create ns rss
-`
+#### Create namespace on Kubernetes
+```
+kubectl create namespace celeborn
+```
 
 #### [Optional] Modify helm values file values.yaml
-You can modify helm values file and set up customed deployment configuration.
-`
+You can modify helm values file and set up customized deployment configuration.
+```
 vim ${CELEBORN_HOME}/docker/helm/values.yaml
-`
+```
 These values are suggested to be checked before deploy:  
 - masterReplicas (number of Celeborn Master)
 - workerReplicas (number of Celeborn Worker)
@@ -37,17 +44,18 @@ These values are suggested to be checked before deploy:
 For more information of Celeborn configurations, see [CONFIGURATIONS](../CONFIGURATION_GUIDE.md)
 
 #### Install Celeborn
-`
-helm install celeborn-helm ${CELEBORN_HOME}/docker/helm -n ${celeborn namespace}
-`
+```
+helm install celeborn ${CELEBORN_HOME}/docker/helm -n ${celeborn namespace}
+```
 
 #### Connect to Celeborn in K8s pod
-After installation, you can connect to Celeborn master through headless service. For example, this is the spark configuration for 3-master RSS:
-`
-spark.celeborn.master.endpoints=shuffleservice-master-0.rss-master-svc.${celeborn namespace},shuffleservice-master-1.rss-master-svc.${celeborn namespace},shuffleservice-master-2.rss-master-svc.${celeborn namespace}
-`
+After installation, you can connect to Celeborn master through headless service. For example,
+this is the spark configuration for 3-master Celeborn:
+```
+spark.celeborn.master.endpoints=celeborn-master-0.celeborn-master-svc.${celeborn namespace},celeborn-master-1.celeborn-master-svc.${celeborn namespace},celeborn-master-2.celeborn-master-svc.${celeborn namespace}
+```
 
 #### Uninstall Celeborn
-`
+```
 helm uninstall celeborn-helm -n ${celeborn namespace}
-`
+```

--- a/docker/DEPLOY_ON_K8S.md
+++ b/docker/DEPLOY_ON_K8S.md
@@ -15,6 +15,7 @@ use following command to build docker image.
 docker build . \
     --file docker/Dockerfile \
     --build-arg celeborn_uid=10006 \
+    --build-arg celeborn_gid=10006 \
     --tag ${your-repo}:${tag} \
 ```
 

--- a/docker/DEPLOY_ON_K8S.md
+++ b/docker/DEPLOY_ON_K8S.md
@@ -16,7 +16,7 @@ docker build . \
     --file docker/Dockerfile \
     --build-arg celeborn_uid=10006 \
     --build-arg celeborn_gid=10006 \
-    --tag ${your-repo}:${tag} \
+    --tag ${your-repo}:${tag}
 ```
 
 ## Deploy Celeborn with helm

--- a/docker/DEPLOY_ON_K8S.md
+++ b/docker/DEPLOY_ON_K8S.md
@@ -58,5 +58,5 @@ spark.celeborn.master.endpoints=celeborn-master-0.celeborn-master-svc.${celeborn
 
 #### Uninstall Celeborn
 ```
-helm uninstall celeborn-helm -n ${celeborn namespace}
+helm uninstall celeborn -n ${celeborn namespace}
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ COPY master-jars /opt/celeborn/master-jars
 COPY worker-jars /opt/celeborn/worker-jars
 COPY RELEASE /opt/celeborn/RELEASE
 
-RUN chown -R celeborn:0 ${CELEBORN_HOME} && \
+RUN chown -R celeborn:celeborn ${CELEBORN_HOME} && \
     chmod -R ug+rw ${CELEBORN_HOME} && \
     chmod a+x ${CELEBORN_HOME}/bin/* && \
     chmod a+x ${CELEBORN_HOME}/sbin/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,14 +18,22 @@
 ARG java_image_tag=8-jdk-focal
 FROM eclipse-temurin:${java_image_tag}
 
-USER root
+ARG celeborn_uid=10006
+ARG celeborn_gid=10006
+
+ENV CELEBORN_HOME=/opt/celeborn
+ENV PATH=/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/busybox:${CELEBORN_HOME}/sbin:${CELEBORN_HOME}/bin
 
 RUN set -ex && \
     apt-get update && \
     apt-get install -y bash tini busybox bind9-utils telnet net-tools procps krb5-user dnsutils && \
     ln -snf /bin/bash /bin/sh && \
     rm -rf /var/cache/apt/* && \
-    mkdir -p /opt/celeborn
+    mkdir /opt/busybox && \
+    busybox --install /opt/busybox && \
+    groupadd --gid=${celeborn_gid} celeborn && \
+    useradd  --uid=${celeborn_uid} --gid=${celeborn_gid} celeborn -d /home/celeborn -m && \
+    mkdir -p ${CELEBORN_HOME}
 
 COPY bin /opt/celeborn/bin
 COPY sbin /opt/celeborn/sbin
@@ -34,3 +42,12 @@ COPY jars /opt/celeborn/jars
 COPY master-jars /opt/celeborn/master-jars
 COPY worker-jars /opt/celeborn/worker-jars
 COPY RELEASE /opt/celeborn/RELEASE
+
+RUN chown -R celeborn:0 ${CELEBORN_HOME} && \
+    chmod -R ug+rw ${CELEBORN_HOME} && \
+    chmod a+x ${CELEBORN_HOME}/bin/* && \
+    chmod a+x ${CELEBORN_HOME}/sbin/*
+
+USER celeborn
+
+ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/docker/helm/templates/configmap.yaml
+++ b/docker/helm/templates/configmap.yaml
@@ -31,9 +31,9 @@ data:
     {{- end }}
     {{- range $key, $val := .Values.celeborn }}
     {{ $key }}={{ $val }}
-    {{- end -}} 
-    
-  rss-env.sh: |
+    {{- end }}
+
+  celeborn-env.sh: |
     {{- range $key, $val := .Values.environments }}
     {{ $key }}="{{ $val }}"
     {{- end}} 

--- a/docker/helm/templates/master-statefulset.yaml
+++ b/docker/helm/templates/master-statefulset.yaml
@@ -58,6 +58,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        fsGroup: {{ .Values.gid }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/docker/helm/templates/master-statefulset.yaml
+++ b/docker/helm/templates/master-statefulset.yaml
@@ -63,10 +63,6 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent"}}
         command:
-          - "/usr/bin/tini"
-          - "--"
-          - "/bin/sh"
-          - '-c'
           - "until {{ range until (.Values.masterReplicas |int) }}nslookup celeborn-master-{{ . }}.celeborn-master-svc && {{ end }}true; do echo waiting for master; sleep 2; done && /opt/celeborn/sbin/start-master.sh"
         resources:
           {{- toYaml .Values.resources.master | nindent 12 }}

--- a/docker/helm/templates/master-statefulset.yaml
+++ b/docker/helm/templates/master-statefulset.yaml
@@ -65,6 +65,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent"}}
         command:
+          - "/usr/bin/tini"
+          - "--"
+          - "/bin/sh"
+          - '-c'
           - "until {{ range until (.Values.masterReplicas |int) }}nslookup celeborn-master-{{ . }}.celeborn-master-svc && {{ end }}true; do echo waiting for master; sleep 2; done && /opt/celeborn/sbin/start-master.sh"
         resources:
           {{- toYaml .Values.resources.master | nindent 12 }}

--- a/docker/helm/templates/worker-statefulset.yaml
+++ b/docker/helm/templates/worker-statefulset.yaml
@@ -63,10 +63,6 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent"}}
         command:
-          - "/usr/bin/tini"
-          - "--"
-          - "/bin/sh"
-          - '-c'
           - "until {{ range until (.Values.masterReplicas |int) }}nslookup celeborn-master-{{ . }}.celeborn-master-svc && {{ end }}true; do echo waiting for master; sleep 2; done && /opt/celeborn/sbin/start-worker.sh"
         resources:
           {{- toYaml .Values.resources.worker | nindent 12 }}

--- a/docker/helm/templates/worker-statefulset.yaml
+++ b/docker/helm/templates/worker-statefulset.yaml
@@ -65,6 +65,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent"}}
         command:
+          - "/usr/bin/tini"
+          - "--"
+          - "/bin/sh"
+          - '-c'
           - "until {{ range until (.Values.masterReplicas |int) }}nslookup celeborn-master-{{ . }}.celeborn-master-svc && {{ end }}true; do echo waiting for master; sleep 2; done && /opt/celeborn/sbin/start-worker.sh"
         resources:
           {{- toYaml .Values.resources.worker | nindent 12 }}

--- a/docker/helm/templates/worker-statefulset.yaml
+++ b/docker/helm/templates/worker-statefulset.yaml
@@ -58,6 +58,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        fsGroup: {{ .Values.gid }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/docker/helm/values.yaml
+++ b/docker/helm/values.yaml
@@ -36,27 +36,28 @@ workerReplicas: 5
 # celeborn release version
 celebornVersion: 0.1.1
 
+gid: 10006
+
 # celeborn configurations
 celeborn:
-  # please update celeborn.worker.storage.dirs to disk mount path on k8s node
+  celeborn.ha.master.ratis.raft.server.storage.dir: /mnt/rss_ratis/
   celeborn.worker.storage.dirs: /mnt/disk1,/mnt/disk2,/mnt/disk3,/mnt/disk4
   celeborn.push.replicate.enabled: true
-  celeborn.master.metrics.prometheus.port: 9098
-  celeborn.worker.monitor.disk.enabled: false
-  rss.rpc.io.serverThreads: 64
-  rss.worker.fetch.chunk.size: 8m
-  rss.rpc.io.numConnectionsPerPeer: 2
-  celeborn.worker.flush.buffer.size: 256K
   celeborn.metrics.enabled: true
-  rss.push.io.threads: 32
-  celeborn.worker.fetch.io.threads: 32
-  celeborn.push.stageEnd.timeout: 120s
+  celeborn.master.metrics.prometheus.port: 9098
   celeborn.worker.metrics.prometheus.port: 9096
-  rss.rpc.io.clientThreads: 64
+  celeborn.worker.monitor.disk.enabled: false
+  celeborn.worker.fetch.chunk.size: 8m
+  celeborn.rpc.io.serverThreads: 64
+  celeborn.rpc.io.numConnectionsPerPeer: 2
+  celeborn.rpc.io.clientThreads: 64
+  celeborn.rpc.dispatcher.numThreads: 4
+  celeborn.worker.flush.buffer.size: 256K
+  celeborn.worker.fetch.io.threads: 32
+  celeborn.push.io.threads: 32
+  celeborn.push.stageEnd.timeout: 120s
   celeborn.application.heartbeat.timeout: 120s
-  rss.rpc.dispatcher.numThreads: 4
   celeborn.worker.heartbeat.timeout: 120s
-  celeborn.ha.master.ratis.raft.server.storage.dir: /mnt/rss_ratis/
 
 environments:
   CELEBORN_MASTER_MEMORY: 2g
@@ -64,7 +65,7 @@ environments:
   CELEBORN_WORKER_MEMORY: 2g
   CELEBORN_WORKER_OFFHEAP_MEMORY: 12g
   CELEBORN_WORKER_JAVA_OPTS: "-XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced"
-  CELEBORN_NO_DAEMONIZE: "yes"
+  CELEBORN_NO_DAEMONIZE: 1
   TZ: "Asia/Shanghai"
 
 podMonitor:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- new args `celeborn_uid` and `celeborn_gid` for `Dockerfile`
- add `busybox` to docker image
- updated outdated configurations for helm charts

### Why are the changes needed?

For security, we should avoid using `root` to run image.

### Does this PR introduce _any_ user-facing change?

No, it's not officially released

### How was this patch tested?

Run `helm templates celeborn docker/helm`