### PR TITLE
[ISSUE-228][BUG] When CommitFile, worker endpoint may be closed by ReserveSlots failed, we should try reconnect endpoint when endpoint not active

### DIFF
--- a/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
+++ b/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
@@ -312,9 +312,6 @@ class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint wit
       try {
         workerInfo.endpoint = rpcEnv.setupEndpointRef(
           RpcAddress.apply(workerInfo.host, workerInfo.rpcPort), WORKER_EP)
-        workerInfo.endpoint.asInstanceOf[NettyRpcEndpointRef].client =
-          rpcEnv.asInstanceOf[NettyRpcEnv].clientFactory.createClient(workerInfo.host,
-            workerInfo.rpcPort)
       } catch {
         case t: Throwable =>
           logError(s"Init rpc client for $workerInfo failed", t)
@@ -865,13 +862,6 @@ class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint wit
               failedPartitionLocations += (reduceId -> failedSlave)
             }
           })
-        }
-        // remove failed slot from total slots, close transport client
-        if (workerInfo.endpoint != null) {
-          val transportClient = workerInfo.endpoint.asInstanceOf[NettyRpcEndpointRef].client
-          if (null != transportClient && transportClient.isActive) {
-            transportClient.close()
-          }
         }
       })
 

--- a/common/src/main/scala/com/aliyun/emr/rss/common/rpc/netty/NettyRpcEnv.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/rpc/netty/NettyRpcEnv.scala
@@ -139,7 +139,7 @@ class NettyRpcEnv(
   }
 
   private def postToOutbox(receiver: NettyRpcEndpointRef, message: OutboxMessage): Unit = {
-    if (receiver.client != null) {
+    if (receiver.client != null && receiver.client.isActive) {
       message.sendWith(receiver.client)
     } else {
       require(receiver.address != null,

--- a/common/src/main/scala/com/aliyun/emr/rss/common/rpc/netty/NettyRpcEnv.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/rpc/netty/NettyRpcEnv.scala
@@ -18,7 +18,7 @@
 package com.aliyun.emr.rss.common.rpc.netty
 
 import java.io._
-import java.net.{InetSocketAddress}
+import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicBoolean
@@ -26,7 +26,7 @@ import javax.annotation.Nullable
 
 import scala.concurrent.{Future, Promise}
 import scala.reflect.ClassTag
-import scala.util.{DynamicVariable, Failure, Success, Try}
+import scala.util.{DynamicVariable, Failure, Success}
 import scala.util.control.NonFatal
 
 import com.google.common.base.Throwables

--- a/common/src/main/scala/com/aliyun/emr/rss/common/rpc/netty/Outbox.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/rpc/netty/Outbox.scala
@@ -145,7 +145,7 @@ private[rss] class Outbox(nettyEnv: NettyRpcEnv, val address: RpcAddress) {
         // We are connecting to the remote address, so just exit
         return
       }
-      if (client == null) {
+      if (client == null || !client.isActive) {
         // There is no connect task but client is null, so we need to launch the connect task.
         launchConnectTask()
         return


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?


### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
#228 

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
