### PR TITLE
[ISSUE-934][REFACTOR]Device check should report error after check failed a certain number of times

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/meta/DiskStatus.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/DiskStatus.java
@@ -21,7 +21,8 @@ public enum DiskStatus {
   HEALTHY(0),
   READ_OR_WRITE_FAILURE(1),
   IO_HANG(2),
-  HIGH_DISK_USAGE(3);
+  HIGH_DISK_USAGE(3),
+  CRITICAL_ERROR(4);
 
   private final byte value;
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -692,6 +692,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def diskMonitorCheckInterval: Long = get(WORKER_DISK_MONITOR_CHECK_INTERVAL)
   def diskMonitorSysBlockDir: String = get(WORKER_DISK_MONITOR_SYS_BLOCK_DIR)
   def diskMonitorReportErrorThreshold: Int = get(WORKER_DISK_MONITOR_REPORT_ERROR_THRESHOLD)
+  def diskMonitorReportErrorExpireDuration: Long =
+    get(WORKER_DISK_MONITOR_REPORT_ERROR_EXPIRE_DURATION)
   def createWriterMaxAttempts: Int = get(WORKER_WRITER_CREATE_MAX_ATTEMPTS)
   def workerStorageBaseDirPrefix: String = get(WORKER_STORAGE_BASE_DIR_PREFIX)
   def workerStorageBaseDirNumber: Int = get(WORKER_STORAGE_BASE_DIR_COUNT)
@@ -2281,13 +2283,21 @@ object CelebornConf extends Logging {
       .createWithDefault("/sys/block")
 
   val WORKER_DISK_MONITOR_REPORT_ERROR_THRESHOLD: ConfigEntry[Int] =
-    buildConf("celeborn.worker.monitor.disk.reportErrorThreshold")
+    buildConf("celeborn.worker.monitor.disk.reportError.threshold")
       .categories("worker")
       .version("0.2.0")
-      .doc("Device monitor will report device critical error once the accumulated non-critical error number exceed " +
-        "this threshold.")
+      .doc("Device monitor will report critical error once the accumulated valid non-critical error number " +
+        "exceeding this threshold.")
       .intConf
       .createWithDefault(64)
+
+  val WORKER_DISK_MONITOR_REPORT_ERROR_EXPIRE_DURATION: ConfigEntry[Long] =
+    buildConf("celeborn.worker.monitor.disk.reportError.expireDuration")
+      .categories("worker")
+      .version("0.2.0")
+      .doc("The expire duration of a non-critical device error.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("1h")
 
   val WORKER_WRITER_CREATE_MAX_ATTEMPTS: ConfigEntry[Int] =
     buildConf("celeborn.worker.writer.create.maxAttempts")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -691,6 +691,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def diskMonitorCheckList: Seq[String] = get(WORKER_DISK_MONITOR_CHECKLIST)
   def diskMonitorCheckInterval: Long = get(WORKER_DISK_MONITOR_CHECK_INTERVAL)
   def diskMonitorSysBlockDir: String = get(WORKER_DISK_MONITOR_SYS_BLOCK_DIR)
+  def diskMonitorReportErrorThreshold: Int = get(WORKER_DISK_MONITOR_REPORT_ERROR_THRESHOLD)
   def createWriterMaxAttempts: Int = get(WORKER_WRITER_CREATE_MAX_ATTEMPTS)
   def workerStorageBaseDirPrefix: String = get(WORKER_STORAGE_BASE_DIR_PREFIX)
   def workerStorageBaseDirNumber: Int = get(WORKER_STORAGE_BASE_DIR_COUNT)
@@ -2278,6 +2279,15 @@ object CelebornConf extends Logging {
       .doc("The directory where linux file block information is stored.")
       .stringConf
       .createWithDefault("/sys/block")
+
+  val WORKER_DISK_MONITOR_REPORT_ERROR_THRESHOLD: ConfigEntry[Int] =
+    buildConf("celeborn.worker.monitor.disk.reportErrorThreshold")
+      .categories("worker")
+      .version("0.2.0")
+      .doc("Device monitor will report device critical error once the accumulated non-critical error number exceed " +
+        "this threshold.")
+      .intConf
+      .createWithDefault(64)
 
   val WORKER_WRITER_CREATE_MAX_ATTEMPTS: ConfigEntry[Int] =
     buildConf("celeborn.worker.writer.create.maxAttempts")

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -922,6 +922,7 @@ object Utils extends Logging {
       case 1 => DiskStatus.READ_OR_WRITE_FAILURE
       case 2 => DiskStatus.IO_HANG
       case 3 => DiskStatus.HIGH_DISK_USAGE
+      case 4 => DiskStatus.CRITICAL_ERROR
       case _ => null
     }
   }

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -60,6 +60,7 @@ license: |
 | celeborn.worker.monitor.disk.checkInterval | 60s | Intervals between device monitor to check disk. | 0.2.0 | 
 | celeborn.worker.monitor.disk.checklist | readwrite,diskusage | Monitor type for disk, available items are: iohang, readwrite and diskusage. | 0.2.0 | 
 | celeborn.worker.monitor.disk.enabled | true | When true, worker will monitor device and report to master. | 0.2.0 | 
+| celeborn.worker.monitor.disk.reportErrorThreshold | 64 | Device monitor will report device critical error once the accumulated non-critical error number exceed this threshold. | 0.2.0 | 
 | celeborn.worker.monitor.disk.sys.block.dir | /sys/block | The directory where linux file block information is stored. | 0.2.0 | 
 | celeborn.worker.noneEmptyDirExpireDuration | 1d | If a non-empty application shuffle data dir have not been operated during le duration time, will mark this application as expired. | 0.2.0 | 
 | celeborn.worker.partitionSorter.directMemoryRatioThreshold | 0.1 | Max ratio of partition sorter's memory for sorting, when reserved memory is higher than max partition sorter memory, partition sorter will stop sorting. | 0.2.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -60,7 +60,8 @@ license: |
 | celeborn.worker.monitor.disk.checkInterval | 60s | Intervals between device monitor to check disk. | 0.2.0 | 
 | celeborn.worker.monitor.disk.checklist | readwrite,diskusage | Monitor type for disk, available items are: iohang, readwrite and diskusage. | 0.2.0 | 
 | celeborn.worker.monitor.disk.enabled | true | When true, worker will monitor device and report to master. | 0.2.0 | 
-| celeborn.worker.monitor.disk.reportErrorThreshold | 64 | Device monitor will report device critical error once the accumulated non-critical error number exceed this threshold. | 0.2.0 | 
+| celeborn.worker.monitor.disk.reportError.expireDuration | 1h | The expire duration of a non-critical device error. | 0.2.0 | 
+| celeborn.worker.monitor.disk.reportError.threshold | 64 | Device monitor will report critical error once the accumulated valid non-critical error number exceeding this threshold. | 0.2.0 | 
 | celeborn.worker.monitor.disk.sys.block.dir | /sys/block | The directory where linux file block information is stored. | 0.2.0 | 
 | celeborn.worker.noneEmptyDirExpireDuration | 1d | If a non-empty application shuffle data dir have not been operated during le duration time, will mark this application as expired. | 0.2.0 | 
 | celeborn.worker.partitionSorter.directMemoryRatioThreshold | 0.1 | Max ratio of partition sorter's memory for sorting, when reserved memory is higher than max partition sorter memory, partition sorter will stop sorting. | 0.2.0 | 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -65,6 +65,7 @@ object WorkerSource {
 
   // flush
   val TakeBufferTime = "TakeBufferTime"
+  val LocalDeviceErrorFrequency = "LocalDeviceErrorFrequency"
 
   val RegisteredShuffleCount = "RegisteredShuffleCount"
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -137,8 +137,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     }
 
   override def notifyError(mountPoint: String, diskStatus: DiskStatus): Unit = this.synchronized {
-    if (diskStatus == DiskStatus.IO_HANG) {
-      logInfo("IoHang, remove disk operator.")
+    if (diskStatus == DiskStatus.CRITICAL_ERROR) {
+      logInfo("Face critical error, remove disk operator.")
       val operator = diskOperators.remove(mountPoint)
       if (operator != null) {
         operator.shutdown()

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
@@ -214,29 +214,29 @@ class DeviceMonitorSuite extends AnyFunSuite {
         deviceMonitor.observedDevices.get(vdbDeviceInfo).observers.contains(storageManager))
       assert(deviceMonitor.observedDevices.get(vdbDeviceInfo).observers.contains(df4))
 
-      when(fw2.notifyError("vda", DiskStatus.IO_HANG))
+      when(fw2.notifyError("vda", DiskStatus.CRITICAL_ERROR))
         .thenAnswer((a: String, b: List[File]) => {
           deviceMonitor.unregisterFileWriter(fw2)
         })
-      when(fw4.notifyError("vdb", DiskStatus.IO_HANG))
+      when(fw4.notifyError("vdb", DiskStatus.CRITICAL_ERROR))
         .thenAnswer((a: String, b: List[File]) => {
           deviceMonitor.unregisterFileWriter(fw4)
         })
-      when(df2.notifyError("vda", DiskStatus.IO_HANG))
+      when(df2.notifyError("vda", DiskStatus.CRITICAL_ERROR))
         .thenAnswer((a: String, b: List[File]) => {
           df2.stopFlag.set(true)
         })
-      when(df4.notifyError("vdb", DiskStatus.IO_HANG))
+      when(df4.notifyError("vdb", DiskStatus.CRITICAL_ERROR))
         .thenAnswer((a: String, b: List[File]) => {
           df4.stopFlag.set(true)
         })
 
       deviceMonitor.observedDevices
         .get(vdaDeviceInfo)
-        .notifyObserversOnError(List("/mnt/disk1"), DiskStatus.IO_HANG)
+        .notifyObserversOnError(List("/mnt/disk1"), DiskStatus.CRITICAL_ERROR)
       deviceMonitor.observedDevices
         .get(vdbDeviceInfo)
-        .notifyObserversOnError(List("/mnt/disk2"), DiskStatus.IO_HANG)
+        .notifyObserversOnError(List("/mnt/disk2"), DiskStatus.CRITICAL_ERROR)
       assertEquals(deviceMonitor.observedDevices.get(vdaDeviceInfo).observers.size(), 3)
       assertEquals(deviceMonitor.observedDevices.get(vdbDeviceInfo).observers.size(), 3)
       assert(
@@ -262,7 +262,7 @@ class DeviceMonitorSuite extends AnyFunSuite {
         .thenAnswer((_: Any) => {
           deviceMonitor.unregisterFileWriter(fw2)
         })
-      deviceMonitor.reportDeviceError("/mnt/disk1", null, DiskStatus.IO_HANG)
+      deviceMonitor.reportDeviceError("/mnt/disk1", null, DiskStatus.CRITICAL_ERROR)
       assertEquals(deviceMonitor.observedDevices.get(vdaDeviceInfo).observers.size(), 2)
       assert(
         deviceMonitor.observedDevices.get(vdaDeviceInfo).observers.contains(storageManager))
@@ -276,7 +276,7 @@ class DeviceMonitorSuite extends AnyFunSuite {
         .thenAnswer((_: Any) => {
           deviceMonitor.unregisterFileWriter(fw4)
         })
-      deviceMonitor.reportDeviceError("/mnt/disk2", null, DiskStatus.IO_HANG)
+      deviceMonitor.reportDeviceError("/mnt/disk2", null, DiskStatus.CRITICAL_ERROR)
       assertEquals(deviceMonitor.observedDevices.get(vdbDeviceInfo).observers.size(), 2)
       assert(
         deviceMonitor.observedDevices.get(vdbDeviceInfo).observers.contains(storageManager))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Device check should report error after check failed a certain number of times
Add new DiskStatus to represent critical error
Add expire duration for non-critical error
Change the logic of trigger notifyObserversOnHealthy

### Why are the changes needed?
Ensure critical error will only be triggered once non-critical error surge in a given size time window.

### What are the items that need reviewer attention?


### Related issues.
#934 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 
/assign @main-reviewer
