### PR TITLE
[CELEBORN-59][REFACTOR] Support send destroy slots request in parallel

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1506,10 +1506,11 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       shuffleId: Int,
       slotsToDestroy: WorkerResource): Unit = {
     val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
+    val parallelism = Math.min(Math.max(1, slotsToDestroy.size()), conf.rpcMaxParallelism)
     ThreadUtils.parmap(
       slotsToDestroy.asScala,
       "DestroySlot",
-      slotsToDestroy.size()) { case (workerInfo, (masterLocations, slaveLocations)) =>
+      parallelism) { case (workerInfo, (masterLocations, slaveLocations)) =>
       val destroy = Destroy(
         shuffleKey,
         masterLocations.asScala.map(_.getUniqueId).asJava,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support LifeCycleManager to send destroy slots request in parallel

### Why are the changes needed?
In order to reduce the time consumed by sending Destroy RPC one by one. Currently, LifeCycleManager needs to wait for Worker finish `handleDestroy` one by one. 

### What are the items that need reviewer attention?


### Related issues.
[CELEBORN-59](https://issues.apache.org/jira/browse/CELEBORN-59)

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
