### PR TITLE
[ISSUE-987][FEATURE] During worker shutdown, return HARD_SPLIT for all existed partition

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -942,7 +942,23 @@ public class ShuffleClientImpl extends ShuffleClient {
         new RpcResponseCallback() {
           @Override
           public void onSuccess(ByteBuffer response) {
-            callback.onSuccess(response);
+            if (response.remaining() > 0) {
+              byte reason = response.get();
+              if (reason == StatusCode.HARD_SPLIT.getValue()) {
+                logger.info("Push merged data return hard split for map " + mapId +
+                    " attempt " + attemptId + " batches " + Arrays.toString(batchIds) + ".");
+                pushDataRetryPool.submit(() ->
+                    submitRetryPushMergedData(pushState, applicationId, shuffleId, mapId,
+                        attemptId, batches, StatusCode.HARD_SPLIT, groupedBatchId));
+              } else {
+                // Should not happen in current architecture.
+                response.rewind();
+                logger.error("Push merged data should not receive this response");
+                callback.onSuccess(response);
+              }
+            } else {
+              callback.onSuccess(response);
+            }
           }
 
           @Override

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -945,11 +945,25 @@ public class ShuffleClientImpl extends ShuffleClient {
             if (response.remaining() > 0) {
               byte reason = response.get();
               if (reason == StatusCode.HARD_SPLIT.getValue()) {
-                logger.info("Push merged data return hard split for map " + mapId +
-                    " attempt " + attemptId + " batches " + Arrays.toString(batchIds) + ".");
-                pushDataRetryPool.submit(() ->
-                    submitRetryPushMergedData(pushState, applicationId, shuffleId, mapId,
-                        attemptId, batches, StatusCode.HARD_SPLIT, groupedBatchId));
+                logger.info(
+                    "Push merged data return hard split for map "
+                        + mapId
+                        + " attempt "
+                        + attemptId
+                        + " batches "
+                        + Arrays.toString(batchIds)
+                        + ".");
+                pushDataRetryPool.submit(
+                    () ->
+                        submitRetryPushMergedData(
+                            pushState,
+                            applicationId,
+                            shuffleId,
+                            mapId,
+                            attemptId,
+                            batches,
+                            StatusCode.HARD_SPLIT,
+                            groupedBatchId));
               } else {
                 // Should not happen in current architecture.
                 response.rewind();


### PR DESCRIPTION
### What changes were proposed in this pull request?

To support quick restart, during worker shutdown, return HARD_SPLIT for existed reserved partition


### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
close #987

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
