### PR TITLE
[CELEBORN-12]Retry on CommitFile request

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
@@ -53,7 +53,9 @@ public enum StatusCode {
   WORKER_SHUTDOWN(25),
   NO_AVAILABLE_WORKING_DIR(26),
   WORKER_IN_BLACKLIST(27),
-  UNKNOWN_WORKER(28);
+  UNKNOWN_WORKER(28),
+
+  COMMIT_FILE_EXCEPTION(29);
 
   private final byte value;
 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -62,8 +62,8 @@ license: |
 | celeborn.slots.reserve.maxRetries | 3 | Max retry times for client to reserve slots. | 0.2.0 | 
 | celeborn.slots.reserve.retryWait | 3s | Wait time before next retry if reserve slots failed. | 0.2.0 | 
 | celeborn.storage.hdfs.dir | &lt;undefined&gt; | HDFS dir configuration for Celeborn to access HDFS. | 0.2.0 | 
-| celeborn.test.fail.commitFile | false | Fail commitFile request for test | 0.2.0 | 
 | celeborn.test.fetchFailure | false | Wheter to test fetch chunk failure | 0.2.0 | 
+| celeborn.test.retryCommitFiles | false | Fail commitFile request for test | 0.2.0 | 
 | celeborn.worker.excluded.checkInterval | 30s | Interval for client to refresh excluded worker list. | 0.2.0 | 
 | celeborn.worker.excluded.expireTimeout | 600s | Timeout time for LifecycleManager to clear reserved excluded worker. | 0.2.0 | 
 <!--end-include-->

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -41,6 +41,7 @@ license: |
 | celeborn.rpc.cache.expireTime | 15s | The time before a cache item is removed. | 0.2.0 | 
 | celeborn.rpc.cache.size | 256 | The max cache items count for rpc cache. | 0.2.0 | 
 | celeborn.rpc.maxParallelism | 1024 | Max parallelism of client on sending RPC requests. | 0.2.0 | 
+| celeborn.rpc.requestCommitFiles.maxRetries | 2 | Max retry times for requestCommitFiles RPC. | 1.0.0 | 
 | celeborn.shuffle.batchHandleChangePartition.enabled | false | When true, LifecycleManager will handle change partition request in batch. Otherwise, LifecycleManager will process the requests one by one | 0.2.0 | 
 | celeborn.shuffle.batchHandleChangePartition.interval | 100ms | Interval for LifecycleManager to schedule handling change partition requests in batch. | 0.2.0 | 
 | celeborn.shuffle.batchHandleChangePartition.threads | 8 | Threads number for LifecycleManager to handle change partition request in batch. | 0.2.0 | 
@@ -61,6 +62,7 @@ license: |
 | celeborn.slots.reserve.maxRetries | 3 | Max retry times for client to reserve slots. | 0.2.0 | 
 | celeborn.slots.reserve.retryWait | 3s | Wait time before next retry if reserve slots failed. | 0.2.0 | 
 | celeborn.storage.hdfs.dir | &lt;undefined&gt; | HDFS dir configuration for Celeborn to access HDFS. | 0.2.0 | 
+| celeborn.test.fail.commitFile | false | Fail commitFile request for test | 0.2.0 | 
 | celeborn.test.fetchFailure | false | Wheter to test fetch chunk failure | 0.2.0 | 
 | celeborn.worker.excluded.checkInterval | 30s | Interval for client to refresh excluded worker list. | 0.2.0 | 
 | celeborn.worker.excluded.expireTimeout | 600s | Timeout time for LifecycleManager to clear reserved excluded worker. | 0.2.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -73,7 +73,7 @@ license: |
 | celeborn.worker.replicate.port | 0 | Server port for Worker to receive replicate data request from other Workers. | 0.2.0 | 
 | celeborn.worker.replicate.threads | 64 | Thread number of worker to replicate shuffle data. | 0.2.0 | 
 | celeborn.worker.rpc.port | 0 | Server port for Worker to receive RPC request. | 0.2.0 | 
-| celeborn.worker.shuffle.commit.timeout | 120s | Timeout for a Celeborn worker to commit files of a shuffle. | 0.2.0 | 
+| celeborn.worker.shuffle.commit.timeout | &lt;value of celeborn.rpc.askTimeout&gt; | Timeout for a Celeborn worker to commit files of a shuffle. | 0.2.0 | 
 | celeborn.worker.storage.baseDir.number | 16 | How many directories will be used if `celeborn.worker.storage.dirs` is not set. The directory name is a combination of `celeborn.worker.storage.baseDir.prefix` and from one(inclusive) to `celeborn.worker.storage.baseDir.number`(inclusive) step by one. | 0.2.0 | 
 | celeborn.worker.storage.baseDir.prefix | /mnt/disk | Base directory for Celeborn worker to write if `celeborn.worker.storage.dirs` is not set. | 0.2.0 | 
 | celeborn.worker.storage.dirs | &lt;undefined&gt; | Directory list to store shuffle data. It's recommended to configure one directory on each disk. Storage size limit can be set for each directory. For the sake of performance, there should be no more than 2 flush threads on the same disk partition if you are using HDD, and should be 8 or more flush threads on the same disk partition if you are using SSD. For example: `dir1[:capacity=][:disktype=][:flushthread=],dir2[:capacity=][:disktype=][:flushthread=]` | 0.2.0 | 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HugeDataTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HugeDataTest.scala
@@ -31,7 +31,7 @@ class HugeDataTest extends AnyFunSuite
 
   override def beforeAll(): Unit = {
     logInfo("test initialized , setup rss mini cluster")
-    tuple = setupRssMiniCluster()
+    tuple = setupRssMiniClusterSpark()
   }
 
   override def afterAll(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RssSortSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RssSortSuite.scala
@@ -31,7 +31,7 @@ class RssSortSuite extends AnyFunSuite
 
   override def beforeAll(): Unit = {
     logInfo("test initialized , setup rss mini cluster")
-    tuple = setupRssMiniCluster()
+    tuple = setupRssMiniClusterSpark()
   }
 
   override def afterAll(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SkewJoinSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SkewJoinSuite.scala
@@ -35,7 +35,7 @@ class SkewJoinSuite extends AnyFunSuite
 
   override def beforeAll(): Unit = {
     logInfo("test initialized , setup rss mini cluster")
-    tuple = setupRssMiniCluster()
+    tuple = setupRssMiniClusterSpark()
   }
 
   override def afterAll(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SparkTestBase.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SparkTestBase.scala
@@ -76,7 +76,9 @@ trait SparkTestBase extends Logging with MiniClusterFeature {
     tuple._12.interrupt()
   }
 
-  def setupRssMiniCluster(): (
+  def setupRssMiniClusterSpark(
+      masterConfs: Map[String, String] = null,
+      workerConfs: Map[String, String] = null): (
       Master,
       RpcEnv,
       Worker,
@@ -91,10 +93,10 @@ trait SparkTestBase extends Logging with MiniClusterFeature {
       Thread) = {
     Thread.sleep(3000L)
 
-    val (master, masterRpcEnv) = createMaster()
-    val (worker1, workerRpcEnv1) = createWorker()
-    val (worker2, workerRpcEnv2) = createWorker()
-    val (worker3, workerRpcEnv3) = createWorker()
+    val (master, masterRpcEnv) = createMaster(masterConfs)
+    val (worker1, workerRpcEnv1) = createWorker(workerConfs)
+    val (worker2, workerRpcEnv2) = createWorker(workerConfs)
+    val (worker3, workerRpcEnv3) = createWorker(workerConfs)
     val masterThread = runnerWrap(masterRpcEnv.awaitTermination())
     val workerThread1 = runnerWrap(worker1.initialize())
     val workerThread2 = runnerWrap(worker2.initialize())

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -200,6 +200,11 @@ public final class FileWriter implements DeviceObserver {
     final int numBytes = data.readableBytes();
     MemoryTracker.instance().incrementDiskBuffer(numBytes);
     synchronized (this) {
+      if (closed) {
+        String msg = "FileWriter has already closed!, fileName " + fileInfo.getFilePath();
+        logger.warn(msg);
+        throw new AlreadyClosedException(msg);
+      }
       if (rangeReadFilter) {
         mapIdBitMap.add(mapId);
       }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/CommitInfo.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/CommitInfo.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker
+
+import org.apache.celeborn.common.protocol.message.ControlMessages.CommitFilesResponse
+
+class CommitInfo(var response: CommitFilesResponse, var status: Int)
+
+object CommitInfo {
+  val COMMIT_NOTSTARTED: Int = 0
+  val COMMIT_INPROCESS: Int = 1
+  val COMMIT_FINISHED: Int = 2
+}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -179,6 +179,8 @@ private[celeborn] class Worker(
   val shuffleMapperAttempts = new ConcurrentHashMap[String, Array[Int]]()
   val partitionLocationInfo = new PartitionLocationInfo
 
+  val shuffleCommitInfos = new ConcurrentHashMap[String, CommitInfo]()
+
   private val rssHARetryClient = new RssHARetryClient(rpcEnv, conf)
 
   // (workerInfo -> last connect timeout timestamp)
@@ -420,6 +422,7 @@ private[celeborn] class Worker(
       partitionLocationInfo.removeMasterPartitions(shuffleKey)
       partitionLocationInfo.removeSlavePartitions(shuffleKey)
       shuffleMapperAttempts.remove(shuffleKey)
+      shuffleCommitInfos.remove(shuffleKey)
       workerInfo.releaseSlots(shuffleKey)
       logInfo(s"Cleaned up expired shuffle $shuffleKey")
     }


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?


### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?
Add config in client side
```
spark.celeborn.test.retryCommitFiles=true
```
Optionally, can also add a config in worker side
```
celeborn.test.retryCommitFiles=true
```
We can see logs like
```
22/11/26 20:45:30 ERROR LifecycleManager: AskSync CommitFiles for 10 failed (attempt 2/3).
java.lang.Exception: Mock fail for CommitFiles
	at org.apache.celeborn.client.LifecycleManager.requestCommitFilesWithRetry(LifecycleManager.scala:1653) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-SNAPSHOT.jar:?]
	at org.apache.celeborn.client.LifecycleManager.$anonfun$handleStageEnd$4(LifecycleManager.scala:997) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-SNAPSHOT.jar:?]
	at org.apache.celeborn.client.LifecycleManager.$anonfun$handleStageEnd$4$adapted(LifecycleManager.scala:971) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-SNAPSHOT.jar:?]
	at org.apache.celeborn.common.util.ThreadUtils$.$anonfun$parmap$2(ThreadUtils.scala:301) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-SNAPSHOT.jar:?]
```

/cc @related-reviewer

/assign @main-reviewer
