### PR TITLE
[CELEBORN-109][FEATURE] Add new DiskStatus to represent critical error

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/meta/DiskStatus.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/DiskStatus.java
@@ -21,7 +21,8 @@ public enum DiskStatus {
   HEALTHY(0),
   READ_OR_WRITE_FAILURE(1),
   IO_HANG(2),
-  HIGH_DISK_USAGE(3);
+  HIGH_DISK_USAGE(3),
+  CRITICAL_ERROR(4);
 
   private final byte value;
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -926,6 +926,7 @@ object Utils extends Logging {
       case 1 => DiskStatus.READ_OR_WRITE_FAILURE
       case 2 => DiskStatus.IO_HANG
       case 3 => DiskStatus.HIGH_DISK_USAGE
+      case 4 => DiskStatus.CRITICAL_ERROR
       case _ => null
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Add new DiskStatus to represent critical error

### Why are the changes needed?
To represent the critical error when DeviceMonitor collects a certain number of non-critical error.

### What are the items that need reviewer attention?


### Related issues.
[CELEBORN-109](https://issues.apache.org/jira/browse/CELEBORN-109)

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
