### PR TITLE
add heartbeat and write timeout for transport clients

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -84,7 +84,9 @@ public abstract class Message implements Encodable {
     PUSH_MERGED_DATA(12),
     REGION_START(13),
     REGION_FINISH(14),
-    PUSH_DATA_HAND_SHAKE(15);
+    PUSH_DATA_HAND_SHAKE(15),
+    Ping(16),
+    Pong(17);
 
     private final byte id;
 
@@ -138,6 +140,8 @@ public abstract class Message implements Encodable {
           return REGION_FINISH;
         case 15:
           return PUSH_DATA_HAND_SHAKE;
+        case 16: return Ping;
+        case 17: return Pong;
         case -1:
           throw new IllegalArgumentException("User type messages cannot be decoded.");
         default:
@@ -193,6 +197,13 @@ public abstract class Message implements Encodable {
 
       case PUSH_DATA_HAND_SHAKE:
         return PushDataHandShake.decode(in);
+
+      case Ping:
+        return Ping.decode(in);
+
+      case Pong:
+        return Pong.decode(in);
+
       default:
         throw new IllegalArgumentException("Unexpected message type: " + msgType);
     }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Ping.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Ping.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.protocol;
+
+import io.netty.buffer.ByteBuf;
+
+/** Request to read a set of blocks. Returns {@link StreamHandle}. */
+public final class Ping extends Message {
+  byte type = Type.Ping.id();
+
+  @Override
+  public Type type() { return Type.Ping; }
+
+  @Override
+  public int encodedLength() {
+    return 1;
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {
+    buf.writeByte(type);
+  }
+
+  public static Ping decode(ByteBuf buf) {
+    buf.readByte();
+    return new Ping();
+  }
+
+  @Override
+  public int hashCode() {
+    return Type.Ping.id();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return other instanceof Ping;
+  }
+
+  @Override
+  public String toString() {
+    return "Ping";
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Pong.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Pong.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.protocol;
+
+import io.netty.buffer.ByteBuf;
+
+/** Request to read a set of blocks. Returns {@link StreamHandle}. */
+public final class Pong extends Message {
+  byte type = Type.Pong.id();
+
+  @Override
+  public Type type() { return Type.Pong; }
+
+  @Override
+  public int encodedLength() {
+    return 1;
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {
+    buf.writeByte(type);
+  }
+
+  public static Pong decode(ByteBuf buf) {
+    buf.readByte();
+    return new Pong();
+  }
+
+  @Override
+  public int hashCode() {
+    return Type.Pong.id();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return other instanceof Pong;
+  }
+
+  @Override
+  public String toString() {
+    return "Pong";
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
@@ -55,6 +55,18 @@ public class TransportConf {
     return conf.networkIoConnectionTimeoutMs(module);
   }
 
+  /** Connection heartbeat timeout in milliseconds. Default 0 secs (never). */
+  public int heartbeatTimeoutMs() {
+    return (int) JavaUtils.timeStringAsSec(
+      conf.get("rss.network.heartbeat.timeout", "0s")) * 1000;
+  }
+
+  /** Channel write timeout in milliseconds. Default 0 secs (never). */
+  public int writeTimeoutMs() {
+    return (int) JavaUtils.timeStringAsSec(
+      conf.get("rss.network.write.timeout", "0s")) * 1000;
+  }
+
   /** Number of concurrent connections between two nodes for fetching data. */
   public int numConnectionsPerPeer() {
     return conf.networkIoNumConnectionsPerPeer(module);


### PR DESCRIPTION
# add heartbeat and write timeout for transport clients

### What changes were proposed in this pull request?

- Add optional heartbeat for idle connections in the client pool
- Add optional write timeout timer for data clients (which already exists in rpc clients)

### Why are the changes needed?

Changes are mainly made in the channel pipelines which are inited in TransportContext#initializePipeline

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
