### PR TITLE
[CELEBORN-94][BUG] StateMachine should implement pause to change status

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
@@ -191,8 +191,10 @@ public class StateMachine extends BaseStateMachine {
   @Override
   public void reinitialize() throws IOException {
     LOG.info("Reinitializing state machine.");
+    getLifeCycle().compareAndTransition(PAUSED, STARTING);
     storage.loadLatestSnapshot();
     loadSnapshot(storage.getLatestSnapshot());
+    getLifeCycle().compareAndTransition(STARTING, RUNNING);
   }
 
   @Override

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
@@ -63,6 +63,8 @@ import org.apache.celeborn.common.util.ThreadUtils;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos.ResourceResponse;
 
+import static org.apache.ratis.util.LifeCycle.State.*;
+
 public class StateMachine extends BaseStateMachine {
   private static final Logger LOG = LoggerFactory.getLogger(StateMachine.class);
 
@@ -191,6 +193,12 @@ public class StateMachine extends BaseStateMachine {
     LOG.info("Reinitializing state machine.");
     storage.loadLatestSnapshot();
     loadSnapshot(storage.getLatestSnapshot());
+  }
+
+  @Override
+  public void pause() {
+    getLifeCycle().compareAndTransition(RUNNING, PAUSING);
+    getLifeCycle().compareAndTransition(PAUSING, PAUSED);
   }
 
   private synchronized void loadSnapshot(SingleFileSnapshotInfo snapshot) throws IOException {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
@@ -17,6 +17,8 @@
 
 package org.apache.celeborn.service.deploy.master.clustermeta.ha;
 
+import static org.apache.ratis.util.LifeCycle.State.*;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -62,8 +64,6 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.util.ThreadUtils;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos.ResourceResponse;
-
-import static org.apache.ratis.util.LifeCycle.State.*;
 
 public class StateMachine extends BaseStateMachine {
   private static final Logger LOG = LoggerFactory.getLogger(StateMachine.class);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Meet such problem 
```
22/11/30 19:11:14,814 INFO [main] Dispatcher: Dispatcher numThreads: 64
22/11/30 19:11:14,842 INFO [main] TransportClientFactory: mode NIO threads 64
22/11/30 19:11:14,996 DEBUG [main] TransportServer: Shuffle server started on port: 9097
22/11/30 19:11:14,999 INFO [main] Utils: Successfully started service 'MasterSys' on port 9097.
22/11/30 19:11:15,108 INFO [main] RaftServer: raft.rpc.type = NETTY (custom)
22/11/30 19:11:15,215 INFO [main] NettyConfigKeys$Server: raft.netty.server.host = null (default)
22/11/30 19:11:15,217 INFO [main] NettyConfigKeys$Server: raft.netty.server.port = 9872 (custom)
22/11/30 19:11:15,219 INFO [main] DataStreamServerImpl: raft.datastream.type = DISABLED (default)
22/11/30 19:11:15,299 INFO [main] RaftServerConfigKeys: raft.server.threadpool.proxy.cached = true (default)
22/11/30 19:11:15,300 INFO [main] RaftServerConfigKeys: raft.server.threadpool.proxy.size = 0 (default)
22/11/30 19:11:15,302 INFO [main] RaftServerConfigKeys: raft.server.rpc.slowness.timeout = 120s (custom)
22/11/30 19:11:15,303 INFO [main] RaftServerConfigKeys: raft.server.leaderelection.leader.step-down.wait-time = 10s (default)
22/11/30 19:11:15,309 INFO [main] RaftServerConfigKeys: raft.server.storage.dir = [/mnt/disk/0/rss_ratis] (custom)
22/11/30 19:11:15,317 INFO [main] RaftServer: master2: addNew group-1FBDD5AC3BE1:[master1|rpc:ip-10-130-24-168.idata-server.shopee.io:9872|priority:0|startupRole:FOLLOWER, master2|rpc:ip-10-130-26-2.idata-server.shopee.io:9872|priority:0|startupRole:FOLL
OWER, master3|rpc:ip-10-130-24-100.idata-server.shopee.io:9872|priority:0|startupRole:FOLLOWER] returns group-1FBDD5AC3BE1:java.util.concurrent.CompletableFuture@4d6025c5[Not completed]
22/11/30 19:11:15,317 INFO [main] HARaftServer: Ratis server started with GroupID: rss-cluster-tl and Raft Peers: ip-10-130-26-2.idata-server.shopee.io:9872, ip-10-130-24-168.idata-server.shopee.io:9872, ip-10-130-24-100.idata-server.shopee.io:9872.
22/11/30 19:11:15,318 INFO [main] HARaftServer: Starting HARaftServer master2 at port 9872
22/11/30 19:11:15,334 INFO [pool-5-thread-1] RaftServer$Division: master2: new RaftServerImpl for group-1FBDD5AC3BE1:[master1|rpc:ip-10-130-24-168.idata-server.shopee.io:9872|priority:0|startupRole:FOLLOWER, master2|rpc:ip-10-130-26-2.idata-server.shopee
.io:9872|priority:0|startupRole:FOLLOWER, master3|rpc:ip-10-130-24-100.idata-server.shopee.io:9872|priority:0|startupRole:FOLLOWER] with StateMachine:uninitialized
22/11/30 19:11:15,335 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.rpc.timeout.min = 10s (custom)
22/11/30 19:11:15,335 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.rpc.timeout.max = 12s (custom)
22/11/30 19:11:15,336 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.rpc.sleep.time = 25ms (default)
22/11/30 19:11:15,336 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.rpc.slowness.timeout = 120s (custom)
22/11/30 19:11:15,336 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.leaderelection.leader.step-down.wait-time = 10s (default)
22/11/30 19:11:15,336 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.sleep.deviation.threshold = 300ms (default)
22/11/30 19:11:15,343 INFO [pool-5-thread-1] RaftServer$Division: master2@group-1FBDD5AC3BE1: ConfigurationManager, init=-1: peers:[master1|rpc:ip-10-130-24-168.idata-server.shopee.io:9872|priority:0|startupRole:FOLLOWER, master2|rpc:ip-10-130-26-2.idata
-server.shopee.io:9872|priority:0|startupRole:FOLLOWER, master3|rpc:ip-10-130-24-100.idata-server.shopee.io:9872|priority:0|startupRole:FOLLOWER]|listeners:[], old=null, confs=<EMPTY_MAP>
22/11/30 19:11:15,343 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.storage.dir = [/mnt/disk/0/rss_ratis] (custom)
22/11/30 19:11:15,348 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.log.corruption.policy = EXCEPTION (default)
22/11/30 19:11:15,349 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.storage.free-space.min = 0MB (=0) (default)
22/11/30 19:11:15,354 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.notification.no-leader.timeout = 120s (custom)
22/11/30 19:11:15,357 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.retrycache.expirytime = 600s (custom)
22/11/30 19:11:15,357 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.retrycache.statistics.expirytime = 100μs (default)
22/11/30 19:11:15,380 INFO [pool-5-thread-1] MetricRegistries: Loaded MetricRegistries class org.apache.ratis.metrics.impl.MetricRegistriesImpl
22/11/30 19:11:15,447 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.log.appender.install.snapshot.enabled = true (default)
22/11/30 19:11:15,447 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.threadpool.server.cached = true (default)
22/11/30 19:11:15,448 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.threadpool.server.size = 0 (default)
22/11/30 19:11:15,448 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.threadpool.client.cached = true (default)
22/11/30 19:11:15,449 INFO [pool-5-thread-1] RaftServerConfigKeys: raft.server.threadpool.client.size = 0 (default)
22/11/30 19:11:15,449 INFO [master2-impl-thread1] RaftStorageDirectory: The storage directory /mnt/disk/0/rss_ratis/52bfb65d-0607-35b8-b151-1fbdd5ac3be1 does not exist. Creating ...
22/11/30 19:11:15,461 INFO [master2-impl-thread1] RaftStorageDirectory: Lock on /mnt/disk/0/rss_ratis/52bfb65d-0607-35b8-b151-1fbdd5ac3be1/in_use.lock acquired by nodename 52337@ip-10-130-26-2.idata-server.shopee.io
22/11/30 19:11:15,481 INFO [master2-impl-thread1] RaftStorage: Storage directory /mnt/disk/0/rss_ratis/52bfb65d-0607-35b8-b151-1fbdd5ac3be1 has been successfully formatted.
22/11/30 19:11:15,483 INFO [master2-impl-thread1] StateMachine: Initialized State Machine.
22/11/30 19:11:15,485 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.use.memory = false (default)
22/11/30 19:11:15,492 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.purge.gap = 1000000 (custom)
22/11/30 19:11:15,492 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.appender.buffer.byte-limit = 33554432 (custom)
22/11/30 19:11:15,494 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.statemachine.data.read.timeout = 1000ms (default)
22/11/30 19:11:15,494 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.purge.preservation.log.num = 200000 (custom)
22/11/30 19:11:15,496 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.segment.size.max = 4194304 (custom)
22/11/30 19:11:15,501 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.segment.cache.num.max = 2 (custom)
22/11/30 19:11:15,502 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.segment.cache.size.max = 200MB (=209715200) (default)
22/11/30 19:11:15,506 INFO [master2-impl-thread1] SegmentedRaftLogWorker: new master2@group-1FBDD5AC3BE1-SegmentedRaftLogWorker for RaftStorageImpl:Storage Directory /mnt/disk/0/rss_ratis/52bfb65d-0607-35b8-b151-1fbdd5ac3be1
22/11/30 19:11:15,506 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.queue.byte-limit = 64MB (=67108864) (default)
22/11/30 19:11:15,507 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.queue.element-limit = 4096 (default)
22/11/30 19:11:15,508 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.segment.size.max = 4194304 (custom)
22/11/30 19:11:15,508 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.preallocated.size = 4194304 (custom)
22/11/30 19:11:15,509 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.force.sync.num = 128 (default)
22/11/30 19:11:15,509 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.statemachine.data.sync = true (default)
22/11/30 19:11:15,510 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.statemachine.data.sync.timeout = 10s (default)
22/11/30 19:11:15,510 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.statemachine.data.sync.timeout.retry = -1 (default)
22/11/30 19:11:15,519 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.write.buffer.size = 64KB (=65536) (default)
22/11/30 19:11:15,520 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.unsafe-flush.enabled = false (default)
22/11/30 19:11:15,520 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.async-flush.enabled = false (default)
22/11/30 19:11:15,521 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.statemachine.data.caching.enabled = false (default)
22/11/30 19:11:15,526 INFO [master2-impl-thread1] SegmentedRaftLogWorker: master2@group-1FBDD5AC3BE1-SegmentedRaftLogWorker: flushIndex: setUnconditionally 0 -> -1
22/11/30 19:11:15,526 INFO [master2-impl-thread1] SegmentedRaftLogWorker: master2@group-1FBDD5AC3BE1-SegmentedRaftLogWorker: safeCacheEvictIndex: setUnconditionally 0 -> -1
22/11/30 19:11:15,528 INFO [master2-impl-thread1] RaftServer$Division: master2@group-1FBDD5AC3BE1: start as a follower, conf=-1: peers:[master1|rpc:ip-10-130-24-168.idata-server.shopee.io:9872|priority:0|startupRole:FOLLOWER, master2|rpc:ip-10-130-26-2.i
data-server.shopee.io:9872|priority:0|startupRole:FOLLOWER, master3|rpc:ip-10-130-24-100.idata-server.shopee.io:9872|priority:0|startupRole:FOLLOWER]|listeners:[], old=null
22/11/30 19:11:15,528 INFO [master2-impl-thread1] RaftServer$Division: master2@group-1FBDD5AC3BE1: changes role from      null to FOLLOWER at term 0 for startAsFollower
22/11/30 19:11:15,529 INFO [master2-impl-thread1] RoleInfo: master2: start master2@group-1FBDD5AC3BE1-FollowerState
22/11/30 19:11:15,530 INFO [master2@group-1FBDD5AC3BE1-FollowerState] RaftServerConfigKeys: raft.server.rpc.first-election.timeout.min = 10s (fallback to raft.server.rpc.timeout.min)
22/11/30 19:11:15,530 INFO [master2@group-1FBDD5AC3BE1-FollowerState] RaftServerConfigKeys: raft.server.rpc.first-election.timeout.max = 12s (fallback to raft.server.rpc.timeout.max)
22/11/30 19:11:15,531 INFO [master2-impl-thread1] JmxRegister: Successfully registered JMX Bean with object name Ratis:service=RaftServer,group=group-1FBDD5AC3BE1,id=master2
22/11/30 19:11:15,532 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.snapshot.auto.trigger.enabled = true (custom)
22/11/30 19:11:15,533 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.snapshot.auto.trigger.threshold = 200000 (custom)
22/11/30 19:11:15,533 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.snapshot.retention.file.num = 3 (custom)
22/11/30 19:11:15,534 INFO [master2-impl-thread1] RaftServerConfigKeys: raft.server.log.purge.upto.snapshot.index = true (custom)
22/11/30 19:11:15,536 INFO [main] RaftServer: master2: start RPC server
22/11/30 19:11:15,634 INFO [nioEventLoopGroup-2-1] LoggingHandler: [id: 0x6d461846] REGISTERED
22/11/30 19:11:15,636 INFO [nioEventLoopGroup-2-1] LoggingHandler: [id: 0x6d461846] BIND: 0.0.0.0/0.0.0.0:9872
22/11/30 19:11:15,639 INFO [nioEventLoopGroup-2-1] LoggingHandler: [id: 0x6d461846, L:/0:0:0:0:0:0:0:0:9872] ACTIVE
22/11/30 19:11:15,639 INFO [JvmPauseMonitor0] JvmPauseMonitor: JvmPauseMonitor-master2: Started
22/11/30 19:11:15,661 INFO [main] Master: Metrics system enabled.
22/11/30 19:11:15,669 INFO [nioEventLoopGroup-2-1] LoggingHandler: [id: 0x6d461846, L:/0:0:0:0:0:0:0:0:9872] READ: [id: 0x94ac74e5, L:/10.130.26.2:9872 - R:/10.130.24.168:56886]
22/11/30 19:11:15,670 INFO [nioEventLoopGroup-2-1] LoggingHandler: [id: 0x6d461846, L:/0:0:0:0:0:0:0:0:9872] READ COMPLETE
22/11/30 19:11:15,674 INFO [main] HttpServer: HttpServer started on port 9098.
22/11/30 19:11:15,736 INFO [nioEventLoopGroup-3-1] RaftServer$Division: master2@group-1FBDD5AC3BE1: change Leader from null to master1 at term 12 for appendEntries, leader elected after 382ms
22/11/30 19:11:15,739 INFO [nioEventLoopGroup-3-1] RaftServer$Division: master2@group-1FBDD5AC3BE1: Failed appendEntries as previous log entry ((t:11, i:79860084)) is not found
22/11/30 19:11:15,751 INFO [nioEventLoopGroup-3-1] RaftServer$Division: master2@group-1FBDD5AC3BE1: inconsistency entries. Reply:master1<-master2#5:FAIL-t0,INCONSISTENCY,nextIndex=0,followerCommit=-1,matchIndex=-1
22/11/30 19:11:15,790 INFO [nioEventLoopGroup-3-1] SnapshotInstallationHandler: master2@group-1FBDD5AC3BE1: receive installSnapshot: master1->master2#0-t12,chunk:71633bf0-8a9f-45c3-bf24-3937966fd156,0
22/11/30 19:11:15,791 INFO [nioEventLoopGroup-3-1] SnapshotManager: Installing snapshot:master1->master2#0-t12,chunk:71633bf0-8a9f-45c3-bf24-3937966fd156,0, to tmp dir:/mnt/disk/0/rss_ratis/52bfb65d-0607-35b8-b151-1fbdd5ac3be1/tmp/snapshot-71633bf0-8a9f-
45c3-bf24-3937966fd156
22/11/30 19:11:15,809 INFO [nioEventLoopGroup-3-1] SnapshotManager: Installed snapshot, renaming temporary dir /mnt/disk/0/rss_ratis/52bfb65d-0607-35b8-b151-1fbdd5ac3be1/tmp/snapshot-71633bf0-8a9f-45c3-bf24-3937966fd156 to /mnt/disk/0/rss_ratis/52bfb65d-
0607-35b8-b151-1fbdd5ac3be1/sm
22/11/30 19:11:15,819 INFO [nioEventLoopGroup-3-1] SegmentedRaftLogWorker: master2@group-1FBDD5AC3BE1-SegmentedRaftLogWorker: flushIndex: setUnconditionally -1 -> 79801207
22/11/30 19:11:15,819 INFO [nioEventLoopGroup-3-1] SegmentedRaftLogWorker: master2@group-1FBDD5AC3BE1-SegmentedRaftLogWorker: safeCacheEvictIndex: setUnconditionally -1 -> 79801207
22/11/30 19:11:15,820 INFO [nioEventLoopGroup-3-1] RaftLog: master2@group-1FBDD5AC3BE1-SegmentedRaftLog: snapshotIndex: updateIncreasingly -1 -> 79801207
22/11/30 19:11:15,820 INFO [nioEventLoopGroup-3-1] SnapshotInstallationHandler: master2@group-1FBDD5AC3BE1: successfully install the entire snapshot-79801207
22/11/30 19:11:15,820 ERROR [master2@group-1FBDD5AC3BE1-StateMachineUpdater] StateMachineUpdater: master2@group-1FBDD5AC3BE1-StateMachineUpdater caught a Throwable.
java.lang.IllegalStateException
        at org.apache.ratis.util.Preconditions.assertTrue(Preconditions.java:33)
        at org.apache.ratis.server.impl.StateMachineUpdater.reload(StateMachineUpdater.java:214)
        at org.apache.ratis.server.impl.StateMachineUpdater.run(StateMachineUpdater.java:179)
        at java.lang.Thread.run(Thread.java:748)
22/11/30 19:11:15,824 INFO [master2@group-1FBDD5AC3BE1-StateMachineUpdater] RaftServer$Division: master2@group-1FBDD5AC3BE1: shutdown
22/11/30 19:11:15,824 INFO [master2@group-1FBDD5AC3BE1-StateMachineUpdater] JmxRegister: Successfully un-registered JMX Bean with object name Ratis:service=RaftServer,group=group-1FBDD5AC3BE1,id=master2
22/11/30 19:11:15,824 INFO [master2@group-1FBDD5AC3BE1-StateMachineUpdater] RoleInfo: master2: shutdown master2@group-1FBDD5AC3BE1-FollowerState
22/11/30 19:11:15,825 INFO [master2@group-1FBDD5AC3BE1-FollowerState] FollowerState: master2@group-1FBDD5AC3BE1-FollowerState was interrupted
22/11/30 19:11:15,826 INFO [master2@group-1FBDD5AC3BE1-StateMachineUpdater] RaftServer$Division: master2@group-1FBDD5AC3BE1: closes. applyIndex: -1
22/11/30 19:11:15,827 INFO [master2@group-1FBDD5AC3BE1-SegmentedRaftLogWorker] SegmentedRaftLogWorker: master2@group-1FBDD5AC3BE1-SegmentedRaftLogWorker was interrupted, exiting. There are 0 tasks remaining in the queue.
22/11/30 19:11:15,828 INFO [master2@group-1FBDD5AC3BE1-StateMachineUpdater] SegmentedRaftLogWorker: master2@group-1FBDD5AC3BE1-SegmentedRaftLogWorker close()
22/11/30 19:11:15,905 INFO [nioEventLoopGroup-3-1] SnapshotInstallationHandler: master2@group-1FBDD5AC3BE1: set new configuration index: 79860085
configurationEntry {
  peers {
    id: "master1"
    address: "ip-xx-xx-xx-xx.idata-server.shopee.io:9872"
    startupRole: FOLLOWER
  }
  peers {
    id: "master2"
    address: "ip-xx-xx-xx-xx.idata-server.shopee.io:9872"
    startupRole: FOLLOWER
  }
  peers {
    id: "master3"
    address: "ip-xx-xx-xx-xx.idata-server.shopee.io:9872"
    startupRole: FOLLOWER
  }
}
 from snapshot
22/11/30 19:11:15,906 INFO [nioEventLoopGroup-3-1] RaftServer$Division: master2@group-1FBDD5AC3BE1: set configuration 79860085: peers:[master1|rpc:ip-10-130-24-168.idata-server.shopee.io:9872|admin:|client:|dataStream:|priority:0|startupRole:FOLLOWER, ma
ster2|rpc:ip-10-130-26-2.idata-server.shopee.io:9872|admin:|client:|dataStream:|priority:0|startupRole:FOLLOWER, master3|rpc:ip-10-130-24-100.idata-server.shopee.io:9872|admin:|client:|dataStream:|priority:0|startupRole:FOLLOWER]|listeners:[], old=null
```

<img width="1091" alt="截屏2022-11-30 下午8 25 13" src="https://user-images.githubusercontent.com/46485123/204795829-eaa7e2a7-8051-4b8b-a907-5a795b526043.png">
After install snapshot, will notify StateMachineUpdate to reload
<img width="915" alt="截屏2022-11-30 下午8 26 12" src="https://user-images.githubusercontent.com/46485123/204796010-7c0b3539-6ca3-4fb8-8841-e8cd8fa293a2.png">
In StateMachineUpdater `reload()` will check StateMachine status should be PAUSED, then reinitialize StateMachine with latest snapshot
<img width="1077" alt="截屏2022-11-30 下午8 26 39" src="https://user-images.githubusercontent.com/46485123/204796186-90775a71-363f-4597-990c-208501a557c9.png">

In ServerState.installSnapshot method there will call StateMachine's `pause()`
```
  void installSnapshot(InstallSnapshotRequestProto request) throws IOException {
    // TODO: verify that we need to install the snapshot
    StateMachine sm = server.getStateMachine();
    sm.pause(); // pause the SM to prepare for install snapshot
    snapshotManager.installSnapshot(sm, request);
    updateInstalledSnapshotIndex(TermIndex.valueOf(request.getSnapshotChunk().getTermIndex()));
  }
```

We should implement `pause()` in StateMachine and change the status



### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
