### PR TITLE
[CELEBORN-55][FEATURE] Split maxReqsInFlight limitation into level of target worker

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,5 +36,5 @@ github:
     projects: false
 notifications:
   commits: commits@celeborn.apache.org
-  issues: notifications@celeborn.apache.org
-  pullrequests: notifications@celeborn.apache.org
+  issues: issues@celeborn.apache.org
+  pullrequests: issues@celeborn.apache.org

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,3 +34,8 @@ jobs:
         check-latest: false
     - name: Test with Maven
       run: build/mvn -Pgoogle-mirror,spark-${{ matrix.spark }} test
+    - name: Upload coverage to Codecov
+      if: |
+        matrix.java == 8 &&
+        matrix.spark == '3.3'
+      uses: codecov/codecov-action@v3

--- a/client-flink/flink-1.14/pom.xml
+++ b/client-flink/flink-1.14/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements.  See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache License, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License.  You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.celeborn</groupId>
+    <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
+    <version>${project.version}</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>celeborn-client-flink-${flink.version}_${scala.binary.version}</artifactId>
+  <packaging>jar</packaging>
+  <name>Celeborn Client for flink</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-runtime</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client-flink-common-${flink.version}_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/FlinkResultPartitionInfo.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/FlinkResultPartitionInfo.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+
+import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
+
+public class FlinkResultPartitionInfo {
+  private final PartitionDescriptor partitionDescriptor;
+  private final ProducerDescriptor producerDescriptor;
+
+  public FlinkResultPartitionInfo(
+      PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+    this.partitionDescriptor = partitionDescriptor;
+    this.producerDescriptor = producerDescriptor;
+  }
+
+  public ResultPartitionID getResultPartitionId() {
+    return new ResultPartitionID(
+        partitionDescriptor.getPartitionId(), producerDescriptor.getProducerExecutionId());
+  }
+
+  public String getShuffleId() {
+    return FlinkUtils.toShuffleId(partitionDescriptor.getResultId());
+  }
+
+  public int getTaskId() {
+    return partitionDescriptor.getPartitionId().getPartitionNumber();
+  }
+
+  public String getAttemptId() {
+    return FlinkUtils.toAttemptId(producerDescriptor.getProducerExecutionId());
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleDescriptor.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleDescriptor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.util.Optional;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+
+public class RemoteShuffleDescriptor implements ShuffleDescriptor {
+
+  private final ResultPartitionID resultPartitionID;
+
+  private final JobID jobID;
+
+  private final ShuffleResource shuffleResource;
+
+  public RemoteShuffleDescriptor(
+      JobID jobID, ResultPartitionID resultPartitionID, ShuffleResource shuffleResource) {
+    this.jobID = jobID;
+    this.resultPartitionID = resultPartitionID;
+    this.shuffleResource = shuffleResource;
+  }
+
+  @Override
+  public ResultPartitionID getResultPartitionID() {
+    return resultPartitionID;
+  }
+
+  public JobID getJobID() {
+    return jobID;
+  }
+
+  public ShuffleResource getShuffleResource() {
+    return shuffleResource;
+  }
+
+  @Override
+  public Optional<ResourceID> storesLocalResourcesOn() {
+    return Optional.empty();
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.client.LifecycleManager;
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
+import org.apache.celeborn.plugin.flink.utils.ThreadUtils;
+
+public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescriptor> {
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteShuffleMaster.class);
+
+  private final ShuffleMasterContext shuffleMasterContext;
+  // Flink JobId -> Celeborn LifecycleManager
+  private Map<JobID, LifecycleManager> lifecycleManagers = new ConcurrentHashMap<>();
+  private final ScheduledThreadPoolExecutor executor =
+      new ScheduledThreadPoolExecutor(
+          1,
+          ThreadUtils.createFactoryWithDefaultExceptionHandler(
+              "remote-shuffle-master-executor", LOG));
+
+  public RemoteShuffleMaster(ShuffleMasterContext shuffleMasterContext) {
+    this.shuffleMasterContext = shuffleMasterContext;
+  }
+
+  @Override
+  public void registerJob(JobShuffleContext context) {
+    JobID jobId = context.getJobId();
+    Future<?> submit =
+        executor.submit(
+            () -> {
+              if (lifecycleManagers.containsKey(jobId)) {
+                throw new RuntimeException("Duplicated registration job: " + jobId);
+              } else {
+                CelebornConf celebornConf =
+                    FlinkUtils.toCelebornConf(shuffleMasterContext.getConfiguration());
+                LifecycleManager lifecycleManager =
+                    new LifecycleManager(FlinkUtils.toCelebornAppId(jobId), celebornConf);
+                lifecycleManagers.put(jobId, lifecycleManager);
+              }
+            });
+
+    try {
+      submit.get();
+    } catch (InterruptedException e) {
+      LOG.error("Encounter interruptedException when registration job: {}.", jobId, e);
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      LOG.error("Encounter an error when registration job: {}.", jobId, e);
+      throw new RuntimeException(e.getCause());
+    }
+  }
+
+  @Override
+  public void unregisterJob(JobID jobID) {
+    executor.execute(
+        () -> {
+          try {
+            LOG.info("Unregister job: {}.", jobID);
+            LifecycleManager lifecycleManager = lifecycleManagers.remove(jobID);
+            if (lifecycleManager != null) {
+              lifecycleManager.stop();
+            }
+          } catch (Throwable throwable) {
+            LOG.error("Encounter an error when unregistering job: {}.", jobID, throwable);
+          }
+        });
+  }
+
+  @Override
+  public CompletableFuture<RemoteShuffleDescriptor> registerPartitionWithProducer(
+      JobID jobID, PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+    CompletableFuture<RemoteShuffleDescriptor> completableFuture =
+        CompletableFuture.supplyAsync(
+            () -> {
+              LifecycleManager lifecycleManager = lifecycleManagers.get(jobID);
+              FlinkResultPartitionInfo resultPartitionInfo =
+                  new FlinkResultPartitionInfo(partitionDescriptor, producerDescriptor);
+              LifecycleManager.ShuffleTask shuffleTask =
+                  lifecycleManager.encodeExternalShuffleTask(
+                      resultPartitionInfo.getShuffleId(),
+                      resultPartitionInfo.getTaskId(),
+                      resultPartitionInfo.getAttemptId());
+              ShuffleResourceDescriptor shuffleResourceDescriptor =
+                  new ShuffleResourceDescriptor(shuffleTask);
+              RemoteShuffleResource remoteShuffleResource =
+                  new RemoteShuffleResource(
+                      lifecycleManager.getRssMetaServiceHost(),
+                      lifecycleManager.getRssMetaServicePort(),
+                      shuffleResourceDescriptor);
+              return new RemoteShuffleDescriptor(
+                  jobID, resultPartitionInfo.getResultPartitionId(), remoteShuffleResource);
+            },
+            executor);
+
+    return completableFuture;
+  }
+
+  @Override
+  public void releasePartitionExternally(ShuffleDescriptor shuffleDescriptor) {
+    // TODO
+  }
+
+  @Override
+  public void close() throws Exception {
+    try {
+      for (LifecycleManager lifecycleManager : lifecycleManagers.values()) {
+        lifecycleManager.stop();
+      }
+    } catch (Exception e) {
+      LOG.warn("Encounter exception when shutdown: " + e.getMessage(), e);
+    }
+
+    ThreadUtils.shutdownExecutors(10, executor);
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.util.function.SupplierWithException;
+
+import org.apache.celeborn.client.ShuffleClient;
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
+import org.apache.celeborn.common.protocol.PartitionLocation;
+import org.apache.celeborn.plugin.flink.utils.Utils;
+
+/**
+ * A transportation gate used to spill buffers from {@link ResultPartitionWriter} to remote shuffle
+ * worker.
+ */
+public class RemoteShuffleOutputGate {
+
+  private final RemoteShuffleDescriptor shuffleDesc;
+  protected final int numSubs;
+  private final ShuffleClient shuffleWriteClient;
+  protected final SupplierWithException<BufferPool, IOException> bufferPoolFactory;
+  protected BufferPool bufferPool;
+  private CelebornConf celebornConf;
+  private final int numMappers;
+  private PartitionLocation partitionLocation;
+
+  private int currentRegionIndex = 0;
+
+  private int bufferSize;
+  private String applicationId;
+  private int shuffleId;
+  private int mapId;
+  private int attemptId;
+  private String rssMetaServiceHost;
+  private int rssMetaServicePort;
+  private UserIdentifier userIdentifier;
+
+  /**
+   * @param shuffleDesc Describes shuffle meta and shuffle worker address.
+   * @param numSubs Number of subpartitions of the corresponding {@link ResultPartitionWriter}.
+   * @param bufferPoolFactory {@link BufferPool} provider.
+   */
+  public RemoteShuffleOutputGate(
+      RemoteShuffleDescriptor shuffleDesc,
+      int numSubs,
+      int bufferSize,
+      SupplierWithException<BufferPool, IOException> bufferPoolFactory,
+      CelebornConf celebornConf,
+      int numMappers) {
+
+    this.shuffleDesc = shuffleDesc;
+    this.numSubs = numSubs;
+    this.bufferPoolFactory = bufferPoolFactory;
+    this.shuffleWriteClient = createWriteClient();
+    // this.bufferPacker = new BufferPacker(this::write);
+    this.celebornConf = celebornConf;
+    this.numMappers = numMappers;
+    this.bufferSize = bufferSize;
+    this.applicationId = shuffleDesc.getJobID().toString();
+    this.shuffleId =
+        shuffleDesc.getShuffleResource().getMapPartitionShuffleDescriptor().getShuffleId();
+    this.mapId = shuffleDesc.getShuffleResource().getMapPartitionShuffleDescriptor().getMapId();
+    this.attemptId =
+        shuffleDesc.getShuffleResource().getMapPartitionShuffleDescriptor().getAttemptId();
+    this.rssMetaServiceHost =
+        ((RemoteShuffleResource) shuffleDesc.getShuffleResource()).getRssMetaServiceHost();
+    this.rssMetaServicePort =
+        ((RemoteShuffleResource) shuffleDesc.getShuffleResource()).getRssMetaServicePort();
+  }
+
+  /** Initialize transportation gate. */
+  public void setup() throws IOException, InterruptedException {
+    bufferPool = Utils.checkNotNull(bufferPoolFactory.get());
+    Utils.checkArgument(
+        bufferPool.getNumberOfRequiredMemorySegments() >= 2,
+        "Too few buffers for transfer, the minimum valid required size is 2.");
+
+    // guarantee that we have at least one buffer
+    // BufferUtils.reserveNumRequiredBuffers(bufferPool, 1);
+
+    // handshake
+    handshake();
+  }
+
+  /** Get transportation buffer pool. */
+  public BufferPool getBufferPool() {
+    return bufferPool;
+  }
+
+  /** Writes a {@link Buffer} to a subpartition. */
+  public void write(Buffer buffer, int subIdx) throws InterruptedException {
+    // bufferPacker.process(buffer, subIdx);
+  }
+
+  /**
+   * Indicates the start of a region. A region of buffers guarantees the records inside are
+   * completed.
+   *
+   * @param isBroadcast Whether it's a broadcast region.
+   */
+  public void regionStart(boolean isBroadcast) {
+    Optional<PartitionLocation> newPartitionLoc = null;
+    try {
+      newPartitionLoc =
+          shuffleWriteClient.regionStart(
+              applicationId,
+              shuffleId,
+              mapId,
+              attemptId,
+              partitionLocation,
+              currentRegionIndex,
+              isBroadcast);
+      // revived
+      if (newPartitionLoc.isPresent()) {
+        partitionLocation = newPartitionLoc.get();
+        // send handshake again
+        handshake();
+        // send regionstart again
+        shuffleWriteClient.regionStart(
+            applicationId,
+            shuffleId,
+            mapId,
+            attemptId,
+            newPartitionLoc.get(),
+            currentRegionIndex,
+            isBroadcast);
+      }
+    } catch (IOException e) {
+      Utils.rethrowAsRuntimeException(e);
+    }
+  }
+
+  /**
+   * Indicates the finish of a region. A region is always bounded by a pair of region-start and
+   * region-finish.
+   */
+  public void regionFinish() throws InterruptedException {
+    // bufferPacker.drain();
+    try {
+      shuffleWriteClient.regionFinish(
+          applicationId, shuffleId, mapId, attemptId, partitionLocation);
+      currentRegionIndex++;
+    } catch (IOException e) {
+      Utils.rethrowAsRuntimeException(e);
+    }
+  }
+
+  /** Indicates the writing/spilling is finished. */
+  public void finish() throws InterruptedException, IOException {
+    shuffleWriteClient.mapperEnd(applicationId, shuffleId, mapId, attemptId, numMappers);
+  }
+
+  /** Close the transportation gate. */
+  public void close() throws IOException {
+    if (bufferPool != null) {
+      bufferPool.lazyDestroy();
+    }
+    // bufferPacker.close();
+    shuffleWriteClient.shutDown();
+  }
+
+  /** Returns shuffle descriptor. */
+  public RemoteShuffleDescriptor getShuffleDesc() {
+    return shuffleDesc;
+  }
+
+  private ShuffleClient createWriteClient() {
+    return ShuffleClient.get(rssMetaServiceHost, rssMetaServicePort, celebornConf, userIdentifier);
+  }
+
+  /** Writes a piece of data to a subpartition. */
+  public void write(ByteBuf byteBuf, int subIdx) throws InterruptedException {
+    //    try {
+    //         byteBuf.retain();
+    //      shuffleWriteClient.pushData(
+    //          applicationId,
+    //          shuffleId,
+    //          mapId,
+    //          attemptId,
+    //          subIdx,
+    //          io.netty.buffer.Unpooled.wrappedBuffer(byteBuf.nioBuffer()),
+    //          partitionLocation,
+    //          () -> byteBuf.release());
+    //    } catch (IOException e) {
+    //      Utils.rethrowAsRuntimeException(e);
+    //    }
+  }
+
+  public void handshake() {
+    if (partitionLocation == null) {
+      partitionLocation =
+          shuffleWriteClient.registerMapPartitionTask(
+              applicationId, shuffleId, numMappers, mapId, attemptId);
+    }
+    currentRegionIndex = 0;
+    try {
+      shuffleWriteClient.pushDataHandShake(
+          applicationId, shuffleId, mapId, attemptId, numSubs, bufferSize, partitionLocation);
+    } catch (IOException e) {
+      Utils.rethrowAsRuntimeException(e);
+    }
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResource.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResource.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+public class RemoteShuffleResource implements ShuffleResource {
+
+  private static final long serialVersionUID = 6497939083185255973L;
+
+  private final String rssMetaServiceHost;
+  private final int rssMetaServicePort;
+
+  private ShuffleResourceDescriptor shuffleResourceDescriptor;
+
+  public RemoteShuffleResource(
+      String rssMetaServiceHost,
+      int rssMetaServicePort,
+      ShuffleResourceDescriptor remoteShuffleDescriptor) {
+    this.rssMetaServiceHost = rssMetaServiceHost;
+    this.rssMetaServicePort = rssMetaServicePort;
+    this.shuffleResourceDescriptor = remoteShuffleDescriptor;
+  }
+
+  @Override
+  public ShuffleResourceDescriptor getMapPartitionShuffleDescriptor() {
+    return shuffleResourceDescriptor;
+  }
+
+  public String getRssMetaServiceHost() {
+    return rssMetaServiceHost;
+  }
+
+  public int getRssMetaServicePort() {
+    return rssMetaServicePort;
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleServiceFactory.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleServiceFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
+import org.apache.flink.runtime.shuffle.*;
+
+public class RemoteShuffleServiceFactory
+    implements ShuffleServiceFactory<
+        RemoteShuffleDescriptor, ResultPartitionWriter, IndexedInputGate> {
+
+  @Override
+  public ShuffleMaster<RemoteShuffleDescriptor> createShuffleMaster(
+      ShuffleMasterContext shuffleMasterContext) {
+    return new RemoteShuffleMaster(shuffleMasterContext);
+  }
+
+  @Override
+  public ShuffleEnvironment<ResultPartitionWriter, IndexedInputGate> createShuffleEnvironment(
+      ShuffleEnvironmentContext shuffleEnvironmentContext) {
+    // TODO
+    return null;
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResource.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResource.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.io.Serializable;
+
+public interface ShuffleResource extends Serializable {
+
+  ShuffleResourceDescriptor getMapPartitionShuffleDescriptor();
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResourceDescriptor.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResourceDescriptor.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.io.Serializable;
+
+import org.apache.celeborn.client.LifecycleManager;
+import org.apache.celeborn.common.util.PackedPartitionId;
+
+public class ShuffleResourceDescriptor implements Serializable {
+
+  private static final long serialVersionUID = -1251659747395561342L;
+
+  private final int shuffleId;
+  private final int mapId;
+  private final int attemptId;
+  private final int partitionId;
+
+  public ShuffleResourceDescriptor(LifecycleManager.ShuffleTask shuffleTask) {
+    this.shuffleId = shuffleTask.shuffleId();
+    this.mapId = shuffleTask.mapId();
+    this.attemptId = shuffleTask.attemptId();
+    this.partitionId = PackedPartitionId.packedPartitionId(mapId, attemptId);
+  }
+
+  public int getShuffleId() {
+    return shuffleId;
+  }
+
+  public int getMapId() {
+    return mapId;
+  }
+
+  public int getAttemptId() {
+    return attemptId;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("ShuffleResourceDescriptor{");
+    sb.append("shuffleId=").append(shuffleId);
+    sb.append(", mapId=").append(mapId);
+    sb.append(", attemptId=").append(attemptId);
+    sb.append(", partitionId=").append(partitionId);
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink.utils;
+
+import java.util.Map;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import org.apache.celeborn.common.CelebornConf;
+
+public class FlinkUtils {
+
+  public static CelebornConf toCelebornConf(Configuration configuration) {
+    CelebornConf tmpCelebornConf = new CelebornConf();
+    Map<String, String> confMap = configuration.toMap();
+    for (Map.Entry<String, String> entry : confMap.entrySet()) {
+      String key = entry.getKey();
+      if (key.startsWith("celeborn.")) {
+        tmpCelebornConf.set(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return tmpCelebornConf;
+  }
+
+  public static String toCelebornAppId(JobID jobID) {
+    return jobID.toString();
+  }
+
+  public static String toShuffleId(IntermediateDataSetID dataSetID) {
+    return dataSetID.toString();
+  }
+
+  public static String toAttemptId(ExecutionAttemptID attemptID) {
+    return attemptID.toString();
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/utils/ThreadUtils.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/utils/ThreadUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink.utils;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.flink.util.ExecutorUtils;
+import org.slf4j.Logger;
+
+public class ThreadUtils {
+
+  public static ThreadFactory createFactoryWithDefaultExceptionHandler(
+      final String executorServiceName, final Logger LOG) {
+    return new ThreadFactoryBuilder()
+        .setNameFormat(executorServiceName + "-%d")
+        .setDaemon(true)
+        .setUncaughtExceptionHandler(
+            (Thread t, Throwable e) ->
+                LOG.error(
+                    "exception in serviceName: {}, thread: {}",
+                    executorServiceName,
+                    t.getName(),
+                    e))
+        .build();
+  }
+
+  public static void shutdownExecutors(int timeoutSecs, ExecutorService executorService) {
+    ExecutorUtils.gracefulShutdown(timeoutSecs, TimeUnit.SECONDS, executorService);
+  }
+}

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.util.PackedPartitionId;
+
+public class RemoteShuffleMasterTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteShuffleMasterTest.class);
+  private RemoteShuffleMaster remoteShuffleMaster;
+
+  @Before
+  public void setUp() {
+    Configuration configuration = new Configuration();
+    remoteShuffleMaster = createShuffleMaster(configuration);
+  }
+
+  @Test
+  public void testRegisterJob() {
+    JobShuffleContext jobShuffleContext = createJobShuffleContext(JobID.generate());
+    remoteShuffleMaster.registerJob(jobShuffleContext);
+
+    // reRunRegister job
+    try {
+      remoteShuffleMaster.registerJob(jobShuffleContext);
+    } catch (Exception e) {
+      Assert.assertTrue(true);
+    }
+
+    // unRegister job
+    remoteShuffleMaster.unregisterJob(jobShuffleContext.getJobId());
+  }
+
+  @Test
+  public void testRegisterPartitionWithProducer()
+      throws UnknownHostException, ExecutionException, InterruptedException {
+    JobID jobID = JobID.generate();
+    JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
+    remoteShuffleMaster.registerJob(jobShuffleContext);
+
+    IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
+    PartitionDescriptor partitionDescriptor = createPartitionDescriptor(intermediateDataSetID, 0);
+    ProducerDescriptor producerDescriptor = createProducerDescriptor();
+    RemoteShuffleDescriptor remoteShuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    ShuffleResource shuffleResource = remoteShuffleDescriptor.getShuffleResource();
+    ShuffleResourceDescriptor mapPartitionShuffleDescriptor =
+        shuffleResource.getMapPartitionShuffleDescriptor();
+    System.out.println(mapPartitionShuffleDescriptor.toString());
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getPartitionId());
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getAttemptId());
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getMapId());
+
+    // use same dataset id
+    partitionDescriptor = createPartitionDescriptor(intermediateDataSetID, 1);
+    remoteShuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    mapPartitionShuffleDescriptor =
+        remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
+    Assert.assertEquals(1, mapPartitionShuffleDescriptor.getMapId());
+
+    // use another attemptId
+    producerDescriptor = createProducerDescriptor();
+    remoteShuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    mapPartitionShuffleDescriptor =
+        remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
+    Assert.assertEquals(
+        PackedPartitionId.packedPartitionId(1, 1), mapPartitionShuffleDescriptor.getPartitionId());
+    Assert.assertEquals(1, mapPartitionShuffleDescriptor.getAttemptId());
+    Assert.assertEquals(1, mapPartitionShuffleDescriptor.getMapId());
+  }
+
+  @After
+  public void tearDown() {
+    if (remoteShuffleMaster != null) {
+      try {
+        remoteShuffleMaster.close();
+      } catch (Exception e) {
+        LOG.warn(e.getMessage(), e);
+      }
+    }
+  }
+
+  public RemoteShuffleMaster createShuffleMaster(Configuration configuration) {
+    remoteShuffleMaster =
+        new RemoteShuffleMaster(
+            new ShuffleMasterContext() {
+              @Override
+              public Configuration getConfiguration() {
+                return configuration;
+              }
+
+              @Override
+              public void onFatalError(Throwable throwable) {
+                System.exit(-1);
+              }
+            });
+
+    return remoteShuffleMaster;
+  }
+
+  public JobShuffleContext createJobShuffleContext(JobID jobId) {
+    return new JobShuffleContext() {
+      @Override
+      public org.apache.flink.api.common.JobID getJobId() {
+        return jobId;
+      }
+
+      @Override
+      public CompletableFuture<?> stopTrackingAndReleasePartitions(
+          Collection<ResultPartitionID> collection) {
+        return CompletableFuture.completedFuture(null);
+      }
+    };
+  }
+
+  public PartitionDescriptor createPartitionDescriptor(
+      IntermediateDataSetID intermediateDataSetId, int partitionNum) {
+    IntermediateResultPartitionID intermediateResultPartitionId =
+        new IntermediateResultPartitionID(intermediateDataSetId, partitionNum);
+    return new PartitionDescriptor(
+        intermediateDataSetId,
+        10,
+        intermediateResultPartitionId,
+        ResultPartitionType.BLOCKING,
+        5,
+        1);
+  }
+
+  public ProducerDescriptor createProducerDescriptor() throws UnknownHostException {
+    ExecutionAttemptID executionAttemptId = new ExecutionAttemptID();
+    return new ProducerDescriptor(
+        ResourceID.generate(), executionAttemptId, InetAddress.getLocalHost(), 100);
+  }
+}

--- a/client-flink/flink-common/pom.xml
+++ b/client-flink/flink-common/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements.  See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache License, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License.  You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.celeborn</groupId>
+    <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
+    <version>${project.version}</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>celeborn-client-flink-common-${flink.version}_${scala.binary.version}</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-runtime</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/client-flink/flink-common/src/main/java/org/apache/celeborn/plugin/flink/utils/Utils.java
+++ b/client-flink/flink-common/src/main/java/org/apache/celeborn/plugin/flink/utils/Utils.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink.utils;
+
+/** Utility methods can be used by all modules. */
+public class Utils {
+  /**
+   * Ensures that the target object is not null and returns it. It will throw {@link
+   * NullPointerException} if the target object is null.
+   */
+  public static <T> T checkNotNull(T object) {
+    if (object == null) {
+      throw new NullPointerException("Must be not null.");
+    }
+    return object;
+  }
+
+  /**
+   * Check the legality of method arguments. It will throw {@link IllegalArgumentException} if the
+   * given condition is not true.
+   */
+  public static void checkArgument(boolean condition, String message) {
+    if (!condition) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  /**
+   * Checks the legality of program state. It will throw {@link IllegalStateException} if the given
+   * condition is not true.
+   */
+  public static void checkState(boolean condition, String message) {
+    if (!condition) {
+      throw new IllegalStateException(message);
+    }
+  }
+
+  /** Casts the given long value to int and ensures there is no loss. */
+  public static int checkedDownCast(long value) {
+    int downCast = (int) value;
+    if ((long) downCast != value) {
+      throw new IllegalArgumentException("Cannot downcast long value " + value + " to integer.");
+    }
+
+    return downCast;
+  }
+
+  /** Rethrows the target {@link Throwable} as {@link Error} or {@link RuntimeException}. */
+  public static void rethrowAsRuntimeException(Throwable t) {
+    if (t instanceof Error) {
+      throw (Error) t;
+    } else if (t instanceof RuntimeException) {
+      throw (RuntimeException) t;
+    } else {
+      throw new RuntimeException(t);
+    }
+  }
+}

--- a/client-flink/flink-shaded/pom.xml
+++ b/client-flink/flink-shaded/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements.  See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache License, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License.  You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.celeborn</groupId>
+    <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
+    <version>${project.version}</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>celeborn-client-flink-${flink.version}-shaded_${scala.binary.version}</artifactId>
+  <packaging>jar</packaging>
+  <name>Celeborn Shaded Client for flink</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client-flink-${flink.version}_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.google.protobuf</pattern>
+              <shadedPattern>${shading.prefix}.com.google.protobuf</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>${shading.prefix}.com.google.common</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>io.netty</pattern>
+              <shadedPattern>${shading.prefix}.io.netty</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons</pattern>
+              <shadedPattern>${shading.prefix}.org.apache.commons</shadedPattern>
+            </relocation>
+          </relocations>
+          <artifactSet>
+            <includes>
+              <include>org.apache.celeborn:*</include>
+              <include>com.google.protobuf:protobuf-java</include>
+              <include>com.google.guava:guava</include>
+              <include>io.netty:*</include>
+              <include>org.apache.commons:commons-lang3</include>
+            </includes>
+          </artifactSet>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+                <exclude>**/log4j.properties</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven.plugin.antrun.version}</version>
+        <executions>
+          <execution>
+            <id>rename-native-library</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <echo message="unpacking netty jar"></echo>
+                <unzip dest="${project.build.directory}/unpacked/" src="${project.build.directory}/${artifactId}-${version}.jar"></unzip>
+                <echo message="renaming native epoll library"></echo>
+                <move includeemptydirs="false" todir="${project.build.directory}/unpacked/META-INF/native">
+                  <fileset dir="${project.build.directory}/unpacked/META-INF/native"></fileset>
+                  <mapper from="libnetty_transport_native_epoll_x86_64.so" to="liborg_apache_celeborn_shaded_netty_transport_native_epoll_x86_64.so" type="glob"></mapper>
+                </move>
+                <move includeemptydirs="false" todir="${project.build.directory}/unpacked/META-INF/native">
+                  <fileset dir="${project.build.directory}/unpacked/META-INF/native"></fileset>
+                  <mapper from="libnetty_transport_native_epoll_aarch_64.so" to="liborg_apache_celeborn_shaded_netty_transport_native_epoll_aarch_64.so.so" type="glob"></mapper>
+                </move>
+                <echo message="deleting native kqueue library"></echo>
+                <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib"></delete>
+                <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib"></delete>
+                <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_resolver_dns_native_macos_aarch_64.jnilib"></delete>
+                <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib"></delete>
+                <echo message="repackaging netty jar"></echo>
+                <jar basedir="${project.build.directory}/unpacked" destfile="${project.build.directory}/${artifactId}-${version}.jar"></jar>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleFallbackPolicyRunner.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleFallbackPolicyRunner.scala
@@ -62,7 +62,7 @@ class RssShuffleFallbackPolicyRunner(conf: CelebornConf) extends Logging {
 
     val available = lifecycleManager.checkQuota()
     if (!available) {
-      logWarning(s"Cluster is not alive!")
+      logWarning(s"Quota exceed for current user ${lifecycleManager.getUserIdentifier}.")
     }
     available
   }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -57,6 +57,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -19,7 +19,9 @@ package org.apache.celeborn.client;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 
+import io.netty.buffer.ByteBuf;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
@@ -149,9 +151,19 @@ public abstract class ShuffleClient implements Cloneable {
   public abstract void pushMergedData(String applicationId, int shuffleId, int mapId, int attemptId)
       throws IOException;
 
-  // Report partition locations written by the completed map task
+  // Report partition locations written by the completed map task of ReducePartition Shuffle Type
   public abstract void mapperEnd(
       String applicationId, int shuffleId, int mapId, int attemptId, int numMappers)
+      throws IOException;
+
+  // Report partition locations written by the completed map task of MapPartition Shuffle Type
+  public abstract void mapPartitionMapperEnd(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int numMappers,
+      int partitionId)
       throws IOException;
 
   // Cleanup states of the map task
@@ -174,6 +186,20 @@ public abstract class ShuffleClient implements Cloneable {
   public abstract boolean unregisterShuffle(String applicationId, int shuffleId, boolean isDriver);
 
   public abstract void shutDown();
+
+  // Write data to a specific map partition, input data's type is Bytebuf.
+  // data's type is Bytebuf to avoid copy between application and netty
+  // closecallback will do some clean opertions like memory release.
+  public abstract int pushDataToLocation(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int partitionId,
+      ByteBuf data,
+      PartitionLocation location,
+      BooleanSupplier closeCallBack)
+      throws IOException;
 
   public abstract Optional<PartitionLocation> regionStart(
       String applicationId,
@@ -198,4 +224,7 @@ public abstract class ShuffleClient implements Cloneable {
       int bufferSize,
       PartitionLocation location)
       throws IOException;
+
+  public abstract PartitionLocation registerMapPartitionTask(
+      String appId, int shuffleId, int numMappers, int mapId, int attemptId);
 }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -19,6 +19,7 @@ package org.apache.celeborn.client;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BooleanSupplier;
 
 import io.netty.buffer.ByteBuf;
@@ -26,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
 import org.apache.celeborn.client.read.RssInputStream;
+import org.apache.celeborn.client.write.PushState;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.protocol.PartitionLocation;
@@ -227,4 +229,9 @@ public abstract class ShuffleClient implements Cloneable {
 
   public abstract PartitionLocation registerMapPartitionTask(
       String appId, int shuffleId, int numMappers, int mapId, int attemptId);
+
+  public abstract ConcurrentHashMap<Integer, PartitionLocation> getOrRegisterShuffle(
+      String applicationId, int shuffleId, int numMappers, int numPartitions);
+
+  public abstract PushState getOrRegisterPushState(String mapKey);
 }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -24,11 +24,12 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
-import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.Uninterruptibles;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -48,10 +49,14 @@ import org.apache.celeborn.common.network.client.RpcResponseCallback;
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.client.TransportClientFactory;
 import org.apache.celeborn.common.network.protocol.PushData;
+import org.apache.celeborn.common.network.protocol.PushDataHandShake;
 import org.apache.celeborn.common.network.protocol.PushMergedData;
+import org.apache.celeborn.common.network.protocol.RegionFinish;
+import org.apache.celeborn.common.network.protocol.RegionStart;
 import org.apache.celeborn.common.network.server.BaseMessageHandler;
 import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.protocol.*;
+import org.apache.celeborn.common.protocol.message.ControlMessages;
 import org.apache.celeborn.common.protocol.message.ControlMessages.*;
 import org.apache.celeborn.common.protocol.message.StatusCode;
 import org.apache.celeborn.common.rpc.RpcAddress;
@@ -267,6 +272,7 @@ public class ShuffleClientImpl extends ShuffleClient {
         () ->
             driverRssMetaService.askSync(
                 RegisterShuffle$.MODULE$.apply(appId, shuffleId, numMappers, numPartitions),
+                conf.registerShuffleRpcAskTimeout(),
                 ClassTag$.MODULE$.apply(PbRegisterShuffleResponse.class)));
   }
 
@@ -279,17 +285,6 @@ public class ShuffleClientImpl extends ShuffleClient {
         mapId,
         attemptId,
         partitionId);
-    if (attemptId == 0) {
-      return registerMapPartitionTaskWithFirstAttempt(
-          appId, shuffleId, numMappers, mapId, attemptId, partitionId);
-    }
-
-    // TODO
-    throw new UnsupportedOperationException("can not register shuffle task with attempt beyond 0");
-  }
-
-  private PartitionLocation registerMapPartitionTaskWithFirstAttempt(
-      String appId, int shuffleId, int numMappers, int mapId, int attemptId, int partitionId) {
     ConcurrentHashMap<Integer, PartitionLocation> partitionLocationMap =
         registerShuffleInternal(
             shuffleId,
@@ -299,6 +294,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                 driverRssMetaService.askSync(
                     RegisterMapPartitionTask$.MODULE$.apply(
                         appId, shuffleId, numMappers, mapId, attemptId, partitionId),
+                    conf.registerShuffleRpcAskTimeout(),
                     ClassTag$.MODULE$.apply(PbRegisterShuffleResponse.class)));
     return partitionLocationMap.get(partitionId);
   }
@@ -353,8 +349,8 @@ public class ShuffleClientImpl extends ShuffleClient {
     return null;
   }
 
-  private void limitMaxInFlight(String mapKey, PushState pushState, int limit, String hostAndPushPort)
-      throws IOException {
+  private void limitMaxInFlight(
+      String mapKey, PushState pushState, int limit, String hostAndPushPort) throws IOException {
     if (pushState.exception.get() != null) {
       throw pushState.exception.get();
     }
@@ -388,7 +384,10 @@ public class ShuffleClientImpl extends ShuffleClient {
           hostAndPushPort,
           limit);
       logger.error(
-          "Map: {} with hostAndPushPort {} in flight batches: {}", mapKey, hostAndPushPort, batchIdSet);
+          "Map: {} with hostAndPushPort {} in flight batches: {}",
+          mapKey,
+          hostAndPushPort,
+          batchIdSet);
       throw new IOException("wait timeout for task " + mapKey, pushState.exception.get());
     }
     if (pushState.exception.get() != null) {
@@ -496,6 +495,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                   epoch,
                   oldLocation,
                   cause),
+              conf.requestPartitionLocationRpcAskTimeout(),
               ClassTag$.MODULE$.apply(PbChangeLocationResponse.class));
       // per partitionKey only serve single PartitionLocation in Client Cache.
       StatusCode respStatus = Utils.toStatusCode(response.getStatus());
@@ -642,6 +642,9 @@ public class ShuffleClientImpl extends ShuffleClient {
             @Override
             public void onSuccess(ByteBuffer response) {
               pushState.removeFlightBatches(nextBatchId, loc.hostAndPushPort());
+
+              // TODO Need to adjust maxReqsInFlight if server response is congested, see
+              // CELEBORN-62
               if (response.remaining() > 0 && response.get() == StatusCode.STAGE_ENDED.getValue()) {
                 mapperEndMap
                     .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
@@ -808,6 +811,7 @@ public class ShuffleClientImpl extends ShuffleClient {
 
     ShuffleClientHelper.sendShuffleSplitAsync(
         driverRssMetaService,
+        conf,
         PartitionSplit$.MODULE$.apply(applicationId, shuffleId, partitionId, loc.getEpoch(), loc),
         partitionSplitPool,
         splittingSet,
@@ -946,6 +950,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                 attemptId,
                 groupedBatchId);
             pushState.removeFlightBatches(groupedBatchId, batches.get(0).loc.hostAndPushPort());
+
+            // TODO Need to adjust maxReqsInFlight if server response is congested, see CELEBORN-62
             if (response.remaining() > 0 && response.get() == StatusCode.STAGE_ENDED.getValue()) {
               mapperEndMap
                   .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
@@ -982,7 +988,37 @@ public class ShuffleClientImpl extends ShuffleClient {
         new RpcResponseCallback() {
           @Override
           public void onSuccess(ByteBuffer response) {
-            callback.onSuccess(response);
+            if (response.remaining() > 0) {
+              byte reason = response.get();
+              if (reason == StatusCode.HARD_SPLIT.getValue()) {
+                logger.info(
+                    "Push merged data return hard split for map "
+                        + mapId
+                        + " attempt "
+                        + attemptId
+                        + " batches "
+                        + Arrays.toString(batchIds)
+                        + ".");
+                pushDataRetryPool.submit(
+                    () ->
+                        submitRetryPushMergedData(
+                            pushState,
+                            applicationId,
+                            shuffleId,
+                            mapId,
+                            attemptId,
+                            batches,
+                            StatusCode.HARD_SPLIT,
+                            groupedBatchId));
+              } else {
+                // Should not happen in current architecture.
+                response.rewind();
+                logger.error("Push merged data should not receive this response");
+                callback.onSuccess(response);
+              }
+            } else {
+              callback.onSuccess(response);
+            }
           }
 
           @Override
@@ -1119,11 +1155,12 @@ public class ShuffleClientImpl extends ShuffleClient {
 
                 GetReducerFileGroup getReducerFileGroup =
                     new GetReducerFileGroup(applicationId, shuffleId);
-                ClassTag<GetReducerFileGroupResponse> classTag =
-                    ClassTag$.MODULE$.apply(GetReducerFileGroupResponse.class);
 
                 GetReducerFileGroupResponse response =
-                    driverRssMetaService.askSync(getReducerFileGroup, classTag);
+                    driverRssMetaService.askSync(
+                        getReducerFileGroup,
+                        conf.getReducerFileGroupRpcAskTimeout(),
+                        ClassTag$.MODULE$.apply(GetReducerFileGroupResponse.class));
 
                 if (response.status() == StatusCode.SUCCESS) {
                   logger.info(
@@ -1225,5 +1262,235 @@ public class ShuffleClientImpl extends ShuffleClient {
     return (message.startsWith("Connection from ") && message.endsWith(" closed"))
         || (message.equals("Connection reset by peer"))
         || (message.startsWith("Failed to send RPC "));
+  }
+
+  @Override
+  public void pushDataHandShake(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int numPartitions,
+      int bufferSize,
+      PartitionLocation location)
+      throws IOException {
+    sendMessageInternal(
+        shuffleId,
+        mapId,
+        attemptId,
+        location,
+        () -> {
+          String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
+          logger.info(
+              "pushDataHandShake shuffleKey:{}, attemptId:{}, locationId:{}",
+              shuffleKey,
+              attemptId,
+              location.getUniqueId());
+          logger.debug("pushDataHandShake location:{}", location.toString());
+          TransportClient client =
+              dataClientFactory.createClient(location.getHost(), location.getPushPort());
+          PushDataHandShake handShake =
+              new PushDataHandShake(
+                  MASTER_MODE,
+                  shuffleKey,
+                  location.getUniqueId(),
+                  attemptId,
+                  numPartitions,
+                  bufferSize);
+          client.sendRpcSync(handShake.toByteBuffer(), conf.pushDataRpcTimeoutMs());
+          return null;
+        });
+  }
+
+  @Override
+  public Optional<PartitionLocation> regionStart(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      PartitionLocation location,
+      int currentRegionIdx,
+      boolean isBroadcast)
+      throws IOException {
+    return sendMessageInternal(
+        shuffleId,
+        mapId,
+        attemptId,
+        location,
+        () -> {
+          String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
+          logger.info(
+              "regionStart shuffleKey:{}, attemptId:{}, locationId:{}",
+              shuffleKey,
+              attemptId,
+              location.getUniqueId());
+          logger.debug("regionStart location:{}", location.toString());
+          TransportClient client =
+              dataClientFactory.createClient(location.getHost(), location.getPushPort());
+          RegionStart regionStart =
+              new RegionStart(
+                  MASTER_MODE,
+                  shuffleKey,
+                  location.getUniqueId(),
+                  attemptId,
+                  currentRegionIdx,
+                  isBroadcast);
+          ByteBuffer regionStartResponse =
+              client.sendRpcSync(regionStart.toByteBuffer(), conf.pushDataRpcTimeoutMs());
+          if (regionStartResponse.hasRemaining()
+              && regionStartResponse.get() == StatusCode.HARD_SPLIT.getValue()) {
+            // if split then revive
+            PbChangeLocationResponse response =
+                driverRssMetaService.askSync(
+                    ControlMessages.Revive$.MODULE$.apply(
+                        applicationId,
+                        shuffleId,
+                        mapId,
+                        attemptId,
+                        location.getId(),
+                        location.getEpoch(),
+                        location,
+                        StatusCode.HARD_SPLIT),
+                    conf.requestPartitionLocationRpcAskTimeout(),
+                    ClassTag$.MODULE$.apply(PbChangeLocationResponse.class));
+            // per partitionKey only serve single PartitionLocation in Client Cache.
+            StatusCode respStatus = Utils.toStatusCode(response.getStatus());
+            if (StatusCode.SUCCESS.equals(respStatus)) {
+              return Optional.of(PbSerDeUtils.fromPbPartitionLocation(response.getLocation()));
+            } else if (StatusCode.MAP_ENDED.equals(respStatus)) {
+              final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+              mapperEndMap
+                  .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
+                  .add(mapKey);
+              return Optional.empty();
+            } else {
+              // throw exception
+              logger.error(
+                  "Exception raised while reviving for shuffle {} reduce {} epoch {}.",
+                  shuffleId,
+                  location.getId(),
+                  location.getEpoch());
+              throw new IOException("regiontstart revive failed");
+            }
+          }
+          return Optional.empty();
+        });
+  }
+
+  @Override
+  public void regionFinish(
+      String applicationId, int shuffleId, int mapId, int attemptId, PartitionLocation location)
+      throws IOException {
+    sendMessageInternal(
+        shuffleId,
+        mapId,
+        attemptId,
+        location,
+        () -> {
+          final String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
+          logger.info(
+              "regionFinish shuffleKey:{}, attemptId:{}, locationId:{}",
+              shuffleKey,
+              attemptId,
+              location.getUniqueId());
+          logger.debug("regionFinish location:{}", location.toString());
+          TransportClient client =
+              dataClientFactory.createClient(location.getHost(), location.getPushPort());
+          RegionFinish regionFinish =
+              new RegionFinish(MASTER_MODE, shuffleKey, location.getUniqueId(), attemptId);
+          client.sendRpcSync(regionFinish.toByteBuffer(), conf.pushDataRpcTimeoutMs());
+          return null;
+        });
+  }
+
+  private <R> R sendMessageInternal(
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      PartitionLocation location,
+      ThrowingExceptionSupplier<R, Exception> supplier)
+      throws IOException {
+    PushState pushState = null;
+    int batchId = 0;
+    try {
+      // mapKey
+      final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+      // return if shuffle stage already ended
+      if (mapperEnded(shuffleId, mapId, attemptId)) {
+        logger.debug(
+            "The mapper(shuffle {} map {} attempt {}) has already ended while" + " pushing data.",
+            shuffleId,
+            mapId,
+            attemptId);
+        return null;
+      }
+      pushState = pushStates.computeIfAbsent(mapKey, (s) -> new PushState(conf));
+      // force data has been send
+      limitMaxInFlight(mapKey, pushState, 0, location.hostAndPushPort());
+
+      // add inFlight requests
+      batchId = pushState.batchId.incrementAndGet();
+      pushState.addFlightBatches(batchId, location.hostAndPushPort());
+      return retrySendMessage(supplier);
+    } finally {
+      if (pushState != null) {
+        pushState.removeFlightBatches(batchId, location.hostAndPushPort());
+      }
+    }
+  }
+
+  @FunctionalInterface
+  interface ThrowingExceptionSupplier<R, E extends Exception> {
+    R get() throws E;
+  }
+
+  private <R> R retrySendMessage(ThrowingExceptionSupplier<R, Exception> supplier)
+      throws IOException {
+
+    int retryTimes = 0;
+    boolean isSuccess = false;
+    Exception currentException = null;
+    R result = null;
+    while (!Thread.currentThread().isInterrupted()
+        && !isSuccess
+        && retryTimes < conf.networkIoMaxRetries(TransportModuleConstants.PUSH_MODULE)) {
+      logger.info("retrySendMessage times: {}", retryTimes);
+      try {
+        result = supplier.get();
+        isSuccess = true;
+      } catch (Exception e) {
+        currentException = e;
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
+        if (shouldRetry(e)) {
+          retryTimes++;
+          Uninterruptibles.sleepUninterruptibly(
+              conf.networkIoRetryWaitMs(TransportModuleConstants.PUSH_MODULE),
+              TimeUnit.MILLISECONDS);
+        } else {
+          break;
+        }
+      }
+    }
+    if (!isSuccess) {
+      if (currentException instanceof IOException) {
+        throw (IOException) currentException;
+      } else {
+        throw new IOException(currentException.getMessage(), currentException);
+      }
+    }
+    return result;
+  }
+
+  private boolean shouldRetry(Throwable e) {
+    boolean isIOException =
+        e instanceof IOException
+            || e instanceof TimeoutException
+            || (e.getCause() != null && e.getCause() instanceof TimeoutException)
+            || (e.getCause() != null && e.getCause() instanceof IOException)
+            || (e instanceof RuntimeException
+                && e.getMessage().startsWith(IOException.class.getName()));
+    return isIOException;
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -452,6 +452,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                   epoch,
                   oldLocation,
                   cause),
+              conf.requestPartitionLocationRpcAskTimeout(),
               ClassTag$.MODULE$.apply(PbChangeLocationResponse.class));
       // per partitionKey only serve single PartitionLocation in Client Cache.
       StatusCode respStatus = Utils.toStatusCode(response.getStatus());
@@ -766,6 +767,7 @@ public class ShuffleClientImpl extends ShuffleClient {
 
     ShuffleClientHelper.sendShuffleSplitAsync(
         driverRssMetaService,
+        conf,
         PartitionSplit$.MODULE$.apply(applicationId, shuffleId, partitionId, loc.getEpoch(), loc),
         partitionSplitPool,
         splittingSet,
@@ -1304,6 +1306,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                         location.getEpoch(),
                         location,
                         StatusCode.HARD_SPLIT),
+                    conf.requestPartitionLocationRpcAskTimeout(),
                     ClassTag$.MODULE$.apply(PbChangeLocationResponse.class));
             // per partitionKey only serve single PartitionLocation in Client Cache.
             StatusCode respStatus = Utils.toStatusCode(response.getStatus());

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -1109,11 +1108,12 @@ public class ShuffleClientImpl extends ShuffleClient {
 
                 GetReducerFileGroup getReducerFileGroup =
                     new GetReducerFileGroup(applicationId, shuffleId);
-                ClassTag<GetReducerFileGroupResponse> classTag =
-                    ClassTag$.MODULE$.apply(GetReducerFileGroupResponse.class);
 
                 GetReducerFileGroupResponse response =
-                    driverRssMetaService.askSync(getReducerFileGroup, classTag);
+                    driverRssMetaService.askSync(
+                        getReducerFileGroup,
+                        conf.getReducerFileGroupRpcAskTimeout(),
+                        ClassTag$.MODULE$.apply(GetReducerFileGroupResponse.class));
 
                 if (response.status() == StatusCode.SUCCESS) {
                   logger.info(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -226,7 +226,8 @@ public class ShuffleClientImpl extends ShuffleClient {
         PartitionLocation newLoc = reducePartitionMap.get(shuffleId).get(partitionId);
         logger.info("Revive success, new location for reduce {} is {}.", partitionId, newLoc);
         DataBatches newDataBatches =
-            newDataBatchesMap.computeIfAbsent(Utils.genAddressPair(newLoc), (s) -> new DataBatches());
+            newDataBatchesMap.computeIfAbsent(
+                Utils.genAddressPair(newLoc), (s) -> new DataBatches());
         newDataBatches.addDataBatch(newLoc, batch.batchId, batch.body);
       }
     }
@@ -343,10 +344,8 @@ public class ShuffleClientImpl extends ShuffleClient {
     return null;
   }
 
-  private void limitMaxInFlight(String mapKey,
-                                PushState pushState,
-                                int limit,
-                                String addressPair) throws IOException {
+  private void limitMaxInFlight(String mapKey, PushState pushState, int limit, String addressPair)
+      throws IOException {
     if (pushState.exception.get() != null) {
       throw pushState.exception.get();
     }
@@ -374,8 +373,13 @@ public class ShuffleClientImpl extends ShuffleClient {
       logger.error(
           "After waiting for {} ms, there are still {} batches in flight for map {} and addressPair {}, "
               + "which exceeds the limit {}.",
-          timeoutMs, batchIdSet.size(), mapKey, addressPair, limit);
-      logger.error("Map: {} with addressPair {} in flight batches: {}", mapKey, addressPair, batchIdSet);
+          timeoutMs,
+          batchIdSet.size(),
+          mapKey,
+          addressPair,
+          limit);
+      logger.error(
+          "Map: {} with addressPair {} in flight batches: {}", mapKey, addressPair, batchIdSet);
       throw new IOException("wait timeout for task " + mapKey, pushState.exception.get());
     }
     if (pushState.exception.get() != null) {
@@ -409,8 +413,10 @@ public class ShuffleClientImpl extends ShuffleClient {
 
     if (times <= 0) {
       logger.error(
-              "After waiting for {} ms, there are still {} batches in flight for map {}, expect 0 batches",
-              timeoutMs, inFlightBatches.size(), mapKey);
+          "After waiting for {} ms, there are still {} batches in flight for map {}, expect 0 batches",
+          timeoutMs,
+          inFlightBatches.size(),
+          mapKey);
       throw new IOException("wait timeout for task " + mapKey, pushState.exception.get());
     }
     if (pushState.exception.get() != null) {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -25,11 +25,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
 
 import scala.reflect.ClassTag$;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Uninterruptibles;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -81,7 +83,9 @@ public class ShuffleClientImpl extends ShuffleClient {
 
   private final int registerShuffleMaxRetries;
   private final long registerShuffleRetryWait;
-  private final int maxInFlight;
+  private int maxInFlight;
+  private Integer currentMaxReqsInFlight = 1;
+  private int congestionAvoidanceFlag = 0;
   private final int pushBufferMaxSize;
 
   private final RpcEnv rpcEnv;
@@ -89,6 +93,8 @@ public class ShuffleClientImpl extends ShuffleClient {
   private RpcEndpointRef driverRssMetaService;
 
   protected TransportClientFactory dataClientFactory;
+
+  final int BATCH_HEADER_SIZE = 4 * 4;
 
   // key: shuffleId, value: (partitionId, PartitionLocation)
   private final Map<Integer, ConcurrentHashMap<Integer, PartitionLocation>> reducePartitionMap =
@@ -113,10 +119,10 @@ public class ShuffleClientImpl extends ShuffleClient {
       };
 
   private static class ReduceFileGroups {
-    final PartitionLocation[][] partitionGroups;
+    final Map<Integer, Set<PartitionLocation>> partitionGroups;
     final int[] mapAttempts;
 
-    ReduceFileGroups(PartitionLocation[][] partitionGroups, int[] mapAttempts) {
+    ReduceFileGroups(Map<Integer, Set<PartitionLocation>> partitionGroups, int[] mapAttempts) {
       this.partitionGroups = partitionGroups;
       this.mapAttempts = mapAttempts;
     }
@@ -608,7 +614,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     compressor.compress(data, offset, length);
 
     final int compressedTotalSize = compressor.getCompressedTotalSize();
-    final int BATCH_HEADER_SIZE = 4 * 4;
+
     final byte[] body = new byte[BATCH_HEADER_SIZE + compressedTotalSize];
     Platform.putInt(body, Platform.BYTE_ARRAY_OFFSET, mapId);
     Platform.putInt(body, Platform.BYTE_ARRAY_OFFSET + 4, attemptId);
@@ -689,6 +695,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                       attemptId,
                       nextBatchId);
                   splitPartition(shuffleId, partitionId, applicationId, loc);
+                  slowStart();
                   callback.onSuccess(response);
                 } else if (reason == StatusCode.HARD_SPLIT.getValue()) {
                   logger.debug(
@@ -709,11 +716,27 @@ public class ShuffleClientImpl extends ShuffleClient {
                               this,
                               pushState,
                               StatusCode.HARD_SPLIT));
+                } else if (reason == StatusCode.PUSH_DATA_SUCCESS_MASTER_CONGESTED.getValue()) {
+                  logger.debug(
+                      "Push data split for map {} attempt {} batch {} return master congested.",
+                      mapId,
+                      attemptId,
+                      nextBatchId);
+                  congestionControl();
+                } else if (reason == StatusCode.PUSH_DATA_SUCCESS_SLAVE_CONGESTED.getValue()) {
+                  logger.debug(
+                      "Push data split for map {} attempt {} batch {} return slave congested.",
+                      mapId,
+                      attemptId,
+                      nextBatchId);
+                  congestionControl();
                 } else {
                   response.rewind();
+                  slowStart();
                   callback.onSuccess(response);
                 }
               } else {
+                slowStart();
                 callback.onSuccess(response);
               }
             }
@@ -1010,13 +1033,29 @@ public class ShuffleClientImpl extends ShuffleClient {
                             batches,
                             StatusCode.HARD_SPLIT,
                             groupedBatchId));
+              } else if (reason == StatusCode.PUSH_DATA_SUCCESS_MASTER_CONGESTED.getValue()) {
+                logger.debug(
+                    "Push data split for map {} attempt {} batchs {} return master congested.",
+                    mapId,
+                    attemptId,
+                    Arrays.toString(batchIds));
+                congestionControl();
+              } else if (reason == StatusCode.PUSH_DATA_SUCCESS_SLAVE_CONGESTED.getValue()) {
+                logger.debug(
+                    "Push data split for map {} attempt {} batchs {} return slave congested.",
+                    mapId,
+                    attemptId,
+                    Arrays.toString(batchIds));
+                congestionControl();
               } else {
                 // Should not happen in current architecture.
                 response.rewind();
                 logger.error("Push merged data should not receive this response");
+                slowStart();
                 callback.onSuccess(response);
               }
             } else {
+              slowStart();
               callback.onSuccess(response);
             }
           }
@@ -1073,6 +1112,29 @@ public class ShuffleClientImpl extends ShuffleClient {
   public void mapperEnd(
       String applicationId, int shuffleId, int mapId, int attemptId, int numMappers)
       throws IOException {
+    mapEndInternal(applicationId, shuffleId, mapId, attemptId, numMappers, -1);
+  }
+
+  @Override
+  public void mapPartitionMapperEnd(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int numMappers,
+      int partitionId)
+      throws IOException {
+    mapEndInternal(applicationId, shuffleId, mapId, attemptId, numMappers, partitionId);
+  }
+
+  private void mapEndInternal(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int numMappers,
+      Integer partitionId)
+      throws IOException {
     final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
     PushState pushState = pushStates.computeIfAbsent(mapKey, (s) -> new PushState(conf));
 
@@ -1081,7 +1143,7 @@ public class ShuffleClientImpl extends ShuffleClient {
 
       MapperEndResponse response =
           driverRssMetaService.askSync(
-              new MapperEnd(applicationId, shuffleId, mapId, attemptId, numMappers),
+              new MapperEnd(applicationId, shuffleId, mapId, attemptId, numMappers, partitionId),
               ClassTag$.MODULE$.apply(MapperEndResponse.class));
       if (response.status() != StatusCode.SUCCESS) {
         throw new IOException("MapperEnd failed! StatusCode: " + response.status());
@@ -1164,9 +1226,10 @@ public class ShuffleClientImpl extends ShuffleClient {
 
                 if (response.status() == StatusCode.SUCCESS) {
                   logger.info(
-                      "Shuffle {} request reducer file group success using time:{} ms",
+                      "Shuffle {} request reducer file group success using time:{} ms, result partition ids: {}",
                       shuffleId,
-                      (System.nanoTime() - getReducerFileGroupStartTime) / 1000_000);
+                      (System.nanoTime() - getReducerFileGroupStartTime) / 1000_000,
+                      response.fileGroup().keySet());
                   return new ReduceFileGroups(response.fileGroup(), response.attempts());
                 } else if (response.status() == StatusCode.STAGE_END_TIME_OUT) {
                   logger.warn(
@@ -1192,20 +1255,26 @@ public class ShuffleClientImpl extends ShuffleClient {
       String msg = "Shuffle data lost for shuffle " + shuffleId + " reduce " + partitionId + "!";
       logger.error(msg);
       throw new IOException(msg);
-    } else if (fileGroups.partitionGroups.length == 0) {
-      logger.warn("Shuffle data is empty for shuffle {} reduce {}.", shuffleId, partitionId);
+    } else if (fileGroups.partitionGroups.size() == 0
+        || !fileGroups.partitionGroups.containsKey(partitionId)) {
+      logger.warn("Shuffle data is empty for shuffle {} partitionId {}.", shuffleId, partitionId);
       return RssInputStream.empty();
     } else {
       return RssInputStream.create(
           conf,
           dataClientFactory,
           shuffleKey,
-          fileGroups.partitionGroups[partitionId],
+          fileGroups.partitionGroups.get(partitionId).toArray(new PartitionLocation[0]),
           fileGroups.mapAttempts,
           attemptNumber,
           startMapIndex,
           endMapIndex);
     }
+  }
+
+  @VisibleForTesting
+  public Map<Integer, ReduceFileGroups> getReduceFileGroupsMap() {
+    return reduceFileGroupsMap;
   }
 
   @Override
@@ -1239,6 +1308,33 @@ public class ShuffleClientImpl extends ShuffleClient {
     driverRssMetaService = endpointRef;
   }
 
+  private void slowStart() {
+    synchronized (currentMaxReqsInFlight) {
+      if (currentMaxReqsInFlight > maxInFlight) {
+        // Congestion avoidance
+        congestionAvoidanceFlag++;
+        if (congestionAvoidanceFlag >= currentMaxReqsInFlight) {
+          currentMaxReqsInFlight++;
+          congestionAvoidanceFlag = 0;
+        }
+      } else {
+        // Slow start
+        currentMaxReqsInFlight++;
+      }
+    }
+  }
+
+  private void congestionControl() {
+    synchronized (currentMaxReqsInFlight) {
+      if (currentMaxReqsInFlight <= 1) {
+        currentMaxReqsInFlight = 1;
+      } else {
+        currentMaxReqsInFlight = currentMaxReqsInFlight / 2;
+      }
+      maxInFlight = currentMaxReqsInFlight;
+    }
+  }
+
   private boolean mapperEnded(int shuffleId, int mapId, int attemptId) {
     return mapperEndMap.containsKey(shuffleId)
         && mapperEndMap.get(shuffleId).contains(Utils.makeMapKey(shuffleId, mapId, attemptId));
@@ -1262,6 +1358,131 @@ public class ShuffleClientImpl extends ShuffleClient {
     return (message.startsWith("Connection from ") && message.endsWith(" closed"))
         || (message.equals("Connection reset by peer"))
         || (message.startsWith("Failed to send RPC "));
+  }
+
+  public int pushDataToLocation(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int partitionId,
+      ByteBuf data,
+      PartitionLocation location,
+      BooleanSupplier closeCallBack)
+      throws IOException {
+    // mapKey
+    final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+    final String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
+    // return if shuffle stage already ended
+    if (mapperEnded(shuffleId, mapId, attemptId)) {
+      logger.debug(
+          "The mapper(shuffle {} map {} attempt {}) has already ended while"
+              + " pushing data byteBuf.",
+          shuffleId,
+          mapId,
+          attemptId);
+      PushState pushState = pushStates.get(mapKey);
+      if (pushState != null) {
+        pushState.cancelFutures();
+      }
+      return 0;
+    }
+
+    PushState pushState = pushStates.computeIfAbsent(mapKey, (s) -> new PushState(conf));
+
+    // increment batchId
+    final int nextBatchId = pushState.batchId.addAndGet(1);
+    int totalLength = data.readableBytes();
+    data.markWriterIndex();
+    data.writerIndex(0);
+    data.writeInt(mapId);
+    data.writeInt(attemptId);
+    data.writeInt(nextBatchId);
+    data.writeInt(totalLength - BATCH_HEADER_SIZE);
+    data.resetWriterIndex();
+    logger.debug(
+        "Do push data byteBuf for app {} shuffle {} map {} attempt {} reduce {} batch {}.",
+        applicationId,
+        shuffleId,
+        mapId,
+        attemptId,
+        partitionId,
+        nextBatchId);
+    // check limit
+    limitMaxInFlight(mapKey, pushState, maxInFlight, location.hostAndPushPort());
+
+    // add inFlight requests
+    pushState.addFlightBatches(nextBatchId, location.hostAndPushPort());
+
+    // build PushData request
+    NettyManagedBuffer buffer = new NettyManagedBuffer(data);
+    PushData pushData = new PushData(MASTER_MODE, shuffleKey, location.getUniqueId(), buffer);
+
+    // build callback
+    RpcResponseCallback callback =
+        new RpcResponseCallback() {
+          @Override
+          public void onSuccess(ByteBuffer response) {
+            closeCallBack.getAsBoolean();
+            pushState.removeFlightBatches(nextBatchId, location.hostAndPushPort());
+            pushState.removeFuture(nextBatchId);
+            if (response.remaining() > 0) {
+              byte reason = response.get();
+              if (reason == StatusCode.STAGE_ENDED.getValue()) {
+                mapperEndMap
+                    .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
+                    .add(mapKey);
+              }
+            }
+            logger.debug(
+                "Push data byteBuf to {}:{} success for map {} attempt {} batch {}.",
+                location.getHost(),
+                location.getPushPort(),
+                mapId,
+                attemptId,
+                nextBatchId);
+          }
+
+          @Override
+          public void onFailure(Throwable e) {
+            closeCallBack.getAsBoolean();
+            pushState.removeFlightBatches(nextBatchId, location.hostAndPushPort());
+            pushState.removeFuture(nextBatchId);
+            if (pushState.exception.get() != null) {
+              return;
+            }
+            if (!mapperEnded(shuffleId, mapId, attemptId)) {
+              pushState.exception.compareAndSet(
+                  null, new IOException("PushData byteBuf failed!", e));
+              logger.error(
+                  "Push data byteBuf to {}:{} failed for map {} attempt {} batch {}.",
+                  location.getHost(),
+                  location.getPushPort(),
+                  mapId,
+                  attemptId,
+                  nextBatchId,
+                  e);
+            } else {
+              logger.warn(
+                  "Mapper shuffleId:{} mapId:{} attempt:{} already ended, remove batchId:{}.",
+                  shuffleId,
+                  mapId,
+                  attemptId,
+                  nextBatchId);
+            }
+          }
+        };
+    // do push data
+    try {
+      TransportClient client =
+          dataClientFactory.createClient(location.getHost(), location.getPushPort(), partitionId);
+      ChannelFuture future = client.pushData(pushData, callback);
+      pushState.addFuture(nextBatchId, future);
+    } catch (Exception e) {
+      logger.warn("PushData byteBuf failed", e);
+      callback.onFailure(new Exception(getPushDataFailCause(e.getMessage()).toString(), e));
+    }
+    return totalLength;
   }
 
   @Override

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -24,12 +24,11 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
+import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.Uninterruptibles;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -49,14 +48,10 @@ import org.apache.celeborn.common.network.client.RpcResponseCallback;
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.client.TransportClientFactory;
 import org.apache.celeborn.common.network.protocol.PushData;
-import org.apache.celeborn.common.network.protocol.PushDataHandShake;
 import org.apache.celeborn.common.network.protocol.PushMergedData;
-import org.apache.celeborn.common.network.protocol.RegionFinish;
-import org.apache.celeborn.common.network.protocol.RegionStart;
 import org.apache.celeborn.common.network.server.BaseMessageHandler;
 import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.protocol.*;
-import org.apache.celeborn.common.protocol.message.ControlMessages;
 import org.apache.celeborn.common.protocol.message.ControlMessages.*;
 import org.apache.celeborn.common.protocol.message.StatusCode;
 import org.apache.celeborn.common.rpc.RpcAddress;
@@ -272,7 +267,6 @@ public class ShuffleClientImpl extends ShuffleClient {
         () ->
             driverRssMetaService.askSync(
                 RegisterShuffle$.MODULE$.apply(appId, shuffleId, numMappers, numPartitions),
-                conf.registerShuffleRpcAskTimeout(),
                 ClassTag$.MODULE$.apply(PbRegisterShuffleResponse.class)));
   }
 
@@ -285,6 +279,17 @@ public class ShuffleClientImpl extends ShuffleClient {
         mapId,
         attemptId,
         partitionId);
+    if (attemptId == 0) {
+      return registerMapPartitionTaskWithFirstAttempt(
+          appId, shuffleId, numMappers, mapId, attemptId, partitionId);
+    }
+
+    // TODO
+    throw new UnsupportedOperationException("can not register shuffle task with attempt beyond 0");
+  }
+
+  private PartitionLocation registerMapPartitionTaskWithFirstAttempt(
+      String appId, int shuffleId, int numMappers, int mapId, int attemptId, int partitionId) {
     ConcurrentHashMap<Integer, PartitionLocation> partitionLocationMap =
         registerShuffleInternal(
             shuffleId,
@@ -294,7 +299,6 @@ public class ShuffleClientImpl extends ShuffleClient {
                 driverRssMetaService.askSync(
                     RegisterMapPartitionTask$.MODULE$.apply(
                         appId, shuffleId, numMappers, mapId, attemptId, partitionId),
-                    conf.registerShuffleRpcAskTimeout(),
                     ClassTag$.MODULE$.apply(PbRegisterShuffleResponse.class)));
     return partitionLocationMap.get(partitionId);
   }
@@ -452,7 +456,6 @@ public class ShuffleClientImpl extends ShuffleClient {
                   epoch,
                   oldLocation,
                   cause),
-              conf.requestPartitionLocationRpcAskTimeout(),
               ClassTag$.MODULE$.apply(PbChangeLocationResponse.class));
       // per partitionKey only serve single PartitionLocation in Client Cache.
       StatusCode respStatus = Utils.toStatusCode(response.getStatus());
@@ -599,8 +602,6 @@ public class ShuffleClientImpl extends ShuffleClient {
             @Override
             public void onSuccess(ByteBuffer response) {
               pushState.inFlightBatches.remove(nextBatchId);
-              // TODO Need to adjust maxReqsInFlight if server response is congested, see
-              // CELEBORN-62
               if (response.remaining() > 0 && response.get() == StatusCode.STAGE_ENDED.getValue()) {
                 mapperEndMap
                     .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
@@ -767,7 +768,6 @@ public class ShuffleClientImpl extends ShuffleClient {
 
     ShuffleClientHelper.sendShuffleSplitAsync(
         driverRssMetaService,
-        conf,
         PartitionSplit$.MODULE$.apply(applicationId, shuffleId, partitionId, loc.getEpoch(), loc),
         partitionSplitPool,
         splittingSet,
@@ -906,7 +906,6 @@ public class ShuffleClientImpl extends ShuffleClient {
                 attemptId,
                 groupedBatchId);
             pushState.inFlightBatches.remove(groupedBatchId);
-            // TODO Need to adjust maxReqsInFlight if server response is congested, see CELEBORN-62
             if (response.remaining() > 0 && response.get() == StatusCode.STAGE_ENDED.getValue()) {
               mapperEndMap
                   .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
@@ -943,37 +942,7 @@ public class ShuffleClientImpl extends ShuffleClient {
         new RpcResponseCallback() {
           @Override
           public void onSuccess(ByteBuffer response) {
-            if (response.remaining() > 0) {
-              byte reason = response.get();
-              if (reason == StatusCode.HARD_SPLIT.getValue()) {
-                logger.info(
-                    "Push merged data return hard split for map "
-                        + mapId
-                        + " attempt "
-                        + attemptId
-                        + " batches "
-                        + Arrays.toString(batchIds)
-                        + ".");
-                pushDataRetryPool.submit(
-                    () ->
-                        submitRetryPushMergedData(
-                            pushState,
-                            applicationId,
-                            shuffleId,
-                            mapId,
-                            attemptId,
-                            batches,
-                            StatusCode.HARD_SPLIT,
-                            groupedBatchId));
-              } else {
-                // Should not happen in current architecture.
-                response.rewind();
-                logger.error("Push merged data should not receive this response");
-                callback.onSuccess(response);
-              }
-            } else {
-              callback.onSuccess(response);
-            }
+            callback.onSuccess(response);
           }
 
           @Override
@@ -1110,12 +1079,11 @@ public class ShuffleClientImpl extends ShuffleClient {
 
                 GetReducerFileGroup getReducerFileGroup =
                     new GetReducerFileGroup(applicationId, shuffleId);
+                ClassTag<GetReducerFileGroupResponse> classTag =
+                    ClassTag$.MODULE$.apply(GetReducerFileGroupResponse.class);
 
                 GetReducerFileGroupResponse response =
-                    driverRssMetaService.askSync(
-                        getReducerFileGroup,
-                        conf.getReducerFileGroupRpcAskTimeout(),
-                        ClassTag$.MODULE$.apply(GetReducerFileGroupResponse.class));
+                    driverRssMetaService.askSync(getReducerFileGroup, classTag);
 
                 if (response.status() == StatusCode.SUCCESS) {
                   logger.info(
@@ -1217,235 +1185,5 @@ public class ShuffleClientImpl extends ShuffleClient {
     return (message.startsWith("Connection from ") && message.endsWith(" closed"))
         || (message.equals("Connection reset by peer"))
         || (message.startsWith("Failed to send RPC "));
-  }
-
-  @Override
-  public void pushDataHandShake(
-      String applicationId,
-      int shuffleId,
-      int mapId,
-      int attemptId,
-      int numPartitions,
-      int bufferSize,
-      PartitionLocation location)
-      throws IOException {
-    sendMessageInternal(
-        shuffleId,
-        mapId,
-        attemptId,
-        location,
-        () -> {
-          String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
-          logger.info(
-              "pushDataHandShake shuffleKey:{}, attemptId:{}, locationId:{}",
-              shuffleKey,
-              attemptId,
-              location.getUniqueId());
-          logger.debug("pushDataHandShake location:{}", location.toString());
-          TransportClient client =
-              dataClientFactory.createClient(location.getHost(), location.getPushPort());
-          PushDataHandShake handShake =
-              new PushDataHandShake(
-                  MASTER_MODE,
-                  shuffleKey,
-                  location.getUniqueId(),
-                  attemptId,
-                  numPartitions,
-                  bufferSize);
-          client.sendRpcSync(handShake.toByteBuffer(), conf.pushDataRpcTimeoutMs());
-          return null;
-        });
-  }
-
-  @Override
-  public Optional<PartitionLocation> regionStart(
-      String applicationId,
-      int shuffleId,
-      int mapId,
-      int attemptId,
-      PartitionLocation location,
-      int currentRegionIdx,
-      boolean isBroadcast)
-      throws IOException {
-    return sendMessageInternal(
-        shuffleId,
-        mapId,
-        attemptId,
-        location,
-        () -> {
-          String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
-          logger.info(
-              "regionStart shuffleKey:{}, attemptId:{}, locationId:{}",
-              shuffleKey,
-              attemptId,
-              location.getUniqueId());
-          logger.debug("regionStart location:{}", location.toString());
-          TransportClient client =
-              dataClientFactory.createClient(location.getHost(), location.getPushPort());
-          RegionStart regionStart =
-              new RegionStart(
-                  MASTER_MODE,
-                  shuffleKey,
-                  location.getUniqueId(),
-                  attemptId,
-                  currentRegionIdx,
-                  isBroadcast);
-          ByteBuffer regionStartResponse =
-              client.sendRpcSync(regionStart.toByteBuffer(), conf.pushDataRpcTimeoutMs());
-          if (regionStartResponse.hasRemaining()
-              && regionStartResponse.get() == StatusCode.HARD_SPLIT.getValue()) {
-            // if split then revive
-            PbChangeLocationResponse response =
-                driverRssMetaService.askSync(
-                    ControlMessages.Revive$.MODULE$.apply(
-                        applicationId,
-                        shuffleId,
-                        mapId,
-                        attemptId,
-                        location.getId(),
-                        location.getEpoch(),
-                        location,
-                        StatusCode.HARD_SPLIT),
-                    conf.requestPartitionLocationRpcAskTimeout(),
-                    ClassTag$.MODULE$.apply(PbChangeLocationResponse.class));
-            // per partitionKey only serve single PartitionLocation in Client Cache.
-            StatusCode respStatus = Utils.toStatusCode(response.getStatus());
-            if (StatusCode.SUCCESS.equals(respStatus)) {
-              return Optional.of(PbSerDeUtils.fromPbPartitionLocation(response.getLocation()));
-            } else if (StatusCode.MAP_ENDED.equals(respStatus)) {
-              final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
-              mapperEndMap
-                  .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
-                  .add(mapKey);
-              return Optional.empty();
-            } else {
-              // throw exception
-              logger.error(
-                  "Exception raised while reviving for shuffle {} reduce {} epoch {}.",
-                  shuffleId,
-                  location.getId(),
-                  location.getEpoch());
-              throw new IOException("regiontstart revive failed");
-            }
-          }
-          return Optional.empty();
-        });
-  }
-
-  @Override
-  public void regionFinish(
-      String applicationId, int shuffleId, int mapId, int attemptId, PartitionLocation location)
-      throws IOException {
-    sendMessageInternal(
-        shuffleId,
-        mapId,
-        attemptId,
-        location,
-        () -> {
-          final String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
-          logger.info(
-              "regionFinish shuffleKey:{}, attemptId:{}, locationId:{}",
-              shuffleKey,
-              attemptId,
-              location.getUniqueId());
-          logger.debug("regionFinish location:{}", location.toString());
-          TransportClient client =
-              dataClientFactory.createClient(location.getHost(), location.getPushPort());
-          RegionFinish regionFinish =
-              new RegionFinish(MASTER_MODE, shuffleKey, location.getUniqueId(), attemptId);
-          client.sendRpcSync(regionFinish.toByteBuffer(), conf.pushDataRpcTimeoutMs());
-          return null;
-        });
-  }
-
-  private <R> R sendMessageInternal(
-      int shuffleId,
-      int mapId,
-      int attemptId,
-      PartitionLocation location,
-      ThrowingExceptionSupplier<R, Exception> supplier)
-      throws IOException {
-    PushState pushState = null;
-    int batchId = 0;
-    try {
-      // mapKey
-      final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
-      // return if shuffle stage already ended
-      if (mapperEnded(shuffleId, mapId, attemptId)) {
-        logger.debug(
-            "The mapper(shuffle {} map {} attempt {}) has already ended while" + " pushing data.",
-            shuffleId,
-            mapId,
-            attemptId);
-        return null;
-      }
-      pushState = pushStates.computeIfAbsent(mapKey, (s) -> new PushState(conf));
-      // force data has been send
-      limitMaxInFlight(mapKey, pushState, 0);
-
-      // add inFlight requests
-      batchId = pushState.batchId.incrementAndGet();
-      pushState.inFlightBatches.put(batchId, location);
-      return retrySendMessage(supplier);
-    } finally {
-      if (pushState != null) {
-        pushState.inFlightBatches.remove(batchId);
-      }
-    }
-  }
-
-  @FunctionalInterface
-  interface ThrowingExceptionSupplier<R, E extends Exception> {
-    R get() throws E;
-  }
-
-  private <R> R retrySendMessage(ThrowingExceptionSupplier<R, Exception> supplier)
-      throws IOException {
-
-    int retryTimes = 0;
-    boolean isSuccess = false;
-    Exception currentException = null;
-    R result = null;
-    while (!Thread.currentThread().isInterrupted()
-        && !isSuccess
-        && retryTimes < conf.networkIoMaxRetries(TransportModuleConstants.PUSH_MODULE)) {
-      logger.info("retrySendMessage times: {}", retryTimes);
-      try {
-        result = supplier.get();
-        isSuccess = true;
-      } catch (Exception e) {
-        currentException = e;
-        if (e instanceof InterruptedException) {
-          Thread.currentThread().interrupt();
-        }
-        if (shouldRetry(e)) {
-          retryTimes++;
-          Uninterruptibles.sleepUninterruptibly(
-              conf.networkIoRetryWaitMs(TransportModuleConstants.PUSH_MODULE),
-              TimeUnit.MILLISECONDS);
-        } else {
-          break;
-        }
-      }
-    }
-    if (!isSuccess) {
-      if (currentException instanceof IOException) {
-        throw (IOException) currentException;
-      } else {
-        throw new IOException(currentException.getMessage(), currentException);
-      }
-    }
-    return result;
-  }
-
-  private boolean shouldRetry(Throwable e) {
-    boolean isIOException =
-        e instanceof IOException
-            || e instanceof TimeoutException
-            || (e.getCause() != null && e.getCause() instanceof TimeoutException)
-            || (e.getCause() != null && e.getCause() instanceof IOException)
-            || (e instanceof RuntimeException
-                && e.getMessage().startsWith(IOException.class.getName()));
-    return isIOException;
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client.write;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.client.ShuffleClient;
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.protocol.PartitionLocation;
+import org.apache.celeborn.common.util.Utils;
+
+public class DataPushQueue {
+  private static final Logger logger = LoggerFactory.getLogger(DataPushQueue.class);
+
+  private final List<LinkedBlockingQueue<PushTask>> workingQueuePerPartition;
+  private final PushState pushState;
+  private final DataPusher dataPusher;
+
+  private final String appId;
+  private final int shuffleId;
+  private final int numMappers;
+  private final int numPartitions;
+  private final ShuffleClient client;
+  private int partitionIdIdx = 0;
+
+  public DataPushQueue(
+      CelebornConf conf,
+      DataPusher dataPusher,
+      ShuffleClient client,
+      String appId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int numMappers,
+      int numPartitions) {
+    this.appId = appId;
+    this.shuffleId = shuffleId;
+    this.numMappers = numMappers;
+    this.numPartitions = numPartitions;
+    this.client = client;
+    this.dataPusher = dataPusher;
+    final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+    this.pushState = client.getOrRegisterPushState(mapKey);
+    workingQueuePerPartition = new ArrayList<>(numPartitions);
+    final int capacity = conf.pushQueueCapacity();
+    for (int i = 0; i < numPartitions; i++) {
+      workingQueuePerPartition.add(new LinkedBlockingQueue<>(capacity));
+    }
+  }
+
+  public LinkedBlockingQueue<PushTask> takeAnyWorkingQueue() throws IOException {
+    while (!dataPusher.terminatedOrHasException()) {
+      int partitionId = nextPartitionId();
+      LinkedBlockingQueue<PushTask> pushTasks = workingQueuePerPartition.get(partitionId);
+      if (!pushTasks.isEmpty()) {
+        Map<Integer, PartitionLocation> partitionLocationMap =
+            client.getOrRegisterShuffle(appId, shuffleId, numMappers, numPartitions);
+        PartitionLocation loc = partitionLocationMap.get(partitionId);
+        boolean reachLimit = pushState.limitMaxInFlight(loc.hostAndPushPort());
+        if (!reachLimit) {
+          return pushTasks;
+        }
+      }
+    }
+    return null;
+  }
+
+  public LinkedBlockingQueue<PushTask> takeWorkingQueue(int partitionId) {
+    return workingQueuePerPartition.get(partitionId);
+  }
+
+  public void clear() {
+    workingQueuePerPartition.parallelStream().forEach(LinkedBlockingQueue::clear);
+    workingQueuePerPartition.clear();
+  }
+
+  private int nextPartitionId() {
+    return partitionIdIdx++ % numPartitions;
+  }
+}

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -18,6 +18,7 @@
 package org.apache.celeborn.client.write;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,7 +34,9 @@ public class DataPusher {
   private final long WAIT_TIME_NANOS = TimeUnit.MILLISECONDS.toNanos(500);
 
   private final LinkedBlockingQueue<PushTask> idleQueue;
-  private final LinkedBlockingQueue<PushTask> workingQueue;
+
+  // partition -> PushTask Queue
+  private final DataPushQueue dataPushQueue;
 
   private final ReentrantLock idleLock = new ReentrantLock();
   private final Condition idleFull = idleLock.newCondition();
@@ -69,7 +72,9 @@ public class DataPusher {
     final int pushBufferMaxSize = conf.pushBufferMaxSize();
 
     idleQueue = new LinkedBlockingQueue<>(pushQueueCapacity);
-    workingQueue = new LinkedBlockingQueue<>(pushQueueCapacity);
+    dataPushQueue =
+        new DataPushQueue(
+            conf, this, client, appId, shuffleId, mapId, attemptId, numMappers, numPartitions);
 
     for (int i = 0; i < pushQueueCapacity; i++) {
       try {
@@ -110,6 +115,10 @@ public class DataPusher {
       public void run() {
         while (!terminated && exceptionRef.get() == null) {
           try {
+            LinkedBlockingQueue<PushTask> workingQueue = dataPushQueue.takeAnyWorkingQueue();
+            if (workingQueue == null) {
+              continue;
+            }
             PushTask task = workingQueue.poll(WAIT_TIME_NANOS, TimeUnit.NANOSECONDS);
             if (task == null) {
               continue;
@@ -136,6 +145,8 @@ public class DataPusher {
       task.setSize(size);
       task.setPartitionId(partitionId);
       System.arraycopy(buffer, 0, task.getBuffer(), 0, size);
+
+      LinkedBlockingQueue<PushTask> workingQueue = dataPushQueue.takeWorkingQueue(partitionId);
       while (!workingQueue.offer(task, WAIT_TIME_NANOS, TimeUnit.NANOSECONDS)) {
         checkException();
       }
@@ -158,7 +169,7 @@ public class DataPusher {
 
     terminated = true;
     idleQueue.clear();
-    workingQueue.clear();
+    dataPushQueue.clear();
     checkException();
   }
 
@@ -196,5 +207,9 @@ public class DataPusher {
     } finally {
       idleLock.unlock();
     }
+  }
+
+  protected boolean terminatedOrHasException() {
+    return terminated || Objects.nonNull(exceptionRef.get());
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/write/InFlightTracker.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/InFlightTracker.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client.write;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.CelebornConf;
+
+public class InFlightTracker {
+  private static final Logger logger = LoggerFactory.getLogger(InFlightTracker.class);
+
+  private final long timeoutMs;
+  private final long delta;
+  private final int maxInFlight;
+
+  private final PushState pushState;
+
+  public final AtomicInteger batchId = new AtomicInteger();
+  private final ConcurrentHashMap<String, Set<Integer>> batchIdPerAddressPair =
+      new ConcurrentHashMap<>();
+
+  public InFlightTracker(CelebornConf conf, PushState pushState) {
+    this.timeoutMs = conf.pushLimitInFlightTimeoutMs();
+    this.delta = conf.pushLimitInFlightSleepDeltaMs();
+    this.maxInFlight = conf.pushMaxReqsInFlight();
+    this.pushState = pushState;
+  }
+
+  public void addFlightBatches(int batchId, String hostAndPushPort) {
+    Set<Integer> batchIdSetPerPair =
+        batchIdPerAddressPair.computeIfAbsent(hostAndPushPort, id -> ConcurrentHashMap.newKeySet());
+    batchIdSetPerPair.add(batchId);
+  }
+
+  public void removeFlightBatches(int batchId, String hostAndPushPort) {
+    Set<Integer> batchIdSetPerPair = batchIdPerAddressPair.get(hostAndPushPort);
+    batchIdSetPerPair.remove(batchId);
+    if (batchIdSetPerPair.size() == 0) {
+      batchIdPerAddressPair.remove(hostAndPushPort);
+    }
+  }
+
+  public ConcurrentHashMap<String, Set<Integer>> getBatchIdPerAddressPair() {
+    return batchIdPerAddressPair;
+  }
+
+  public Set<Integer> getBatchIdSetByAddressPair(String addressPair) {
+    return batchIdPerAddressPair.computeIfAbsent(
+        addressPair, pair -> ConcurrentHashMap.newKeySet());
+  }
+
+  public boolean limitMaxInFlight(String hostAndPushPort) throws IOException {
+    if (pushState.exception.get() != null) {
+      throw pushState.exception.get();
+    }
+
+    Set<Integer> batchIdSet = getBatchIdSetByAddressPair(hostAndPushPort);
+    long times = timeoutMs / delta;
+    try {
+      while (times > 0) {
+        if (batchIdSet.size() <= maxInFlight) {
+          break;
+        }
+        if (pushState.exception.get() != null) {
+          throw pushState.exception.get();
+        }
+        Thread.sleep(delta);
+        times--;
+      }
+    } catch (InterruptedException e) {
+      pushState.exception.set(new IOException(e));
+    }
+
+    if (times <= 0) {
+      logger.warn(
+          "After waiting for {} ms, "
+              + "there are still {} batches in flight "
+              + "for hostAndPushPort {}, "
+              + "which exceeds the limit {}.",
+          timeoutMs,
+          batchIdSet.size(),
+          hostAndPushPort,
+          maxInFlight);
+    }
+
+    if (pushState.exception.get() != null) {
+      throw pushState.exception.get();
+    }
+
+    return times <= 0;
+  }
+
+  public boolean limitZeroInFlight() throws IOException {
+    if (pushState.exception.get() != null) {
+      throw pushState.exception.get();
+    }
+    long times = timeoutMs / delta;
+
+    try {
+      while (times > 0) {
+        if (batchIdPerAddressPair.size() == 0) {
+          break;
+        }
+        if (pushState.exception.get() != null) {
+          throw pushState.exception.get();
+        }
+        Thread.sleep(delta);
+        times--;
+      }
+    } catch (InterruptedException e) {
+      pushState.exception.set(new IOException(e));
+    }
+
+    if (times <= 0) {
+      logger.error(
+          "After waiting for {} ms, there are still {} batches in flight, expect 0 batches",
+          timeoutMs,
+          batchIdPerAddressPair.values().stream().map(Set::size).reduce(Integer::sum));
+    }
+
+    if (pushState.exception.get() != null) {
+      throw pushState.exception.get();
+    }
+
+    return times <= 0;
+  }
+
+  protected int nextBatchId() {
+    return batchId.getAndIncrement();
+  }
+}

--- a/client/src/main/java/org/apache/celeborn/client/write/PushState.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/PushState.java
@@ -51,7 +51,8 @@ public class PushState {
   }
 
   public Set<Integer> getBatchIdSetByAddressPair(String addressPair) {
-    return batchIdPerAddressPair.computeIfAbsent(addressPair, pair -> new HashSet<>());
+    return batchIdPerAddressPair.computeIfAbsent(
+        addressPair, pair -> ConcurrentHashMap.newKeySet());
   }
 
   public void addFuture(int batchId, ChannelFuture future) {
@@ -97,15 +98,14 @@ public class PushState {
     return batchesMap.remove(addressPair);
   }
 
-  public void addFlightBatches(int batchId, PartitionLocation loc) {
-    String addressPair = loc.hostAndPushPort();
+  public void addFlightBatches(int batchId, String hostAndPushPort) {
     Set<Integer> batchIdSetPerPair =
-        batchIdPerAddressPair.computeIfAbsent(addressPair, id -> new HashSet<>());
+        batchIdPerAddressPair
+                .computeIfAbsent(hostAndPushPort, id -> ConcurrentHashMap.newKeySet());
     batchIdSetPerPair.add(batchId);
   }
 
-  public void removeFlightBatches(int batchId, PartitionLocation loc) {
-    String hostAndPushPort = loc.hostAndPushPort();
+  public void removeFlightBatches(int batchId, String hostAndPushPort) {
     Set<Integer> batchIdSetPerPair = batchIdPerAddressPair.get(hostAndPushPort);
     batchIdSetPerPair.remove(batchId);
     if (batchIdSetPerPair.size() == 0) {

--- a/client/src/main/java/org/apache/celeborn/client/write/PushState.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/PushState.java
@@ -19,7 +19,6 @@ package org.apache.celeborn.client.write;
 
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,13 +26,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.netty.channel.ChannelFuture;
-import org.apache.celeborn.common.util.Utils;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.protocol.PartitionLocation;
+import org.apache.celeborn.common.util.Utils;
 
 public class PushState {
   private static final Logger logger = LoggerFactory.getLogger(PushState.class);
@@ -42,9 +40,9 @@ public class PushState {
 
   public final AtomicInteger batchId = new AtomicInteger();
   private final ConcurrentHashMap<Integer, PartitionLocation> inFlightBatches =
-          new ConcurrentHashMap<>();
+      new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Set<Integer>> batchIdPerAddressPair =
-          new ConcurrentHashMap<>();
+      new ConcurrentHashMap<>();
   public final ConcurrentHashMap<Integer, ChannelFuture> futures = new ConcurrentHashMap<>();
   public AtomicReference<IOException> exception = new AtomicReference<>();
 
@@ -106,7 +104,7 @@ public class PushState {
   public void addFlightBatches(int batchId, PartitionLocation loc) {
     String addressPair = Utils.genAddressPair(loc);
     Set<Integer> batchIdSetPerPair =
-            batchIdPerAddressPair.computeIfAbsent(addressPair, id -> new HashSet<>());
+        batchIdPerAddressPair.computeIfAbsent(addressPair, id -> new HashSet<>());
     batchIdSetPerPair.add(batchId);
     inFlightBatches.put(batchId, loc);
   }

--- a/client/src/main/java/org/apache/celeborn/client/write/PushState.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/PushState.java
@@ -19,7 +19,6 @@ package org.apache.celeborn.client.write;
 
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -108,11 +107,9 @@ public class PushState {
   public void removeFlightBatches(int batchId, PartitionLocation loc) {
     String hostAndPushPort = loc.hostAndPushPort();
     Set<Integer> batchIdSetPerPair = batchIdPerAddressPair.get(hostAndPushPort);
-    if (Objects.nonNull(batchIdSetPerPair)) {
-      batchIdSetPerPair.remove(batchId);
-      if (batchIdSetPerPair.size() == 0) {
-        batchIdPerAddressPair.remove(hostAndPushPort);
-      }
+    batchIdSetPerPair.remove(batchId);
+    if (batchIdSetPerPair.size() == 0) {
+      batchIdPerAddressPair.remove(hostAndPushPort);
     }
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/write/PushState.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/PushState.java
@@ -100,8 +100,7 @@ public class PushState {
 
   public void addFlightBatches(int batchId, String hostAndPushPort) {
     Set<Integer> batchIdSetPerPair =
-        batchIdPerAddressPair
-                .computeIfAbsent(hostAndPushPort, id -> ConcurrentHashMap.newKeySet());
+        batchIdPerAddressPair.computeIfAbsent(hostAndPushPort, id -> ConcurrentHashMap.newKeySet());
     batchIdSetPerPair.add(batchId);
   }
 

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import java.util
+import java.util.{Set => JSet}
+import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, ScheduledFuture, TimeUnit}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.DurationInt
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.meta.WorkerInfo
+import org.apache.celeborn.common.protocol.PartitionLocation
+import org.apache.celeborn.common.protocol.message.ControlMessages.WorkerResource
+import org.apache.celeborn.common.protocol.message.StatusCode
+import org.apache.celeborn.common.util.{ThreadUtils, Utils}
+
+case class ChangePartitionRequest(
+    context: RequestLocationCallContext,
+    applicationId: String,
+    shuffleId: Int,
+    partitionId: Int,
+    epoch: Int,
+    oldPartition: PartitionLocation,
+    causes: Option[StatusCode])
+
+class ChangePartitionManager(
+    conf: CelebornConf,
+    lifecycleManager: LifecycleManager) extends Logging {
+
+  private val pushReplicateEnabled = conf.pushReplicateEnabled
+  // shuffleId -> (partitionId -> set of ChangePartition)
+  private val changePartitionRequests =
+    new ConcurrentHashMap[Int, ConcurrentHashMap[Integer, JSet[ChangePartitionRequest]]]()
+  // shuffleId -> set of partition id
+  private val inBatchPartitions = new ConcurrentHashMap[Int, JSet[Integer]]()
+
+  private val batchHandleChangePartitionEnabled = conf.batchHandleChangePartitionEnabled
+  private val batchHandleChangePartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(
+    "rss-lifecycle-manager-change-partition-executor",
+    conf.batchHandleChangePartitionNumThreads)
+  private val batchHandleChangePartitionRequestInterval =
+    conf.batchHandleChangePartitionRequestInterval
+  private val batchHandleChangePartitionSchedulerThread: Option[ScheduledExecutorService] =
+    if (batchHandleChangePartitionEnabled) {
+      Some(ThreadUtils.newDaemonSingleThreadScheduledExecutor(
+        "rss-lifecycle-manager-change-partition-scheduler"))
+    } else {
+      None
+    }
+
+  private var batchHandleChangePartition: Option[ScheduledFuture[_]] = _
+
+  def start(): Unit = {
+    batchHandleChangePartition = batchHandleChangePartitionSchedulerThread.map {
+      // noinspection ConvertExpressionToSAM
+      _.scheduleAtFixedRate(
+        new Runnable {
+          override def run(): Unit = {
+            try {
+              changePartitionRequests.asScala.foreach { case (shuffleId, requests) =>
+                requests.synchronized {
+                  batchHandleChangePartitionExecutors.submit {
+                    new Runnable {
+                      override def run(): Unit = {
+                        // For each partition only need handle one request
+                        val distinctPartitions = requests.asScala.filter { case (partitionId, _) =>
+                          !inBatchPartitions.get(shuffleId).contains(partitionId)
+                        }.map { case (partitionId, request) =>
+                          inBatchPartitions.get(shuffleId).add(partitionId)
+                          request.asScala.toArray.maxBy(_.epoch)
+                        }.toArray
+                        if (distinctPartitions.nonEmpty) {
+                          batchHandleRequestPartitions(
+                            distinctPartitions.head.applicationId,
+                            shuffleId,
+                            distinctPartitions)
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            } catch {
+              case e: InterruptedException =>
+                logError("Partition split scheduler thread is shutting down, detail: ", e)
+                throw e
+            }
+          }
+        },
+        0,
+        batchHandleChangePartitionRequestInterval,
+        TimeUnit.MILLISECONDS)
+    }
+  }
+
+  def stop(): Unit = {
+    batchHandleChangePartition.foreach(_.cancel(true))
+    batchHandleChangePartitionSchedulerThread.foreach(ThreadUtils.shutdown(_, 800.millis))
+  }
+
+  private val rpcContextRegisterFunc =
+    new util.function.Function[
+      Int,
+      ConcurrentHashMap[Integer, util.Set[ChangePartitionRequest]]]() {
+      override def apply(s: Int): ConcurrentHashMap[Integer, util.Set[ChangePartitionRequest]] =
+        new ConcurrentHashMap()
+    }
+
+  private val inBatchShuffleIdRegisterFunc = new util.function.Function[Int, util.Set[Integer]]() {
+    override def apply(s: Int): util.Set[Integer] = new util.HashSet[Integer]()
+  }
+
+  def handleRequestPartitionLocation(
+      context: RequestLocationCallContext,
+      applicationId: String,
+      shuffleId: Int,
+      partitionId: Int,
+      oldEpoch: Int,
+      oldPartition: PartitionLocation,
+      cause: Option[StatusCode] = None): Unit = {
+
+    val changePartition = ChangePartitionRequest(
+      context,
+      applicationId,
+      shuffleId,
+      partitionId,
+      oldEpoch,
+      oldPartition,
+      cause)
+    // check if there exists request for the partition, if do just register
+    val requests = changePartitionRequests.computeIfAbsent(shuffleId, rpcContextRegisterFunc)
+    inBatchPartitions.computeIfAbsent(shuffleId, inBatchShuffleIdRegisterFunc)
+
+    lifecycleManager.registerCommitPartition(applicationId, shuffleId, oldPartition, cause)
+
+    requests.synchronized {
+      if (requests.containsKey(partitionId)) {
+        requests.get(partitionId).add(changePartition)
+        logTrace(s"[handleRequestPartitionLocation] For $shuffleId, request for same partition" +
+          s"$partitionId-$oldEpoch exists, register context.")
+        return
+      } else {
+        // If new slot for the partition has been allocated, reply and return.
+        // Else register and allocate for it.
+        getLatestPartition(shuffleId, partitionId, oldEpoch).foreach { latestLoc =>
+          context.reply(StatusCode.SUCCESS, Some(latestLoc))
+          logDebug(s"New partition found, old partition $partitionId-$oldEpoch return it." +
+            s" shuffleId: $shuffleId $latestLoc")
+          return
+        }
+        val set = new util.HashSet[ChangePartitionRequest]()
+        set.add(changePartition)
+        requests.put(partitionId, set)
+      }
+    }
+    if (!batchHandleChangePartitionEnabled) {
+      batchHandleRequestPartitions(applicationId, shuffleId, Array(changePartition))
+    }
+  }
+
+  private def getLatestPartition(
+      shuffleId: Int,
+      partitionId: Int,
+      epoch: Int): Option[PartitionLocation] = {
+    val map = lifecycleManager.latestPartitionLocation.get(shuffleId)
+    if (map != null) {
+      val loc = map.get(partitionId)
+      if (loc != null && loc.getEpoch > epoch) {
+        return Some(loc)
+      }
+    }
+    None
+  }
+
+  def batchHandleRequestPartitions(
+      applicationId: String,
+      shuffleId: Int,
+      changePartitions: Array[ChangePartitionRequest]): Unit = {
+    val requestsMap = changePartitionRequests.get(shuffleId)
+
+    val changes = changePartitions.map { change =>
+      s"${change.shuffleId}-${change.partitionId}-${change.epoch}"
+    }.mkString("[", ",", "]")
+    logWarning(s"Batch handle change partition for $applicationId of $changes")
+
+    // Blacklist all failed workers
+    if (changePartitions.exists(_.causes.isDefined)) {
+      changePartitions.filter(_.causes.isDefined).foreach { changePartition =>
+        lifecycleManager.blacklistPartition(
+          shuffleId,
+          changePartition.oldPartition,
+          changePartition.causes.get)
+      }
+    }
+
+    // remove together to reduce lock time
+    def replySuccess(locations: Array[PartitionLocation]): Unit = {
+      requestsMap.synchronized {
+        locations.map { location =>
+          if (batchHandleChangePartitionEnabled) {
+            inBatchPartitions.get(shuffleId).remove(location.getId)
+          }
+          // Here one partition id can be remove more than once,
+          // so need to filter null result before reply.
+          location -> Option(requestsMap.remove(location.getId))
+        }
+      }.foreach { case (newLocation, requests) =>
+        requests.map(_.asScala.toList.foreach(_.context.reply(
+          StatusCode.SUCCESS,
+          Option(newLocation))))
+      }
+    }
+
+    // remove together to reduce lock time
+    def replyFailure(status: StatusCode): Unit = {
+      requestsMap.synchronized {
+        changePartitions.map { changePartition =>
+          if (batchHandleChangePartitionEnabled) {
+            inBatchPartitions.get(shuffleId).remove(changePartition.partitionId)
+          }
+          Option(requestsMap.remove(changePartition.partitionId))
+        }
+      }.foreach { requests =>
+        requests.map(_.asScala.toList.foreach(_.context.reply(status, None)))
+      }
+    }
+
+    // Get candidate worker that not in blacklist of shuffleId
+    val candidates =
+      lifecycleManager
+        .workerSnapshots(shuffleId)
+        .keySet()
+        .asScala
+        .filter(w => !lifecycleManager.blacklist.keySet().contains(w))
+        .toList
+    if (candidates.size < 1 || (pushReplicateEnabled && candidates.size < 2)) {
+      logError("[Update partition] failed for not enough candidates for revive.")
+      replyFailure(StatusCode.SLOT_NOT_AVAILABLE)
+      return
+    }
+
+    // PartitionSplit all contains oldPartition
+    val newlyAllocatedLocations =
+      reallocateChangePartitionRequestSlotsFromCandidates(changePartitions.toList, candidates)
+
+    if (!lifecycleManager.registeredShuffle.contains(shuffleId)) {
+      logError(s"[handleChangePartition] shuffle $shuffleId not registered!")
+      replyFailure(StatusCode.SHUFFLE_NOT_REGISTERED)
+      return
+    }
+
+    if (lifecycleManager.stageEndShuffleSet.contains(shuffleId)) {
+      logError(s"[handleChangePartition] shuffle $shuffleId already ended!")
+      replyFailure(StatusCode.STAGE_ENDED)
+      return
+    }
+
+    if (!lifecycleManager.reserveSlotsWithRetry(
+        applicationId,
+        shuffleId,
+        new util.HashSet(candidates.toSet.asJava),
+        newlyAllocatedLocations)) {
+      logError(s"[Update partition] failed for $shuffleId.")
+      replyFailure(StatusCode.RESERVE_SLOTS_FAILED)
+      return
+    }
+
+    val newMasterLocations =
+      newlyAllocatedLocations.asScala.flatMap {
+        case (workInfo, (masterLocations, slaveLocations)) =>
+          // Add all re-allocated slots to worker snapshots.
+          lifecycleManager.workerSnapshots(shuffleId).asScala
+            .get(workInfo)
+            .foreach { partitionLocationInfo =>
+              partitionLocationInfo.addMasterPartitions(shuffleId.toString, masterLocations)
+              lifecycleManager.updateLatestPartitionLocations(shuffleId, masterLocations)
+              partitionLocationInfo.addSlavePartitions(shuffleId.toString, slaveLocations)
+            }
+          // partition location can be null when call reserveSlotsWithRetry().
+          val locations = (masterLocations.asScala ++ slaveLocations.asScala.map(_.getPeer))
+            .distinct.filter(_ != null)
+          if (locations.nonEmpty) {
+            val changes = locations.map { partition =>
+              s"(partition ${partition.getId} epoch from ${partition.getEpoch - 1} to ${partition.getEpoch})"
+            }.mkString("[", ", ", "]")
+            logDebug(s"[Update partition] success for " +
+              s"shuffle ${Utils.makeShuffleKey(applicationId, shuffleId)}, succeed partitions: " +
+              s"$changes.")
+          }
+          locations
+      }
+    replySuccess(newMasterLocations.toArray)
+  }
+
+  private def reallocateChangePartitionRequestSlotsFromCandidates(
+      changePartitionRequests: List[ChangePartitionRequest],
+      candidates: List[WorkerInfo]): WorkerResource = {
+    val slots = new WorkerResource()
+    changePartitionRequests.foreach { partition =>
+      lifecycleManager.allocateFromCandidates(
+        partition.partitionId,
+        partition.epoch,
+        candidates,
+        slots)
+    }
+    slots
+  }
+
+  def removeExpiredShuffle(shuffleId: Int): Unit = {
+    changePartitionRequests.remove(shuffleId)
+    inBatchPartitions.remove(shuffleId)
+  }
+}

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -149,7 +149,11 @@ class ChangePartitionManager(
     val requests = changePartitionRequests.computeIfAbsent(shuffleId, rpcContextRegisterFunc)
     inBatchPartitions.computeIfAbsent(shuffleId, inBatchShuffleIdRegisterFunc)
 
-    lifecycleManager.registerCommitPartition(applicationId, shuffleId, oldPartition, cause)
+    lifecycleManager.commitManager.registerCommitPartitionRequest(
+      applicationId,
+      shuffleId,
+      oldPartition,
+      cause)
 
     requests.synchronized {
       if (requests.containsKey(partitionId)) {
@@ -267,7 +271,7 @@ class ChangePartitionManager(
       return
     }
 
-    if (lifecycleManager.stageEndShuffleSet.contains(shuffleId)) {
+    if (lifecycleManager.commitManager.stageEndShuffleSet.contains(shuffleId)) {
       logError(s"[handleChangePartition] shuffle $shuffleId already ended!")
       replyFailure(StatusCode.STAGE_ENDED)
       return

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -1,0 +1,543 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import java.util
+import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, ScheduledFuture, TimeUnit}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, LongAdder}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.DurationInt
+
+import org.roaringbitmap.RoaringBitmap
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.meta.{PartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.protocol.{PartitionLocation, StorageInfo}
+import org.apache.celeborn.common.protocol.message.ControlMessages.{CommitFiles, CommitFilesResponse}
+import org.apache.celeborn.common.protocol.message.StatusCode
+import org.apache.celeborn.common.rpc.RpcEndpointRef
+import org.apache.celeborn.common.util.{ThreadUtils, Utils}
+
+case class CommitPartitionRequest(
+    applicationId: String,
+    shuffleId: Int,
+    partition: PartitionLocation)
+
+case class ShuffleCommittedInfo(
+    committedMasterIds: util.List[String],
+    committedSlaveIds: util.List[String],
+    failedMasterPartitionIds: ConcurrentHashMap[String, WorkerInfo],
+    failedSlavePartitionIds: ConcurrentHashMap[String, WorkerInfo],
+    committedMasterStorageInfos: ConcurrentHashMap[String, StorageInfo],
+    committedSlaveStorageInfos: ConcurrentHashMap[String, StorageInfo],
+    committedMapIdBitmap: ConcurrentHashMap[String, RoaringBitmap],
+    currentShuffleFileCount: LongAdder,
+    commitPartitionRequests: util.Set[CommitPartitionRequest],
+    handledCommitPartitionRequests: util.Set[PartitionLocation],
+    inFlightCommitRequest: AtomicInteger)
+
+class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: LifecycleManager)
+  extends Logging {
+  // shuffle id -> ShuffleCommittedInfo
+  private val committedPartitionInfo = new ConcurrentHashMap[Int, ShuffleCommittedInfo]()
+  val dataLostShuffleSet = ConcurrentHashMap.newKeySet[Int]()
+  val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
+  private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
+
+  private val pushReplicateEnabled = conf.pushReplicateEnabled
+
+  private val batchHandleCommitPartitionEnabled = conf.batchHandleCommitPartitionEnabled
+  private val batchHandleCommitPartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(
+    "rss-lifecycle-manager-commit-partition-executor",
+    conf.batchHandleCommitPartitionNumThreads)
+  private val batchHandleCommitPartitionRequestInterval =
+    conf.batchHandleCommitPartitionRequestInterval
+  private val batchHandleCommitPartitionSchedulerThread: Option[ScheduledExecutorService] =
+    if (batchHandleCommitPartitionEnabled) {
+      Some(ThreadUtils.newDaemonSingleThreadScheduledExecutor(
+        "rss-lifecycle-manager-commit-partition-scheduler"))
+    } else {
+      None
+    }
+  private var batchHandleCommitPartition: Option[ScheduledFuture[_]] = _
+
+  private val totalWritten = new LongAdder
+  private val fileCount = new LongAdder
+
+  private val testRetryCommitFiles = conf.testRetryCommitFiles
+  private val commitEpoch = new AtomicLong()
+
+  def start(): Unit = {
+    batchHandleCommitPartition = batchHandleCommitPartitionSchedulerThread.map {
+      _.scheduleAtFixedRate(
+        new Runnable {
+          override def run(): Unit = {
+            committedPartitionInfo.asScala.foreach { case (shuffleId, shuffleCommittedInfo) =>
+              batchHandleCommitPartitionExecutors.submit {
+                new Runnable {
+                  override def run(): Unit = {
+                    val workerToRequests = shuffleCommittedInfo.synchronized {
+                      // When running to here, if handleStageEnd got lock first and commitFiles,
+                      // then this batch get this lock, commitPartitionRequests may contains
+                      // partitions which are already committed by stageEnd process.
+                      // But inProcessStageEndShuffleSet should have contain this shuffle id,
+                      // can directly return.
+                      if (inProcessStageEndShuffleSet.contains(shuffleId) ||
+                        stageEndShuffleSet.contains(shuffleId)) {
+                        logWarning(s"Shuffle $shuffleId ended or during processing stage end.")
+                        shuffleCommittedInfo.commitPartitionRequests.clear()
+                        Map.empty[WorkerInfo, Set[PartitionLocation]]
+                      } else {
+                        val batch = new util.HashSet[CommitPartitionRequest]()
+                        batch.addAll(shuffleCommittedInfo.commitPartitionRequests)
+                        val currentBatch = batch.asScala.filterNot { request =>
+                          shuffleCommittedInfo.handledCommitPartitionRequests
+                            .contains(request.partition)
+                        }
+                        shuffleCommittedInfo.commitPartitionRequests.clear()
+                        currentBatch.foreach { commitPartitionRequest =>
+                          shuffleCommittedInfo.handledCommitPartitionRequests
+                            .add(commitPartitionRequest.partition)
+                          if (commitPartitionRequest.partition.getPeer != null) {
+                            shuffleCommittedInfo.handledCommitPartitionRequests
+                              .add(commitPartitionRequest.partition.getPeer)
+                          }
+                        }
+
+                        if (currentBatch.nonEmpty) {
+                          logWarning(s"Commit current batch HARD_SPLIT partitions for $shuffleId: " +
+                            s"${currentBatch.map(_.partition.getUniqueId).mkString("[", ",", "]")}")
+                          val workerToRequests = currentBatch.flatMap { request =>
+                            if (request.partition.getPeer != null) {
+                              Seq(request.partition, request.partition.getPeer)
+                            } else {
+                              Seq(request.partition)
+                            }
+                          }.groupBy(_.getWorker)
+                          shuffleCommittedInfo.inFlightCommitRequest.addAndGet(
+                            workerToRequests.size)
+                          workerToRequests
+                        } else {
+                          Map.empty[WorkerInfo, Set[PartitionLocation]]
+                        }
+                      }
+                    }
+                    if (workerToRequests.nonEmpty) {
+                      val commitFilesFailedWorkers =
+                        new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]()
+                      val parallelism = workerToRequests.size
+                      try {
+                        ThreadUtils.parmap(
+                          workerToRequests.to,
+                          "CommitFiles",
+                          parallelism) {
+                          case (worker, requests) =>
+                            val workerInfo =
+                              lifecycleManager.shuffleAllocatedWorkers
+                                .get(shuffleId)
+                                .asScala
+                                .find(_._1.equals(worker))
+                                .get
+                                ._1
+                            val mastersIds =
+                              requests
+                                .filter(_.getMode == PartitionLocation.Mode.MASTER)
+                                .map(_.getUniqueId)
+                                .toList
+                                .asJava
+                            val slaveIds =
+                              requests
+                                .filter(_.getMode == PartitionLocation.Mode.SLAVE)
+                                .map(_.getUniqueId)
+                                .toList
+                                .asJava
+
+                            commitFiles(
+                              appId,
+                              shuffleId,
+                              shuffleCommittedInfo,
+                              workerInfo,
+                              mastersIds,
+                              slaveIds,
+                              commitFilesFailedWorkers)
+                        }
+                        lifecycleManager.recordWorkerFailure(commitFilesFailedWorkers)
+                      } finally {
+                        shuffleCommittedInfo.inFlightCommitRequest.addAndGet(-workerToRequests.size)
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        0,
+        batchHandleCommitPartitionRequestInterval,
+        TimeUnit.MILLISECONDS)
+    }
+  }
+
+  def stop(): Unit = {
+    batchHandleCommitPartition.foreach(_.cancel(true))
+    batchHandleCommitPartitionSchedulerThread.foreach(ThreadUtils.shutdown(_, 800.millis))
+  }
+
+  def registerShuffle(shuffleId: Int): Unit = {
+    committedPartitionInfo.put(
+      shuffleId,
+      ShuffleCommittedInfo(
+        new util.ArrayList[String](),
+        new util.ArrayList[String](),
+        new ConcurrentHashMap[String, WorkerInfo](),
+        new ConcurrentHashMap[String, WorkerInfo](),
+        new ConcurrentHashMap[String, StorageInfo](),
+        new ConcurrentHashMap[String, StorageInfo](),
+        new ConcurrentHashMap[String, RoaringBitmap](),
+        new LongAdder,
+        new util.HashSet[CommitPartitionRequest](),
+        new util.HashSet[PartitionLocation](),
+        new AtomicInteger()))
+  }
+
+  def removeExpiredShuffle(shuffleId: Int): Unit = {
+    committedPartitionInfo.remove(shuffleId)
+    dataLostShuffleSet.remove(shuffleId)
+    stageEndShuffleSet.remove(shuffleId)
+  }
+
+  def registerCommitPartitionRequest(
+      applicationId: String,
+      shuffleId: Int,
+      partition: PartitionLocation,
+      cause: Option[StatusCode]): Unit = {
+    if (batchHandleCommitPartitionEnabled && cause.isDefined && cause.get == StatusCode.HARD_SPLIT) {
+      val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
+      shuffleCommittedInfo.synchronized {
+        shuffleCommittedInfo.commitPartitionRequests
+          .add(CommitPartitionRequest(applicationId, shuffleId, partition))
+      }
+    }
+  }
+
+  private def commitFiles(
+      applicationId: String,
+      shuffleId: Int,
+      shuffleCommittedInfo: ShuffleCommittedInfo,
+      worker: WorkerInfo,
+      masterIds: util.List[String],
+      slaveIds: util.List[String],
+      commitFilesFailedWorkers: ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]): Unit = {
+
+    val res =
+      if (!testRetryCommitFiles) {
+        val commitFiles = CommitFiles(
+          applicationId,
+          shuffleId,
+          masterIds,
+          slaveIds,
+          lifecycleManager.shuffleMapperAttempts.get(shuffleId),
+          commitEpoch.incrementAndGet())
+        val res = requestCommitFilesWithRetry(worker.endpoint, commitFiles)
+
+        res.status match {
+          case StatusCode.SUCCESS => // do nothing
+          case StatusCode.PARTIAL_SUCCESS | StatusCode.SHUFFLE_NOT_REGISTERED | StatusCode.FAILED =>
+            logDebug(s"Request $commitFiles return ${res.status} for " +
+              s"${Utils.makeShuffleKey(applicationId, shuffleId)}")
+            commitFilesFailedWorkers.put(worker, (res.status, System.currentTimeMillis()))
+          case _ => // won't happen
+        }
+        res
+      } else {
+        // for test
+        val commitFiles1 = CommitFiles(
+          applicationId,
+          shuffleId,
+          masterIds.subList(0, masterIds.size() / 2),
+          slaveIds.subList(0, slaveIds.size() / 2),
+          lifecycleManager.shuffleMapperAttempts.get(shuffleId),
+          commitEpoch.incrementAndGet())
+        val res1 = requestCommitFilesWithRetry(worker.endpoint, commitFiles1)
+
+        val commitFiles = CommitFiles(
+          applicationId,
+          shuffleId,
+          masterIds.subList(masterIds.size() / 2, masterIds.size()),
+          slaveIds.subList(slaveIds.size() / 2, slaveIds.size()),
+          lifecycleManager.shuffleMapperAttempts.get(shuffleId),
+          commitEpoch.incrementAndGet())
+        val res2 = requestCommitFilesWithRetry(worker.endpoint, commitFiles)
+
+        res1.committedMasterStorageInfos.putAll(res2.committedMasterStorageInfos)
+        res1.committedSlaveStorageInfos.putAll(res2.committedSlaveStorageInfos)
+        res1.committedMapIdBitMap.putAll(res2.committedMapIdBitMap)
+        CommitFilesResponse(
+          status = if (res1.status == StatusCode.SUCCESS) res2.status else res1.status,
+          (res1.committedMasterIds.asScala ++ res2.committedMasterIds.asScala).toList.asJava,
+          (res1.committedSlaveIds.asScala ++ res1.committedSlaveIds.asScala).toList.asJava,
+          (res1.failedMasterIds.asScala ++ res1.failedMasterIds.asScala).toList.asJava,
+          (res1.failedSlaveIds.asScala ++ res2.failedSlaveIds.asScala).toList.asJava,
+          res1.committedMasterStorageInfos,
+          res1.committedSlaveStorageInfos,
+          res1.committedMapIdBitMap,
+          res1.totalWritten + res2.totalWritten,
+          res1.fileCount + res2.fileCount)
+      }
+
+    shuffleCommittedInfo.synchronized {
+      // record committed partitionIds
+      shuffleCommittedInfo.committedMasterIds.addAll(res.committedMasterIds)
+      shuffleCommittedInfo.committedSlaveIds.addAll(res.committedSlaveIds)
+
+      // record committed partitions storage hint and disk hint
+      shuffleCommittedInfo.committedMasterStorageInfos.putAll(res.committedMasterStorageInfos)
+      shuffleCommittedInfo.committedSlaveStorageInfos.putAll(res.committedSlaveStorageInfos)
+
+      // record failed partitions
+      shuffleCommittedInfo.failedMasterPartitionIds.putAll(
+        res.failedMasterIds.asScala.map((_, worker)).toMap.asJava)
+      shuffleCommittedInfo.failedSlavePartitionIds.putAll(
+        res.failedSlaveIds.asScala.map((_, worker)).toMap.asJava)
+
+      shuffleCommittedInfo.committedMapIdBitmap.putAll(res.committedMapIdBitMap)
+
+      totalWritten.add(res.totalWritten)
+      fileCount.add(res.fileCount)
+      shuffleCommittedInfo.currentShuffleFileCount.add(res.fileCount)
+    }
+  }
+
+  private def requestCommitFilesWithRetry(
+      endpoint: RpcEndpointRef,
+      message: CommitFiles): CommitFilesResponse = {
+    val maxRetries = conf.requestCommitFilesMaxRetries
+    var retryTimes = 0
+    while (retryTimes < maxRetries) {
+      try {
+        if (testRetryCommitFiles && retryTimes < maxRetries - 1) {
+          endpoint.ask[CommitFilesResponse](message)
+          Thread.sleep(1000)
+          throw new Exception("Mock fail for CommitFiles")
+        } else {
+          return endpoint.askSync[CommitFilesResponse](message)
+        }
+      } catch {
+        case e: Throwable =>
+          retryTimes += 1
+          logError(
+            s"AskSync CommitFiles for ${message.shuffleId} failed (attempt $retryTimes/$maxRetries).",
+            e)
+      }
+    }
+
+    CommitFilesResponse(
+      StatusCode.FAILED,
+      List.empty.asJava,
+      List.empty.asJava,
+      message.masterIds,
+      message.slaveIds)
+  }
+
+  def finalCommit(
+      applicationId: String,
+      shuffleId: Int,
+      fileGroups: Array[Array[PartitionLocation]]): Unit = {
+    if (stageEndShuffleSet.contains(shuffleId)) {
+      logInfo(s"[handleStageEnd] Shuffle $shuffleId already ended!")
+      return
+    }
+    inProcessStageEndShuffleSet.synchronized {
+      if (inProcessStageEndShuffleSet.contains(shuffleId)) {
+        logWarning(s"[handleStageEnd] Shuffle $shuffleId is in process!")
+        return
+      }
+      inProcessStageEndShuffleSet.add(shuffleId)
+    }
+    // ask allLocations workers holding partitions to commit files
+    val masterPartMap = new ConcurrentHashMap[String, PartitionLocation]
+    val slavePartMap = new ConcurrentHashMap[String, PartitionLocation]
+
+    val allocatedWorkers = lifecycleManager.shuffleAllocatedWorkers.get(shuffleId)
+    val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
+    val commitFilesFailedWorkers = new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]()
+    val commitFileStartTime = System.nanoTime()
+
+    val parallelism = Math.min(allocatedWorkers.size(), conf.rpcMaxParallelism)
+    ThreadUtils.parmap(
+      allocatedWorkers.asScala.to,
+      "CommitFiles",
+      parallelism) { case (worker, partitionLocationInfo) =>
+      if (partitionLocationInfo.containsShuffle(shuffleId.toString)) {
+        val masterParts = partitionLocationInfo.getAllMasterLocations(shuffleId.toString)
+        val slaveParts = partitionLocationInfo.getAllSlaveLocations(shuffleId.toString)
+        masterParts.asScala.foreach { p =>
+          val partition = new PartitionLocation(p)
+          partition.setFetchPort(worker.fetchPort)
+          partition.setPeer(null)
+          masterPartMap.put(partition.getUniqueId, partition)
+        }
+        slaveParts.asScala.foreach { p =>
+          val partition = new PartitionLocation(p)
+          partition.setFetchPort(worker.fetchPort)
+          partition.setPeer(null)
+          slavePartMap.put(partition.getUniqueId, partition)
+        }
+
+        val (masterIds, slaveIds) = shuffleCommittedInfo.synchronized {
+          (
+            masterParts.asScala
+              .filterNot(shuffleCommittedInfo.handledCommitPartitionRequests.contains)
+              .map(_.getUniqueId).asJava,
+            slaveParts.asScala
+              .filterNot(shuffleCommittedInfo.handledCommitPartitionRequests.contains)
+              .map(_.getUniqueId).asJava)
+        }
+
+        commitFiles(
+          applicationId,
+          shuffleId,
+          shuffleCommittedInfo,
+          worker,
+          masterIds,
+          slaveIds,
+          commitFilesFailedWorkers)
+      }
+    }
+
+    def hasCommitFailedIds: Boolean = {
+      val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
+      if (!pushReplicateEnabled && shuffleCommittedInfo.failedMasterPartitionIds.size() != 0) {
+        val msg =
+          shuffleCommittedInfo.failedMasterPartitionIds.asScala.map {
+            case (partitionId, workerInfo) =>
+              s"Lost partition $partitionId in worker [${workerInfo.readableAddress()}]"
+          }.mkString("\n")
+        logError(
+          s"""
+             |For shuffle $shuffleKey partition data lost:
+             |$msg
+             |""".stripMargin)
+        true
+      } else {
+        val failedBothPartitionIdsToWorker =
+          shuffleCommittedInfo.failedMasterPartitionIds.asScala.flatMap {
+            case (partitionId, worker) =>
+              if (shuffleCommittedInfo.failedSlavePartitionIds.contains(partitionId)) {
+                Some(partitionId -> (worker, shuffleCommittedInfo.failedSlavePartitionIds.get(
+                  partitionId)))
+              } else {
+                None
+              }
+          }
+        if (failedBothPartitionIdsToWorker.nonEmpty) {
+          val msg = failedBothPartitionIdsToWorker.map {
+            case (partitionId, (masterWorker, slaveWorker)) =>
+              s"Lost partition $partitionId " +
+                s"in master worker [${masterWorker.readableAddress()}] and slave worker [$slaveWorker]"
+          }.mkString("\n")
+          logError(
+            s"""
+               |For shuffle $shuffleKey partition data lost:
+               |$msg
+               |""".stripMargin)
+          true
+        } else {
+          false
+        }
+      }
+    }
+
+    while (shuffleCommittedInfo.inFlightCommitRequest.get() > 0) {
+      Thread.sleep(1000)
+    }
+
+    val dataLost = hasCommitFailedIds
+
+    if (!dataLost) {
+      val committedPartitions = new util.HashMap[String, PartitionLocation]
+      shuffleCommittedInfo.committedMasterIds.asScala.foreach { id =>
+        if (shuffleCommittedInfo.committedMasterStorageInfos.get(id) == null) {
+          logDebug(s"$applicationId-$shuffleId $id storage hint was not returned")
+        } else {
+          masterPartMap.get(id).setStorageInfo(
+            shuffleCommittedInfo.committedMasterStorageInfos.get(id))
+          masterPartMap.get(id).setMapIdBitMap(shuffleCommittedInfo.committedMapIdBitmap.get(id))
+          committedPartitions.put(id, masterPartMap.get(id))
+        }
+      }
+
+      shuffleCommittedInfo.committedSlaveIds.asScala.foreach { id =>
+        val slavePartition = slavePartMap.get(id)
+        if (shuffleCommittedInfo.committedSlaveStorageInfos.get(id) == null) {
+          logDebug(s"$applicationId-$shuffleId $id storage hint was not returned")
+        } else {
+          slavePartition.setStorageInfo(shuffleCommittedInfo.committedSlaveStorageInfos.get(id))
+          val masterPartition = committedPartitions.get(id)
+          if (masterPartition ne null) {
+            masterPartition.setPeer(slavePartition)
+            slavePartition.setPeer(masterPartition)
+          } else {
+            logInfo(s"Shuffle $shuffleId partition $id: master lost, " +
+              s"use slave $slavePartition.")
+            slavePartition.setMapIdBitMap(shuffleCommittedInfo.committedMapIdBitmap.get(id))
+            committedPartitions.put(id, slavePartition)
+          }
+        }
+      }
+
+      val sets = Array.fill(fileGroups.length)(new util.HashSet[PartitionLocation]())
+      committedPartitions.values().asScala.foreach { partition =>
+        sets(partition.getId).add(partition)
+      }
+      var i = 0
+      while (i < fileGroups.length) {
+        fileGroups(i) = sets(i).toArray(new Array[PartitionLocation](0))
+        i += 1
+      }
+
+      logInfo(s"Shuffle $shuffleId " +
+        s"commit files complete. File count ${shuffleCommittedInfo.currentShuffleFileCount.sum()} " +
+        s"using ${(System.nanoTime() - commitFileStartTime) / 1000000} ms")
+    }
+
+    // reply
+    if (!dataLost) {
+      logInfo(s"Succeed to handle stageEnd for $shuffleId.")
+      // record in stageEndShuffleSet
+      stageEndShuffleSet.add(shuffleId)
+    } else {
+      logError(s"Failed to handle stageEnd for $shuffleId, lost file!")
+      dataLostShuffleSet.add(shuffleId)
+      // record in stageEndShuffleSet
+      stageEndShuffleSet.add(shuffleId)
+    }
+    inProcessStageEndShuffleSet.remove(shuffleId)
+    lifecycleManager.recordWorkerFailure(commitFilesFailedWorkers)
+  }
+
+  def removeExpiredShuffle(shuffleId: String): Unit = {
+    stageEndShuffleSet.remove(shuffleId)
+    dataLostShuffleSet.remove(shuffleId)
+    committedPartitionInfo.remove(shuffleId)
+  }
+
+  def commitMetrics(): (Long, Long) = (totalWritten.sumThenReset(), fileCount.sumThenReset())
+}

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -64,16 +64,12 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   private val rpcCacheExpireTime = conf.rpcCacheExpireTime
 
   val registeredShuffle = ConcurrentHashMap.newKeySet[Int]()
-  private val shuffleMapperAttempts = new ConcurrentHashMap[Int, Array[Int]]()
+  val shuffleMapperAttempts = new ConcurrentHashMap[Int, Array[Int]]()
   private val reducerFileGroupsMap =
     new ConcurrentHashMap[Int, Array[Array[PartitionLocation]]]()
-  private val dataLostShuffleSet = ConcurrentHashMap.newKeySet[Int]()
-  val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
-  private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   // maintain each shuffle's map relation of WorkerInfo and partition location
-  private val shuffleAllocatedWorkers = {
+  val shuffleAllocatedWorkers =
     new ConcurrentHashMap[Int, ConcurrentHashMap[WorkerInfo, PartitionLocationInfo]]()
-  }
   // shuffle id -> (partitionId -> newest PartitionLocation)
   val latestPartitionLocation =
     new ConcurrentHashMap[Int, ConcurrentHashMap[Int, PartitionLocation]]()
@@ -84,9 +80,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     .expireAfterWrite(rpcCacheExpireTime, TimeUnit.MILLISECONDS)
     .maximumSize(rpcCacheSize)
     .build().asInstanceOf[Cache[Int, ByteBuffer]]
-
-  private val testRetryCommitFiles = conf.testRetryCommitFiles
-  private val commitEpoch = new AtomicLong()
 
   @VisibleForTesting
   def workerSnapshots(shuffleId: Int): util.Map[WorkerInfo, PartitionLocationInfo] =
@@ -112,41 +105,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     }
   }
 
-  case class CommitPartitionRequest(
-      applicationId: String,
-      shuffleId: Int,
-      partition: PartitionLocation)
-
-  case class ShuffleCommittedInfo(
-      committedMasterIds: util.List[String],
-      committedSlaveIds: util.List[String],
-      failedMasterPartitionIds: ConcurrentHashMap[String, WorkerInfo],
-      failedSlavePartitionIds: ConcurrentHashMap[String, WorkerInfo],
-      committedMasterStorageInfos: ConcurrentHashMap[String, StorageInfo],
-      committedSlaveStorageInfos: ConcurrentHashMap[String, StorageInfo],
-      committedMapIdBitmap: ConcurrentHashMap[String, RoaringBitmap],
-      currentShuffleFileCount: LongAdder,
-      commitPartitionRequests: util.Set[CommitPartitionRequest],
-      handledCommitPartitionRequests: util.Set[PartitionLocation],
-      inFlightCommitRequest: AtomicInteger)
-
-  // shuffle id -> ShuffleCommittedInfo
-  private val committedPartitionInfo = new ConcurrentHashMap[Int, ShuffleCommittedInfo]()
-  def registerCommitPartition(
-      applicationId: String,
-      shuffleId: Int,
-      partition: PartitionLocation,
-      cause: Option[StatusCode]): Unit = {
-    // handle hard split
-    if (batchHandleCommitPartitionEnabled && cause.isDefined && cause.get == StatusCode.HARD_SPLIT) {
-      val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
-      shuffleCommittedInfo.synchronized {
-        shuffleCommittedInfo.commitPartitionRequests
-          .add(CommitPartitionRequest(applicationId, shuffleId, partition))
-      }
-    }
-  }
-
   // register shuffle request waiting for response
   private val registeringShuffleRequest =
     new ConcurrentHashMap[Int, util.Set[RegisterCallContext]]()
@@ -160,20 +118,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   private var checkForShuffleRemoval: ScheduledFuture[_] = _
   private var getBlacklist: ScheduledFuture[_] = _
 
-  private val batchHandleCommitPartitionEnabled = conf.batchHandleCommitPartitionEnabled
-  private val batchHandleCommitPartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(
-    "rss-lifecycle-manager-commit-partition-executor",
-    conf.batchHandleCommitPartitionNumThreads)
-  private val batchHandleCommitPartitionRequestInterval =
-    conf.batchHandleCommitPartitionRequestInterval
-  private val batchHandleCommitPartitionSchedulerThread: Option[ScheduledExecutorService] =
-    if (batchHandleCommitPartitionEnabled) {
-      Some(ThreadUtils.newDaemonSingleThreadScheduledExecutor(
-        "rss-lifecycle-manager-commit-partition-scheduler"))
-    } else {
-      None
-    }
-
   // init driver rss meta rpc service
   override val rpcEnv: RpcEnv = RpcEnv.create(
     RpcNameConstants.RSS_METASERVICE_SYS,
@@ -185,14 +129,9 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   logInfo(s"Starting LifecycleManager on ${rpcEnv.address}")
 
   private val rssHARetryClient = new RssHARetryClient(rpcEnv, conf)
-  private val totalWritten = new LongAdder
-  private val fileCount = new LongAdder
+  val commitManager = new CommitManager(appId, conf, this)
   private val heartbeater =
-    new ApplicationHeartbeater(
-      appId,
-      conf,
-      rssHARetryClient,
-      () => (totalWritten.sumThenReset(), fileCount.sumThenReset()))
+    new ApplicationHeartbeater(appId, conf, rssHARetryClient, () => commitManager.commitMetrics())
   private val changePartitionManager = new ChangePartitionManager(conf, this)
 
   // Since method `onStart` is executed when `rpcEnv.setupEndpoint` is executed, and
@@ -202,117 +141,9 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   // method at the end of the construction of the class to perform the initialization operations.
   private def initialize(): Unit = {
     // noinspection ConvertExpressionToSAM
+    commitManager.start()
     heartbeater.start()
     changePartitionManager.start()
-
-    batchHandleCommitPartitionSchedulerThread.foreach {
-      _.scheduleAtFixedRate(
-        new Runnable {
-          override def run(): Unit = {
-            committedPartitionInfo.asScala.foreach { case (shuffleId, shuffleCommittedInfo) =>
-              batchHandleCommitPartitionExecutors.submit {
-                new Runnable {
-                  override def run(): Unit = {
-                    val workerToRequests = shuffleCommittedInfo.synchronized {
-                      // When running to here, if handleStageEnd got lock first and commitFiles,
-                      // then this batch get this lock, commitPartitionRequests may contains
-                      // partitions which are already committed by stageEnd process.
-                      // But inProcessStageEndShuffleSet should have contain this shuffle id,
-                      // can directly return.
-                      if (inProcessStageEndShuffleSet.contains(shuffleId) ||
-                        stageEndShuffleSet.contains(shuffleId)) {
-                        logWarning(s"Shuffle $shuffleId ended or during processing stage end.")
-                        shuffleCommittedInfo.commitPartitionRequests.clear()
-                        Map.empty[WorkerInfo, Set[PartitionLocation]]
-                      } else {
-                        val batch = new util.HashSet[CommitPartitionRequest]()
-                        batch.addAll(shuffleCommittedInfo.commitPartitionRequests)
-                        val currentBatch = batch.asScala.filterNot { request =>
-                          shuffleCommittedInfo.handledCommitPartitionRequests
-                            .contains(request.partition)
-                        }
-                        shuffleCommittedInfo.commitPartitionRequests.clear()
-                        currentBatch.foreach { commitPartitionRequest =>
-                          shuffleCommittedInfo.handledCommitPartitionRequests
-                            .add(commitPartitionRequest.partition)
-                          if (commitPartitionRequest.partition.getPeer != null) {
-                            shuffleCommittedInfo.handledCommitPartitionRequests
-                              .add(commitPartitionRequest.partition.getPeer)
-                          }
-                        }
-
-                        if (currentBatch.nonEmpty) {
-                          logWarning(s"Commit current batch HARD_SPLIT partitions for $shuffleId: " +
-                            s"${currentBatch.map(_.partition.getUniqueId).mkString("[", ",", "]")}")
-                          val workerToRequests = currentBatch.flatMap { request =>
-                            if (request.partition.getPeer != null) {
-                              Seq(request.partition, request.partition.getPeer)
-                            } else {
-                              Seq(request.partition)
-                            }
-                          }.groupBy(_.getWorker)
-                          shuffleCommittedInfo.inFlightCommitRequest.addAndGet(
-                            workerToRequests.size)
-                          workerToRequests
-                        } else {
-                          Map.empty[WorkerInfo, Set[PartitionLocation]]
-                        }
-                      }
-                    }
-                    if (workerToRequests.nonEmpty) {
-                      val commitFilesFailedWorkers =
-                        new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]()
-                      val parallelism = workerToRequests.size
-                      try {
-                        ThreadUtils.parmap(
-                          workerToRequests.to,
-                          "CommitFiles",
-                          parallelism) {
-                          case (worker, requests) =>
-                            val workerInfo =
-                              shuffleAllocatedWorkers
-                                .get(shuffleId)
-                                .asScala
-                                .find(_._1.equals(worker))
-                                .get
-                                ._1
-                            val mastersIds =
-                              requests
-                                .filter(_.getMode == PartitionLocation.Mode.MASTER)
-                                .map(_.getUniqueId)
-                                .toList
-                                .asJava
-                            val slaveIds =
-                              requests
-                                .filter(_.getMode == PartitionLocation.Mode.SLAVE)
-                                .map(_.getUniqueId)
-                                .toList
-                                .asJava
-
-                            commitFiles(
-                              appId,
-                              shuffleId,
-                              shuffleCommittedInfo,
-                              workerInfo,
-                              mastersIds,
-                              slaveIds,
-                              commitFilesFailedWorkers)
-                        }
-                        recordWorkerFailure(commitFilesFailedWorkers)
-                      } finally {
-                        shuffleCommittedInfo.inFlightCommitRequest.addAndGet(-workerToRequests.size)
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        0,
-        batchHandleCommitPartitionRequestInterval,
-        TimeUnit.MILLISECONDS)
-    }
   }
 
   override def onStart(): Unit = {
@@ -346,6 +177,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     getBlacklist.cancel(true)
     ThreadUtils.shutdown(forwardMessageThread, 800.millis)
 
+    commitManager.stop()
     changePartitionManager.stop()
     heartbeater.stop()
 
@@ -638,20 +470,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
       // Fifth, reply the allocated partition location to ShuffleClient.
       logInfo(s"Handle RegisterShuffle Success for $shuffleId.")
-      committedPartitionInfo.put(
-        shuffleId,
-        ShuffleCommittedInfo(
-          new util.ArrayList[String](),
-          new util.ArrayList[String](),
-          new ConcurrentHashMap[String, WorkerInfo](),
-          new ConcurrentHashMap[String, WorkerInfo](),
-          new ConcurrentHashMap[String, StorageInfo](),
-          new ConcurrentHashMap[String, StorageInfo](),
-          new ConcurrentHashMap[String, RoaringBitmap](),
-          new LongAdder,
-          new util.HashSet[CommitPartitionRequest](),
-          new util.HashSet[PartitionLocation](),
-          new AtomicInteger()))
+      commitManager.registerShuffle(shuffleId)
       val allMasterPartitionLocations = slots.asScala.flatMap(_._2._1.asScala).toArray
       reply(RegisterShuffleResponse(StatusCode.SUCCESS, allMasterPartitionLocations))
     }
@@ -784,7 +603,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       shuffleId: Int): Unit = {
     var timeout = stageEndTimeout
     val delta = 100
-    while (!stageEndShuffleSet.contains(shuffleId)) {
+    while (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
       Thread.sleep(delta)
       if (timeout <= 0) {
         logError(s"[handleGetReducerFileGroup] Wait for handleStageEnd Timeout! $shuffleId.")
@@ -797,7 +616,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     logDebug("[handleGetReducerFileGroup] Wait for handleStageEnd complete cost" +
       s" ${stageEndTimeout - timeout}ms")
 
-    if (dataLostShuffleSet.contains(shuffleId)) {
+    if (commitManager.dataLostShuffleSet.contains(shuffleId)) {
       context.reply(
         GetReducerFileGroupResponse(StatusCode.SHUFFLE_DATA_LOST, Array.empty, Array.empty))
     } else {
@@ -830,182 +649,13 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       logInfo(s"[handleStageEnd]" +
         s"$shuffleId not registered, maybe no shuffle data within this stage.")
       // record in stageEndShuffleSet
-      stageEndShuffleSet.add(shuffleId)
+      commitManager.stageEndShuffleSet.add(shuffleId)
       return
     }
-    if (stageEndShuffleSet.contains(shuffleId)) {
-      logInfo(s"[handleStageEnd] Shuffle $shuffleId already ended!")
-      return
-    }
-    inProcessStageEndShuffleSet.synchronized {
-      if (inProcessStageEndShuffleSet.contains(shuffleId)) {
-        logWarning(s"[handleStageEnd] Shuffle $shuffleId is in process!")
-        return
-      }
-      inProcessStageEndShuffleSet.add(shuffleId)
-    }
-
-    // ask allLocations workers holding partitions to commit files
-    val masterPartMap = new ConcurrentHashMap[String, PartitionLocation]
-    val slavePartMap = new ConcurrentHashMap[String, PartitionLocation]
-
-    val allocatedWorkers = shuffleAllocatedWorkers.get(shuffleId)
-    val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
-    val commitFilesFailedWorkers = new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]()
-    val commitFileStartTime = System.nanoTime()
-
-    val parallelism = Math.min(workerSnapshots(shuffleId).size(), conf.rpcMaxParallelism)
-    ThreadUtils.parmap(
-      allocatedWorkers.asScala.to,
-      "CommitFiles",
-      parallelism) { case (worker, partitionLocationInfo) =>
-      if (partitionLocationInfo.containsShuffle(shuffleId.toString)) {
-        val masterParts = partitionLocationInfo.getAllMasterLocations(shuffleId.toString)
-        val slaveParts = partitionLocationInfo.getAllSlaveLocations(shuffleId.toString)
-        masterParts.asScala.foreach { p =>
-          val partition = new PartitionLocation(p)
-          partition.setFetchPort(worker.fetchPort)
-          partition.setPeer(null)
-          masterPartMap.put(partition.getUniqueId, partition)
-        }
-        slaveParts.asScala.foreach { p =>
-          val partition = new PartitionLocation(p)
-          partition.setFetchPort(worker.fetchPort)
-          partition.setPeer(null)
-          slavePartMap.put(partition.getUniqueId, partition)
-        }
-
-        val (masterIds, slaveIds) = shuffleCommittedInfo.synchronized {
-          (
-            masterParts.asScala
-              .filterNot(shuffleCommittedInfo.handledCommitPartitionRequests.contains)
-              .map(_.getUniqueId).asJava,
-            slaveParts.asScala
-              .filterNot(shuffleCommittedInfo.handledCommitPartitionRequests.contains)
-              .map(_.getUniqueId).asJava)
-        }
-
-        commitFiles(
-          applicationId,
-          shuffleId,
-          shuffleCommittedInfo,
-          worker,
-          masterIds,
-          slaveIds,
-          commitFilesFailedWorkers)
-      }
-    }
-
-    def hasCommitFailedIds: Boolean = {
-      val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
-      if (!pushReplicateEnabled && shuffleCommittedInfo.failedMasterPartitionIds.size() != 0) {
-        val msg =
-          shuffleCommittedInfo.failedMasterPartitionIds.asScala.map {
-            case (partitionId, workerInfo) =>
-              s"Lost partition $partitionId in worker [${workerInfo.readableAddress()}]"
-          }.mkString("\n")
-        logError(
-          s"""
-             |For shuffle $shuffleKey partition data lost:
-             |$msg
-             |""".stripMargin)
-        true
-      } else {
-        val failedBothPartitionIdsToWorker =
-          shuffleCommittedInfo.failedMasterPartitionIds.asScala.flatMap {
-            case (partitionId, worker) =>
-              if (shuffleCommittedInfo.failedSlavePartitionIds.contains(partitionId)) {
-                Some(partitionId -> (worker, shuffleCommittedInfo.failedSlavePartitionIds.get(
-                  partitionId)))
-              } else {
-                None
-              }
-          }
-        if (failedBothPartitionIdsToWorker.nonEmpty) {
-          val msg = failedBothPartitionIdsToWorker.map {
-            case (partitionId, (masterWorker, slaveWorker)) =>
-              s"Lost partition $partitionId " +
-                s"in master worker [${masterWorker.readableAddress()}] and slave worker [$slaveWorker]"
-          }.mkString("\n")
-          logError(
-            s"""
-               |For shuffle $shuffleKey partition data lost:
-               |$msg
-               |""".stripMargin)
-          true
-        } else {
-          false
-        }
-      }
-    }
-
-    while (shuffleCommittedInfo.inFlightCommitRequest.get() > 0) {
-      Thread.sleep(1000)
-    }
-
-    val dataLost = hasCommitFailedIds
-
-    if (!dataLost) {
-      val committedPartitions = new util.HashMap[String, PartitionLocation]
-      shuffleCommittedInfo.committedMasterIds.asScala.foreach { id =>
-        if (shuffleCommittedInfo.committedMasterStorageInfos.get(id) == null) {
-          logDebug(s"$applicationId-$shuffleId $id storage hint was not returned")
-        } else {
-          masterPartMap.get(id).setStorageInfo(
-            shuffleCommittedInfo.committedMasterStorageInfos.get(id))
-          masterPartMap.get(id).setMapIdBitMap(shuffleCommittedInfo.committedMapIdBitmap.get(id))
-          committedPartitions.put(id, masterPartMap.get(id))
-        }
-      }
-
-      shuffleCommittedInfo.committedSlaveIds.asScala.foreach { id =>
-        val slavePartition = slavePartMap.get(id)
-        if (shuffleCommittedInfo.committedSlaveStorageInfos.get(id) == null) {
-          logDebug(s"$applicationId-$shuffleId $id storage hint was not returned")
-        } else {
-          slavePartition.setStorageInfo(shuffleCommittedInfo.committedSlaveStorageInfos.get(id))
-          val masterPartition = committedPartitions.get(id)
-          if (masterPartition ne null) {
-            masterPartition.setPeer(slavePartition)
-            slavePartition.setPeer(masterPartition)
-          } else {
-            logInfo(s"Shuffle $shuffleId partition $id: master lost, " +
-              s"use slave $slavePartition.")
-            slavePartition.setMapIdBitMap(shuffleCommittedInfo.committedMapIdBitmap.get(id))
-            committedPartitions.put(id, slavePartition)
-          }
-        }
-      }
-
-      val fileGroups = reducerFileGroupsMap.get(shuffleId)
-      val sets = Array.fill(fileGroups.length)(new util.HashSet[PartitionLocation]())
-      committedPartitions.values().asScala.foreach { partition =>
-        sets(partition.getId).add(partition)
-      }
-      var i = 0
-      while (i < fileGroups.length) {
-        fileGroups(i) = sets(i).toArray(new Array[PartitionLocation](0))
-        i += 1
-      }
-
-      logInfo(s"Shuffle $shuffleId " +
-        s"commit files complete. File count ${shuffleCommittedInfo.currentShuffleFileCount.sum()} " +
-        s"using ${(System.nanoTime() - commitFileStartTime) / 1000000} ms")
-    }
-
-    // reply
-    if (!dataLost) {
-      logInfo(s"Succeed to handle stageEnd for $shuffleId.")
-      // record in stageEndShuffleSet
-      stageEndShuffleSet.add(shuffleId)
-    } else {
-      logError(s"Failed to handle stageEnd for $shuffleId, lost file!")
-      dataLostShuffleSet.add(shuffleId)
-      // record in stageEndShuffleSet
-      stageEndShuffleSet.add(shuffleId)
-    }
-    inProcessStageEndShuffleSet.remove(shuffleId)
-    recordWorkerFailure(commitFilesFailedWorkers)
+    commitManager.finalCommit(
+      applicationId,
+      shuffleId,
+      reducerFileGroupsMap.get(shuffleId))
     // release resources and clear worker info
     workerSnapshots(shuffleId).asScala.foreach { case (_, partitionLocationInfo) =>
       partitionLocationInfo.removeMasterPartitions(shuffleId.toString)
@@ -1016,103 +666,16 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       ReleaseSlots(applicationId, shuffleId, List.empty.asJava, List.empty.asJava))
   }
 
-  private def commitFiles(
-      applicationId: String,
-      shuffleId: Int,
-      shuffleCommittedInfo: ShuffleCommittedInfo,
-      worker: WorkerInfo,
-      masterIds: util.List[String],
-      slaveIds: util.List[String],
-      commitFilesFailedWorkers: ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]): Unit = {
-
-    val res =
-      if (!testRetryCommitFiles) {
-        val commitFiles = CommitFiles(
-          applicationId,
-          shuffleId,
-          masterIds,
-          slaveIds,
-          shuffleMapperAttempts.get(shuffleId),
-          commitEpoch.incrementAndGet())
-        val res = requestCommitFilesWithRetry(worker.endpoint, commitFiles)
-        res.status match {
-          case StatusCode.SUCCESS => // do nothing
-          case StatusCode.PARTIAL_SUCCESS | StatusCode.SHUFFLE_NOT_REGISTERED | StatusCode.FAILED =>
-            logDebug(s"Request $commitFiles return ${res.status} for " +
-              s"${Utils.makeShuffleKey(applicationId, shuffleId)}")
-            commitFilesFailedWorkers.put(worker, (res.status, System.currentTimeMillis()))
-          case _ => // won't happen
-        }
-        res
-      } else {
-        // for test
-        val commitFiles1 = CommitFiles(
-          applicationId,
-          shuffleId,
-          masterIds.subList(0, masterIds.size() / 2),
-          slaveIds.subList(0, slaveIds.size() / 2),
-          shuffleMapperAttempts.get(shuffleId),
-          commitEpoch.incrementAndGet())
-        val res1 = requestCommitFilesWithRetry(worker.endpoint, commitFiles1)
-
-        val commitFiles = CommitFiles(
-          applicationId,
-          shuffleId,
-          masterIds.subList(masterIds.size() / 2, masterIds.size()),
-          slaveIds.subList(slaveIds.size() / 2, slaveIds.size()),
-          shuffleMapperAttempts.get(shuffleId),
-          commitEpoch.incrementAndGet())
-        val res2 = requestCommitFilesWithRetry(worker.endpoint, commitFiles)
-
-        res1.committedMasterStorageInfos.putAll(res2.committedMasterStorageInfos)
-        res1.committedSlaveStorageInfos.putAll(res2.committedSlaveStorageInfos)
-        res1.committedMapIdBitMap.putAll(res2.committedMapIdBitMap)
-        CommitFilesResponse(
-          status = if (res1.status == StatusCode.SUCCESS) res2.status else res1.status,
-          (res1.committedMasterIds.asScala ++ res2.committedMasterIds.asScala).toList.asJava,
-          (res1.committedSlaveIds.asScala ++ res1.committedSlaveIds.asScala).toList.asJava,
-          (res1.failedMasterIds.asScala ++ res1.failedMasterIds.asScala).toList.asJava,
-          (res1.failedSlaveIds.asScala ++ res2.failedSlaveIds.asScala).toList.asJava,
-          res1.committedMasterStorageInfos,
-          res1.committedSlaveStorageInfos,
-          res1.committedMapIdBitMap,
-          res1.totalWritten + res2.totalWritten,
-          res1.fileCount + res2.fileCount)
-      }
-
-    shuffleCommittedInfo.synchronized {
-      // record committed partitionIds
-      shuffleCommittedInfo.committedMasterIds.addAll(res.committedMasterIds)
-      shuffleCommittedInfo.committedSlaveIds.addAll(res.committedSlaveIds)
-
-      // record committed partitions storage hint and disk hint
-      shuffleCommittedInfo.committedMasterStorageInfos.putAll(res.committedMasterStorageInfos)
-      shuffleCommittedInfo.committedSlaveStorageInfos.putAll(res.committedSlaveStorageInfos)
-
-      // record failed partitions
-      shuffleCommittedInfo.failedMasterPartitionIds.putAll(
-        res.failedMasterIds.asScala.map((_, worker)).toMap.asJava)
-      shuffleCommittedInfo.failedSlavePartitionIds.putAll(
-        res.failedSlaveIds.asScala.map((_, worker)).toMap.asJava)
-
-      shuffleCommittedInfo.committedMapIdBitmap.putAll(res.committedMapIdBitMap)
-
-      totalWritten.add(res.totalWritten)
-      fileCount.add(res.fileCount)
-      shuffleCommittedInfo.currentShuffleFileCount.add(res.fileCount)
-    }
-  }
-
   private def handleUnregisterShuffle(
       appId: String,
       shuffleId: Int): Unit = {
     // if StageEnd has not been handled, trigger StageEnd
-    if (!stageEndShuffleSet.contains(shuffleId)) {
+    if (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
       logInfo(s"Call StageEnd before Unregister Shuffle $shuffleId.")
       handleStageEnd(appId, shuffleId)
       var timeout = stageEndTimeout
       val delta = 100
-      while (!stageEndShuffleSet.contains(shuffleId) && timeout > 0) {
+      while (!commitManager.stageEndShuffleSet.contains(shuffleId) && timeout > 0) {
         Thread.sleep(delta)
         timeout = timeout - delta
       }
@@ -1496,13 +1059,11 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         registeredShuffle.remove(shuffleId)
         registeringShuffleRequest.remove(shuffleId)
         reducerFileGroupsMap.remove(shuffleId)
-        dataLostShuffleSet.remove(shuffleId)
         shuffleMapperAttempts.remove(shuffleId)
-        stageEndShuffleSet.remove(shuffleId)
-        committedPartitionInfo.remove(shuffleId)
         unregisterShuffleTime.remove(shuffleId)
         shuffleAllocatedWorkers.remove(shuffleId)
         latestPartitionLocation.remove(shuffleId)
+        commitManager.removeExpiredShuffle(shuffleId)
         changePartitionManager.removeExpiredShuffle(shuffleId)
 
         requestUnregisterShuffle(
@@ -1597,37 +1158,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         logError(s"AskSync Destroy for ${message.shuffleKey} failed.", e)
         DestroyResponse(StatusCode.FAILED, message.masterLocations, message.slaveLocations)
     }
-  }
-
-  private def requestCommitFilesWithRetry(
-      endpoint: RpcEndpointRef,
-      message: CommitFiles): CommitFilesResponse = {
-    val maxRetries = conf.requestCommitFilesMaxRetries
-    var retryTimes = 0
-    while (retryTimes < maxRetries) {
-      try {
-        if (testRetryCommitFiles && retryTimes < maxRetries - 1) {
-          endpoint.ask[CommitFilesResponse](message)
-          Thread.sleep(1000)
-          throw new Exception("Mock fail for CommitFiles")
-        } else {
-          return endpoint.askSync[CommitFilesResponse](message)
-        }
-      } catch {
-        case e: Throwable =>
-          retryTimes += 1
-          logError(
-            s"AskSync CommitFiles for ${message.shuffleId} failed (attempt $retryTimes/$maxRetries).",
-            e)
-      }
-    }
-
-    CommitFilesResponse(
-      StatusCode.FAILED,
-      List.empty.asJava,
-      List.empty.asJava,
-      message.masterIds,
-      message.slaveIds)
   }
 
   private def requestReleaseSlots(

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -20,8 +20,7 @@ package org.apache.celeborn.client
 import java.nio.ByteBuffer
 import java.util
 import java.util.{function, List => JList}
-import java.util.concurrent.{Callable, ConcurrentHashMap, ScheduledExecutorService, ScheduledFuture, TimeUnit}
-import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, LongAdder}
+import java.util.concurrent.{Callable, ConcurrentHashMap, ScheduledFuture, TimeUnit}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -29,7 +28,6 @@ import scala.util.Random
 
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.cache.{Cache, CacheBuilder}
-import org.roaringbitmap.RoaringBitmap
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.haclient.RssHARetryClient
@@ -43,6 +41,7 @@ import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc._
 import org.apache.celeborn.common.rpc.netty.{LocalNettyRpcCallContext, RemoteNettyRpcCallContext}
 import org.apache.celeborn.common.util.{PbSerDeUtils, ThreadUtils, Utils}
+import org.apache.celeborn.common.util.FunctionConverter._
 
 class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoint with Logging {
 
@@ -66,7 +65,8 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   val registeredShuffle = ConcurrentHashMap.newKeySet[Int]()
   val shuffleMapperAttempts = new ConcurrentHashMap[Int, Array[Int]]()
   private val reducerFileGroupsMap =
-    new ConcurrentHashMap[Int, Array[Array[PartitionLocation]]]()
+    new ConcurrentHashMap[Int, ConcurrentHashMap[Integer, util.Set[PartitionLocation]]]()
+  private val shuffleTaskInfo = new ShuffleTaskInfo()
   // maintain each shuffle's map relation of WorkerInfo and partition location
   val shuffleAllocatedWorkers =
     new ConcurrentHashMap[Int, ConcurrentHashMap[WorkerInfo, PartitionLocationInfo]]()
@@ -104,6 +104,11 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       context.reply(response)
     }
   }
+
+  case class ShuffleTask(
+      shuffleId: Int,
+      mapId: Int,
+      attemptId: Int)
 
   // register shuffle request waiting for response
   private val registeringShuffleRequest =
@@ -204,6 +209,18 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     shufflePartitionType.getOrDefault(shuffleId, conf.shufflePartitionType)
   }
 
+  def encodeExternalShuffleTask(
+      taskShuffleId: String,
+      mapId: Int,
+      taskAttemptId: String): ShuffleTask = {
+    val shuffleId = shuffleTaskInfo.getShuffleId(taskShuffleId)
+    val attemptId = shuffleTaskInfo.getAttemptId(taskShuffleId, mapId, taskAttemptId)
+    logInfo(
+      s"encode task from " + s"($taskShuffleId, $mapId, $taskAttemptId) to ($shuffleId, $mapId, " +
+        s"$attemptId)")
+    ShuffleTask(shuffleId, mapId, attemptId)
+  }
+
   override def receive: PartialFunction[Any, Unit] = {
     case RemoveExpiredShuffle =>
       removeExpiredShuffle()
@@ -292,10 +309,16 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         epoch,
         oldPartition)
 
-    case MapperEnd(applicationId, shuffleId, mapId, attemptId, numMappers) =>
-      logTrace(s"Received MapperEnd request, " +
-        s"${Utils.makeMapKey(applicationId, shuffleId, mapId, attemptId)}.")
-      handleMapperEnd(context, applicationId, shuffleId, mapId, attemptId, numMappers)
+    case MapperEnd(applicationId, shuffleId, mapId, attemptId, numMappers, partitionId) =>
+      logTrace(s"Received MapperEnd TaskEnd request, " +
+        s"${Utils.makeMapKey(applicationId, shuffleId, mapId, attemptId)}")
+      val partitionType = getPartitionType(shuffleId)
+      partitionType match {
+        case PartitionType.REDUCE =>
+          handleMapperEnd(context, applicationId, shuffleId, mapId, attemptId, numMappers)
+        case PartitionType.MAP =>
+          handleMapPartitionEnd(context, applicationId, shuffleId, mapId, attemptId, partitionId)
+      }
 
     case GetReducerFileGroup(applicationId: String, shuffleId: Int) =>
       logDebug(s"Received GetShuffleFileGroup request," +
@@ -465,8 +488,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
           }
         }
       }
-
-      reducerFileGroupsMap.put(shuffleId, new Array[Array[PartitionLocation]](numReducers))
+      reducerFileGroupsMap.put(shuffleId, new ConcurrentHashMap())
 
       // Fifth, reply the allocated partition location to ShuffleClient.
       logInfo(s"Handle RegisterShuffle Success for $shuffleId.")
@@ -533,13 +555,15 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       return
     }
 
-    // If shuffle registered and corresponding map finished, reply MapEnd and return.
-    if (shuffleMapperAttempts.containsKey(shuffleId)
-      && shuffleMapperAttempts.get(shuffleId)(mapId) != -1) {
-      logWarning(s"[handleRevive] Mapper ended, mapId $mapId, current attemptId $attemptId, " +
-        s"ended attemptId ${shuffleMapperAttempts.get(shuffleId)(mapId)}, shuffleId $shuffleId.")
-      context.reply(ChangeLocationResponse(StatusCode.MAP_ENDED, None))
-      return
+    // If shuffle registered and corresponding map finished, reply MapEnd and return. Only for reduce partition type
+    if (getPartitionType(shuffleId) == PartitionType.REDUCE) {
+      if (shuffleMapperAttempts.containsKey(shuffleId) && shuffleMapperAttempts.get(shuffleId)(
+          mapId) != -1) {
+        logWarning(s"[handleRevive] Mapper ended, mapId $mapId, current attemptId $attemptId, " +
+          s"ended attemptId ${shuffleMapperAttempts.get(shuffleId)(mapId)}, shuffleId $shuffleId.")
+        context.reply(ChangeLocationResponse(StatusCode.MAP_ENDED, None))
+        return
+      }
     }
 
     logWarning(s"Do Revive for shuffle ${Utils.makeShuffleKey(applicationId, shuffleId)}, " +
@@ -603,28 +627,39 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       shuffleId: Int): Unit = {
     var timeout = stageEndTimeout
     val delta = 100
-    while (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
-      Thread.sleep(delta)
-      if (timeout <= 0) {
-        logError(s"[handleGetReducerFileGroup] Wait for handleStageEnd Timeout! $shuffleId.")
-        context.reply(
-          GetReducerFileGroupResponse(StatusCode.STAGE_END_TIME_OUT, Array.empty, Array.empty))
-        return
+    // reduce partition need wait stage end. While map partition Would commit every partition synchronously.
+    if (getPartitionType(shuffleId) == PartitionType.REDUCE) {
+      while (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
+        Thread.sleep(delta)
+        if (timeout <= 0) {
+          logError(s"[handleGetReducerFileGroup] Wait for handleStageEnd Timeout! $shuffleId.")
+          context.reply(
+            GetReducerFileGroupResponse(
+              StatusCode.STAGE_END_TIME_OUT,
+              new ConcurrentHashMap(),
+              Array.empty))
+          return
+        }
+        timeout = timeout - delta
       }
-      timeout = timeout - delta
+      logDebug("[handleGetReducerFileGroup] Wait for handleStageEnd complete cost" +
+        s" ${stageEndTimeout - timeout}ms")
     }
-    logDebug("[handleGetReducerFileGroup] Wait for handleStageEnd complete cost" +
-      s" ${stageEndTimeout - timeout}ms")
 
     if (commitManager.dataLostShuffleSet.contains(shuffleId)) {
       context.reply(
-        GetReducerFileGroupResponse(StatusCode.SHUFFLE_DATA_LOST, Array.empty, Array.empty))
+        GetReducerFileGroupResponse(
+          StatusCode.SHUFFLE_DATA_LOST,
+          new ConcurrentHashMap(),
+          Array.empty))
     } else {
       if (context.isInstanceOf[LocalNettyRpcCallContext]) {
         // This branch is for the UTs
         context.reply(GetReducerFileGroupResponse(
           StatusCode.SUCCESS,
-          reducerFileGroupsMap.getOrDefault(shuffleId, Array.empty),
+          reducerFileGroupsMap.getOrDefault(
+            shuffleId,
+            new ConcurrentHashMap()),
           shuffleMapperAttempts.getOrDefault(shuffleId, Array.empty)))
       } else {
         val cachedMsg = getReducerFileGroupRpcCache.get(
@@ -633,7 +668,9 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
             override def call(): ByteBuffer = {
               val returnedMsg = GetReducerFileGroupResponse(
                 StatusCode.SUCCESS,
-                reducerFileGroupsMap.getOrDefault(shuffleId, Array.empty),
+                reducerFileGroupsMap.getOrDefault(
+                  shuffleId,
+                  new ConcurrentHashMap()),
                 shuffleMapperAttempts.getOrDefault(shuffleId, Array.empty))
               context.asInstanceOf[RemoteNettyRpcCallContext].nettyEnv.serialize(returnedMsg)
             }
@@ -666,24 +703,55 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       ReleaseSlots(applicationId, shuffleId, List.empty.asJava, List.empty.asJava))
   }
 
+  private def handleMapPartitionEnd(
+      context: RpcCallContext,
+      applicationId: String,
+      shuffleId: Int,
+      mapId: Int,
+      attemptId: Int,
+      partitionId: Int): Unit = {
+    def reply(result: Boolean): Unit = {
+      val message =
+        s"to handle MapPartitionEnd for ${Utils.makeMapKey(appId, shuffleId, mapId, attemptId)}, " +
+          s"$partitionId.";
+      result match {
+        case true => // if already committed by another try
+          logDebug(s"Succeed $message")
+          context.reply(MapperEndResponse(StatusCode.SUCCESS))
+        case false =>
+          logError(s"Failed $message")
+          context.reply(MapperEndResponse(StatusCode.SHUFFLE_DATA_LOST))
+      }
+    }
+
+    val dataCommitSuccess = commitManager.finalPartitionCommit(
+      applicationId,
+      shuffleId,
+      reducerFileGroupsMap.get(shuffleId),
+      partitionId)
+    reply(dataCommitSuccess)
+  }
+
   private def handleUnregisterShuffle(
       appId: String,
       shuffleId: Int): Unit = {
-    // if StageEnd has not been handled, trigger StageEnd
-    if (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
-      logInfo(s"Call StageEnd before Unregister Shuffle $shuffleId.")
-      handleStageEnd(appId, shuffleId)
-      var timeout = stageEndTimeout
-      val delta = 100
-      while (!commitManager.stageEndShuffleSet.contains(shuffleId) && timeout > 0) {
-        Thread.sleep(delta)
-        timeout = timeout - delta
-      }
-      if (timeout <= 0) {
-        logError(s"StageEnd Timeout! $shuffleId.")
-      } else {
-        logInfo("[handleUnregisterShuffle] Wait for handleStageEnd complete cost" +
-          s" ${stageEndTimeout - timeout}ms")
+    if (getPartitionType(shuffleId) == PartitionType.REDUCE) {
+      // if StageEnd has not been handled, trigger StageEnd
+      if (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
+        logInfo(s"Call StageEnd before Unregister Shuffle $shuffleId.")
+        handleStageEnd(appId, shuffleId)
+        var timeout = stageEndTimeout
+        val delta = 100
+        while (!commitManager.stageEndShuffleSet.contains(shuffleId) && timeout > 0) {
+          Thread.sleep(delta)
+          timeout = timeout - delta
+        }
+        if (timeout <= 0) {
+          logError(s"StageEnd Timeout! $shuffleId.")
+        } else {
+          logInfo("[handleUnregisterShuffle] Wait for handleStageEnd complete cost" +
+            s" ${stageEndTimeout - timeout}ms")
+        }
       }
     }
 
@@ -1065,7 +1133,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         latestPartitionLocation.remove(shuffleId)
         commitManager.removeExpiredShuffle(shuffleId)
         changePartitionManager.removeExpiredShuffle(shuffleId)
-
+        shuffleTaskInfo.remove(shuffleId)
         requestUnregisterShuffle(
           rssHARetryClient,
           UnregisterShuffle(appId, shuffleId, RssHARetryClient.genRequestId()))

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -63,19 +63,19 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   private val rpcCacheConcurrencyLevel = conf.rpcCacheConcurrencyLevel
   private val rpcCacheExpireTime = conf.rpcCacheExpireTime
 
-  private val registeredShuffle = ConcurrentHashMap.newKeySet[Int]()
+  val registeredShuffle = ConcurrentHashMap.newKeySet[Int]()
   private val shuffleMapperAttempts = new ConcurrentHashMap[Int, Array[Int]]()
   private val reducerFileGroupsMap =
     new ConcurrentHashMap[Int, Array[Array[PartitionLocation]]]()
   private val dataLostShuffleSet = ConcurrentHashMap.newKeySet[Int]()
-  private val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
+  val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   // maintain each shuffle's map relation of WorkerInfo and partition location
   private val shuffleAllocatedWorkers = {
     new ConcurrentHashMap[Int, ConcurrentHashMap[WorkerInfo, PartitionLocationInfo]]()
   }
   // shuffle id -> (partitionId -> newest PartitionLocation)
-  private val latestPartitionLocation =
+  val latestPartitionLocation =
     new ConcurrentHashMap[Int, ConcurrentHashMap[Int, PartitionLocation]]()
   private val userIdentifier: UserIdentifier = IdentityProvider.instantiate(conf).provide()
   // noinspection UnstableApiUsage
@@ -99,33 +99,18 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       }
     }
 
-  private def updateLatestPartitionLocations(
+  def updateLatestPartitionLocations(
       shuffleId: Int,
       locations: util.List[PartitionLocation]): Unit = {
     val map = latestPartitionLocation.computeIfAbsent(shuffleId, newMapFunc)
     locations.asScala.foreach(location => map.put(location.getId, location))
   }
 
-  case class ChangePartitionRequest(
-      context: RequestLocationCallContext,
-      applicationId: String,
-      shuffleId: Int,
-      partitionId: Int,
-      epoch: Int,
-      oldPartition: PartitionLocation,
-      causes: Option[StatusCode])
-
   case class RegisterCallContext(context: RpcCallContext, partitionId: Int = -1) {
     def reply(response: PbRegisterShuffleResponse) = {
       context.reply(response)
     }
   }
-
-  // shuffleId -> (partitionId -> set of ChangePartition)
-  private val changePartitionRequests =
-    new ConcurrentHashMap[Int, ConcurrentHashMap[Integer, util.Set[ChangePartitionRequest]]]()
-  // shuffleId -> set of partition id
-  private val inBatchPartitions = new ConcurrentHashMap[Int, util.Set[Integer]]()
 
   case class CommitPartitionRequest(
       applicationId: String,
@@ -147,33 +132,33 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
   // shuffle id -> ShuffleCommittedInfo
   private val committedPartitionInfo = new ConcurrentHashMap[Int, ShuffleCommittedInfo]()
+  def registerCommitPartition(
+      applicationId: String,
+      shuffleId: Int,
+      partition: PartitionLocation,
+      cause: Option[StatusCode]): Unit = {
+    // handle hard split
+    if (batchHandleCommitPartitionEnabled && cause.isDefined && cause.get == StatusCode.HARD_SPLIT) {
+      val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
+      shuffleCommittedInfo.synchronized {
+        shuffleCommittedInfo.commitPartitionRequests
+          .add(CommitPartitionRequest(applicationId, shuffleId, partition))
+      }
+    }
+  }
 
   // register shuffle request waiting for response
   private val registeringShuffleRequest =
     new ConcurrentHashMap[Int, util.Set[RegisterCallContext]]()
 
   // blacklist
-  private val blacklist = new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]()
+  val blacklist = new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]()
 
   // Threads
   private val forwardMessageThread =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("master-forward-message-thread")
   private var checkForShuffleRemoval: ScheduledFuture[_] = _
   private var getBlacklist: ScheduledFuture[_] = _
-
-  private val batchHandleChangePartitionEnabled = conf.batchHandleChangePartitionEnabled
-  private val batchHandleChangePartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(
-    "rss-lifecycle-manager-change-partition-executor",
-    conf.batchHandleChangePartitionNumThreads)
-  private val batchHandleChangePartitionRequestInterval =
-    conf.batchHandleChangePartitionRequestInterval
-  private val batchHandleChangePartitionSchedulerThread: Option[ScheduledExecutorService] =
-    if (batchHandleChangePartitionEnabled) {
-      Some(ThreadUtils.newDaemonSingleThreadScheduledExecutor(
-        "rss-lifecycle-manager-change-partition-scheduler"))
-    } else {
-      None
-    }
 
   private val batchHandleCommitPartitionEnabled = conf.batchHandleCommitPartitionEnabled
   private val batchHandleCommitPartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(
@@ -208,6 +193,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       conf,
       rssHARetryClient,
       () => (totalWritten.sumThenReset(), fileCount.sumThenReset()))
+  private val changePartitionManager = new ChangePartitionManager(conf, this)
 
   // Since method `onStart` is executed when `rpcEnv.setupEndpoint` is executed, and
   // `rssHARetryClient` is initialized after `rpcEnv` is initialized, if method `onStart` contains
@@ -217,46 +203,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   private def initialize(): Unit = {
     // noinspection ConvertExpressionToSAM
     heartbeater.start()
-    batchHandleChangePartitionSchedulerThread.foreach {
-      // noinspection ConvertExpressionToSAM
-      _.scheduleAtFixedRate(
-        new Runnable {
-          override def run(): Unit = {
-            try {
-              changePartitionRequests.asScala.foreach { case (shuffleId, requests) =>
-                requests.synchronized {
-                  batchHandleChangePartitionExecutors.submit {
-                    new Runnable {
-                      override def run(): Unit = {
-                        // For each partition only need handle one request
-                        val distinctPartitions = requests.asScala.filter { case (partitionId, _) =>
-                          !inBatchPartitions.get(shuffleId).contains(partitionId)
-                        }.map { case (partitionId, request) =>
-                          inBatchPartitions.get(shuffleId).add(partitionId)
-                          request.asScala.toArray.maxBy(_.epoch)
-                        }.toArray
-                        if (distinctPartitions.nonEmpty) {
-                          batchHandleRequestPartitions(
-                            distinctPartitions.head.applicationId,
-                            shuffleId,
-                            distinctPartitions)
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            } catch {
-              case e: InterruptedException =>
-                logError("Partition split scheduler thread is shutting down, detail: ", e)
-                throw e
-            }
-          }
-        },
-        0,
-        batchHandleChangePartitionRequestInterval,
-        TimeUnit.MILLISECONDS)
-    }
+    changePartitionManager.start()
 
     batchHandleCommitPartitionSchedulerThread.foreach {
       _.scheduleAtFixedRate(
@@ -399,6 +346,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     getBlacklist.cancel(true)
     ThreadUtils.shutdown(forwardMessageThread, 800.millis)
 
+    changePartitionManager.stop()
     heartbeater.stop()
 
     rssHARetryClient.close()
@@ -504,7 +452,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       val oldPartition = PbSerDeUtils.fromPbPartitionLocation(pb.getOldPartition)
       logTrace(s"Received split request, " +
         s"$applicationId, $shuffleId, $partitionId, $epoch, $oldPartition")
-      handleRequestPartitionLocation(
+      changePartitionManager.handleRequestPartitionLocation(
         ChangeLocationCallContext(context),
         applicationId,
         shuffleId,
@@ -720,7 +668,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       context.reply(RegisterShuffleResponse(StatusCode.SUCCESS, partitionLocations))
     } else {
       // request new resource for this task
-      handleRequestPartitionLocation(
+      changePartitionManager.handleRequestPartitionLocation(
         ApplyNewLocationCallContext(context),
         applicationId,
         shuffleId,
@@ -730,7 +678,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     }
   }
 
-  private def blacklistPartition(
+  def blacklistPartition(
       shuffleId: Int,
       oldPartition: PartitionLocation,
       cause: StatusCode): Unit = {
@@ -778,7 +726,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     logWarning(s"Do Revive for shuffle ${Utils.makeShuffleKey(applicationId, shuffleId)}, " +
       s"oldPartition: $oldPartition, cause: $cause")
 
-    handleRequestPartitionLocation(
+    changePartitionManager.handleRequestPartitionLocation(
       ChangeLocationCallContext(context),
       applicationId,
       shuffleId,
@@ -786,195 +734,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       oldEpoch,
       oldPartition,
       Some(cause))
-  }
-
-  private val rpcContextRegisterFunc =
-    new util.function.Function[
-      Int,
-      ConcurrentHashMap[Integer, util.Set[ChangePartitionRequest]]]() {
-      override def apply(s: Int): ConcurrentHashMap[Integer, util.Set[ChangePartitionRequest]] =
-        new ConcurrentHashMap()
-    }
-
-  private val inBatchShuffleIdRegisterFunc = new util.function.Function[Int, util.Set[Integer]]() {
-    override def apply(s: Int): util.Set[Integer] = new util.HashSet[Integer]()
-  }
-
-  private def handleRequestPartitionLocation(
-      context: RequestLocationCallContext,
-      applicationId: String,
-      shuffleId: Int,
-      partitionId: Int,
-      oldEpoch: Int,
-      oldPartition: PartitionLocation,
-      cause: Option[StatusCode] = None): Unit = {
-
-    val changePartition = ChangePartitionRequest(
-      context,
-      applicationId,
-      shuffleId,
-      partitionId,
-      oldEpoch,
-      oldPartition,
-      cause)
-    // check if there exists request for the partition, if do just register
-    val requests = changePartitionRequests.computeIfAbsent(shuffleId, rpcContextRegisterFunc)
-    inBatchPartitions.computeIfAbsent(shuffleId, inBatchShuffleIdRegisterFunc)
-
-    // handle hard split
-    if (batchHandleCommitPartitionEnabled && cause.isDefined && cause.get == StatusCode.HARD_SPLIT) {
-      val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
-      shuffleCommittedInfo.synchronized {
-        shuffleCommittedInfo.commitPartitionRequests
-          .add(CommitPartitionRequest(applicationId, shuffleId, oldPartition))
-      }
-    }
-
-    requests.synchronized {
-      if (requests.containsKey(partitionId)) {
-        requests.get(partitionId).add(changePartition)
-        logTrace(s"[handleRequestPartitionLocation] For $shuffleId, request for same partition" +
-          s"$partitionId-$oldEpoch exists, register context.")
-        return
-      } else {
-        // If new slot for the partition has been allocated, reply and return.
-        // Else register and allocate for it.
-        getLatestPartition(shuffleId, partitionId, oldEpoch).foreach { latestLoc =>
-          context.reply(StatusCode.SUCCESS, Some(latestLoc))
-          logDebug(s"New partition found, old partition $partitionId-$oldEpoch return it." +
-            s" shuffleId: $shuffleId $latestLoc")
-          return
-        }
-        val set = new util.HashSet[ChangePartitionRequest]()
-        set.add(changePartition)
-        requests.put(partitionId, set)
-      }
-    }
-    if (!batchHandleChangePartitionEnabled) {
-      batchHandleRequestPartitions(applicationId, shuffleId, Array(changePartition))
-    }
-  }
-
-  def batchHandleRequestPartitions(
-      applicationId: String,
-      shuffleId: Int,
-      changePartitions: Array[ChangePartitionRequest]): Unit = {
-    val requestsMap = changePartitionRequests.get(shuffleId)
-
-    val changes = changePartitions.map { change =>
-      s"${change.shuffleId}-${change.partitionId}-${change.epoch}"
-    }.mkString("[", ",", "]")
-    logWarning(s"Batch handle change partition for $applicationId of $changes")
-
-    // Blacklist all failed workers
-    if (changePartitions.exists(_.causes.isDefined)) {
-      changePartitions.filter(_.causes.isDefined).foreach { changePartition =>
-        blacklistPartition(shuffleId, changePartition.oldPartition, changePartition.causes.get)
-      }
-    }
-
-    // remove together to reduce lock time
-    def replySuccess(locations: Array[PartitionLocation]): Unit = {
-      requestsMap.synchronized {
-        locations.map { location =>
-          if (batchHandleChangePartitionEnabled) {
-            inBatchPartitions.get(shuffleId).remove(location.getId)
-          }
-          // Here one partition id can be remove more than once,
-          // so need to filter null result before reply.
-          location -> Option(requestsMap.remove(location.getId))
-        }
-      }.foreach { case (newLocation, requests) =>
-        requests.map(_.asScala.toList.foreach(_.context.reply(
-          StatusCode.SUCCESS,
-          Option(newLocation))))
-      }
-    }
-
-    // remove together to reduce lock time
-    def replyFailure(status: StatusCode): Unit = {
-      requestsMap.synchronized {
-        changePartitions.map { changePartition =>
-          if (batchHandleChangePartitionEnabled) {
-            inBatchPartitions.get(shuffleId).remove(changePartition.partitionId)
-          }
-          Option(requestsMap.remove(changePartition.partitionId))
-        }
-      }.foreach { requests =>
-        requests.map(_.asScala.toList.foreach(_.context.reply(status, None)))
-      }
-    }
-
-    val candidates = workersNotBlacklisted(shuffleId)
-    if (candidates.size < 1 || (pushReplicateEnabled && candidates.size < 2)) {
-      logError("[Update partition] failed for not enough candidates for revive.")
-      replyFailure(StatusCode.SLOT_NOT_AVAILABLE)
-      return
-    }
-
-    // PartitionSplit all contains oldPartition
-    val newlyAllocatedLocations =
-      reallocateChangePartitionRequestSlotsFromCandidates(changePartitions.toList, candidates)
-
-    if (!registeredShuffle.contains(shuffleId)) {
-      logError(s"[handleChangePartition] shuffle $shuffleId not registered!")
-      replyFailure(StatusCode.SHUFFLE_NOT_REGISTERED)
-      return
-    }
-
-    if (stageEndShuffleSet.contains(shuffleId)) {
-      logError(s"[handleChangePartition] shuffle $shuffleId already ended!")
-      replyFailure(StatusCode.STAGE_ENDED)
-      return
-    }
-
-    if (!reserveSlotsWithRetry(
-        applicationId,
-        shuffleId,
-        new util.HashSet(candidates.toSet.asJava),
-        newlyAllocatedLocations)) {
-      logError(s"[Update partition] failed for $shuffleId.")
-      replyFailure(StatusCode.RESERVE_SLOTS_FAILED)
-      return
-    }
-
-    val newMasterLocations =
-      newlyAllocatedLocations.asScala.flatMap {
-        case (workInfo, (masterLocations, slaveLocations)) =>
-          // Add all re-allocated slots to worker snapshots.
-          workerSnapshots(shuffleId).asScala.get(workInfo).foreach { partitionLocationInfo =>
-            partitionLocationInfo.addMasterPartitions(shuffleId.toString, masterLocations)
-            updateLatestPartitionLocations(shuffleId, masterLocations)
-            partitionLocationInfo.addSlavePartitions(shuffleId.toString, slaveLocations)
-          }
-          // partition location can be null when call reserveSlotsWithRetry().
-          val locations = (masterLocations.asScala ++ slaveLocations.asScala.map(_.getPeer))
-            .distinct.filter(_ != null)
-          if (locations.nonEmpty) {
-            val changes = locations.map { partition =>
-              s"(partition ${partition.getId} epoch from ${partition.getEpoch - 1} to ${partition.getEpoch})"
-            }.mkString("[", ", ", "]")
-            logDebug(s"[Update partition] success for " +
-              s"shuffle ${Utils.makeShuffleKey(applicationId, shuffleId)}, succeed partitions: " +
-              s"$changes.")
-          }
-          locations
-      }
-    replySuccess(newMasterLocations.toArray)
-  }
-
-  private def getLatestPartition(
-      shuffleId: Int,
-      partitionId: Int,
-      epoch: Int): Option[PartitionLocation] = {
-    val map = latestPartitionLocation.get(shuffleId)
-    if (map != null) {
-      val loc = map.get(partitionId)
-      if (loc != null && loc.getEpoch > epoch) {
-        return Some(loc)
-      }
-    }
-    None
   }
 
   private def handleMapperEnd(
@@ -1554,7 +1313,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
    * @param slots         the total allocated worker resources that need to be applied for the slot
    * @return If reserve all slots success
    */
-  private def reserveSlotsWithRetry(
+  def reserveSlotsWithRetry(
       applicationId: String,
       shuffleId: Int,
       candidates: util.HashSet[WorkerInfo],
@@ -1645,7 +1404,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
    * @param candidates WorkerInfo list can be used to offer worker slots
    * @param slots      Current WorkerResource
    */
-  private def allocateFromCandidates(
+  def allocateFromCandidates(
       id: Int,
       oldEpochId: Int,
       candidates: List[WorkerInfo],
@@ -1681,16 +1440,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
     val masterAndSlavePairs = slots.computeIfAbsent(candidates(masterIndex), newLocationFunc)
     masterAndSlavePairs._1.add(masterLocation)
-  }
-
-  private def reallocateChangePartitionRequestSlotsFromCandidates(
-      changePartitionRequests: List[ChangePartitionRequest],
-      candidates: List[WorkerInfo]): WorkerResource = {
-    val slots = new WorkerResource()
-    changePartitionRequests.foreach { partition =>
-      allocateFromCandidates(partition.partitionId, partition.epoch, candidates, slots)
-    }
-    slots
   }
 
   private def reallocateSlotsFromCandidates(
@@ -1750,12 +1499,11 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         dataLostShuffleSet.remove(shuffleId)
         shuffleMapperAttempts.remove(shuffleId)
         stageEndShuffleSet.remove(shuffleId)
-        changePartitionRequests.remove(shuffleId)
-        inBatchPartitions.remove(shuffleId)
         committedPartitionInfo.remove(shuffleId)
         unregisterShuffleTime.remove(shuffleId)
         shuffleAllocatedWorkers.remove(shuffleId)
         latestPartitionLocation.remove(shuffleId)
+        changePartitionManager.removeExpiredShuffle(shuffleId)
 
         requestUnregisterShuffle(
           rssHARetryClient,
@@ -1920,8 +1668,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     }
   }
 
-  private def recordWorkerFailure(failures: ConcurrentHashMap[WorkerInfo, (StatusCode, Long)])
-      : Unit = {
+  def recordWorkerFailure(failures: ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]): Unit = {
     val failedWorker = new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)](failures)
     logInfo(s"Report Worker Failure: ${failedWorker.asScala}, current blacklist $blacklist")
     failedWorker.asScala.foreach { case (worker, (statusCode, registerTime)) =>
@@ -1959,14 +1706,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     } else {
       workers.values().asScala.exists(_.containsShuffle(shuffleId.toString))
     }
-  }
-
-  private def workersNotBlacklisted(shuffleId: Int): List[WorkerInfo] = {
-    workerSnapshots(shuffleId)
-      .keySet()
-      .asScala
-      .filter(w => !blacklist.keySet().contains(w))
-      .toList
   }
 
   // Initialize at the end of LifecycleManager construction.

--- a/client/src/main/scala/org/apache/celeborn/client/ShuffleTaskInfo.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ShuffleTaskInfo.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function
+import javax.annotation.concurrent.ThreadSafe
+
+@ThreadSafe
+class ShuffleTaskInfo {
+
+  private var currentShuffleIndex: Int = 0
+  // task shuffle id -> mapId_taskAttemptId -> attemptIdx
+  private val taskShuffleAttemptIdToAttemptId =
+    new ConcurrentHashMap[String, ConcurrentHashMap[String, Int]]
+  // map attemptId index
+  private val taskShuffleAttemptIdIndex =
+    new ConcurrentHashMap[String, ConcurrentHashMap[Int, Int]]
+  // task shuffle id -> celeborn shuffle id
+  private val taskShuffleIdToShuffleId = new ConcurrentHashMap[String, Int]
+  // celeborn shuffle id -> task shuffle id
+  private val shuffleIdToTaskShuffleId = new ConcurrentHashMap[Int, String]
+
+  val newMapFunc: function.Function[String, ConcurrentHashMap[Int, Int]] =
+    new function.Function[String, ConcurrentHashMap[Int, Int]]() {
+      override def apply(s: String): ConcurrentHashMap[Int, Int] = {
+        new ConcurrentHashMap[Int, Int]()
+      }
+    }
+
+  val newMapFunc2: function.Function[String, ConcurrentHashMap[String, Int]] =
+    new function.Function[String, ConcurrentHashMap[String, Int]]() {
+      override def apply(s: String): ConcurrentHashMap[String, Int] = {
+        new ConcurrentHashMap[String, Int]()
+      }
+    }
+
+  def getShuffleId(taskShuffleId: String): Int = {
+    taskShuffleIdToShuffleId.synchronized {
+      if (taskShuffleIdToShuffleId.containsKey(taskShuffleId)) {
+        taskShuffleIdToShuffleId.get(taskShuffleId)
+      } else {
+        taskShuffleIdToShuffleId.put(taskShuffleId, currentShuffleIndex)
+        shuffleIdToTaskShuffleId.put(currentShuffleIndex, taskShuffleId)
+        val tempShuffleIndex = currentShuffleIndex
+        currentShuffleIndex = currentShuffleIndex + 1
+        tempShuffleIndex
+      }
+    }
+  }
+
+  def getAttemptId(taskShuffleId: String, mapId: Int, attemptId: String): Int = {
+    val attemptIndex = taskShuffleAttemptIdIndex.computeIfAbsent(taskShuffleId, newMapFunc)
+    val attemptIdMap =
+      taskShuffleAttemptIdToAttemptId.computeIfAbsent(taskShuffleId, newMapFunc2)
+    val mapAttemptId = mapId + "_" + attemptId
+    attemptIndex.synchronized {
+      if (!attemptIdMap.containsKey(mapAttemptId)) {
+        if (attemptIndex.containsKey(mapId)) {
+          val index = attemptIndex.get(mapId)
+          attemptIdMap.put(mapAttemptId, index + 1)
+          attemptIndex.put(mapId, index + 1)
+        } else {
+          attemptIdMap.put(mapAttemptId, 0)
+          attemptIndex.put(mapId, 0)
+        }
+      }
+    }
+
+    attemptIdMap.get(mapAttemptId)
+  }
+
+  def remove(shuffleId: Int): Unit = {
+    val taskShuffleId = shuffleIdToTaskShuffleId.remove(shuffleId)
+    taskShuffleIdToShuffleId.remove(taskShuffleId)
+    taskShuffleAttemptIdIndex.remove(shuffleId)
+    taskShuffleAttemptIdToAttemptId.remove(taskShuffleId)
+  }
+}

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -23,6 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BooleanSupplier;
 
 import io.netty.buffer.ByteBuf;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.client.read.RssInputStream;
+import org.apache.celeborn.client.write.PushState;
 import org.apache.celeborn.common.protocol.PartitionLocation;
 import org.apache.celeborn.common.rpc.RpcEndpointRef;
 
@@ -182,6 +184,17 @@ public class DummyShuffleClient extends ShuffleClient {
   @Override
   public PartitionLocation registerMapPartitionTask(
       String appId, int shuffleId, int numMappers, int mapId, int attemptId) {
+    return null;
+  }
+
+  @Override
+  public ConcurrentHashMap<Integer, PartitionLocation> getOrRegisterShuffle(
+      String applicationId, int shuffleId, int numMappers, int numPartitions) {
+    return null;
+  }
+
+  @Override
+  public PushState getOrRegisterPushState(String mapKey) {
     return null;
   }
 }

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -23,7 +23,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 
+import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,6 +94,16 @@ public class DummyShuffleClient extends ShuffleClient {
       String applicationId, int shuffleId, int mapId, int attemptId, int numMappers) {}
 
   @Override
+  public void mapPartitionMapperEnd(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int numMappers,
+      int partitionId)
+      throws IOException {}
+
+  @Override
   public void cleanup(String applicationId, int shuffleId, int mapId, int attemptId) {}
 
   @Override
@@ -126,6 +138,19 @@ public class DummyShuffleClient extends ShuffleClient {
   }
 
   @Override
+  public int pushDataToLocation(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int partitionId,
+      ByteBuf data,
+      PartitionLocation location,
+      BooleanSupplier closeCallBack) {
+    return 0;
+  }
+
+  @Override
   public Optional<PartitionLocation> regionStart(
       String applicationId,
       int shuffleId,
@@ -153,4 +178,10 @@ public class DummyShuffleClient extends ShuffleClient {
       int bufferSize,
       PartitionLocation location)
       throws IOException {}
+
+  @Override
+  public PartitionLocation registerMapPartitionTask(
+      String appId, int shuffleId, int numMappers, int mapId, int attemptId) {
+    return null;
+  }
 }

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import scala.reflect.ClassTag$;
+
+import io.netty.channel.ChannelFuture;
+
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
+import org.apache.celeborn.common.network.client.TransportClient;
+import org.apache.celeborn.common.network.client.TransportClientFactory;
+import org.apache.celeborn.common.protocol.CompressionCodec;
+import org.apache.celeborn.common.protocol.PartitionLocation;
+import org.apache.celeborn.common.protocol.PbRegisterShuffleResponse;
+import org.apache.celeborn.common.protocol.message.ControlMessages;
+import org.apache.celeborn.common.protocol.message.StatusCode;
+import org.apache.celeborn.common.rpc.RpcEndpointRef;
+
+public abstract class ShuffleClientBaseSuiteJ {
+  protected ShuffleClientImpl shuffleClient = null;
+  protected static final RpcEndpointRef endpointRef = mock(RpcEndpointRef.class);
+  protected static final TransportClientFactory clientFactory = mock(TransportClientFactory.class);
+  protected final TransportClient client = mock(TransportClient.class);
+
+  protected static final String TEST_APPLICATION_ID = "testapp1";
+  protected static final int TEST_SHUFFLE_ID = 1;
+  protected static final int TEST_ATTEMPT_ID = 0;
+  protected static final int TEST_REDUCRE_ID = 0;
+
+  protected static final int MASTER_RPC_PORT = 1234;
+  protected static final int MASTER_PUSH_PORT = 1235;
+  protected static final int MASTER_FETCH_PORT = 1236;
+  protected static final int MASTER_REPLICATE_PORT = 1237;
+  protected static final int SLAVE_RPC_PORT = 4321;
+  protected static final int SLAVE_PUSH_PORT = 4322;
+  protected static final int SLAVE_FETCH_PORT = 4323;
+  protected static final int SLAVE_REPLICATE_PORT = 4324;
+  protected static final PartitionLocation masterLocation =
+      new PartitionLocation(
+          0,
+          1,
+          "localhost",
+          MASTER_RPC_PORT,
+          MASTER_PUSH_PORT,
+          MASTER_FETCH_PORT,
+          MASTER_REPLICATE_PORT,
+          PartitionLocation.Mode.MASTER);
+  protected static final PartitionLocation slaveLocation =
+      new PartitionLocation(
+          0,
+          1,
+          "localhost",
+          SLAVE_RPC_PORT,
+          SLAVE_PUSH_PORT,
+          SLAVE_FETCH_PORT,
+          SLAVE_REPLICATE_PORT,
+          PartitionLocation.Mode.SLAVE);
+
+  protected final int BATCH_HEADER_SIZE = 4 * 4;
+  protected ChannelFuture mockedFuture = mock(ChannelFuture.class);
+
+  protected CelebornConf setupEnv(CompressionCodec codec) throws IOException, InterruptedException {
+    CelebornConf conf = new CelebornConf();
+    conf.set("celeborn.shuffle.compression.codec", codec.name());
+    conf.set("celeborn.push.retry.threads", "1");
+    conf.set("celeborn.push.buffer.size", "1K");
+    shuffleClient = new ShuffleClientImpl(conf, new UserIdentifier("mock", "mock"));
+    masterLocation.setPeer(slaveLocation);
+
+    when(endpointRef.askSync(
+            ControlMessages.RegisterShuffle$.MODULE$.apply(
+                TEST_APPLICATION_ID, TEST_SHUFFLE_ID, 1, 1),
+            ClassTag$.MODULE$.apply(PbRegisterShuffleResponse.class)))
+        .thenAnswer(
+            t ->
+                ControlMessages.RegisterShuffleResponse$.MODULE$.apply(
+                    StatusCode.SUCCESS, new PartitionLocation[] {masterLocation}));
+
+    shuffleClient.setupMetaServiceRef(endpointRef);
+    when(clientFactory.createClient(
+            masterLocation.getHost(), masterLocation.getPushPort(), TEST_REDUCRE_ID))
+        .thenAnswer(t -> client);
+
+    shuffleClient.dataClientFactory = clientFactory;
+    return conf;
+  }
+}

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.network.client.RpcResponseCallback;
+import org.apache.celeborn.common.protocol.CompressionCodec;
+import org.apache.celeborn.common.protocol.message.StatusCode;
+
+public class ShuffleClientImplSuiteJ extends ShuffleClientBaseSuiteJ {
+  static int BufferSize = 64;
+  static byte[] TEST_BUF1 = new byte[BufferSize];
+  static CelebornConf conf;
+
+  @Before
+  public void setup() throws IOException, InterruptedException {
+    conf = setupEnv(CompressionCodec.LZ4);
+  }
+
+  public ByteBuf createByteBuf() {
+    for (int i = BATCH_HEADER_SIZE; i < BufferSize; i++) {
+      TEST_BUF1[i] = 1;
+    }
+    ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
+    byteBuf.writerIndex(BufferSize);
+    return byteBuf;
+  }
+
+  @Test
+  public void testPushDataByteBufSuccess() throws IOException {
+    ByteBuf byteBuf = createByteBuf();
+    when(client.pushData(any(), any()))
+        .thenAnswer(
+            t -> {
+              RpcResponseCallback rpcResponseCallback =
+                  t.getArgumentAt(1, RpcResponseCallback.class);
+              ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[0]);
+              rpcResponseCallback.onSuccess(byteBuffer);
+              return mockedFuture;
+            });
+
+    int pushDataLen =
+        shuffleClient.pushDataToLocation(
+            TEST_APPLICATION_ID,
+            TEST_SHUFFLE_ID,
+            TEST_ATTEMPT_ID,
+            TEST_ATTEMPT_ID,
+            TEST_REDUCRE_ID,
+            byteBuf,
+            masterLocation,
+            () -> true);
+    Assert.assertEquals(BufferSize, pushDataLen);
+  }
+
+  @Test
+  public void testPushDataByteBufHardSplit() throws IOException {
+    ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
+    when(client.pushData(any(), any()))
+        .thenAnswer(
+            t -> {
+              RpcResponseCallback rpcResponseCallback =
+                  t.getArgumentAt(1, RpcResponseCallback.class);
+              ByteBuffer byteBuffer =
+                  ByteBuffer.wrap(new byte[] {StatusCode.HARD_SPLIT.getValue()});
+              rpcResponseCallback.onSuccess(byteBuffer);
+              return mockedFuture;
+            });
+    int pushDataLen =
+        shuffleClient.pushDataToLocation(
+            TEST_APPLICATION_ID,
+            TEST_SHUFFLE_ID,
+            TEST_ATTEMPT_ID,
+            TEST_ATTEMPT_ID,
+            TEST_REDUCRE_ID,
+            byteBuf,
+            masterLocation,
+            () -> true);
+  }
+
+  @Test
+  public void testPushDataByteBufFail() throws IOException {
+    ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
+    when(client.pushData(any(), any()))
+        .thenAnswer(
+            t -> {
+              RpcResponseCallback rpcResponseCallback =
+                  t.getArgumentAt(1, RpcResponseCallback.class);
+              rpcResponseCallback.onFailure(new Exception("pushDataFailed"));
+              return mockedFuture;
+            });
+    // first push just  set pushdata.exception
+    shuffleClient.pushDataToLocation(
+        TEST_APPLICATION_ID,
+        TEST_SHUFFLE_ID,
+        TEST_ATTEMPT_ID,
+        TEST_ATTEMPT_ID,
+        TEST_REDUCRE_ID,
+        byteBuf,
+        masterLocation,
+        () -> true);
+
+    boolean isFailed = false;
+    // second push will throw exception
+    try {
+      shuffleClient.pushDataToLocation(
+          TEST_APPLICATION_ID,
+          TEST_SHUFFLE_ID,
+          TEST_ATTEMPT_ID,
+          TEST_ATTEMPT_ID,
+          TEST_REDUCRE_ID,
+          byteBuf,
+          masterLocation,
+          () -> true);
+    } catch (IOException e) {
+      isFailed = true;
+    } finally {
+      Assert.assertTrue("should failed", isFailed);
+    }
+  }
+}

--- a/client/src/test/scala/org/apache/celeborn/client/ShuffleTaskInfoSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/ShuffleTaskInfoSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class ShuffleTaskInfoSuite extends AnyFunSuite {
+
+  test("encode shuffle id & map attemptId") {
+    val shuffleTaskInfo = new ShuffleTaskInfo
+    val encodeShuffleId = shuffleTaskInfo.getShuffleId("shuffleId")
+    assert(encodeShuffleId == 0)
+
+    // another shuffle
+    val encodeShuffleId1 = shuffleTaskInfo.getShuffleId("shuffleId1")
+    assert(encodeShuffleId1 == 1)
+
+    val encodeShuffleId0 = shuffleTaskInfo.getShuffleId("shuffleId")
+    assert(encodeShuffleId0 == 0)
+
+    val encodeAttemptId011 = shuffleTaskInfo.getAttemptId("shuffleId", 1, "attempt1")
+    val encodeAttemptId112 = shuffleTaskInfo.getAttemptId("shuffleId1", 1, "attempt2")
+    val encodeAttemptId021 = shuffleTaskInfo.getAttemptId("shuffleId", 2, "attempt1")
+    val encodeAttemptId012 = shuffleTaskInfo.getAttemptId("shuffleId", 1, "attempt2")
+    assert(encodeAttemptId011 == 0)
+    assert(encodeAttemptId112 == 0)
+    assert(encodeAttemptId021 == 0)
+    assert(encodeAttemptId012 == 1)
+
+    // remove shuffleId and reEncode
+    shuffleTaskInfo.remove(encodeShuffleId)
+    val encodeShuffleIdNew = shuffleTaskInfo.getShuffleId("shuffleId")
+    assert(encodeShuffleIdNew == 2)
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/meta/DiskStatus.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/DiskStatus.java
@@ -21,7 +21,8 @@ public enum DiskStatus {
   HEALTHY(0),
   READ_OR_WRITE_FAILURE(1),
   IO_HANG(2),
-  HIGH_DISK_USAGE(3);
+  HIGH_DISK_USAGE(3),
+  CRITICAL_ERROR(4);
 
   private final byte value;
 

--- a/common/src/main/java/org/apache/celeborn/common/network/server/ChannelsLimiter.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/ChannelsLimiter.java
@@ -29,9 +29,11 @@ import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.celeborn.common.network.server.memory.MemoryManager;
+
 @ChannelHandler.Sharable
 public class ChannelsLimiter extends ChannelDuplexHandler
-    implements MemoryTracker.MemoryTrackerListener {
+    implements MemoryManager.MemoryPressureListener {
 
   private static final Logger logger = LoggerFactory.getLogger(ChannelsLimiter.class);
   private final Set<Channel> channels = ConcurrentHashMap.newKeySet();
@@ -40,8 +42,8 @@ public class ChannelsLimiter extends ChannelDuplexHandler
 
   public ChannelsLimiter(String moduleName) {
     this.moduleName = moduleName;
-    MemoryTracker memoryTracker = MemoryTracker.instance();
-    memoryTracker.registerMemoryListener(this);
+    MemoryManager memoryManager = MemoryManager.instance();
+    memoryManager.registerMemoryListener(this);
   }
 
   private void pauseAllChannels() {

--- a/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferDispatcher.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferDispatcher.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.server.memory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.network.util.NettyUtils;
+
+public class ReadBufferDispatcher extends Thread {
+  private Logger logger = LoggerFactory.getLogger(ReadBufferDispatcher.class);
+  private final LinkedBlockingQueue<ReadBufferRequest> requests = new LinkedBlockingQueue<>();
+  private final MemoryManager memoryManager;
+  private final PooledByteBufAllocator readBufferAllocator;
+
+  public ReadBufferDispatcher(MemoryManager memoryManager) {
+    readBufferAllocator = NettyUtils.createPooledByteBufAllocator(true, true, 1);
+    this.memoryManager = memoryManager;
+    this.setName("Read-Buffer-Dispatcher");
+    this.start();
+  }
+
+  public void addBufferRequest(ReadBufferRequest request) {
+    requests.add(request);
+  }
+
+  public void recycle(ByteBuf buf) {
+    buf.release();
+    int bufferSize = buf.capacity();
+    memoryManager.changeReadBufferCounter(-1 * bufferSize);
+  }
+
+  @Override
+  public void run() {
+    while (true) {
+      ReadBufferRequest request = null;
+      try {
+        request = requests.poll(500, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException e) {
+        logger.info("Buffer dispatcher is closing");
+      }
+      if (request != null) {
+        List<ByteBuf> buffers = new ArrayList<>();
+        int bufferSize = request.getBufferSize();
+        while (buffers.size() < request.getMin()) {
+          if (memoryManager.readBufferAvailable(bufferSize)) {
+            memoryManager.incrementDiskBuffer(bufferSize);
+            buffers.add(readBufferAllocator.buffer(bufferSize, bufferSize));
+          } else {
+            try {
+              Thread.sleep(3);
+            } catch (InterruptedException e) {
+              logger.info("Buffer dispatcher is closing");
+              request.getBufferListener().notifyBuffers(null, e);
+              return;
+            }
+          }
+        }
+        while (memoryManager.readBufferAvailable(request.getBufferSize())
+            && buffers.size() < request.getMax()) {
+          memoryManager.changeReadBufferCounter(bufferSize);
+          buffers.add(readBufferAllocator.buffer(bufferSize, bufferSize));
+        }
+        request.getBufferListener().notifyBuffers(buffers, null);
+      } else {
+        // Free buffer pool memory to main direct memory when dispatcher is idle.
+        readBufferAllocator.trimCurrentThreadCache();
+      }
+    }
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferListener.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferListener.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 The Flink Remote Shuffle Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.server.memory;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+
+// Do not execute blocking task here.
+public interface ReadBufferListener {
+  void notifyBuffers(List<ByteBuf> allocatedBuffers, Throwable throwable);
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.server.memory;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class ReadBufferRequest {
+  private final int min;
+  private final int max;
+  private final int bufferSize;
+  private final ReadBufferListener readBufferListener;
+
+  ReadBufferRequest(int min, int max, int bufferSize, ReadBufferListener readBufferListener) {
+    checkArgument(
+        min > 0 && max > 0 && max >= min, String.format("Invalid min=%d, max=%d.", min, max));
+    this.min = min;
+    this.max = max;
+    this.bufferSize = bufferSize;
+    this.readBufferListener = readBufferListener;
+  }
+
+  public int getMin() {
+    return min;
+  }
+
+  public int getMax() {
+    return max;
+  }
+
+  public int getBufferSize() {
+    return bufferSize;
+  }
+
+  public ReadBufferListener getBufferListener() {
+    return readBufferListener;
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
@@ -59,7 +59,14 @@ public enum StatusCode {
 
   // Rate limit statuses
   PUSH_DATA_SUCCESS_MASTER_CONGESTED(30),
-  PUSH_DATA_SUCCESS_SLAVE_CONGESTED(31);
+  PUSH_DATA_SUCCESS_SLAVE_CONGESTED(31),
+
+  PUSH_DATA_HANDSHAKE_FAIL_SLAVE(32),
+  PUSH_DATA_HANDSHAKE_FAIL_MASTER(33),
+  REGION_START_FAIL_SLAVE(34),
+  REGION_START_FAIL_MASTER(35),
+  REGION_FINISH_FAIL_SLAVE(36),
+  REGION_FINISH_FAIL_MASTER(37);
 
   private final byte value;
 
@@ -84,7 +91,20 @@ public enum StatusCode {
       msg = "PushDataFailPartitionNotFound";
     } else if (value == HARD_SPLIT.getValue()) {
       msg = "PartitionFileSplit";
+    } else if (value == PUSH_DATA_HANDSHAKE_FAIL_MASTER.getValue()) {
+      msg = "PushDataHandShakeFailMaster";
+    } else if (value == PUSH_DATA_HANDSHAKE_FAIL_SLAVE.getValue()) {
+      msg = "PushDataHandShakeFailSlave";
+    } else if (value == REGION_START_FAIL_MASTER.getValue()) {
+      msg = "RegionStartFailMaster";
+    } else if (value == REGION_START_FAIL_SLAVE.getValue()) {
+      msg = "RegionStartFailSlave";
+    } else if (value == REGION_FINISH_FAIL_MASTER.getValue()) {
+      msg = "RegionFinishFailMaster";
+    } else if (value == REGION_FINISH_FAIL_SLAVE.getValue()) {
+      msg = "RegionFinishFailSlave";
     }
+
     return msg;
   }
 

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -232,6 +232,7 @@ message PbMapperEnd {
   int32 mapId = 3;
   int32 attemptId = 4;
   int32 numMappers = 5;
+  int32 partitionId = 6;
 }
 
 message PbMapperEndResponse {
@@ -245,7 +246,10 @@ message PbGetReducerFileGroup {
 
 message PbGetReducerFileGroupResponse {
   int32 status = 1;
-  repeated PbFileGroup fileGroup = 2;
+  // PartitionId -> Partition FileGroup
+  map<int32, PbFileGroup> fileGroups = 2;
+
+  // only reduce partition mode need know valid attempts
   repeated int32 attempts = 3;
 }
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -724,7 +724,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerStorageBaseDirNumber: Int = get(WORKER_STORAGE_BASE_DIR_COUNT)
 
   // //////////////////////////////////////////////////////
-  //                  Memory Tracker                    //
+  //                  Memory Manager                    //
   // //////////////////////////////////////////////////////
   def workerDirectMemoryRatioToPauseReceive: Double = get(WORKER_DIRECT_MEMORY_RATIO_PAUSE_RECEIVE)
   def workerDirectMemoryRatioToPauseReplicate: Double =
@@ -734,6 +734,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(PARTITION_SORTER_DIRECT_MEMORY_RATIO_THRESHOLD)
   def workerDirectMemoryPressureCheckIntervalMs: Long = get(WORKER_DIRECT_MEMORY_CHECK_INTERVAL)
   def workerDirectMemoryReportIntervalSecond: Long = get(WORKER_DIRECT_MEMORY_REPORT_INTERVAL)
+  def workerDirectMemoryRatioForReadBuffer: Double = get(WORKER_DIRECT_MEMORY_RATIO_FOR_READ_BUFFER)
+  def workerDirectMemoryRatioForShuffleStorage: Double =
+    get(WORKER_DIRECT_MEMORY_RATIO_FOR_SHUFFLE_STORAGE)
 
   /**
    * @return workingDir, usable space, flusher thread count, disk type
@@ -2480,6 +2483,24 @@ object CelebornConf extends Logging {
       .version("0.2.0")
       .doubleConf
       .checkValue(v => v >= 0.0 && v <= 1.0, "should be in [0.0, 1.0].")
+      .createWithDefault(0.1)
+
+  val WORKER_DIRECT_MEMORY_RATIO_FOR_READ_BUFFER: ConfigEntry[Double] =
+    buildConf("celeborn.worker.directMemoryRatioForReadBuffer")
+      .categories("worker")
+      .doc("Max ratio of direct memory for read buffer")
+      .version("0.2.0")
+      .doubleConf
+      .checkValue(v => v >= 0.0 && v <= 0.4, "should be in [0.0, 0.4].")
+      .createWithDefault(0.1)
+
+  val WORKER_DIRECT_MEMORY_RATIO_FOR_SHUFFLE_STORAGE: ConfigEntry[Double] =
+    buildConf("celeborn.worker.directMemoryRatioForMemoryShuffleStorage")
+      .categories("worker")
+      .doc("Max ratio of direct memory to store shuffle data")
+      .version("0.2.0")
+      .doubleConf
+      .checkValue(v => v >= 0.0 && v <= 0.4, "should be in [0.0, 0.4].")
       .createWithDefault(0.1)
 
   val WORKER_DIRECT_MEMORY_RATIO_PAUSE_RECEIVE: ConfigEntry[Double] =

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -384,6 +384,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     new RpcTimeout(
       get(REGISTER_SHUFFLE_RPC_ASK_TIMEOUT).milli,
       REGISTER_SHUFFLE_RPC_ASK_TIMEOUT.key)
+  def requestPartitionLocationRpcAskTimeout: RpcTimeout =
+    new RpcTimeout(
+      get(REQUEST_PARTITION_LOCATION_RPC_ASK_TIMEOUT).milli,
+      REQUEST_PARTITION_LOCATION_RPC_ASK_TIMEOUT.key)
   def getReducerFileGroupRpcAskTimeout: RpcTimeout =
     new RpcTimeout(
       get(GET_REDUCER_FILE_GROUP_RPC_ASK_TIMEOUT).milli,
@@ -1033,6 +1037,14 @@ object CelebornConf extends Logging {
       .categories("network")
       .version("0.2.0")
       .doc("Timeout for ask operations during register shuffle.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("600s")
+
+  val REQUEST_PARTITION_LOCATION_RPC_ASK_TIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.rpc.requestPartition.askTimeout")
+      .categories("network")
+      .version("0.2.0")
+      .doc("Timeout for ask operations during request change partition location, such as revive or split partition.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("600s")
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1257,7 +1257,7 @@ object CelebornConf extends Logging {
       .withAlternative("rss.push.data.maxReqsInFlight")
       .categories("client")
       .version("0.2.0")
-      .doc("Amount of Netty in-flight requests. The maximum memory is " +
+      .doc("Amount of Netty in-flight requests per worker. The maximum memory is " +
         "`celeborn.push.maxReqsInFlight` * `celeborn.push.buffer.max.size` * " +
         "compression ratio(1 in worst case), default: 64Kib * 32 = 2Mib")
       .intConf

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -384,6 +384,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     new RpcTimeout(
       get(REGISTER_SHUFFLE_RPC_ASK_TIMEOUT).milli,
       REGISTER_SHUFFLE_RPC_ASK_TIMEOUT.key)
+  def getReducerFileGroupRpcAskTimeout: RpcTimeout =
+    new RpcTimeout(
+      get(GET_REDUCER_FILE_GROUP_RPC_ASK_TIMEOUT).milli,
+      GET_REDUCER_FILE_GROUP_RPC_ASK_TIMEOUT.key)
 
   def networkIoMode(module: String): String = {
     val key = NETWORK_IO_MODE.key.replace("<module>", module)
@@ -1029,6 +1033,14 @@ object CelebornConf extends Logging {
       .categories("network")
       .version("0.2.0")
       .doc("Timeout for ask operations during register shuffle.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("600s")
+
+  val GET_REDUCER_FILE_GROUP_RPC_ASK_TIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.rpc.getReducerFileGroup.askTimeout")
+      .categories("network")
+      .version("0.2.0")
+      .doc("Timeout for ask operations during get reducer file group.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("600s")
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/FunctionConverter.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/FunctionConverter.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.util
+
+/**
+ * Implicit conversion for scala(2.11) function to java function
+ */
+object FunctionConverter {
+
+  implicit def scalaFunctionToJava[From, To](function: (From) => To)
+      : java.util.function.Function[From, To] = {
+    new java.util.function.Function[From, To] {
+      override def apply(input: From): To = function(input)
+    }
+  }
+
+}

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
 import java.util
-import java.util.{Locale, Objects, Properties, Random, UUID}
+import java.util.{Locale, Properties, Random, UUID}
 import java.util.concurrent.{Callable, ConcurrentHashMap, ThreadPoolExecutor, TimeoutException, TimeUnit}
 
 import scala.collection.JavaConverters._
@@ -980,13 +980,4 @@ object Utils extends Logging {
     }
   }
 
-  def genAddressPair(loc: PartitionLocation): String = {
-    if (Objects.isNull(loc)) {
-      return null
-    }
-    if (loc.getPeer != null)
-      loc.hostAndPushPort + "-" + loc.getPeer.hostAndPushPort
-    else
-      loc.hostAndPushPort
-  }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.common.util
 
-import java.io.{File, FileInputStream, IOException, InputStreamReader}
+import java.io.{File, FileInputStream, InputStreamReader, IOException}
 import java.lang.management.ManagementFactory
 import java.math.{MathContext, RoundingMode}
 import java.net._
@@ -26,24 +26,26 @@ import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
 import java.util
 import java.util.{Locale, Objects, Properties, Random, UUID}
-import java.util.concurrent.{Callable, ConcurrentHashMap, ThreadPoolExecutor, TimeUnit, TimeoutException}
+import java.util.concurrent.{Callable, ConcurrentHashMap, ThreadPoolExecutor, TimeoutException, TimeUnit}
+
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 import scala.util.Try
 import scala.util.control.{ControlThrowable, NonFatal}
+
 import com.google.common.net.InetAddresses
 import com.google.protobuf.{ByteString, GeneratedMessageV3}
 import io.netty.channel.unix.Errors.NativeIoException
 import org.apache.commons.lang3.SystemUtils
 import org.roaringbitmap.RoaringBitmap
+
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskStatus, WorkerInfo}
 import org.apache.celeborn.common.network.protocol.TransportMessage
-import org.apache.celeborn.common.network.util.{ConfigProvider, JavaUtils, TransportConf}
+import org.apache.celeborn.common.network.util.{JavaUtils, TransportConf}
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType}
-import org.apache.celeborn.common.protocol.PbWorkerResource
 import org.apache.celeborn.common.protocol.message.{ControlMessages, Message, StatusCode}
 import org.apache.celeborn.common.protocol.message.ControlMessages.WorkerResource
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.common.util
 
-import java.io.{File, FileInputStream, InputStreamReader, IOException}
+import java.io.{File, FileInputStream, IOException, InputStreamReader}
 import java.lang.management.ManagementFactory
 import java.math.{MathContext, RoundingMode}
 import java.net._
@@ -25,20 +25,17 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
 import java.util
-import java.util.{Locale, Properties, Random, UUID}
-import java.util.concurrent.{Callable, ConcurrentHashMap, ThreadPoolExecutor, TimeoutException, TimeUnit}
-
+import java.util.{Locale, Objects, Properties, Random, UUID}
+import java.util.concurrent.{Callable, ConcurrentHashMap, ThreadPoolExecutor, TimeUnit, TimeoutException}
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 import scala.util.Try
 import scala.util.control.{ControlThrowable, NonFatal}
-
 import com.google.common.net.InetAddresses
 import com.google.protobuf.{ByteString, GeneratedMessageV3}
 import io.netty.channel.unix.Errors.NativeIoException
 import org.apache.commons.lang3.SystemUtils
 import org.roaringbitmap.RoaringBitmap
-
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
@@ -981,4 +978,13 @@ object Utils extends Logging {
     }
   }
 
+  def genAddressPair(loc: PartitionLocation): String = {
+    if (Objects.isNull(loc)) {
+      return null
+    }
+    if (loc.getPeer != null)
+      loc.hostAndPushPort + "-" + loc.getPeer.hostAndPushPort
+    else
+      loc.hostAndPushPort
+  }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -925,6 +925,7 @@ object Utils extends Logging {
       case 1 => DiskStatus.READ_OR_WRITE_FAILURE
       case 2 => DiskStatus.IO_HANG
       case 3 => DiskStatus.HIGH_DISK_USAGE
+      case 4 => DiskStatus.CRITICAL_ERROR
       case _ => null
     }
   }

--- a/dev/reformat
+++ b/dev/reformat
@@ -23,3 +23,5 @@ RSS_HOME="$(cd "`dirname "$0"`/.."; pwd)"
 ${RSS_HOME}/build/mvn spotless:apply -Pspark-2.4
 
 ${RSS_HOME}/build/mvn spotless:apply -Pspark-3.1
+
+${RSS_HOME}/build/mvn spotless:apply -Pflink-1.14

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -30,7 +30,7 @@ license: |
 | celeborn.push.data.rpc.timeout | 120s | Timeout for a task to push data rpc message. | 0.2.0 | 
 | celeborn.push.limit.inFlight.sleepInterval | 50ms | Sleep interval when check netty in-flight requests to be done. | 0.2.0 | 
 | celeborn.push.limit.inFlight.timeout | 240s | Timeout for netty in-flight requests to be done. | 0.2.0 | 
-| celeborn.push.maxReqsInFlight | 32 | Amount of Netty in-flight requests. The maximum memory is `celeborn.push.maxReqsInFlight` * `celeborn.push.buffer.max.size` * compression ratio(1 in worst case), default: 64Kib * 32 = 2Mib | 0.2.0 | 
+| celeborn.push.maxReqsInFlight | 32 | Amount of Netty in-flight requests per worker. The maximum memory is `celeborn.push.maxReqsInFlight` * `celeborn.push.buffer.max.size` * compression ratio(1 in worst case), default: 64Kib * 32 = 2Mib | 0.2.0 | 
 | celeborn.push.queue.capacity | 512 | Push buffer queue size for a task. The maximum memory is `celeborn.push.buffer.max.size` * `celeborn.push.queue.capacity`, default: 64KiB * 512 = 32MiB | 0.2.0 | 
 | celeborn.push.replicate.enabled | true | When true, Celeborn worker will replicate shuffle data to another Celeborn worker asynchronously to ensure the pushed shuffle data won't be lost after the node failure. | 0.2.0 | 
 | celeborn.push.retry.threads | 8 | Thread number to process shuffle re-send push data requests. | 0.2.0 | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -36,12 +36,15 @@ license: |
 | celeborn.push.retry.threads | 8 | Thread number to process shuffle re-send push data requests. | 0.2.0 | 
 | celeborn.push.sortMemory.threshold | 64m | When SortBasedPusher use memory over the threshold, will trigger push data. | 0.2.0 | 
 | celeborn.push.splitPartition.threads | 8 | Thread number to process shuffle split request in shuffle client. | 0.2.0 | 
-| celeborn.push.stageEnd.timeout | 240s | Timeout for StageEnd. | 0.2.0 | 
+| celeborn.push.stageEnd.timeout | &lt;undefined&gt; | Timeout for waiting StageEnd. Default value should be `celeborn.rpc.askTimeout * (celeborn.rpc.requestCommitFiles.maxRetries + 1)`. | 0.2.0 | 
 | celeborn.rpc.cache.concurrencyLevel | 32 | The number of write locks to update rpc cache. | 0.2.0 | 
 | celeborn.rpc.cache.expireTime | 15s | The time before a cache item is removed. | 0.2.0 | 
 | celeborn.rpc.cache.size | 256 | The max cache items count for rpc cache. | 0.2.0 | 
+| celeborn.rpc.getReducerFileGroup.askTimeout | &lt;undefined&gt; | Timeout for ask operations during get reducer file group. Default value should be `celeborn.rpc.askTimeout * (celeborn.rpc.requestCommitFiles.maxRetries + 1 + 1)`. | 0.2.0 | 
 | celeborn.rpc.maxParallelism | 1024 | Max parallelism of client on sending RPC requests. | 0.2.0 | 
+| celeborn.rpc.registerShuffle.askTimeout | &lt;undefined&gt; | Timeout for ask operations during register shuffle. Default value should be `celeborn.rpc.askTimeout * (celeborn.slots.reserve.maxRetries + 1 + 1)`. | 0.2.0 | 
 | celeborn.rpc.requestCommitFiles.maxRetries | 2 | Max retry times for requestCommitFiles RPC. | 1.0.0 | 
+| celeborn.rpc.requestPartition.askTimeout | &lt;undefined&gt; | Timeout for ask operations during request change partition location, such as revive or split partition. Default value should be `celeborn.rpc.askTimeout * (celeborn.slots.reserve.maxRetries + 1)`. | 0.2.0 | 
 | celeborn.shuffle.batchHandleChangePartition.enabled | false | When true, LifecycleManager will handle change partition request in batch. Otherwise, LifecycleManager will process the requests one by one | 0.2.0 | 
 | celeborn.shuffle.batchHandleChangePartition.interval | 100ms | Interval for LifecycleManager to schedule handling change partition requests in batch. | 0.2.0 | 
 | celeborn.shuffle.batchHandleChangePartition.threads | 8 | Threads number for LifecycleManager to handle change partition request in batch. | 0.2.0 | 

--- a/docs/configuration/network.md
+++ b/docs/configuration/network.md
@@ -43,5 +43,6 @@ license: |
 | celeborn.rpc.haClient.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for HA client RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.lookupTimeout | 30s | Timeout for RPC lookup operations. | 0.2.0 | 
 | celeborn.rpc.registerShuffle.askTimeout | 600s | Timeout for ask operations during register shuffle. | 0.2.0 | 
+| celeborn.rpc.requestPartition.askTimeout | 600s | Timeout for ask operations during request change partition location, such as revive or split partition. | 0.2.0 | 
 | celeborn.shuffle.maxChunksBeingTransferred | 9223372036854775807 | The max number of chunks allowed to be transferred at the same time on shuffle service. Note that new incoming connections will be closed when the max number is hit. The client will retry according to the shuffle retry configs (see `celeborn.shuffle.io.maxRetries` and `celeborn.shuffle.io.retryWait`), if those limits are reached the task will fail with fetch failure. | 0.2.0 | 
 <!--end-include-->

--- a/docs/configuration/network.md
+++ b/docs/configuration/network.md
@@ -39,6 +39,7 @@ license: |
 | celeborn.port.maxRetries | 1 | When port is occupied, we will retry for max retry times. | 0.2.0 | 
 | celeborn.rpc.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.connect.threads | 64 |  | 0.2.0 | 
+| celeborn.rpc.getReducerFileGroup.askTimeout | 600s | Timeout for ask operations during get reducer file group. | 0.2.0 | 
 | celeborn.rpc.haClient.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for HA client RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.lookupTimeout | 30s | Timeout for RPC lookup operations. | 0.2.0 | 
 | celeborn.rpc.registerShuffle.askTimeout | 600s | Timeout for ask operations during register shuffle. | 0.2.0 | 

--- a/docs/configuration/network.md
+++ b/docs/configuration/network.md
@@ -39,10 +39,7 @@ license: |
 | celeborn.port.maxRetries | 1 | When port is occupied, we will retry for max retry times. | 0.2.0 | 
 | celeborn.rpc.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.connect.threads | 64 |  | 0.2.0 | 
-| celeborn.rpc.getReducerFileGroup.askTimeout | 600s | Timeout for ask operations during get reducer file group. | 0.2.0 | 
 | celeborn.rpc.haClient.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for HA client RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.lookupTimeout | 30s | Timeout for RPC lookup operations. | 0.2.0 | 
-| celeborn.rpc.registerShuffle.askTimeout | 600s | Timeout for ask operations during register shuffle. | 0.2.0 | 
-| celeborn.rpc.requestPartition.askTimeout | 600s | Timeout for ask operations during request change partition location, such as revive or split partition. | 0.2.0 | 
 | celeborn.shuffle.maxChunksBeingTransferred | 9223372036854775807 | The max number of chunks allowed to be transferred at the same time on shuffle service. Note that new incoming connections will be closed when the max number is hit. The client will retry according to the shuffle retry configs (see `celeborn.shuffle.io.maxRetries` and `celeborn.shuffle.io.retryWait`), if those limits are reached the task will fail with fetch failure. | 0.2.0 | 
 <!--end-include-->

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -31,6 +31,8 @@ license: |
 | celeborn.storage.hdfs.dir | &lt;undefined&gt; | HDFS dir configuration for Celeborn to access HDFS. | 0.2.0 | 
 | celeborn.worker.closeIdleConnections | false | Whether worker will close idle connections. | 0.2.0 | 
 | celeborn.worker.commit.threads | 32 | Thread number of worker to commit shuffle data files asynchronously. | 0.2.0 | 
+| celeborn.worker.directMemoryRatioForMemoryShuffleStorage | 0.1 | Max ratio of direct memory to store shuffle data | 0.2.0 | 
+| celeborn.worker.directMemoryRatioForReadBuffer | 0.1 | Max ratio of direct memory for read buffer | 0.2.0 | 
 | celeborn.worker.directMemoryRatioToPauseReceive | 0.85 | If direct memory usage reaches this limit, the worker will stop to receive data from Celeborn shuffle clients. | 0.2.0 | 
 | celeborn.worker.directMemoryRatioToPauseReplicate | 0.95 | If direct memory usage reaches this limit, the worker will stop to receive replication data from other workers. | 0.2.0 | 
 | celeborn.worker.directMemoryRatioToResume | 0.5 | If direct memory usage is less than this limit, worker will resume. | 0.2.0 | 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterArguments.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterArguments.scala
@@ -51,10 +51,6 @@ class MasterArguments(args: Array[String], conf: CelebornConf) {
     _port = _port.orElse(Some(conf.masterPort))
   }
 
-  if (_host.isEmpty || _port.isEmpty) {
-    printUsageAndExit(1)
-  }
-
   def host: String = _host.get
 
   def port: Int = _port.get

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterArgumentsSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterArgumentsSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.CelebornConf.{MASTER_HOST, MASTER_PORT}
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.util.Utils
+
+class MasterArgumentsSuite extends AnyFunSuite with Logging {
+
+  test("[CELEBORN-98] Test build masterArguments in different case") {
+    val args1 = Array.empty[String]
+    val conf1 = new CelebornConf()
+
+    val arguments1 = new MasterArguments(args1, conf1)
+    assert(arguments1.host.equals(Utils.localHostName))
+    assert(arguments1.port == 9097)
+
+    // should use celeborn conf
+    val conf2 = new CelebornConf()
+    conf2.set(MASTER_HOST, "test-host-1")
+    conf2.set(MASTER_PORT, 19097)
+
+    val arguments2 = new MasterArguments(args1, conf2)
+    assert(arguments2.host.equals("test-host-1"))
+    assert(arguments2.port == 19097)
+
+    // should use cli args
+    val args2 = Array("-h", "test-host-2", "-p", "29097")
+
+    val arguments3 = new MasterArguments(args2, conf2)
+    assert(arguments3.host.equals("test-host-2"))
+    assert(arguments3.port == 29097)
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <module>service</module>
     <module>master</module>
     <module>worker</module>
-    <module>tests/spark-it</module>
   </modules>
 
   <distributionManagement>
@@ -84,6 +83,9 @@
     <slf4j.version>1.7.36</slf4j.version>
     <roaringbitmap.version>0.9.32</roaringbitmap.version>
     <snakeyaml.version>1.30</snakeyaml.version>
+    <!--  default flink version  -->
+    <flink.version>1.14.0</flink.version>
+
     <!--  default hadoop version  -->
     <hadoop.version>3.2.1</hadoop.version>
     <shading.prefix>org.apache.celeborn.shaded</shading.prefix>
@@ -101,6 +103,7 @@
     <maven.plugin.shade.version>3.4.0</maven.plugin.shade.version>
     <maven.plugin.spotless.version>2.24.1</maven.plugin.spotless.version>
     <maven.plugin.surefire.version>3.0.0-M7</maven.plugin.surefire.version>
+    <maven.plugin.jacoco-maven-plugin.version>0.8.7</maven.plugin.jacoco-maven-plugin.version>
 
     <!-- Allow modules to enable / disable certain build plugins easily. -->
     <testJarPhase>prepare-package</testJarPhase>
@@ -140,6 +143,25 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-runtime</artifactId>
+        <version>${flink.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.tysafe</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -577,7 +599,7 @@
               <include>**/*Test*.*</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=128m ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
+            <argLine>${argLine} -ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=128m ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
             <systemProperties>
               <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
               <log4j2.configurationFile>src/test/resources/log4j2-test.xml</log4j2.configurationFile>
@@ -803,6 +825,31 @@
             </execution>
           </executions>
         </plugin>
+
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${maven.plugin.jacoco-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>pre-test</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>report</id>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <phase>test</phase>
+              <configuration>
+                <outputDirectory>${project.build.directory}/codecov</outputDirectory>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
       </plugins>
     </pluginManagement>
 
@@ -841,6 +888,11 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 
@@ -851,6 +903,7 @@
         <module>client-spark/common</module>
         <module>client-spark/spark-2</module>
         <module>client-spark/spark-2-shaded</module>
+        <module>tests/spark-it</module>
       </modules>
       <properties>
         <jackson.version>2.6.7</jackson.version>
@@ -881,6 +934,7 @@
         <module>client-spark/common</module>
         <module>client-spark/spark-3</module>
         <module>client-spark/spark-3-shaded</module>
+        <module>tests/spark-it</module>
       </modules>
       <properties>
         <jackson.version>2.10.0</jackson.version>
@@ -899,6 +953,7 @@
         <module>client-spark/common</module>
         <module>client-spark/spark-3</module>
         <module>client-spark/spark-3-shaded</module>
+        <module>tests/spark-it</module>
       </modules>
       <properties>
         <jackson.version>2.10.0</jackson.version>
@@ -917,6 +972,7 @@
         <module>client-spark/common</module>
         <module>client-spark/spark-3</module>
         <module>client-spark/spark-3-shaded</module>
+        <module>tests/spark-it</module>
       </modules>
       <properties>
         <jackson.version>2.12.3</jackson.version>
@@ -935,6 +991,7 @@
         <module>client-spark/common</module>
         <module>client-spark/spark-3</module>
         <module>client-spark/spark-3-shaded</module>
+        <module>tests/spark-it</module>
       </modules>
       <properties>
         <jackson.version>2.13.4</jackson.version>
@@ -944,6 +1001,24 @@
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.3.1</spark.version>
         <zstd-jni.version>1.5.2-1</zstd-jni.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>flink-1.14</id>
+      <modules>
+        <module>client-flink/flink-1.14</module>
+        <module>client-flink/flink-common</module>
+        <module>client-flink/flink-shaded</module>
+      </modules>
+      <properties>
+        <jackson.version>2.6.7</jackson.version>
+        <jackson.databind.version>2.6.7.3</jackson.databind.version>
+        <lz4-java.version>1.4.0</lz4-java.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <zstd-jni.version>1.4.4-3</zstd-jni.version>
+        <scala.version>2.12.15</scala.version>
+        <flink.version>1.14.0</flink.version>
       </properties>
     </profile>
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
@@ -24,7 +24,7 @@ import org.junit.Assert
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.celeborn.client.{LifecycleManager, ShuffleClient, ShuffleClientImpl}
+import org.apache.celeborn.client.{LifecycleManager, ShuffleClientImpl}
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.util.PackedPartitionId
@@ -36,6 +36,9 @@ class ShuffleClientSuite extends AnyFunSuite with MiniClusterFeature
   val APP = "app-1"
   var shuffleClient: ShuffleClientImpl = _
   var lifecycleManager: LifecycleManager = _
+  val numMappers = 8
+  val mapId = 1
+  val attemptId = 0
 
   override def beforeAll(): Unit = {
     val masterConf = Map(
@@ -54,11 +57,8 @@ class ShuffleClientSuite extends AnyFunSuite with MiniClusterFeature
     shuffleClient.setupMetaServiceRef(lifecycleManager.self)
   }
 
-  test(s"test register map partition task with first attemptId") {
+  test(s"test register map partition task") {
     val shuffleId = 1
-    val numMappers = 8
-    val mapId = 1
-    val attemptId = 0
     var location =
       shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId)
     Assert.assertEquals(location.getId, PackedPartitionId.packedPartitionId(mapId, attemptId))
@@ -91,6 +91,39 @@ class ShuffleClientSuite extends AnyFunSuite with MiniClusterFeature
     count =
       partitionLocationInfos.map(r => r.getAllMasterLocations(shuffleId.toString).size()).sum
     Assert.assertEquals(count, numMappers + 1)
+  }
+
+  test(s"test map end & get reducer file group") {
+    val shuffleId = 2
+    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId)
+    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId + 1, attemptId)
+    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId + 2, attemptId)
+    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId + 1)
+    shuffleClient.mapPartitionMapperEnd(APP, shuffleId, numMappers, mapId, attemptId, mapId)
+    // retry
+    shuffleClient.mapPartitionMapperEnd(APP, shuffleId, numMappers, mapId, attemptId, mapId)
+    // another attempt
+    shuffleClient.mapPartitionMapperEnd(
+      APP,
+      shuffleId,
+      numMappers,
+      mapId,
+      attemptId + 1,
+      PackedPartitionId
+        .packedPartitionId(mapId, attemptId + 1))
+    // another mapper
+    shuffleClient.mapPartitionMapperEnd(APP, shuffleId, numMappers, mapId + 1, attemptId, mapId + 1)
+
+    // reduce file group size (for empty partitions)
+    Assert.assertEquals(shuffleClient.getReduceFileGroupsMap.size(), 0)
+
+    // reduce normal empty RssInputStream
+    var stream = shuffleClient.readPartition(APP, shuffleId, 1, 1)
+    Assert.assertEquals(stream.read(), -1)
+
+    // reduce normal null partition for RssInputStream
+    stream = shuffleClient.readPartition(APP, shuffleId, 3, 1)
+    Assert.assertEquals(stream.read(), -1)
   }
 
   override def afterAll(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HugeDataTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HugeDataTest.scala
@@ -50,8 +50,16 @@ class HugeDataTest extends AnyFunSuite
   test("celeborn spark integration test - huge data") {
     val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[4]")
     val ss = SparkSession.builder().config(updateSparkConf(sparkConf, false)).getOrCreate()
-    ss.sparkContext.parallelize(1 to 10000, 2)
-      .map { i => (i, Range(1, 10000).mkString(",")) }.groupByKey(16).collect()
+    val value = Range(1, 10000).mkString(",")
+    val tuples = ss.sparkContext.parallelize(1 to 10000, 2)
+      .map { i => (i, value) }.groupByKey(16).collect()
+
+    // verify result
+    assert(tuples.length == 10000)
+    for (elem <- tuples) {
+      assert(elem._2.mkString(",").equals(value))
+    }
+
     ss.stop()
   }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -48,58 +48,38 @@ import org.apache.celeborn.service.deploy.worker.WorkerSource;
  * Note: Once FlushNotifier.exception is set, the whole file is not available.
  *       That's fine some of the internal state(e.g. bytesFlushed) may be inaccurate.
  */
-public final class FileWriter implements DeviceObserver {
+public abstract class FileWriter implements DeviceObserver {
   private static final Logger logger = LoggerFactory.getLogger(FileWriter.class);
   private static final long WAIT_INTERVAL_MS = 20;
 
-  private final FileInfo fileInfo;
-  private FileChannel channel;
-  private FSDataOutputStream stream;
-  private volatile boolean closed;
-  private volatile boolean destroyed;
+  protected final FileInfo fileInfo;
+  protected FileChannel channel;
+  protected FSDataOutputStream stream;
+  protected volatile boolean closed;
+  protected volatile boolean destroyed;
 
-  private final AtomicInteger numPendingWrites = new AtomicInteger();
-  private long nextBoundary;
-  private long bytesFlushed;
+  protected final AtomicInteger numPendingWrites = new AtomicInteger();
+  protected long bytesFlushed;
 
   public final Flusher flusher;
   private final int flushWorkerIndex;
-  private CompositeByteBuf flushBuffer;
+  protected CompositeByteBuf flushBuffer;
 
-  private final long shuffleChunkSize;
   private final long writerCloseTimeoutMs;
 
-  private final long flusherBufferSize;
+  protected final long flusherBufferSize;
 
-  private final DeviceMonitor deviceMonitor;
-  private final AbstractSource source; // metrics
+  protected final DeviceMonitor deviceMonitor;
+  protected final AbstractSource source; // metrics
 
   private long splitThreshold = 0;
   private final PartitionSplitMode splitMode;
   private final PartitionType partitionType;
   private final boolean rangeReadFilter;
-
   private Runnable destroyHook;
-  private boolean deleted = false;
+  protected boolean deleted = false;
   private RoaringBitmap mapIdBitMap = null;
-
-  private final FlushNotifier notifier = new FlushNotifier();
-
-  // //////////////////////////////////////////////////////
-  //            map partition                            //
-  // //////////////////////////////////////////////////////
-
-  /** Number of reducepartitions */
-  private int numReducePartitions;
-
-  /** Index number of the current data region being written. */
-  private int currentDataRegionIndex;
-
-  /**
-   * Whether current data region is a broadcast region or not. If true, buffers added to this region
-   * will be written to all reduce partitions.
-   */
-  private boolean isBroadcastRegion;
+  protected final FlushNotifier notifier = new FlushNotifier();
 
   public FileWriter(
       FileInfo fileInfo,
@@ -115,8 +95,6 @@ public final class FileWriter implements DeviceObserver {
     this.fileInfo = fileInfo;
     this.flusher = flusher;
     this.flushWorkerIndex = flusher.getWorkerIndex();
-    this.shuffleChunkSize = conf.shuffleChunkSize();
-    this.nextBoundary = this.shuffleChunkSize;
     this.writerCloseTimeoutMs = conf.writerCloseTimeoutMs();
     this.splitThreshold = splitThreshold;
     this.flusherBufferSize = conf.workerFlusherBufferSize();
@@ -153,7 +131,7 @@ public final class FileWriter implements DeviceObserver {
     numPendingWrites.decrementAndGet();
   }
 
-  private void flush(boolean finalFlush) throws IOException {
+  protected void flush(boolean finalFlush) throws IOException {
     int numBytes = flushBuffer.readableBytes();
     notifier.checkException();
     notifier.numPendingFlushes.incrementAndGet();
@@ -166,26 +144,6 @@ public final class FileWriter implements DeviceObserver {
     addTask(task);
     flushBuffer = null;
     bytesFlushed += numBytes;
-    maybeSetChunkOffsets(finalFlush);
-  }
-
-  private void maybeSetChunkOffsets(boolean forceSet) {
-    if (bytesFlushed >= nextBoundary || forceSet) {
-      fileInfo.addChunkOffset(bytesFlushed);
-      nextBoundary = bytesFlushed + shuffleChunkSize;
-    }
-  }
-
-  private boolean isChunkOffsetValid() {
-    // Consider a scenario where some bytes have been flushed
-    // but the chunk offset boundary has not yet been updated.
-    // we should check if the chunk offset boundary equals
-    // bytesFlush or not. For example:
-    // The last record is a giant record and it has been flushed
-    // but its size is smaller than the nextBoundary, then the
-    // chunk offset will not be set after flushing. we should
-    // set it during FileWriter close.
-    return fileInfo.getLastChunkOffset() == bytesFlushed;
   }
 
   /**
@@ -254,7 +212,18 @@ public final class FileWriter implements DeviceObserver {
     }
   }
 
-  public synchronized long close() throws IOException {
+  public abstract long close() throws IOException;
+
+  @FunctionalInterface
+  public interface RunnableWithException<R extends IOException> {
+    void run() throws R;
+  }
+
+  protected synchronized long close(
+      RunnableWithException tryClose,
+      RunnableWithException streamClose,
+      RunnableWithException finalClose)
+      throws IOException {
     if (closed) {
       String msg = "FileWriter has already closed! fileName " + fileInfo.getFilePath();
       logger.error(msg);
@@ -269,9 +238,7 @@ public final class FileWriter implements DeviceObserver {
         if (flushBuffer.readableBytes() > 0) {
           flush(true);
         }
-        if (!isChunkOffsetValid()) {
-          maybeSetChunkOffsets(true);
-        }
+        tryClose.run();
       }
 
       waitOnNoPending(notifier.numPendingFlushes);
@@ -283,23 +250,13 @@ public final class FileWriter implements DeviceObserver {
         }
         if (stream != null) {
           stream.close();
-          if (StorageManager.hdfsFs().exists(fileInfo.getHdfsPeerWriterSuccessPath())) {
-            StorageManager.hdfsFs().delete(fileInfo.getHdfsPath(), false);
-            deleted = true;
-          } else {
-            StorageManager.hdfsFs().create(fileInfo.getHdfsWriterSuccessPath()).close();
-            FSDataOutputStream indexOutputStream =
-                StorageManager.hdfsFs().create(fileInfo.getHdfsIndexPath());
-            indexOutputStream.writeInt(fileInfo.getChunkOffsets().size());
-            for (Long offset : fileInfo.getChunkOffsets()) {
-              indexOutputStream.writeLong(offset);
-            }
-            indexOutputStream.close();
-          }
+          streamClose.run();
         }
       } catch (IOException e) {
         logger.warn("close file writer" + this + "failed", e);
       }
+
+      finalClose.run();
 
       // unregister from DeviceMonitor
       if (!fileInfo.isHdfs()) {
@@ -364,7 +321,7 @@ public final class FileWriter implements DeviceObserver {
     }
   }
 
-  private void waitOnNoPending(AtomicInteger counter) throws IOException {
+  protected void waitOnNoPending(AtomicInteger counter) throws IOException {
     long waitTime = writerCloseTimeoutMs;
     while (counter.get() > 0 && waitTime > 0) {
       try {
@@ -385,7 +342,7 @@ public final class FileWriter implements DeviceObserver {
     notifier.checkException();
   }
 
-  private void takeBuffer() {
+  protected void takeBuffer() {
     // metrics start
     String metricsName = null;
     String fileAbsPath = null;
@@ -410,7 +367,7 @@ public final class FileWriter implements DeviceObserver {
     }
   }
 
-  private void addTask(FlushTask task) throws IOException {
+  protected void addTask(FlushTask task) throws IOException {
     if (!flusher.addTask(task, writerCloseTimeoutMs, flushWorkerIndex)) {
       IOException e = new IOException("Add flush task timeout.");
       notifier.setException(e);
@@ -418,7 +375,7 @@ public final class FileWriter implements DeviceObserver {
     }
   }
 
-  private synchronized void returnBuffer() {
+  protected synchronized void returnBuffer() {
     if (flushBuffer != null) {
       flusher.returnBuffer(flushBuffer);
       flushBuffer = null;
@@ -481,18 +438,5 @@ public final class FileWriter implements DeviceObserver {
 
   public PartitionType getPartitionType() {
     return partitionType;
-  }
-
-  public void pushDataHandShake(int numReducePartitions) {
-    this.numReducePartitions = numReducePartitions;
-  }
-
-  public void regionStart(int currentDataRegionIndex, boolean isBroadcastRegion) {
-    this.currentDataRegionIndex = currentDataRegionIndex;
-    this.isBroadcastRegion = isBroadcastRegion;
-  }
-
-  public void regionFinish() {
-    // flush index
   }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -37,7 +37,7 @@ import org.apache.celeborn.common.exception.AlreadyClosedException;
 import org.apache.celeborn.common.meta.DiskStatus;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.metrics.source.AbstractSource;
-import org.apache.celeborn.common.network.server.MemoryTracker;
+import org.apache.celeborn.common.network.server.memory.MemoryManager;
 import org.apache.celeborn.common.protocol.PartitionSplitMode;
 import org.apache.celeborn.common.protocol.PartitionType;
 import org.apache.celeborn.common.protocol.StorageInfo;
@@ -214,7 +214,7 @@ public final class FileWriter implements DeviceObserver {
     }
 
     final int numBytes = data.readableBytes();
-    MemoryTracker.instance().incrementDiskBuffer(numBytes);
+    MemoryManager.instance().incrementDiskBuffer(numBytes);
     synchronized (this) {
       if (closed) {
         String msg = "FileWriter has already closed!, fileName " + fileInfo.getFilePath();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -85,6 +85,22 @@ public final class FileWriter implements DeviceObserver {
 
   private final FlushNotifier notifier = new FlushNotifier();
 
+  // //////////////////////////////////////////////////////
+  //            map partition                            //
+  // //////////////////////////////////////////////////////
+
+  /** Number of reducepartitions */
+  private int numReducePartitions;
+
+  /** Index number of the current data region being written. */
+  private int currentDataRegionIndex;
+
+  /**
+   * Whether current data region is a broadcast region or not. If true, buffers added to this region
+   * will be written to all reduce partitions.
+   */
+  private boolean isBroadcastRegion;
+
   public FileWriter(
       FileInfo fileInfo,
       Flusher flusher,
@@ -462,4 +478,21 @@ public final class FileWriter implements DeviceObserver {
 
   @Override
   public void notifyNonCriticalError(String mountPoint, DiskStatus diskStatus) {}
+
+  public PartitionType getPartitionType() {
+    return partitionType;
+  }
+
+  public void pushDataHandShake(int numReducePartitions) {
+    this.numReducePartitions = numReducePartitions;
+  }
+
+  public void regionStart(int currentDataRegionIndex, boolean isBroadcastRegion) {
+    this.currentDataRegionIndex = currentDataRegionIndex;
+    this.isBroadcastRegion = isBroadcastRegion;
+  }
+
+  public void regionFinish() {
+    // flush index
+  }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.storage;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import io.netty.buffer.CompositeByteBuf;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.metrics.source.AbstractSource;
+import org.apache.celeborn.common.protocol.PartitionSplitMode;
+import org.apache.celeborn.common.protocol.PartitionType;
+
+/*
+ * map partition file writer, it will create index for each partition
+ */
+public final class MapPartitionFileWriter extends FileWriter {
+  private static final Logger logger = LoggerFactory.getLogger(MapPartitionFileWriter.class);
+
+  private int numReducePartitions;
+  private int currentDataRegionIndex;
+  private boolean isBroadcastRegion;
+  private long[] numReducePartitionBytes;
+  private ByteBuffer indexBuffer;
+  private int currentReducePartition;
+  private long totalBytes;
+  private long regionStartingOffset;
+  private long numDataRegions;
+  private FileChannel channelIndex;
+  private FSDataOutputStream streamIndex;
+  private CompositeByteBuf flushBufferIndex;
+
+  public MapPartitionFileWriter(
+      FileInfo fileInfo,
+      Flusher flusher,
+      AbstractSource workerSource,
+      CelebornConf conf,
+      DeviceMonitor deviceMonitor,
+      long splitThreshold,
+      PartitionSplitMode splitMode,
+      boolean rangeReadFilter)
+      throws IOException {
+    super(
+        fileInfo,
+        flusher,
+        workerSource,
+        conf,
+        deviceMonitor,
+        splitThreshold,
+        splitMode,
+        PartitionType.MAP,
+        rangeReadFilter);
+    if (!fileInfo.isHdfs()) {
+      channelIndex = new FileOutputStream(fileInfo.getIndexPath()).getChannel();
+    } else {
+      streamIndex = StorageManager.hdfsFs().create(fileInfo.getHdfsIndexPath(), true);
+    }
+  }
+
+  @Override
+  public long close() throws IOException {
+    return 0;
+  }
+
+  public void pushDataHandShake(int numReducePartitions) {
+    this.numReducePartitions = numReducePartitions;
+  }
+
+  public void regionStart(int currentDataRegionIndex, boolean isBroadcastRegion) {
+    this.currentDataRegionIndex = currentDataRegionIndex;
+    this.isBroadcastRegion = isBroadcastRegion;
+  }
+
+  public void regionFinish() throws IOException {}
+}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionFileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionFileWriter.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.storage;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.metrics.source.AbstractSource;
+import org.apache.celeborn.common.protocol.PartitionSplitMode;
+import org.apache.celeborn.common.protocol.PartitionType;
+
+/*
+ * reduce partition file writer, it will create chunkindex
+ */
+public final class ReducePartitionFileWriter extends FileWriter {
+  private static final Logger logger = LoggerFactory.getLogger(ReducePartitionFileWriter.class);
+
+  private long nextBoundary;
+  private final long shuffleChunkSize;
+
+  public ReducePartitionFileWriter(
+      FileInfo fileInfo,
+      Flusher flusher,
+      AbstractSource workerSource,
+      CelebornConf conf,
+      DeviceMonitor deviceMonitor,
+      long splitThreshold,
+      PartitionSplitMode splitMode,
+      boolean rangeReadFilter)
+      throws IOException {
+    super(
+        fileInfo,
+        flusher,
+        workerSource,
+        conf,
+        deviceMonitor,
+        splitThreshold,
+        splitMode,
+        PartitionType.REDUCE,
+        rangeReadFilter);
+    this.shuffleChunkSize = conf.shuffleChunkSize();
+    this.nextBoundary = this.shuffleChunkSize;
+  }
+
+  protected void flush(boolean finalFlush) throws IOException {
+    super.flush(finalFlush);
+    maybeSetChunkOffsets(finalFlush);
+  }
+
+  private void maybeSetChunkOffsets(boolean forceSet) {
+    if (bytesFlushed >= nextBoundary || forceSet) {
+      fileInfo.addChunkOffset(bytesFlushed);
+      nextBoundary = bytesFlushed + shuffleChunkSize;
+    }
+  }
+
+  private boolean isChunkOffsetValid() {
+    // Consider a scenario where some bytes have been flushed
+    // but the chunk offset boundary has not yet been updated.
+    // we should check if the chunk offset boundary equals
+    // bytesFlush or not. For example:
+    // The last record is a giant record and it has been flushed
+    // but its size is smaller than the nextBoundary, then the
+    // chunk offset will not be set after flushing. we should
+    // set it during FileWriter close.
+    return fileInfo.getLastChunkOffset() == bytesFlushed;
+  }
+
+  public synchronized long close() throws IOException {
+    return super.close(
+        () -> {
+          if (!isChunkOffsetValid()) {
+            maybeSetChunkOffsets(true);
+          }
+        },
+        () -> {
+          if (StorageManager.hdfsFs().exists(fileInfo.getHdfsPeerWriterSuccessPath())) {
+            StorageManager.hdfsFs().delete(fileInfo.getHdfsPath(), false);
+            deleted = true;
+          } else {
+            StorageManager.hdfsFs().create(fileInfo.getHdfsWriterSuccessPath()).close();
+            FSDataOutputStream indexOutputStream =
+                StorageManager.hdfsFs().create(fileInfo.getHdfsIndexPath());
+            indexOutputStream.writeInt(fileInfo.getChunkOffsets().size());
+            for (Long offset : fileInfo.getChunkOffsets()) {
+              indexOutputStream.writeLong(offset);
+            }
+            indexOutputStream.close();
+          }
+        },
+        () -> {});
+  }
+}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -51,6 +51,7 @@ private[deploy] class Controller(
   var shuffleMapperAttempts: ConcurrentHashMap[String, AtomicIntegerArray] = _
   // shuffleKe -> (epoch -> CommitInfo)
   var shuffleCommitInfos: ConcurrentHashMap[String, ConcurrentHashMap[Long, CommitInfo]] = _
+  var shufflePartitionType: ConcurrentHashMap[String, PartitionType] = _
   var workerInfo: WorkerInfo = _
   var partitionLocationInfo: PartitionLocationInfo = _
   var timer: HashedWheelTimer = _
@@ -64,6 +65,7 @@ private[deploy] class Controller(
   def init(worker: Worker): Unit = {
     workerSource = worker.workerSource
     storageManager = worker.storageManager
+    shufflePartitionType = worker.shufflePartitionType
     shuffleMapperAttempts = worker.shuffleMapperAttempts
     shuffleCommitInfos = worker.shuffleCommitInfos
     workerInfo = worker.workerInfo
@@ -236,7 +238,7 @@ private[deploy] class Controller(
     // reserve success, update status
     partitionLocationInfo.addMasterPartitions(shuffleKey, masterLocs)
     partitionLocationInfo.addSlavePartitions(shuffleKey, slaveLocs)
-
+    shufflePartitionType.put(shuffleKey, partitionType)
     workerInfo.allocateSlots(shuffleKey, Utils.getSlotsPerDisk(requestMasterLocs, requestSlaveLocs))
 
     logInfo(s"Reserved ${masterLocs.size()} master location" +

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -30,12 +30,13 @@ import org.apache.celeborn.common.meta.{PartitionLocationInfo, WorkerInfo}
 import org.apache.celeborn.common.metrics.source.RPCSource
 import org.apache.celeborn.common.network.buffer.{NettyManagedBuffer, NioManagedBuffer}
 import org.apache.celeborn.common.network.client.{RpcResponseCallback, TransportClient, TransportClientFactory}
-import org.apache.celeborn.common.network.protocol.{Message, PushData, PushMergedData, RequestMessage, RpcFailure, RpcResponse}
+import org.apache.celeborn.common.network.protocol.{Message, PushData, PushDataHandShake, PushMergedData, RegionFinish, RegionStart, RequestMessage, RpcFailure, RpcRequest, RpcResponse}
 import org.apache.celeborn.common.network.protocol.Message.Type
 import org.apache.celeborn.common.network.server.BaseMessageHandler
-import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode}
+import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType}
 import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.unsafe.Platform
+import org.apache.celeborn.common.util.PackedPartitionId
 import org.apache.celeborn.service.deploy.worker.storage.{FileWriter, LocalFlusher, StorageManager}
 
 class PushDataHandler extends BaseMessageHandler with Logging {
@@ -44,6 +45,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
   var rpcSource: RPCSource = _
   var partitionLocationInfo: PartitionLocationInfo = _
   var shuffleMapperAttempts: ConcurrentHashMap[String, AtomicIntegerArray] = _
+  var shufflePartitionType: ConcurrentHashMap[String, PartitionType] = _
   var replicateThreadPool: ThreadPoolExecutor = _
   var unavailablePeers: ConcurrentHashMap[WorkerInfo, Long] = _
   var pushClientFactory: TransportClientFactory = _
@@ -58,6 +60,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     workerSource = worker.workerSource
     rpcSource = worker.rpcSource
     partitionLocationInfo = worker.partitionLocationInfo
+    shufflePartitionType = worker.shufflePartitionType
     shuffleMapperAttempts = worker.shuffleMapperAttempts
     replicateThreadPool = worker.replicateThreadPool
     unavailablePeers = worker.unavailablePeers
@@ -103,6 +106,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
                 pushMergedData.shuffleKey,
                 pushMergedData.partitionUniqueIds.mkString(","))))
       }
+      case rpcRequest: RpcRequest => handleRpcRequest(client, rpcRequest)
     }
 
   def handlePushData(pushData: PushData, callback: RpcResponseCallback): Unit = {
@@ -525,6 +529,277 @@ class PushDataHandler extends BaseMessageHandler with Logging {
           Throwables.getStackTraceAsString(e)));
     } finally {
       message.body().release()
+    }
+  }
+
+  private def handleRpcRequest(client: TransportClient, rpcRequest: RpcRequest): Unit = {
+    val msg = Message.decode(rpcRequest.body().nioByteBuffer())
+    val requestId = rpcRequest.requestId
+    val (mode, shuffleKey, partitionUniqueId, isCheckSplit) = msg match {
+      case p: PushDataHandShake => (p.mode, p.shuffleKey, p.partitionUniqueId, false)
+      case rs: RegionStart => (rs.mode, rs.shuffleKey, rs.partitionUniqueId, true)
+      case rf: RegionFinish => (rf.mode, rf.shuffleKey, rf.partitionUniqueId, false)
+    }
+    handleCore(
+      client,
+      rpcRequest,
+      requestId,
+      () =>
+        handleRpcRequestCore(
+          mode,
+          msg,
+          shuffleKey,
+          partitionUniqueId,
+          requestId,
+          isCheckSplit,
+          new SimpleRpcResponseCallback(
+            msg.`type`(),
+            client,
+            requestId,
+            shuffleKey,
+            partitionUniqueId)))
+
+  }
+
+  private def handleRpcRequestCore(
+      mode: Byte,
+      message: Message,
+      shuffleKey: String,
+      partitionUniqueId: String,
+      requestId: Long,
+      isCheckSplit: Boolean,
+      callback: RpcResponseCallback): Unit = {
+    val isMaster = mode == PartitionLocation.Mode.MASTER
+    val messageType = message.`type`()
+    log.info(s"requestId:$requestId, pushdata rpc:$messageType, mode:$mode, shuffleKey:$shuffleKey, partitionUniqueId:$partitionUniqueId")
+    val (workerSourceMaster, workerSourceSlave) =
+      messageType match {
+        case Type.PUSH_DATA_HAND_SHAKE =>
+          (WorkerSource.MasterPushDataHandshakeTime, WorkerSource.SlavePushDataHandshakeTime)
+        case Type.REGION_START =>
+          (WorkerSource.MasterRegionStartTime, WorkerSource.SlaveRegionStartTime)
+        case Type.REGION_FINISH =>
+          (WorkerSource.MasterRegionFinishTime, WorkerSource.SlaveRegionFinishTime)
+      }
+
+    val location = isMaster match {
+      case true => partitionLocationInfo.getMasterLocation(shuffleKey, partitionUniqueId)
+      case false => partitionLocationInfo.getSlaveLocation(shuffleKey, partitionUniqueId)
+    }
+    workerSource.startTimer(if (isMaster) workerSourceMaster else workerSourceSlave, s"$requestId")
+    val wrappedCallback =
+      new WrappedRpcResponseCallback(
+        messageType,
+        isMaster,
+        requestId,
+        null,
+        location,
+        if (isMaster) workerSourceMaster else workerSourceSlave,
+        callback)
+
+    if (checkLocationNull(
+        messageType,
+        shuffleKey,
+        partitionUniqueId,
+        null,
+        location,
+        callback,
+        wrappedCallback)) return
+
+    val fileWriter =
+      getFileWriterAndCheck(messageType, location, isMaster, callback) match {
+        case (true, _) => return
+        case (false, f: FileWriter) => f
+      }
+
+    if (isCheckSplit && checkDiskFullAndSplit(fileWriter, isMaster, null, callback)) return
+
+    try {
+      messageType match {
+        case Type.PUSH_DATA_HAND_SHAKE => {
+          fileWriter.pushDataHandShake(message.asInstanceOf[PushDataHandShake].numPartitions)
+        }
+        case Type.REGION_START => {
+          fileWriter.regionStart(
+            message.asInstanceOf[RegionStart].currentRegionIndex,
+            message.asInstanceOf[RegionStart].isBroadcast)
+        }
+        case Type.REGION_FINISH => {
+          fileWriter.regionFinish()
+        }
+      }
+      // for master, send data to slave
+      if (location.getPeer != null && isMaster) {
+        // to do replica
+        wrappedCallback.onSuccess(ByteBuffer.wrap(Array[Byte]()))
+      } else {
+        wrappedCallback.onSuccess(ByteBuffer.wrap(Array[Byte]()))
+      }
+    } catch {
+      case t: Throwable =>
+        callback.onFailure(new Exception(s"$messageType failed", t))
+    }
+  }
+
+  class WrappedRpcResponseCallback(
+      messageType: Message.Type,
+      isMaster: Boolean,
+      requestId: Long,
+      softSplit: AtomicBoolean,
+      location: PartitionLocation,
+      workerSourceTime: String,
+      callback: RpcResponseCallback)
+    extends RpcResponseCallback {
+    override def onSuccess(response: ByteBuffer): Unit = {
+      workerSource.stopTimer(workerSourceTime, s"$requestId")
+      if (isMaster) {
+        if (response.remaining() > 0) {
+          val resp = ByteBuffer.allocate(response.remaining())
+          resp.put(response)
+          resp.flip()
+          callback.onSuccess(resp)
+        } else if (softSplit != null && softSplit.get()) {
+          callback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.SOFT_SPLIT.getValue)))
+        } else {
+          callback.onSuccess(response)
+        }
+      } else {
+        callback.onSuccess(response)
+      }
+    }
+
+    override def onFailure(e: Throwable): Unit = {
+      if (location != null) {
+        logError(s"[handle$messageType.onFailure] partitionLocation: $location")
+      }
+      messageType match {
+        case Type.PUSH_DATA_HAND_SHAKE =>
+          workerSource.incCounter(WorkerSource.PushDataHandshakeFailCount)
+          callback.onFailure(new Exception(
+            StatusCode.PUSH_DATA_HANDSHAKE_FAIL_SLAVE.getMessage,
+            e))
+        case Type.REGION_START =>
+          workerSource.incCounter(WorkerSource.RegionStartFailCount)
+          callback.onFailure(new Exception(StatusCode.REGION_START_FAIL_SLAVE.getMessage, e))
+        case Type.REGION_FINISH =>
+          workerSource.incCounter(WorkerSource.RegionFinishFailCount)
+          callback.onFailure(new Exception(StatusCode.REGION_FINISH_FAIL_SLAVE.getMessage, e))
+        case _ =>
+          workerSource.incCounter(WorkerSource.PushDataFailCount)
+          callback.onFailure(new Exception(StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage, e))
+      }
+    }
+  }
+
+  private def checkLocationNull(
+      messageType: Message.Type,
+      shuffleKey: String,
+      partitionUniqueId: String,
+      body: ByteBuf,
+      location: PartitionLocation,
+      callback: RpcResponseCallback,
+      wrappedCallback: RpcResponseCallback): Boolean = {
+    if (location == null) {
+      val (mapId, attemptId) = getMapAttempt(body, shuffleKey, partitionUniqueId)
+      if (shuffleMapperAttempts.containsKey(shuffleKey) &&
+        -1 != shuffleMapperAttempts.get(shuffleKey).get(mapId)) {
+        // partition data has already been committed
+        logInfo(s"Receive push data from speculative task(shuffle $shuffleKey, map $mapId, " +
+          s" attempt $attemptId), but this mapper has already been ended.")
+        wrappedCallback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.STAGE_ENDED.getValue)))
+      } else {
+        val msg = s"Partition location wasn't found for task(shuffle $shuffleKey, map $mapId, " +
+          s"attempt $attemptId, uniqueId $partitionUniqueId)."
+        logWarning(s"[handle$messageType] $msg")
+        messageType match {
+          case Type.PUSH_MERGED_DATA => callback.onFailure(new Exception(msg))
+          case _ => callback.onFailure(
+              new Exception(StatusCode.PUSH_DATA_FAIL_PARTITION_NOT_FOUND.getMessage()))
+        }
+      }
+      return true
+    }
+    false
+  }
+
+  private def checkFileWriterException(
+      messageType: Message.Type,
+      isMaster: Boolean,
+      fileWriter: FileWriter,
+      callback: RpcResponseCallback): Unit = {
+    logWarning(
+      s"[handle$messageType] fileWriter $fileWriter has Exception ${fileWriter.getException}")
+
+    val (messageMaster, messageSlave) =
+      messageType match {
+        case Type.PUSH_DATA | Type.PUSH_DATA_HAND_SHAKE =>
+          (
+            StatusCode.PUSH_DATA_FAIL_MASTER.getMessage(),
+            StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage())
+        case Type.PUSH_DATA_HAND_SHAKE => (
+            StatusCode.PUSH_DATA_HANDSHAKE_FAIL_MASTER.getMessage,
+            StatusCode.PUSH_DATA_HANDSHAKE_FAIL_SLAVE.getMessage)
+        case Type.REGION_START => (
+            StatusCode.REGION_START_FAIL_MASTER.getMessage,
+            StatusCode.REGION_START_FAIL_SLAVE.getMessage)
+        case Type.REGION_FINISH => (
+            StatusCode.REGION_FINISH_FAIL_MASTER.getMessage,
+            StatusCode.REGION_FINISH_FAIL_SLAVE.getMessage)
+      }
+    callback.onFailure(new Exception(
+      if (isMaster) messageMaster else messageSlave,
+      fileWriter.getException))
+  }
+
+  private def getFileWriterAndCheck(
+      messageType: Message.Type,
+      location: PartitionLocation,
+      isMaster: Boolean,
+      callback: RpcResponseCallback): (Boolean, FileWriter) = {
+    val fileWriter = location.asInstanceOf[WorkingPartition].getFileWriter
+    val exception = fileWriter.getException
+    if (exception != null) {
+      checkFileWriterException(messageType, isMaster, fileWriter, callback)
+      return (true, fileWriter)
+    }
+    (false, fileWriter)
+  }
+
+  private def checkDiskFull(fileWriter: FileWriter): Boolean = {
+    val diskFull = workerInfo.diskInfos
+      .get(fileWriter.flusher.asInstanceOf[LocalFlusher].mountPoint)
+      .actualUsableSpace < diskReserveSize
+    diskFull
+  }
+
+  private def checkDiskFullAndSplit(
+      fileWriter: FileWriter,
+      isMaster: Boolean,
+      softSplit: AtomicBoolean,
+      callback: RpcResponseCallback): Boolean = {
+    val diskFull = checkDiskFull(fileWriter)
+    if ((diskFull && fileWriter.getFileInfo.getFileLength > partitionSplitMinimumSize) ||
+      (isMaster && fileWriter.getFileInfo.getFileLength > fileWriter.getSplitThreshold())) {
+      if (softSplit != null && fileWriter.getSplitMode == PartitionSplitMode.SOFT) {
+        softSplit.set(true)
+      } else {
+        callback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
+        return true
+      }
+    }
+    false
+  }
+
+  private def getMapAttempt(
+      body: ByteBuf,
+      shuffleKey: String,
+      partitionUniqueId: String): (Int, Int) = {
+    shufflePartitionType.get(shuffleKey) match {
+      case PartitionType.MAP => {
+        val id = partitionUniqueId.split("-")(0).toInt
+        (PackedPartitionId.getRawPartitionId(id), PackedPartitionId.getAttemptId(id))
+      }
+      case PartitionType.REDUCE => getMapAttempt(body)
     }
   }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -40,7 +40,7 @@ import org.apache.celeborn.common.metrics.MetricsSystem
 import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, RPCSource}
 import org.apache.celeborn.common.network.TransportContext
 import org.apache.celeborn.common.network.server.{ChannelsLimiter, MemoryTracker}
-import org.apache.celeborn.common.protocol.{PbRegisterWorkerResponse, RpcNameConstants, TransportModuleConstants}
+import org.apache.celeborn.common.protocol.{PartitionType, PbRegisterWorkerResponse, RpcNameConstants, TransportModuleConstants}
 import org.apache.celeborn.common.protocol.message.ControlMessages._
 import org.apache.celeborn.common.quota.ResourceConsumption
 import org.apache.celeborn.common.rpc._
@@ -175,8 +175,8 @@ private[celeborn] class Worker(
 
   // whether this Worker registered to Master successfully
   val registered = new AtomicBoolean(false)
-
   val shuffleMapperAttempts = new ConcurrentHashMap[String, AtomicIntegerArray]()
+  val shufflePartitionType = new ConcurrentHashMap[String, PartitionType]
   val partitionLocationInfo = new PartitionLocationInfo
 
   val shuffleCommitInfos = new ConcurrentHashMap[String, ConcurrentHashMap[Long, CommitInfo]]()
@@ -421,6 +421,7 @@ private[celeborn] class Worker(
       }
       partitionLocationInfo.removeMasterPartitions(shuffleKey)
       partitionLocationInfo.removeSlavePartitions(shuffleKey)
+      shufflePartitionType.remove(shuffleKey)
       shuffleMapperAttempts.remove(shuffleKey)
       shuffleCommitInfos.remove(shuffleKey)
       workerInfo.releaseSlots(shuffleKey)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -39,7 +39,8 @@ import org.apache.celeborn.common.meta.{DiskInfo, PartitionLocationInfo, WorkerI
 import org.apache.celeborn.common.metrics.MetricsSystem
 import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, RPCSource}
 import org.apache.celeborn.common.network.TransportContext
-import org.apache.celeborn.common.network.server.{ChannelsLimiter, MemoryTracker}
+import org.apache.celeborn.common.network.server.ChannelsLimiter
+import org.apache.celeborn.common.network.server.memory.MemoryManager
 import org.apache.celeborn.common.protocol.{PartitionType, PbRegisterWorkerResponse, RpcNameConstants, TransportModuleConstants}
 import org.apache.celeborn.common.protocol.message.ControlMessages._
 import org.apache.celeborn.common.quota.ResourceConsumption
@@ -90,11 +91,13 @@ private[celeborn] class Worker(
 
   val storageManager = new StorageManager(conf, workerSource)
 
-  val memoryTracker = MemoryTracker.initialize(
+  val memoryTracker = MemoryManager.initialize(
     conf.workerDirectMemoryRatioToPauseReceive,
     conf.workerDirectMemoryRatioToPauseReplicate,
     conf.workerDirectMemoryRatioToResume,
     conf.partitionSorterDirectMemoryRatioThreshold,
+    conf.workerDirectMemoryRatioForReadBuffer,
+    conf.workerDirectMemoryRatioForShuffleStorage,
     conf.workerDirectMemoryPressureCheckIntervalMs,
     conf.workerDirectMemoryReportIntervalSecond)
   memoryTracker.registerMemoryListener(storageManager)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerArguments.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerArguments.scala
@@ -38,10 +38,6 @@ class WorkerArguments(args: Array[String], conf: CelebornConf) {
   _host = _host.orElse(Some(Utils.localHostName))
   _port = _port.orElse(Some(conf.workerRpcPort))
 
-  if (_host.isEmpty || _port.isEmpty) {
-    printUsageAndExit(1)
-  }
-
   def host: String = _host.get
 
   def port: Int = _port.get

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -74,6 +74,7 @@ object WorkerSource {
 
   // flush
   val TakeBufferTime = "TakeBufferTime"
+  val TakeBufferTimeIndex = "TakeBufferTimeIndex"
 
   val RegisteredShuffleCount = "RegisteredShuffleCount"
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -62,6 +62,15 @@ object WorkerSource {
   val MasterPushDataTime = "MasterPushDataTime"
   val SlavePushDataTime = "SlavePushDataTime"
   val PushDataFailCount = "PushDataFailCount"
+  val PushDataHandshakeFailCount = "PushDataHandshakeFailCount"
+  val RegionStartFailCount = "RegionStartFailCount"
+  val RegionFinishFailCount = "RegionFinishFailCount"
+  val MasterPushDataHandshakeTime = "MasterPushDataHandshakeTime"
+  val SlavePushDataHandshakeTime = "SlavePushDataHandshakeTime"
+  val MasterRegionStartTime = "MasterRegionStartTime"
+  val SlaveRegionStartTime = "SlaveRegionStartTime"
+  val MasterRegionFinishTime = "MasterRegionFinishTime"
+  val SlaveRegionFinishTime = "SlaveRegionFinishTime"
 
   // flush
   val TakeBufferTime = "TakeBufferTime"

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -30,7 +30,7 @@ import io.netty.buffer.{CompositeByteBuf, Unpooled}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.DiskStatus
 import org.apache.celeborn.common.metrics.source.AbstractSource
-import org.apache.celeborn.common.network.server.MemoryTracker
+import org.apache.celeborn.common.network.server.memory.MemoryManager
 import org.apache.celeborn.common.protocol.StorageInfo
 import org.apache.celeborn.service.deploy.worker.WorkerSource
 
@@ -141,7 +141,7 @@ abstract private[worker] class Flusher(
   }
 
   def returnBuffer(buffer: CompositeByteBuf): Unit = {
-    MemoryTracker.instance().releaseDiskBuffer(buffer.readableBytes())
+    MemoryManager.instance().releaseDiskBuffer(buffer.readableBytes())
     buffer.removeComponents(0, buffer.numComponents())
     buffer.clear()
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -40,7 +40,7 @@ import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus, FileInfo}
 import org.apache.celeborn.common.metrics.source.AbstractSource
-import org.apache.celeborn.common.network.server.MemoryTracker.MemoryTrackerListener
+import org.apache.celeborn.common.network.server.memory.MemoryManager.MemoryPressureListener
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType}
 import org.apache.celeborn.common.quota.ResourceConsumption
 import org.apache.celeborn.common.util.{PbSerDeUtils, ThreadUtils, Utils}
@@ -48,7 +48,7 @@ import org.apache.celeborn.service.deploy.worker._
 import org.apache.celeborn.service.deploy.worker.storage.StorageManager.hdfsFs
 
 final private[worker] class StorageManager(conf: CelebornConf, workerSource: AbstractSource)
-  extends ShuffleRecoverHelper with DeviceObserver with Logging with MemoryTrackerListener {
+  extends ShuffleRecoverHelper with DeviceObserver with Logging with MemoryPressureListener {
   // mount point -> filewriter
   val workingDirWriters = new ConcurrentHashMap[File, util.ArrayList[FileWriter]]()
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -284,16 +284,27 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         FileSystem.mkdirs(StorageManager.hdfsFs, shuffleDir, hdfsPermission)
         val fileInfo =
           new FileInfo(new Path(shuffleDir, fileName).toString, userIdentifier, partitionType)
-        val hdfsWriter = new FileWriter(
-          fileInfo,
-          hdfsFlusher.get,
-          workerSource,
-          conf,
-          deviceMonitor,
-          splitThreshold,
-          splitMode,
-          partitionType,
-          rangeReadFilter)
+        val hdfsWriter = partitionType match {
+          case PartitionType.MAP => new MapPartitionFileWriter(
+              fileInfo,
+              hdfsFlusher.get,
+              workerSource,
+              conf,
+              deviceMonitor,
+              splitThreshold,
+              splitMode,
+              rangeReadFilter)
+          case PartitionType.REDUCE => new ReducePartitionFileWriter(
+              fileInfo,
+              hdfsFlusher.get,
+              workerSource,
+              conf,
+              deviceMonitor,
+              splitThreshold,
+              splitMode,
+              rangeReadFilter)
+        }
+
         fileInfos.computeIfAbsent(shuffleKey, newMapFunc).put(fileName, fileInfo)
         hdfsWriters.synchronized {
           hdfsWriters.add(hdfsWriter)
@@ -318,16 +329,27 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
             }
           }
           val fileInfo = new FileInfo(file.getAbsolutePath, userIdentifier, partitionType)
-          val fileWriter = new FileWriter(
-            fileInfo,
-            localFlushers.get(mountPoint),
-            workerSource,
-            conf,
-            deviceMonitor,
-            splitThreshold,
-            splitMode,
-            partitionType,
-            rangeReadFilter)
+
+          val fileWriter = partitionType match {
+            case PartitionType.MAP => new MapPartitionFileWriter(
+                fileInfo,
+                localFlushers.get(mountPoint),
+                workerSource,
+                conf,
+                deviceMonitor,
+                splitThreshold,
+                splitMode,
+                rangeReadFilter)
+            case PartitionType.REDUCE => new ReducePartitionFileWriter(
+                fileInfo,
+                localFlushers.get(mountPoint),
+                workerSource,
+                conf,
+                deviceMonitor,
+                splitThreshold,
+                splitMode,
+                rangeReadFilter)
+          }
           deviceMonitor.registerFileWriter(fileWriter)
           val list = workingDirWriters.computeIfAbsent(dir, workingDirWriterListFunc)
           list.synchronized {

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -238,7 +238,7 @@ public class FileWriterSuiteJ {
     final int threadsNum = 8;
     File file = getTemporaryFile();
     FileWriter fileWriter =
-        new FileWriter(
+        new ReducePartitionFileWriter(
             new FileInfo(file, userIdentifier),
             localFlusher,
             source,
@@ -246,7 +246,6 @@ public class FileWriterSuiteJ {
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             SPLIT_THRESHOLD,
             splitMode,
-            partitionType,
             false);
 
     List<Future<?>> futures = new ArrayList<>();
@@ -283,7 +282,7 @@ public class FileWriterSuiteJ {
     final int threadsNum = Runtime.getRuntime().availableProcessors();
     File file = getTemporaryFile();
     FileWriter fileWriter =
-        new FileWriter(
+        new ReducePartitionFileWriter(
             new FileInfo(file, userIdentifier),
             localFlusher,
             source,
@@ -291,7 +290,6 @@ public class FileWriterSuiteJ {
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             SPLIT_THRESHOLD,
             splitMode,
-            partitionType,
             false);
 
     List<Future<?>> futures = new ArrayList<>();
@@ -337,7 +335,7 @@ public class FileWriterSuiteJ {
     File file = getTemporaryFile();
     FileInfo fileInfo = new FileInfo(file, userIdentifier);
     FileWriter fileWriter =
-        new FileWriter(
+        new ReducePartitionFileWriter(
             fileInfo,
             localFlusher,
             source,
@@ -345,7 +343,6 @@ public class FileWriterSuiteJ {
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             SPLIT_THRESHOLD,
             splitMode,
-            partitionType,
             false);
 
     List<Future<?>> futures = new ArrayList<>();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -67,8 +67,8 @@ import org.apache.celeborn.common.network.client.TransportClientFactory;
 import org.apache.celeborn.common.network.protocol.Message;
 import org.apache.celeborn.common.network.protocol.OpenStream;
 import org.apache.celeborn.common.network.protocol.StreamHandle;
-import org.apache.celeborn.common.network.server.MemoryTracker;
 import org.apache.celeborn.common.network.server.TransportServer;
+import org.apache.celeborn.common.network.server.memory.MemoryManager;
 import org.apache.celeborn.common.network.util.JavaUtils;
 import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.protocol.PartitionSplitMode;
@@ -119,7 +119,7 @@ public class FileWriterSuiteJ {
     localFlusher =
         new LocalFlusher(
             source, DeviceMonitor$.MODULE$.EmptyMonitor(), 1, "disk1", 20, 1, StorageInfo.Type.HDD);
-    MemoryTracker.initialize(0.8, 0.9, 0.5, 0.6, 10, 10);
+    MemoryManager.initialize(0.8, 0.9, 0.5, 0.6, 0.1, 0.1, 10, 10);
   }
 
   public static void setupChunkServer(FileInfo info) throws Exception {

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
-import org.apache.celeborn.common.network.server.MemoryTracker;
+import org.apache.celeborn.common.network.server.memory.MemoryManager;
 import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;
@@ -110,7 +110,7 @@ public class PartitionFilesSorterSuiteJ {
             + (double) originFileLen / 1024 / 1024.0
             + "MB");
 
-    MemoryTracker.initialize(0.8, 0.9, 0.5, 0.6, 10, 10);
+    MemoryManager.initialize(0.8, 0.9, 0.5, 0.6, 0.1, 0.1, 10, 10);
     fileWriter = Mockito.mock(FileWriter.class);
     when(fileWriter.getFile()).thenAnswer(i -> shuffleFile);
     when(fileWriter.getFileInfo()).thenAnswer(i -> fileInfo);
@@ -125,7 +125,7 @@ public class PartitionFilesSorterSuiteJ {
     prepare(false);
     CelebornConf conf = new CelebornConf();
     PartitionFilesSorter partitionFilesSorter =
-        new PartitionFilesSorter(MemoryTracker.instance(), conf, new WorkerSource(conf));
+        new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
     FileInfo info =
         partitionFilesSorter.getSortedFileInfo(
             "application-1", originFileName, fileWriter.getFileInfo(), 5, 10);
@@ -141,7 +141,7 @@ public class PartitionFilesSorterSuiteJ {
     prepare(true);
     CelebornConf conf = new CelebornConf();
     PartitionFilesSorter partitionFilesSorter =
-        new PartitionFilesSorter(MemoryTracker.instance(), conf, new WorkerSource(conf));
+        new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
     FileInfo info =
         partitionFilesSorter.getSortedFileInfo(
             "application-1", originFileName, fileWriter.getFileInfo(), 5, 10);
@@ -162,7 +162,7 @@ public class PartitionFilesSorterSuiteJ {
     conf.set("celeborn.worker.graceful.shutdown.enabled", "true");
     conf.set("celeborn.worker.graceful.shutdown.recoverPath", recoverPath.getPath());
     PartitionFilesSorter partitionFilesSorter =
-        new PartitionFilesSorter(MemoryTracker.instance(), conf, new WorkerSource(conf));
+        new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
     partitionFilesSorter.initSortedShuffleFiles("application-1-1");
     partitionFilesSorter.updateSortedShuffleFiles("application-1-1", "0-0-1", 0);
     partitionFilesSorter.updateSortedShuffleFiles("application-1-1", "0-0-2", 0);
@@ -175,7 +175,7 @@ public class PartitionFilesSorterSuiteJ {
     partitionFilesSorter.deleteSortedShuffleFiles("application-2-1");
     partitionFilesSorter.close();
     PartitionFilesSorter partitionFilesSorter2 =
-        new PartitionFilesSorter(MemoryTracker.instance(), conf, new WorkerSource(conf));
+        new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
     Assert.assertEquals(
         partitionFilesSorter2.getSortedShuffleFiles("application-1-1").toString(),
         "[0-0-3, 0-0-2, 0-0-1]");

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/WorkerArgumentsSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/WorkerArgumentsSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.CelebornConf.WORKER_RPC_PORT
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.util.Utils
+import org.apache.celeborn.service.deploy.worker.WorkerArguments
+
+class WorkerArgumentsSuite extends AnyFunSuite with Logging {
+
+  test("[CELEBORN-98] Test build workerArguments in different case") {
+    val args1 = Array.empty[String]
+    val conf1 = new CelebornConf()
+
+    val arguments1 = new WorkerArguments(args1, conf1)
+    assert(arguments1.host.equals(Utils.localHostName))
+    assert(arguments1.port == 0)
+
+    // should use celeborn conf
+    val conf2 = new CelebornConf()
+    conf2.set(WORKER_RPC_PORT, 12345)
+
+    val arguments2 = new WorkerArguments(args1, conf2)
+    assert(arguments2.port == 12345)
+
+    // should use cli args
+    val args2 = Array("-h", "test-host-1", "-p", "22345")
+
+    val arguments3 = new WorkerArguments(args2, conf2)
+    assert(arguments3.host.equals("test-host-1"))
+    assert(arguments3.port == 22345)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Split maxReqsInFlight limitation into level of target worker
split maxReqsInFlight limitation to every address pair.

### Why are the changes needed?
if one push one worker data is pause, the global limitation will block other healthy worker.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
#992 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @AngersZhuuuu 
