### PR TITLE
[CELEBORN-98][IMPROVEMENT] Remove unreachable code block in master/work arguments

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterArguments.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterArguments.scala
@@ -51,10 +51,6 @@ class MasterArguments(args: Array[String], conf: CelebornConf) {
     _port = _port.orElse(Some(conf.masterPort))
   }
 
-  if (_host.isEmpty || _port.isEmpty) {
-    printUsageAndExit(1)
-  }
-
   def host: String = _host.get
 
   def port: Int = _port.get

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterArgumentsSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterArgumentsSuite.scala
@@ -26,7 +26,7 @@ import org.apache.celeborn.common.util.Utils
 
 class MasterArgumentsSuite extends AnyFunSuite with Logging {
 
-  test("Test build masterArguments") {
+  test("[CELEBORN-98] Test build masterArguments in different case") {
     val args1 = Array.empty[String]
     val conf1 = new CelebornConf()
 

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterArgumentsSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterArgumentsSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.master
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.util.Utils
+import org.scalatest.funsuite.AnyFunSuite
+
+class MasterArgumentsSuite extends AnyFunSuite with Logging {
+
+  test("Test build masterArguments") {
+    import org.apache.celeborn.common.CelebornConf.{MASTER_HOST, MASTER_PORT}
+    val args1 = Array.empty[String]
+    val conf1 = new CelebornConf()
+
+    val arguments1 = new MasterArguments(args1, conf1)
+    assert(arguments1.host.equals(Utils.localHostName))
+    assert(arguments1.port == 9097)
+
+    // should use celeborn conf
+    val conf2 = new CelebornConf()
+    conf2.set(MASTER_HOST, "test-host-1")
+    conf2.set(MASTER_PORT, 19097)
+
+    val arguments2 = new MasterArguments(args1, conf2)
+    assert(arguments2.host.equals("test-host-1"))
+    assert(arguments2.port == 19097)
+
+    // should use cli args
+    val args2 = Array("-h", "test-host-2", "-p", "29097")
+
+    val arguments3 = new MasterArguments(args2, conf2)
+    assert(arguments3.host.equals("test-host-2"))
+    assert(arguments3.port == 29097)
+  }
+}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerArguments.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerArguments.scala
@@ -38,10 +38,6 @@ class WorkerArguments(args: Array[String], conf: CelebornConf) {
   _host = _host.orElse(Some(Utils.localHostName))
   _port = _port.orElse(Some(conf.workerRpcPort))
 
-  if (_host.isEmpty || _port.isEmpty) {
-    printUsageAndExit(1)
-  }
-
   def host: String = _host.get
 
   def port: Int = _port.get

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/WorkerArgumentsSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/WorkerArgumentsSuite.scala
@@ -27,7 +27,7 @@ import org.apache.celeborn.service.deploy.worker.WorkerArguments
 
 class WorkerArgumentsSuite extends AnyFunSuite with Logging {
 
-  test("[CELEBORN-98] Test build workerArguments in different case\"") {
+  test("[CELEBORN-98] Test build workerArguments in different case") {
     val args1 = Array.empty[String]
     val conf1 = new CelebornConf()
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/WorkerArgumentsSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/WorkerArgumentsSuite.scala
@@ -27,7 +27,7 @@ import org.apache.celeborn.service.deploy.worker.WorkerArguments
 
 class WorkerArgumentsSuite extends AnyFunSuite with Logging {
 
-  test("Test build workerArguments") {
+  test("[CELEBORN-98] Test build workerArguments in different case\"") {
     val args1 = Array.empty[String]
     val conf1 = new CelebornConf()
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/WorkerArgumentsSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/WorkerArgumentsSuite.scala
@@ -15,39 +15,38 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.service.deploy.master
+package org.apache.celeborn.service.deploy
 
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.CelebornConf.{MASTER_HOST, MASTER_PORT}
+import org.apache.celeborn.common.CelebornConf.WORKER_RPC_PORT
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.Utils
+import org.apache.celeborn.service.deploy.worker.WorkerArguments
 
-class MasterArgumentsSuite extends AnyFunSuite with Logging {
+class WorkerArgumentsSuite extends AnyFunSuite with Logging {
 
-  test("Test build masterArguments") {
+  test("Test build workerArguments") {
     val args1 = Array.empty[String]
     val conf1 = new CelebornConf()
 
-    val arguments1 = new MasterArguments(args1, conf1)
+    val arguments1 = new WorkerArguments(args1, conf1)
     assert(arguments1.host.equals(Utils.localHostName))
-    assert(arguments1.port == 9097)
+    assert(arguments1.port == 0)
 
     // should use celeborn conf
     val conf2 = new CelebornConf()
-    conf2.set(MASTER_HOST, "test-host-1")
-    conf2.set(MASTER_PORT, 19097)
+    conf2.set(WORKER_RPC_PORT, 12345)
 
-    val arguments2 = new MasterArguments(args1, conf2)
-    assert(arguments2.host.equals("test-host-1"))
-    assert(arguments2.port == 19097)
+    val arguments2 = new WorkerArguments(args1, conf2)
+    assert(arguments2.port == 12345)
 
     // should use cli args
-    val args2 = Array("-h", "test-host-2", "-p", "29097")
+    val args2 = Array("-h", "test-host-1", "-p", "22345")
 
-    val arguments3 = new MasterArguments(args2, conf2)
-    assert(arguments3.host.equals("test-host-2"))
-    assert(arguments3.port == 29097)
+    val arguments3 = new WorkerArguments(args2, conf2)
+    assert(arguments3.host.equals("test-host-1"))
+    assert(arguments3.port == 22345)
   }
 }


### PR DESCRIPTION
# [IMPROVEMENT] Remove never reach code block in master/worker arguments

### What changes were proposed in this pull request?
Host and port check will alway isn't null, due to default value.

Remove this un-reach code block to keep the code neat.

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
https://issues.apache.org/jira/projects/CELEBORN/issues/CELEBORN-98?filter=allissues

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
