### PR TITLE
[CELEBORN-83] 1.fix incompatibility between hadoop 2 and hadoop 3. 2.fix hdfs writer will never be called when there is no healthy disks. 3.fix an NPE when hdfs file writer close.

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/DfsPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/DfsPartitionReader.java
@@ -29,9 +29,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCounted;
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.CelebornConf;
@@ -44,6 +45,7 @@ import org.apache.celeborn.common.util.ShuffleBlockInfoUtils;
 import org.apache.celeborn.common.util.Utils;
 
 public class DfsPartitionReader implements PartitionReader {
+  private static Logger logger = LoggerFactory.getLogger(DfsPartitionReader.class);
   PartitionLocation location;
   private final int shuffleChunkSize;
   private final int fetchMaxReqsInFlight;
@@ -108,7 +110,7 @@ public class DfsPartitionReader implements PartitionReader {
                     }
                     long offset = chunkOffsets.get(currentChunkIndex.get());
                     long length = chunkOffsets.get(currentChunkIndex.get() + 1) - offset;
-                    ByteBuffer buffer = ByteBuffer.allocate((int) length);
+                    byte[] buffer = new byte[(int) length];
                     hdfsInputStream.readFully(offset, buffer);
                     results.add(Unpooled.wrappedBuffer(buffer));
                     currentChunkIndex.incrementAndGet();
@@ -120,6 +122,7 @@ public class DfsPartitionReader implements PartitionReader {
                 }
               });
       fetchThread.start();
+      logger.debug("Start dfs read on location {}", location);
     }
   }
 
