### PR TITLE
[CELEBORN-63] Increase push data return reason types such as CONGESTION ect

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -591,6 +591,7 @@ public class ShuffleClientImpl extends ShuffleClient {
             @Override
             public void onSuccess(ByteBuffer response) {
               pushState.inFlightBatches.remove(nextBatchId);
+              // TODO Need to handle CONGESTED & FREE statuses
               if (response.remaining() > 0 && response.get() == StatusCode.STAGE_ENDED.getValue()) {
                 mapperEndMap
                     .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())

--- a/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
@@ -55,7 +55,12 @@ public enum StatusCode {
   WORKER_IN_BLACKLIST(27),
   UNKNOWN_WORKER(28),
 
-  COMMIT_FILE_EXCEPTION(29);
+  COMMIT_FILE_EXCEPTION(29),
+
+  // Rate limit statuses
+  SUCCESS_FREE(30),
+  SUCCESS_MASTER_CONGESTED(31),
+  SUCCESS_SLAVE_CONGESTED(32);
 
   private final byte value;
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -890,6 +890,12 @@ object Utils extends Logging {
         StatusCode.WORKER_IN_BLACKLIST
       case 28 =>
         StatusCode.UNKNOWN_WORKER
+      case 30 =>
+        StatusCode.SUCCESS_FREE
+      case 31 =>
+        StatusCode.SUCCESS_MASTER_CONGESTED
+      case 32 =>
+        StatusCode.SUCCESS_SLAVE_CONGESTED
       case _ =>
         null
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -262,7 +262,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
         }
       })
     } else {
-      wrappedCallback.onSuccess(ByteBuffer.wrap(Array[Byte]()))
+      wrappedCallback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.SUCCESS_FREE.getValue)))
     }
 
     try {


### PR DESCRIPTION
# [FEATURE] Increase push data return reason types such as CONGESTION ect

### What changes were proposed in this pull request?
Add following statuses to allow `ShuffleServer` return statuses to the client side.

SUCCESS_FREE
SUCCESS_MASTER_CONGESTED
SUCCESS_SLAVE_CONGESTED

### Why are the changes needed?

To support Rate Limit mechanism

### What are the items that need reviewer attention?
No

### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
