### PR TITLE
[CELEBORN-90][REFACTOR] GetReducerFileGroup should support separated timeout configuration

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -1111,9 +1110,10 @@ public class ShuffleClientImpl extends ShuffleClient {
                     new GetReducerFileGroup(applicationId, shuffleId);
 
                 GetReducerFileGroupResponse response =
-                    driverRssMetaService.askSync(getReducerFileGroup,
-                            conf.getReducerFileGroupRpcAskTimeout(),
-                            ClassTag$.MODULE$.apply(GetReducerFileGroupResponse.class));
+                    driverRssMetaService.askSync(
+                        getReducerFileGroup,
+                        conf.getReducerFileGroupRpcAskTimeout(),
+                        ClassTag$.MODULE$.apply(GetReducerFileGroupResponse.class));
 
                 if (response.status() == StatusCode.SUCCESS) {
                   logger.info(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1109,11 +1109,11 @@ public class ShuffleClientImpl extends ShuffleClient {
 
                 GetReducerFileGroup getReducerFileGroup =
                     new GetReducerFileGroup(applicationId, shuffleId);
-                ClassTag<GetReducerFileGroupResponse> classTag =
-                    ClassTag$.MODULE$.apply(GetReducerFileGroupResponse.class);
 
                 GetReducerFileGroupResponse response =
-                    driverRssMetaService.askSync(getReducerFileGroup, classTag);
+                    driverRssMetaService.askSync(getReducerFileGroup,
+                            conf.getReducerFileGroupRpcAskTimeout(),
+                            ClassTag$.MODULE$.apply(GetReducerFileGroupResponse.class));
 
                 if (response.status() == StatusCode.SUCCESS) {
                   logger.info(

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -385,7 +385,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
       get(REGISTER_SHUFFLE_RPC_ASK_TIMEOUT).milli,
       REGISTER_SHUFFLE_RPC_ASK_TIMEOUT.key)
   def getReducerFileGroupRpcAskTimeout: RpcTimeout =
-    new RpcTimeout(get(GET_FILE_GROUP_RPC_ASK_TIMEOUT).milli, GET_FILE_GROUP_RPC_ASK_TIMEOUT.key)
+    new RpcTimeout(
+      get(GET_REDUCER_FILE_GROUP_RPC_ASK_TIMEOUT).milli,
+      GET_REDUCER_FILE_GROUP_RPC_ASK_TIMEOUT.key)
 
   def networkIoMode(module: String): String = {
     val key = NETWORK_IO_MODE.key.replace("<module>", module)
@@ -1034,11 +1036,11 @@ object CelebornConf extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("600s")
 
-  val GET_FILE_GROUP_RPC_ASK_TIMEOUT: ConfigEntry[Long] =
-    buildConf("celeborn.rpc.getFileGroup.askTimeout")
+  val GET_REDUCER_FILE_GROUP_RPC_ASK_TIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.rpc.getReducerFileGroup.askTimeout")
       .categories("network")
       .version("0.2.0")
-      .doc("Timeout for ask operations during get reduce file group.")
+      .doc("Timeout for ask operations during get reducer file group.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("600s")
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -384,6 +384,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     new RpcTimeout(
       get(REGISTER_SHUFFLE_RPC_ASK_TIMEOUT).milli,
       REGISTER_SHUFFLE_RPC_ASK_TIMEOUT.key)
+  def getReducerFileGroupRpcAskTimeout: RpcTimeout =
+    new RpcTimeout(get(GET_FILE_GROUP_RPC_ASK_TIMEOUT).milli, GET_FILE_GROUP_RPC_ASK_TIMEOUT.key)
 
   def networkIoMode(module: String): String = {
     val key = NETWORK_IO_MODE.key.replace("<module>", module)
@@ -1029,6 +1031,14 @@ object CelebornConf extends Logging {
       .categories("network")
       .version("0.2.0")
       .doc("Timeout for ask operations during register shuffle.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("600s")
+
+  val GET_FILE_GROUP_RPC_ASK_TIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.rpc.getFileGroup.askTimeout")
+      .categories("network")
+      .version("0.2.0")
+      .doc("Timeout for ask operations during get reduce file group.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("600s")
 

--- a/docs/configuration/network.md
+++ b/docs/configuration/network.md
@@ -39,7 +39,7 @@ license: |
 | celeborn.port.maxRetries | 1 | When port is occupied, we will retry for max retry times. | 0.2.0 | 
 | celeborn.rpc.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.connect.threads | 64 |  | 0.2.0 | 
-| celeborn.rpc.getFileGroup.askTimeout | 600s | Timeout for ask operations during get reduce file group. | 0.2.0 | 
+| celeborn.rpc.getReducerFileGroup.askTimeout | 600s | Timeout for ask operations during get reducer file group. | 0.2.0 | 
 | celeborn.rpc.haClient.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for HA client RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.lookupTimeout | 30s | Timeout for RPC lookup operations. | 0.2.0 | 
 | celeborn.rpc.registerShuffle.askTimeout | 600s | Timeout for ask operations during register shuffle. | 0.2.0 | 

--- a/docs/configuration/network.md
+++ b/docs/configuration/network.md
@@ -39,6 +39,7 @@ license: |
 | celeborn.port.maxRetries | 1 | When port is occupied, we will retry for max retry times. | 0.2.0 | 
 | celeborn.rpc.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.connect.threads | 64 |  | 0.2.0 | 
+| celeborn.rpc.getFileGroup.askTimeout | 600s | Timeout for ask operations during get reduce file group. | 0.2.0 | 
 | celeborn.rpc.haClient.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for HA client RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.lookupTimeout | 30s | Timeout for RPC lookup operations. | 0.2.0 | 
 | celeborn.rpc.registerShuffle.askTimeout | 600s | Timeout for ask operations during register shuffle. | 0.2.0 | 


### PR DESCRIPTION
### What changes were proposed in this pull request?
GetReducerFileGroup should support separated timeout configuration

### Why are the changes needed?
Because currently when requesting GetReducerFileGroup it will use default timeout of askSync which is same with the stageEnd timeout `PUSH_STAGE_END_TIMEOUT`, we need an independent config to control the timeout of GetReduceFileGroup request to ensure we can control it.

### What are the items that need reviewer attention?


### Related issues.
[CELEBORN-90](https://issues.apache.org/jira/browse/CELEBORN-90)

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