@@ -144,7 +147,7 @@ public class DfsPartitionReader implements PartitionReader {
     FSDataInputStream indexInputStream = ShuffleClient.getHdfsFs(conf).open(new Path(indexPath));
     long indexSize = ShuffleClient.getHdfsFs(conf).getFileStatus(new Path(indexPath)).getLen();
     // Index size won't be large, so it's safe to do the conversion.
-    ByteBuffer indexBuffer = ByteBuffer.allocate((int) indexSize);
+    byte[] indexBuffer = new byte[(int) indexSize];
     indexInputStream.readFully(0L, indexBuffer);
     List<Long> offsets =
         new ArrayList<>(
@@ -191,7 +194,11 @@ public class DfsPartitionReader implements PartitionReader {
   public void close() {
     closed = true;
     fetchThread.interrupt();
-    IOUtils.closeQuietly(hdfsInputStream, null);
+    try {
+      hdfsInputStream.close();
+    } catch (IOException e) {
+      logger.warn("close hdfs input stream failed.", e);
+    }
     if (results.size() > 0) {
       results.forEach(ReferenceCounted::release);
     }

--- a/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
@@ -284,6 +284,8 @@ public abstract class RssInputStream extends InputStream {
         logger.debug("Read peer {} for attempt {}.", location, attemptNumber);
       }
 
+      logger.debug("create reader for location {}", location);
+
       StorageInfo storageInfo = location.getStorageInfo();
       if (storageInfo.getType() == StorageInfo.Type.HDD
           || storageInfo.getType() == StorageInfo.Type.SSD) {

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -108,11 +108,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>${hadoop-client-api.artifact}</artifactId>
+      <artifactId>hadoop-client-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>${hadoop-client-runtime.artifact}</artifactId>
+      <artifactId>hadoop-client-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>org.roaringbitmap</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -108,7 +108,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
+      <artifactId>${hadoop-client-api.artifact}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>${hadoop-client-runtime.artifact}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.roaringbitmap</groupId>

--- a/common/src/main/java/org/apache/celeborn/common/util/ShuffleBlockInfoUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ShuffleBlockInfoUtils.java
@@ -61,6 +61,11 @@ public class ShuffleBlockInfoUtils {
   }
 
   public static Map<Integer, List<ShuffleBlockInfo>> parseShuffleBlockInfosFromByteBuffer(
+      byte[] buffer) {
+    return parseShuffleBlockInfosFromByteBuffer(ByteBuffer.wrap(buffer));
+  }
+
+  public static Map<Integer, List<ShuffleBlockInfo>> parseShuffleBlockInfosFromByteBuffer(
       ByteBuffer buffer) {
     Map<Integer, List<ShuffleBlockInfo>> indexMap = new HashMap<>();
     while (buffer.hasRemaining()) {

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,10 @@
     <roaringbitmap.version>0.9.32</roaringbitmap.version>
     <snakeyaml.version>1.30</snakeyaml.version>
     <!--  default hadoop version  -->
-    <hadoop.version>3.3.1</hadoop.version>
+    <hadoop.version>3.2.1</hadoop.version>
     <shading.prefix>org.apache.celeborn.shaded</shading.prefix>
+    <hadoop-client-api.artifact>hadoop-client-api</hadoop-client-api.artifact>
+    <hadoop-client-runtime.artifact>hadoop-client-runtime</hadoop-client-runtime.artifact>
 
     <maven.plugin.antrun.version>3.0.0</maven.plugin.antrun.version>
     <maven.plugin.clean.version>3.2.0</maven.plugin.clean.version>
@@ -321,7 +323,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-client</artifactId>
+        <artifactId>${hadoop-client-api.artifact}</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
@@ -411,6 +413,11 @@
             <artifactId>reload4j</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>${hadoop-client-runtime.artifact}</artifactId>
+        <version>${hadoop.version}</version>
       </dependency>
       <dependency>
         <groupId>org.roaringbitmap</groupId>
@@ -840,6 +847,18 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>hadoop-2</id>
+      <properties>
+        <hadoop.version>2.7.4</hadoop.version>
+        <hadoop-client-api.artifact>hadoop-client</hadoop-client-api.artifact>
+        <hadoop-client-runtime.artifact>hadoop-yarn-api</hadoop-client-runtime.artifact>
+      </properties>
+    </profile>
+    <profile>
+      <id>hadoop-3</id>
+      <!-- Default hadoop profile. Uses global properties. -->
+    </profile>
     <profile>
       <id>spark-2.4</id>
       <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,6 @@
     <!--  default hadoop version  -->
     <hadoop.version>3.2.1</hadoop.version>
     <shading.prefix>org.apache.celeborn.shaded</shading.prefix>
-    <hadoop-client-api.artifact>hadoop-client-api</hadoop-client-api.artifact>
-    <hadoop-client-runtime.artifact>hadoop-client-runtime</hadoop-client-runtime.artifact>
 
     <maven.plugin.antrun.version>3.0.0</maven.plugin.antrun.version>
     <maven.plugin.clean.version>3.2.0</maven.plugin.clean.version>
@@ -323,7 +321,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
-        <artifactId>${hadoop-client-api.artifact}</artifactId>
+        <artifactId>hadoop-client-api</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
@@ -416,7 +414,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
-        <artifactId>${hadoop-client-runtime.artifact}</artifactId>
+        <artifactId>hadoop-client-runtime</artifactId>
         <version>${hadoop.version}</version>
       </dependency>
       <dependency>
@@ -847,18 +845,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>hadoop-2</id>
-      <properties>
-        <hadoop.version>2.7.4</hadoop.version>
-        <hadoop-client-api.artifact>hadoop-client</hadoop-client-api.artifact>
-        <hadoop-client-runtime.artifact>hadoop-yarn-api</hadoop-client-runtime.artifact>
-      </properties>
-    </profile>
-    <profile>
-      <id>hadoop-3</id>
-      <!-- Default hadoop profile. Uses global properties. -->
-    </profile>
     <profile>
       <id>spark-2.4</id>
       <modules>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -49,10 +49,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.fusesource.leveldbjni</groupId>
       <artifactId>leveldbjni-all</artifactId>
     </dependency>

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -286,7 +286,10 @@ public final class FileWriter implements DeviceObserver {
       }
 
       // unregister from DeviceMonitor
-      deviceMonitor.unregisterFileWriter(this);
+      if (!fileInfo.isHdfs()) {
+        logger.debug("file info {} register from device monitor");
+        deviceMonitor.unregisterFileWriter(this);
+      }
     }
     return bytesFlushed;
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -417,17 +417,9 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
       throws IOException {
     // Worker read a shuffle block whose size is 256K by default.
     // So there is no need to worry about integer overflow.
-    ByteBuffer buffer = ByteBuffer.allocate(Math.toIntExact(length));
-    long transferredSize = 0;
-    while (buffer.hasRemaining()) {
-      int read = origin.read(offset + transferredSize, buffer);
-      transferredSize += read;
-      if (-1 == read) {
-        throw new IOException(
-            "Unexpected EOF, position :" + origin.getPos() + " buffer size :" + buffer.limit());
-      }
-    }
-    sorted.write(buffer.array());
+    byte[] buffer = new byte[Math.toIntExact(length)];
+    origin.readFully(offset, buffer);
+    sorted.write(buffer);
     return length;
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -145,7 +145,7 @@ private[deploy] class Controller(
       return
     }
 
-    if (storageManager.healthyWorkingDirs().size <= 0) {
+    if (storageManager.healthyWorkingDirs().size <= 0 && storageManager.hdfsDir.isEmpty) {
       val msg = "Local storage has no available dirs!"
       logError(s"[handleReserveSlots] $msg")
       context.reply(ReserveSlotsResponse(StatusCode.NO_AVAILABLE_WORKING_DIR, msg))

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -119,6 +119,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   deviceMonitor.startCheck()
 
   val hdfsDir = conf.hdfsDir
+  if (!hdfsDir.isEmpty) {
+    logInfo(s"Initialize HDFS support with path ${hdfsDir}")
+  }
   val hdfsPermission = FsPermission.createImmutable(755)
   val hdfsWriters = new util.ArrayList[FileWriter]()
   val hdfsFlusher =
@@ -253,7 +256,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       partitionType: PartitionType,
       rangeReadFilter: Boolean,
       userIdentifier: UserIdentifier): FileWriter = {
-    if (healthyWorkingDirs().size <= 0) {
+    if (healthyWorkingDirs().size <= 0 && hdfsDir.isEmpty) {
       throw new IOException("No available working dirs!")
     }
 


### PR DESCRIPTION
# [CELEBORN-83] Fix various bug when using HDFS as storage.

### What changes were proposed in this pull request?
1. fix incompitiablity between hadoop 2 and hadoop 3. 
2. fix hdfs writer will never be called when there is no healthy disks. 
3. fix an NPE when hdfs file writer close. 


### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
