### PR TITLE
[CELEBORN-23][FOLLOWUP] Both master and slave data should return HARD_SPLIT during shutdown

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -182,7 +182,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
 
     // During worker shutdown, worker will return HARD_SPLIT for all existed partition.
     // This should before return exception to make current push data can revive and retry.
-    if (isMaster && shutdown.get()) {
+    if (shutdown.get()) {
       logInfo(s"Push data return HARD_SPLIT for shuffle $shuffleKey since worker shutdown.")
       callback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
       return
@@ -351,7 +351,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
 
     // During worker shutdown, worker will return HARD_SPLIT for all existed partition.
     // This should before return exception to make current push data can revive and retry.
-    if (isMaster && shutdown.get()) {
+    if (shutdown.get()) {
       callback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
       return
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Have tested, when slave return HARD_SPLIT, shuffle client side receives HARD_SPLIT too. It can work

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
