### PR TITLE
[CELEBORN-83][FOLLOWUP] Fix various bugs when using HDFS as storage.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,3 +34,8 @@ jobs:
         check-latest: false
     - name: Test with Maven
       run: build/mvn -Pgoogle-mirror,spark-${{ matrix.spark }} test
+    - name: Upload coverage to Codecov
+      if: |
+        matrix.java == 8 &&
+        matrix.spark == '3.3'
+      uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ celeborn.ha.master.node.3.ratis.port 9874
 celeborn.ha.master.ratis.raft.server.storage.dir /mnt/disk1/rss_ratis/
 
 celeborn.metrics.enabled true
+# If you want to use HDFS as shuffle storage, make sure that flush buffer size is at least 4MB or larger.
 celeborn.worker.flush.buffer.size 256k
 celeborn.worker.storage.dirs /mnt/disk1/,/mnt/disk2
 # If your hosts have disk raid or use lvm, set celeborn.worker.monitor.disk.enabled to false

--- a/client-flink/flink-1.14/pom.xml
+++ b/client-flink/flink-1.14/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements.  See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache License, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License.  You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.celeborn</groupId>
+    <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
+    <version>${project.version}</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>celeborn-client-flink-${flink.version}_${scala.binary.version}</artifactId>
+  <packaging>jar</packaging>
+  <name>Celeborn Client for flink</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-runtime</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client-flink-common-${flink.version}_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/FlinkResultPartitionInfo.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/FlinkResultPartitionInfo.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+
+import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
+
+public class FlinkResultPartitionInfo {
+  private final PartitionDescriptor partitionDescriptor;
+  private final ProducerDescriptor producerDescriptor;
+
+  public FlinkResultPartitionInfo(
+      PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+    this.partitionDescriptor = partitionDescriptor;
+    this.producerDescriptor = producerDescriptor;
+  }
+
+  public ResultPartitionID getResultPartitionId() {
+    return new ResultPartitionID(
+        partitionDescriptor.getPartitionId(), producerDescriptor.getProducerExecutionId());
+  }
+
+  public String getShuffleId() {
+    return FlinkUtils.toShuffleId(partitionDescriptor.getResultId());
+  }
+
+  public int getTaskId() {
+    return partitionDescriptor.getPartitionId().getPartitionNumber();
+  }
+
+  public String getAttemptId() {
+    return FlinkUtils.toAttemptId(producerDescriptor.getProducerExecutionId());
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleDescriptor.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleDescriptor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.util.Optional;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+
+public class RemoteShuffleDescriptor implements ShuffleDescriptor {
+
+  private final ResultPartitionID resultPartitionID;
+
+  private final JobID jobID;
+
+  private final ShuffleResource shuffleResource;
+
+  public RemoteShuffleDescriptor(
+      JobID jobID, ResultPartitionID resultPartitionID, ShuffleResource shuffleResource) {
+    this.jobID = jobID;
+    this.resultPartitionID = resultPartitionID;
+    this.shuffleResource = shuffleResource;
+  }
+
+  @Override
+  public ResultPartitionID getResultPartitionID() {
+    return resultPartitionID;
+  }
+
+  public JobID getJobID() {
+    return jobID;
+  }
+
+  public ShuffleResource getShuffleResource() {
+    return shuffleResource;
+  }
+
+  @Override
+  public Optional<ResourceID> storesLocalResourcesOn() {
+    return Optional.empty();
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.client.LifecycleManager;
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
+import org.apache.celeborn.plugin.flink.utils.ThreadUtils;
+
+public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescriptor> {
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteShuffleMaster.class);
+
+  private final ShuffleMasterContext shuffleMasterContext;
+  // Flink JobId -> Celeborn LifecycleManager
+  private Map<JobID, LifecycleManager> lifecycleManagers = new ConcurrentHashMap<>();
+  private final ScheduledThreadPoolExecutor executor =
+      new ScheduledThreadPoolExecutor(
+          1,
+          ThreadUtils.createFactoryWithDefaultExceptionHandler(
+              "remote-shuffle-master-executor", LOG));
+
+  public RemoteShuffleMaster(ShuffleMasterContext shuffleMasterContext) {
+    this.shuffleMasterContext = shuffleMasterContext;
+  }
+
+  @Override
+  public void registerJob(JobShuffleContext context) {
+    JobID jobId = context.getJobId();
+    Future<?> submit =
+        executor.submit(
+            () -> {
+              if (lifecycleManagers.containsKey(jobId)) {
+                throw new RuntimeException("Duplicated registration job: " + jobId);
+              } else {
+                CelebornConf celebornConf =
+                    FlinkUtils.toCelebornConf(shuffleMasterContext.getConfiguration());
+                LifecycleManager lifecycleManager =
+                    new LifecycleManager(FlinkUtils.toCelebornAppId(jobId), celebornConf);
+                lifecycleManagers.put(jobId, lifecycleManager);
+              }
+            });
+
+    try {
+      submit.get();
+    } catch (InterruptedException e) {
+      LOG.error("Encounter interruptedException when registration job: {}.", jobId, e);
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      LOG.error("Encounter an error when registration job: {}.", jobId, e);
+      throw new RuntimeException(e.getCause());
+    }
+  }
+
+  @Override
+  public void unregisterJob(JobID jobID) {
+    executor.execute(
+        () -> {
+          try {
+            LOG.info("Unregister job: {}.", jobID);
+            LifecycleManager lifecycleManager = lifecycleManagers.remove(jobID);
+            if (lifecycleManager != null) {
+              lifecycleManager.stop();
+            }
+          } catch (Throwable throwable) {
+            LOG.error("Encounter an error when unregistering job: {}.", jobID, throwable);
+          }
+        });
+  }
+
+  @Override
+  public CompletableFuture<RemoteShuffleDescriptor> registerPartitionWithProducer(
+      JobID jobID, PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+    CompletableFuture<RemoteShuffleDescriptor> completableFuture =
+        CompletableFuture.supplyAsync(
+            () -> {
+              LifecycleManager lifecycleManager = lifecycleManagers.get(jobID);
+              FlinkResultPartitionInfo resultPartitionInfo =
+                  new FlinkResultPartitionInfo(partitionDescriptor, producerDescriptor);
+              LifecycleManager.ShuffleTask shuffleTask =
+                  lifecycleManager.encodeExternalShuffleTask(
+                      resultPartitionInfo.getShuffleId(),
+                      resultPartitionInfo.getTaskId(),
+                      resultPartitionInfo.getAttemptId());
+              ShuffleResourceDescriptor shuffleResourceDescriptor =
+                  new ShuffleResourceDescriptor(shuffleTask);
+              RemoteShuffleResource remoteShuffleResource =
+                  new RemoteShuffleResource(
+                      lifecycleManager.getRssMetaServiceHost(),
+                      lifecycleManager.getRssMetaServicePort(),
+                      shuffleResourceDescriptor);
+              return new RemoteShuffleDescriptor(
+                  jobID, resultPartitionInfo.getResultPartitionId(), remoteShuffleResource);
+            },
+            executor);
+
+    return completableFuture;
+  }
+
+  @Override
+  public void releasePartitionExternally(ShuffleDescriptor shuffleDescriptor) {
+    // TODO
+  }
+
+  @Override
+  public void close() throws Exception {
+    try {
+      for (LifecycleManager lifecycleManager : lifecycleManagers.values()) {
+        lifecycleManager.stop();
+      }
+    } catch (Exception e) {
+      LOG.warn("Encounter exception when shutdown: " + e.getMessage(), e);
+    }
+
+    ThreadUtils.shutdownExecutors(10, executor);
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.util.function.SupplierWithException;
+
+import org.apache.celeborn.client.ShuffleClient;
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
+import org.apache.celeborn.common.protocol.PartitionLocation;
+import org.apache.celeborn.plugin.flink.utils.Utils;
+
+/**
+ * A transportation gate used to spill buffers from {@link ResultPartitionWriter} to remote shuffle
+ * worker.
+ */
+public class RemoteShuffleOutputGate {
+
+  private final RemoteShuffleDescriptor shuffleDesc;
+  protected final int numSubs;
+  private final ShuffleClient shuffleWriteClient;
+  protected final SupplierWithException<BufferPool, IOException> bufferPoolFactory;
+  protected BufferPool bufferPool;
+  private CelebornConf celebornConf;
+  private final int numMappers;
+  private PartitionLocation partitionLocation;
+
+  private int currentRegionIndex = 0;
+
+  private int bufferSize;
+  private String applicationId;
+  private int shuffleId;
+  private int mapId;
+  private int attemptId;
+  private String rssMetaServiceHost;
+  private int rssMetaServicePort;
+  private UserIdentifier userIdentifier;
+
+  /**
+   * @param shuffleDesc Describes shuffle meta and shuffle worker address.
+   * @param numSubs Number of subpartitions of the corresponding {@link ResultPartitionWriter}.
+   * @param bufferPoolFactory {@link BufferPool} provider.
+   */
+  public RemoteShuffleOutputGate(
+      RemoteShuffleDescriptor shuffleDesc,
+      int numSubs,
+      int bufferSize,
+      SupplierWithException<BufferPool, IOException> bufferPoolFactory,
+      CelebornConf celebornConf,
+      int numMappers) {
+
+    this.shuffleDesc = shuffleDesc;
+    this.numSubs = numSubs;
+    this.bufferPoolFactory = bufferPoolFactory;
+    this.shuffleWriteClient = createWriteClient();
+    // this.bufferPacker = new BufferPacker(this::write);
+    this.celebornConf = celebornConf;
+    this.numMappers = numMappers;
+    this.bufferSize = bufferSize;
+    this.applicationId = shuffleDesc.getJobID().toString();
+    this.shuffleId =
+        shuffleDesc.getShuffleResource().getMapPartitionShuffleDescriptor().getShuffleId();
+    this.mapId = shuffleDesc.getShuffleResource().getMapPartitionShuffleDescriptor().getMapId();
+    this.attemptId =
+        shuffleDesc.getShuffleResource().getMapPartitionShuffleDescriptor().getAttemptId();
+    this.rssMetaServiceHost =
+        ((RemoteShuffleResource) shuffleDesc.getShuffleResource()).getRssMetaServiceHost();
+    this.rssMetaServicePort =
+        ((RemoteShuffleResource) shuffleDesc.getShuffleResource()).getRssMetaServicePort();
+  }
+
+  /** Initialize transportation gate. */
+  public void setup() throws IOException, InterruptedException {
+    bufferPool = Utils.checkNotNull(bufferPoolFactory.get());
+    Utils.checkArgument(
+        bufferPool.getNumberOfRequiredMemorySegments() >= 2,
+        "Too few buffers for transfer, the minimum valid required size is 2.");
+
+    // guarantee that we have at least one buffer
+    // BufferUtils.reserveNumRequiredBuffers(bufferPool, 1);
+
+    // handshake
+    handshake();
+  }
+
+  /** Get transportation buffer pool. */
+  public BufferPool getBufferPool() {
+    return bufferPool;
+  }
+
+  /** Writes a {@link Buffer} to a subpartition. */
+  public void write(Buffer buffer, int subIdx) throws InterruptedException {
+    // bufferPacker.process(buffer, subIdx);
+  }
+
+  /**
+   * Indicates the start of a region. A region of buffers guarantees the records inside are
+   * completed.
+   *
+   * @param isBroadcast Whether it's a broadcast region.
+   */
+  public void regionStart(boolean isBroadcast) {
+    Optional<PartitionLocation> newPartitionLoc = null;
+    try {
+      newPartitionLoc =
+          shuffleWriteClient.regionStart(
+              applicationId,
+              shuffleId,
+              mapId,
+              attemptId,
+              partitionLocation,
+              currentRegionIndex,
+              isBroadcast);
+      // revived
+      if (newPartitionLoc.isPresent()) {
+        partitionLocation = newPartitionLoc.get();
+        // send handshake again
+        handshake();
+        // send regionstart again
+        shuffleWriteClient.regionStart(
+            applicationId,
+            shuffleId,
+            mapId,
+            attemptId,
+            newPartitionLoc.get(),
+            currentRegionIndex,
+            isBroadcast);
+      }
+    } catch (IOException e) {
+      Utils.rethrowAsRuntimeException(e);
+    }
+  }
+
+  /**
+   * Indicates the finish of a region. A region is always bounded by a pair of region-start and
+   * region-finish.
+   */
+  public void regionFinish() throws InterruptedException {
+    // bufferPacker.drain();
+    try {
+      shuffleWriteClient.regionFinish(
+          applicationId, shuffleId, mapId, attemptId, partitionLocation);
+      currentRegionIndex++;
+    } catch (IOException e) {
+      Utils.rethrowAsRuntimeException(e);
+    }
+  }
+
+  /** Indicates the writing/spilling is finished. */
+  public void finish() throws InterruptedException, IOException {
+    shuffleWriteClient.mapperEnd(applicationId, shuffleId, mapId, attemptId, numMappers);
+  }
+
+  /** Close the transportation gate. */
+  public void close() throws IOException {
+    if (bufferPool != null) {
+      bufferPool.lazyDestroy();
+    }
+    // bufferPacker.close();
+    shuffleWriteClient.shutDown();
+  }
+
+  /** Returns shuffle descriptor. */
+  public RemoteShuffleDescriptor getShuffleDesc() {
+    return shuffleDesc;
+  }
+
+  private ShuffleClient createWriteClient() {
+    return ShuffleClient.get(rssMetaServiceHost, rssMetaServicePort, celebornConf, userIdentifier);
+  }
+
+  /** Writes a piece of data to a subpartition. */
+  public void write(ByteBuf byteBuf, int subIdx) throws InterruptedException {
+    //    try {
+    //         byteBuf.retain();
+    //      shuffleWriteClient.pushData(
+    //          applicationId,
+    //          shuffleId,
+    //          mapId,
+    //          attemptId,
+    //          subIdx,
+    //          io.netty.buffer.Unpooled.wrappedBuffer(byteBuf.nioBuffer()),
+    //          partitionLocation,
+    //          () -> byteBuf.release());
+    //    } catch (IOException e) {
+    //      Utils.rethrowAsRuntimeException(e);
+    //    }
+  }
+
+  public void handshake() {
+    if (partitionLocation == null) {
+      partitionLocation =
+          shuffleWriteClient.registerMapPartitionTask(
+              applicationId, shuffleId, numMappers, mapId, attemptId);
+    }
+    currentRegionIndex = 0;
+    try {
+      shuffleWriteClient.pushDataHandShake(
+          applicationId, shuffleId, mapId, attemptId, numSubs, bufferSize, partitionLocation);
+    } catch (IOException e) {
+      Utils.rethrowAsRuntimeException(e);
+    }
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResource.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResource.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+public class RemoteShuffleResource implements ShuffleResource {
+
+  private static final long serialVersionUID = 6497939083185255973L;
+
+  private final String rssMetaServiceHost;
+  private final int rssMetaServicePort;
+
+  private ShuffleResourceDescriptor shuffleResourceDescriptor;
+
+  public RemoteShuffleResource(
+      String rssMetaServiceHost,
+      int rssMetaServicePort,
+      ShuffleResourceDescriptor remoteShuffleDescriptor) {
+    this.rssMetaServiceHost = rssMetaServiceHost;
+    this.rssMetaServicePort = rssMetaServicePort;
+    this.shuffleResourceDescriptor = remoteShuffleDescriptor;
+  }
+
+  @Override
+  public ShuffleResourceDescriptor getMapPartitionShuffleDescriptor() {
+    return shuffleResourceDescriptor;
+  }
+
+  public String getRssMetaServiceHost() {
+    return rssMetaServiceHost;
+  }
+
+  public int getRssMetaServicePort() {
+    return rssMetaServicePort;
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleServiceFactory.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleServiceFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
+import org.apache.flink.runtime.shuffle.*;
+
+public class RemoteShuffleServiceFactory
+    implements ShuffleServiceFactory<
+        RemoteShuffleDescriptor, ResultPartitionWriter, IndexedInputGate> {
+
+  @Override
+  public ShuffleMaster<RemoteShuffleDescriptor> createShuffleMaster(
+      ShuffleMasterContext shuffleMasterContext) {
+    return new RemoteShuffleMaster(shuffleMasterContext);
+  }
+
+  @Override
+  public ShuffleEnvironment<ResultPartitionWriter, IndexedInputGate> createShuffleEnvironment(
+      ShuffleEnvironmentContext shuffleEnvironmentContext) {
+    // TODO
+    return null;
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResource.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResource.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.io.Serializable;
+
+public interface ShuffleResource extends Serializable {
+
+  ShuffleResourceDescriptor getMapPartitionShuffleDescriptor();
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResourceDescriptor.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResourceDescriptor.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.io.Serializable;
+
+import org.apache.celeborn.client.LifecycleManager;
+import org.apache.celeborn.common.util.PackedPartitionId;
+
+public class ShuffleResourceDescriptor implements Serializable {
+
+  private static final long serialVersionUID = -1251659747395561342L;
+
+  private final int shuffleId;
+  private final int mapId;
+  private final int attemptId;
+  private final int partitionId;
+
+  public ShuffleResourceDescriptor(LifecycleManager.ShuffleTask shuffleTask) {
+    this.shuffleId = shuffleTask.shuffleId();
+    this.mapId = shuffleTask.mapId();
+    this.attemptId = shuffleTask.attemptId();
+    this.partitionId = PackedPartitionId.packedPartitionId(mapId, attemptId);
+  }
+
+  public int getShuffleId() {
+    return shuffleId;
+  }
+
+  public int getMapId() {
+    return mapId;
+  }
+
+  public int getAttemptId() {
+    return attemptId;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("ShuffleResourceDescriptor{");
+    sb.append("shuffleId=").append(shuffleId);
+    sb.append(", mapId=").append(mapId);
+    sb.append(", attemptId=").append(attemptId);
+    sb.append(", partitionId=").append(partitionId);
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink.utils;
+
+import java.util.Map;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import org.apache.celeborn.common.CelebornConf;
+
+public class FlinkUtils {
+
+  public static CelebornConf toCelebornConf(Configuration configuration) {
+    CelebornConf tmpCelebornConf = new CelebornConf();
+    Map<String, String> confMap = configuration.toMap();
+    for (Map.Entry<String, String> entry : confMap.entrySet()) {
+      String key = entry.getKey();
+      if (key.startsWith("celeborn.")) {
+        tmpCelebornConf.set(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return tmpCelebornConf;
+  }
+
+  public static String toCelebornAppId(JobID jobID) {
+    return jobID.toString();
+  }
+
+  public static String toShuffleId(IntermediateDataSetID dataSetID) {
+    return dataSetID.toString();
+  }
+
+  public static String toAttemptId(ExecutionAttemptID attemptID) {
+    return attemptID.toString();
+  }
+}

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/utils/ThreadUtils.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/utils/ThreadUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink.utils;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.flink.util.ExecutorUtils;
+import org.slf4j.Logger;
+
+public class ThreadUtils {
+
+  public static ThreadFactory createFactoryWithDefaultExceptionHandler(
+      final String executorServiceName, final Logger LOG) {
+    return new ThreadFactoryBuilder()
+        .setNameFormat(executorServiceName + "-%d")
+        .setDaemon(true)
+        .setUncaughtExceptionHandler(
+            (Thread t, Throwable e) ->
+                LOG.error(
+                    "exception in serviceName: {}, thread: {}",
+                    executorServiceName,
+                    t.getName(),
+                    e))
+        .build();
+  }
+
+  public static void shutdownExecutors(int timeoutSecs, ExecutorService executorService) {
+    ExecutorUtils.gracefulShutdown(timeoutSecs, TimeUnit.SECONDS, executorService);
+  }
+}

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.util.PackedPartitionId;
+
+public class RemoteShuffleMasterTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteShuffleMasterTest.class);
+  private RemoteShuffleMaster remoteShuffleMaster;
+
+  @Before
+  public void setUp() {
+    Configuration configuration = new Configuration();
+    remoteShuffleMaster = createShuffleMaster(configuration);
+  }
+
+  @Test
+  public void testRegisterJob() {
+    JobShuffleContext jobShuffleContext = createJobShuffleContext(JobID.generate());
+    remoteShuffleMaster.registerJob(jobShuffleContext);
+
+    // reRunRegister job
+    try {
+      remoteShuffleMaster.registerJob(jobShuffleContext);
+    } catch (Exception e) {
+      Assert.assertTrue(true);
+    }
+
+    // unRegister job
+    remoteShuffleMaster.unregisterJob(jobShuffleContext.getJobId());
+  }
+
+  @Test
+  public void testRegisterPartitionWithProducer()
+      throws UnknownHostException, ExecutionException, InterruptedException {
+    JobID jobID = JobID.generate();
+    JobShuffleContext jobShuffleContext = createJobShuffleContext(jobID);
+    remoteShuffleMaster.registerJob(jobShuffleContext);
+
+    IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
+    PartitionDescriptor partitionDescriptor = createPartitionDescriptor(intermediateDataSetID, 0);
+    ProducerDescriptor producerDescriptor = createProducerDescriptor();
+    RemoteShuffleDescriptor remoteShuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    ShuffleResource shuffleResource = remoteShuffleDescriptor.getShuffleResource();
+    ShuffleResourceDescriptor mapPartitionShuffleDescriptor =
+        shuffleResource.getMapPartitionShuffleDescriptor();
+    System.out.println(mapPartitionShuffleDescriptor.toString());
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getPartitionId());
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getAttemptId());
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getMapId());
+
+    // use same dataset id
+    partitionDescriptor = createPartitionDescriptor(intermediateDataSetID, 1);
+    remoteShuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    mapPartitionShuffleDescriptor =
+        remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
+    Assert.assertEquals(1, mapPartitionShuffleDescriptor.getMapId());
+
+    // use another attemptId
+    producerDescriptor = createProducerDescriptor();
+    remoteShuffleDescriptor =
+        remoteShuffleMaster
+            .registerPartitionWithProducer(jobID, partitionDescriptor, producerDescriptor)
+            .get();
+    mapPartitionShuffleDescriptor =
+        remoteShuffleDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
+    Assert.assertEquals(0, mapPartitionShuffleDescriptor.getShuffleId());
+    Assert.assertEquals(
+        PackedPartitionId.packedPartitionId(1, 1), mapPartitionShuffleDescriptor.getPartitionId());
+    Assert.assertEquals(1, mapPartitionShuffleDescriptor.getAttemptId());
+    Assert.assertEquals(1, mapPartitionShuffleDescriptor.getMapId());
+  }
+
+  @After
+  public void tearDown() {
+    if (remoteShuffleMaster != null) {
+      try {
+        remoteShuffleMaster.close();
+      } catch (Exception e) {
+        LOG.warn(e.getMessage(), e);
+      }
+    }
+  }
+
+  public RemoteShuffleMaster createShuffleMaster(Configuration configuration) {
+    remoteShuffleMaster =
+        new RemoteShuffleMaster(
+            new ShuffleMasterContext() {
+              @Override
+              public Configuration getConfiguration() {
+                return configuration;
+              }
+
+              @Override
+              public void onFatalError(Throwable throwable) {
+                System.exit(-1);
+              }
+            });
+
+    return remoteShuffleMaster;
+  }
+
+  public JobShuffleContext createJobShuffleContext(JobID jobId) {
+    return new JobShuffleContext() {
+      @Override
+      public org.apache.flink.api.common.JobID getJobId() {
+        return jobId;
+      }
+
+      @Override
+      public CompletableFuture<?> stopTrackingAndReleasePartitions(
+          Collection<ResultPartitionID> collection) {
+        return CompletableFuture.completedFuture(null);
+      }
+    };
+  }
+
+  public PartitionDescriptor createPartitionDescriptor(
+      IntermediateDataSetID intermediateDataSetId, int partitionNum) {
+    IntermediateResultPartitionID intermediateResultPartitionId =
+        new IntermediateResultPartitionID(intermediateDataSetId, partitionNum);
+    return new PartitionDescriptor(
+        intermediateDataSetId,
+        10,
+        intermediateResultPartitionId,
+        ResultPartitionType.BLOCKING,
+        5,
+        1);
+  }
+
+  public ProducerDescriptor createProducerDescriptor() throws UnknownHostException {
+    ExecutionAttemptID executionAttemptId = new ExecutionAttemptID();
+    return new ProducerDescriptor(
+        ResourceID.generate(), executionAttemptId, InetAddress.getLocalHost(), 100);
+  }
+}

--- a/client-flink/flink-common/pom.xml
+++ b/client-flink/flink-common/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements.  See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache License, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License.  You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.celeborn</groupId>
+    <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
+    <version>${project.version}</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>celeborn-client-flink-common-${flink.version}_${scala.binary.version}</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-runtime</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/client-flink/flink-common/src/main/java/org/apache/celeborn/plugin/flink/utils/Utils.java
+++ b/client-flink/flink-common/src/main/java/org/apache/celeborn/plugin/flink/utils/Utils.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink.utils;
+
+/** Utility methods can be used by all modules. */
+public class Utils {
+  /**
+   * Ensures that the target object is not null and returns it. It will throw {@link
+   * NullPointerException} if the target object is null.
+   */
+  public static <T> T checkNotNull(T object) {
+    if (object == null) {
+      throw new NullPointerException("Must be not null.");
+    }
+    return object;
+  }
+
+  /**
+   * Check the legality of method arguments. It will throw {@link IllegalArgumentException} if the
+   * given condition is not true.
+   */
+  public static void checkArgument(boolean condition, String message) {
+    if (!condition) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  /**
+   * Checks the legality of program state. It will throw {@link IllegalStateException} if the given
+   * condition is not true.
+   */
+  public static void checkState(boolean condition, String message) {
+    if (!condition) {
+      throw new IllegalStateException(message);
+    }
+  }
+
+  /** Casts the given long value to int and ensures there is no loss. */
+  public static int checkedDownCast(long value) {
+    int downCast = (int) value;
+    if ((long) downCast != value) {
+      throw new IllegalArgumentException("Cannot downcast long value " + value + " to integer.");
+    }
+
+    return downCast;
+  }
+
+  /** Rethrows the target {@link Throwable} as {@link Error} or {@link RuntimeException}. */
+  public static void rethrowAsRuntimeException(Throwable t) {
+    if (t instanceof Error) {
+      throw (Error) t;
+    } else if (t instanceof RuntimeException) {
+      throw (RuntimeException) t;
+    } else {
+      throw new RuntimeException(t);
+    }
+  }
+}

--- a/client-flink/flink-shaded/pom.xml
+++ b/client-flink/flink-shaded/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements.  See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache License, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License.  You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.celeborn</groupId>
+    <artifactId>celeborn-parent_${scala.binary.version}</artifactId>
+    <version>${project.version}</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>celeborn-client-flink-${flink.version}-shaded_${scala.binary.version}</artifactId>
+  <packaging>jar</packaging>
+  <name>Celeborn Shaded Client for flink</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client-flink-${flink.version}_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.google.protobuf</pattern>
+              <shadedPattern>${shading.prefix}.com.google.protobuf</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>${shading.prefix}.com.google.common</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>io.netty</pattern>
+              <shadedPattern>${shading.prefix}.io.netty</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons</pattern>
+              <shadedPattern>${shading.prefix}.org.apache.commons</shadedPattern>
+            </relocation>
+          </relocations>
+          <artifactSet>
+            <includes>
+              <include>org.apache.celeborn:*</include>
+              <include>com.google.protobuf:protobuf-java</include>
+              <include>com.google.guava:guava</include>
+              <include>io.netty:*</include>
+              <include>org.apache.commons:commons-lang3</include>
+            </includes>
+          </artifactSet>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+                <exclude>**/log4j.properties</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven.plugin.antrun.version}</version>
+        <executions>
+          <execution>
+            <id>rename-native-library</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <echo message="unpacking netty jar"></echo>
+                <unzip dest="${project.build.directory}/unpacked/" src="${project.build.directory}/${artifactId}-${version}.jar"></unzip>
+                <echo message="renaming native epoll library"></echo>
+                <move includeemptydirs="false" todir="${project.build.directory}/unpacked/META-INF/native">
+                  <fileset dir="${project.build.directory}/unpacked/META-INF/native"></fileset>
+                  <mapper from="libnetty_transport_native_epoll_x86_64.so" to="liborg_apache_celeborn_shaded_netty_transport_native_epoll_x86_64.so" type="glob"></mapper>
+                </move>
+                <move includeemptydirs="false" todir="${project.build.directory}/unpacked/META-INF/native">
+                  <fileset dir="${project.build.directory}/unpacked/META-INF/native"></fileset>
+                  <mapper from="libnetty_transport_native_epoll_aarch_64.so" to="liborg_apache_celeborn_shaded_netty_transport_native_epoll_aarch_64.so.so" type="glob"></mapper>
+                </move>
+                <echo message="deleting native kqueue library"></echo>
+                <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib"></delete>
+                <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib"></delete>
+                <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_resolver_dns_native_macos_aarch_64.jnilib"></delete>
+                <delete file="${project.build.directory}/unpacked/META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib"></delete>
+                <echo message="repackaging netty jar"></echo>
+                <jar basedir="${project.build.directory}/unpacked" destfile="${project.build.directory}/${artifactId}-${version}.jar"></jar>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleFallbackPolicyRunner.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleFallbackPolicyRunner.scala
@@ -62,7 +62,7 @@ class RssShuffleFallbackPolicyRunner(conf: CelebornConf) extends Logging {
 
     val available = lifecycleManager.checkQuota()
     if (!available) {
-      logWarning(s"Cluster is not alive!")
+      logWarning(s"Quota exceed for current user ${lifecycleManager.getUserIdentifier}.")
     }
     available
   }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -57,6 +57,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -100,6 +100,8 @@ public abstract class ShuffleClient implements Cloneable {
       synchronized (ShuffleClient.class) {
         if (null == hdfsFs) {
           Configuration hdfsConfiguration = new Configuration();
+          // enable fs cache to avoid too many fs instances
+          hdfsConfiguration.set("fs.hdfs.impl.disable.cache", "false");
           try {
             hdfsFs = FileSystem.get(hdfsConfiguration);
           } catch (IOException e) {

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -149,7 +149,11 @@ class ChangePartitionManager(
     val requests = changePartitionRequests.computeIfAbsent(shuffleId, rpcContextRegisterFunc)
     inBatchPartitions.computeIfAbsent(shuffleId, inBatchShuffleIdRegisterFunc)
 
-    lifecycleManager.registerCommitPartition(applicationId, shuffleId, oldPartition, cause)
+    lifecycleManager.commitManager.registerCommitPartitionRequest(
+      applicationId,
+      shuffleId,
+      oldPartition,
+      cause)
 
     requests.synchronized {
       if (requests.containsKey(partitionId)) {
@@ -267,7 +271,7 @@ class ChangePartitionManager(
       return
     }
 
-    if (lifecycleManager.stageEndShuffleSet.contains(shuffleId)) {
+    if (lifecycleManager.commitManager.stageEndShuffleSet.contains(shuffleId)) {
       logError(s"[handleChangePartition] shuffle $shuffleId already ended!")
       replyFailure(StatusCode.STAGE_ENDED)
       return

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -1,0 +1,543 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import java.util
+import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, ScheduledFuture, TimeUnit}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, LongAdder}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.DurationInt
+
+import org.roaringbitmap.RoaringBitmap
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.meta.{PartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.protocol.{PartitionLocation, StorageInfo}
+import org.apache.celeborn.common.protocol.message.ControlMessages.{CommitFiles, CommitFilesResponse}
+import org.apache.celeborn.common.protocol.message.StatusCode
+import org.apache.celeborn.common.rpc.RpcEndpointRef
+import org.apache.celeborn.common.util.{ThreadUtils, Utils}
+
+case class CommitPartitionRequest(
+    applicationId: String,
+    shuffleId: Int,
+    partition: PartitionLocation)
+
+case class ShuffleCommittedInfo(
+    committedMasterIds: util.List[String],
+    committedSlaveIds: util.List[String],
+    failedMasterPartitionIds: ConcurrentHashMap[String, WorkerInfo],
+    failedSlavePartitionIds: ConcurrentHashMap[String, WorkerInfo],
+    committedMasterStorageInfos: ConcurrentHashMap[String, StorageInfo],
+    committedSlaveStorageInfos: ConcurrentHashMap[String, StorageInfo],
+    committedMapIdBitmap: ConcurrentHashMap[String, RoaringBitmap],
+    currentShuffleFileCount: LongAdder,
+    commitPartitionRequests: util.Set[CommitPartitionRequest],
+    handledCommitPartitionRequests: util.Set[PartitionLocation],
+    inFlightCommitRequest: AtomicInteger)
+
+class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: LifecycleManager)
+  extends Logging {
+  // shuffle id -> ShuffleCommittedInfo
+  private val committedPartitionInfo = new ConcurrentHashMap[Int, ShuffleCommittedInfo]()
+  val dataLostShuffleSet = ConcurrentHashMap.newKeySet[Int]()
+  val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
+  private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
+
+  private val pushReplicateEnabled = conf.pushReplicateEnabled
+
+  private val batchHandleCommitPartitionEnabled = conf.batchHandleCommitPartitionEnabled
+  private val batchHandleCommitPartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(
+    "rss-lifecycle-manager-commit-partition-executor",
+    conf.batchHandleCommitPartitionNumThreads)
+  private val batchHandleCommitPartitionRequestInterval =
+    conf.batchHandleCommitPartitionRequestInterval
+  private val batchHandleCommitPartitionSchedulerThread: Option[ScheduledExecutorService] =
+    if (batchHandleCommitPartitionEnabled) {
+      Some(ThreadUtils.newDaemonSingleThreadScheduledExecutor(
+        "rss-lifecycle-manager-commit-partition-scheduler"))
+    } else {
+      None
+    }
+  private var batchHandleCommitPartition: Option[ScheduledFuture[_]] = _
+
+  private val totalWritten = new LongAdder
+  private val fileCount = new LongAdder
+
+  private val testRetryCommitFiles = conf.testRetryCommitFiles
+  private val commitEpoch = new AtomicLong()
+
+  def start(): Unit = {
+    batchHandleCommitPartition = batchHandleCommitPartitionSchedulerThread.map {
+      _.scheduleAtFixedRate(
+        new Runnable {
+          override def run(): Unit = {
+            committedPartitionInfo.asScala.foreach { case (shuffleId, shuffleCommittedInfo) =>
+              batchHandleCommitPartitionExecutors.submit {
+                new Runnable {
+                  override def run(): Unit = {
+                    val workerToRequests = shuffleCommittedInfo.synchronized {
+                      // When running to here, if handleStageEnd got lock first and commitFiles,
+                      // then this batch get this lock, commitPartitionRequests may contains
+                      // partitions which are already committed by stageEnd process.
+                      // But inProcessStageEndShuffleSet should have contain this shuffle id,
+                      // can directly return.
+                      if (inProcessStageEndShuffleSet.contains(shuffleId) ||
+                        stageEndShuffleSet.contains(shuffleId)) {
+                        logWarning(s"Shuffle $shuffleId ended or during processing stage end.")
+                        shuffleCommittedInfo.commitPartitionRequests.clear()
+                        Map.empty[WorkerInfo, Set[PartitionLocation]]
+                      } else {
+                        val batch = new util.HashSet[CommitPartitionRequest]()
+                        batch.addAll(shuffleCommittedInfo.commitPartitionRequests)
+                        val currentBatch = batch.asScala.filterNot { request =>
+                          shuffleCommittedInfo.handledCommitPartitionRequests
+                            .contains(request.partition)
+                        }
+                        shuffleCommittedInfo.commitPartitionRequests.clear()
+                        currentBatch.foreach { commitPartitionRequest =>
+                          shuffleCommittedInfo.handledCommitPartitionRequests
+                            .add(commitPartitionRequest.partition)
+                          if (commitPartitionRequest.partition.getPeer != null) {
+                            shuffleCommittedInfo.handledCommitPartitionRequests
+                              .add(commitPartitionRequest.partition.getPeer)
+                          }
+                        }
+
+                        if (currentBatch.nonEmpty) {
+                          logWarning(s"Commit current batch HARD_SPLIT partitions for $shuffleId: " +
+                            s"${currentBatch.map(_.partition.getUniqueId).mkString("[", ",", "]")}")
+                          val workerToRequests = currentBatch.flatMap { request =>
+                            if (request.partition.getPeer != null) {
+                              Seq(request.partition, request.partition.getPeer)
+                            } else {
+                              Seq(request.partition)
+                            }
+                          }.groupBy(_.getWorker)
+                          shuffleCommittedInfo.inFlightCommitRequest.addAndGet(
+                            workerToRequests.size)
+                          workerToRequests
+                        } else {
+                          Map.empty[WorkerInfo, Set[PartitionLocation]]
+                        }
+                      }
+                    }
+                    if (workerToRequests.nonEmpty) {
+                      val commitFilesFailedWorkers =
+                        new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]()
+                      val parallelism = workerToRequests.size
+                      try {
+                        ThreadUtils.parmap(
+                          workerToRequests.to,
+                          "CommitFiles",
+                          parallelism) {
+                          case (worker, requests) =>
+                            val workerInfo =
+                              lifecycleManager.shuffleAllocatedWorkers
+                                .get(shuffleId)
+                                .asScala
+                                .find(_._1.equals(worker))
+                                .get
+                                ._1
+                            val mastersIds =
+                              requests
+                                .filter(_.getMode == PartitionLocation.Mode.MASTER)
+                                .map(_.getUniqueId)
+                                .toList
+                                .asJava
+                            val slaveIds =
+                              requests
+                                .filter(_.getMode == PartitionLocation.Mode.SLAVE)
+                                .map(_.getUniqueId)
+                                .toList
+                                .asJava
+
+                            commitFiles(
+                              appId,
+                              shuffleId,
+                              shuffleCommittedInfo,
+                              workerInfo,
+                              mastersIds,
+                              slaveIds,
+                              commitFilesFailedWorkers)
+                        }
+                        lifecycleManager.recordWorkerFailure(commitFilesFailedWorkers)
+                      } finally {
+                        shuffleCommittedInfo.inFlightCommitRequest.addAndGet(-workerToRequests.size)
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        0,
+        batchHandleCommitPartitionRequestInterval,
+        TimeUnit.MILLISECONDS)
+    }
+  }
+
+  def stop(): Unit = {
+    batchHandleCommitPartition.foreach(_.cancel(true))
+    batchHandleCommitPartitionSchedulerThread.foreach(ThreadUtils.shutdown(_, 800.millis))
+  }
+
+  def registerShuffle(shuffleId: Int): Unit = {
+    committedPartitionInfo.put(
+      shuffleId,
+      ShuffleCommittedInfo(
+        new util.ArrayList[String](),
+        new util.ArrayList[String](),
+        new ConcurrentHashMap[String, WorkerInfo](),
+        new ConcurrentHashMap[String, WorkerInfo](),
+        new ConcurrentHashMap[String, StorageInfo](),
+        new ConcurrentHashMap[String, StorageInfo](),
+        new ConcurrentHashMap[String, RoaringBitmap](),
+        new LongAdder,
+        new util.HashSet[CommitPartitionRequest](),
+        new util.HashSet[PartitionLocation](),
+        new AtomicInteger()))
+  }
+
+  def removeExpiredShuffle(shuffleId: Int): Unit = {
+    committedPartitionInfo.remove(shuffleId)
+    dataLostShuffleSet.remove(shuffleId)
+    stageEndShuffleSet.remove(shuffleId)
+  }
+
+  def registerCommitPartitionRequest(
+      applicationId: String,
+      shuffleId: Int,
+      partition: PartitionLocation,
+      cause: Option[StatusCode]): Unit = {
+    if (batchHandleCommitPartitionEnabled && cause.isDefined && cause.get == StatusCode.HARD_SPLIT) {
+      val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
+      shuffleCommittedInfo.synchronized {
+        shuffleCommittedInfo.commitPartitionRequests
+          .add(CommitPartitionRequest(applicationId, shuffleId, partition))
+      }
+    }
+  }
+
+  private def commitFiles(
+      applicationId: String,
+      shuffleId: Int,
+      shuffleCommittedInfo: ShuffleCommittedInfo,
+      worker: WorkerInfo,
+      masterIds: util.List[String],
+      slaveIds: util.List[String],
+      commitFilesFailedWorkers: ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]): Unit = {
+
+    val res =
+      if (!testRetryCommitFiles) {
+        val commitFiles = CommitFiles(
+          applicationId,
+          shuffleId,
+          masterIds,
+          slaveIds,
+          lifecycleManager.shuffleMapperAttempts.get(shuffleId),
+          commitEpoch.incrementAndGet())
+        val res = requestCommitFilesWithRetry(worker.endpoint, commitFiles)
+
+        res.status match {
+          case StatusCode.SUCCESS => // do nothing
+          case StatusCode.PARTIAL_SUCCESS | StatusCode.SHUFFLE_NOT_REGISTERED | StatusCode.FAILED =>
+            logDebug(s"Request $commitFiles return ${res.status} for " +
+              s"${Utils.makeShuffleKey(applicationId, shuffleId)}")
+            commitFilesFailedWorkers.put(worker, (res.status, System.currentTimeMillis()))
+          case _ => // won't happen
+        }
+        res
+      } else {
+        // for test
+        val commitFiles1 = CommitFiles(
+          applicationId,
+          shuffleId,
+          masterIds.subList(0, masterIds.size() / 2),
+          slaveIds.subList(0, slaveIds.size() / 2),
+          lifecycleManager.shuffleMapperAttempts.get(shuffleId),
+          commitEpoch.incrementAndGet())
+        val res1 = requestCommitFilesWithRetry(worker.endpoint, commitFiles1)
+
+        val commitFiles = CommitFiles(
+          applicationId,
+          shuffleId,
+          masterIds.subList(masterIds.size() / 2, masterIds.size()),
+          slaveIds.subList(slaveIds.size() / 2, slaveIds.size()),
+          lifecycleManager.shuffleMapperAttempts.get(shuffleId),
+          commitEpoch.incrementAndGet())
+        val res2 = requestCommitFilesWithRetry(worker.endpoint, commitFiles)
+
+        res1.committedMasterStorageInfos.putAll(res2.committedMasterStorageInfos)
+        res1.committedSlaveStorageInfos.putAll(res2.committedSlaveStorageInfos)
+        res1.committedMapIdBitMap.putAll(res2.committedMapIdBitMap)
+        CommitFilesResponse(
+          status = if (res1.status == StatusCode.SUCCESS) res2.status else res1.status,
+          (res1.committedMasterIds.asScala ++ res2.committedMasterIds.asScala).toList.asJava,
+          (res1.committedSlaveIds.asScala ++ res1.committedSlaveIds.asScala).toList.asJava,
+          (res1.failedMasterIds.asScala ++ res1.failedMasterIds.asScala).toList.asJava,
+          (res1.failedSlaveIds.asScala ++ res2.failedSlaveIds.asScala).toList.asJava,
+          res1.committedMasterStorageInfos,
+          res1.committedSlaveStorageInfos,
+          res1.committedMapIdBitMap,
+          res1.totalWritten + res2.totalWritten,
+          res1.fileCount + res2.fileCount)
+      }
+
+    shuffleCommittedInfo.synchronized {
+      // record committed partitionIds
+      shuffleCommittedInfo.committedMasterIds.addAll(res.committedMasterIds)
+      shuffleCommittedInfo.committedSlaveIds.addAll(res.committedSlaveIds)
+
+      // record committed partitions storage hint and disk hint
+      shuffleCommittedInfo.committedMasterStorageInfos.putAll(res.committedMasterStorageInfos)
+      shuffleCommittedInfo.committedSlaveStorageInfos.putAll(res.committedSlaveStorageInfos)
+
+      // record failed partitions
+      shuffleCommittedInfo.failedMasterPartitionIds.putAll(
+        res.failedMasterIds.asScala.map((_, worker)).toMap.asJava)
+      shuffleCommittedInfo.failedSlavePartitionIds.putAll(
+        res.failedSlaveIds.asScala.map((_, worker)).toMap.asJava)
+
+      shuffleCommittedInfo.committedMapIdBitmap.putAll(res.committedMapIdBitMap)
+
+      totalWritten.add(res.totalWritten)
+      fileCount.add(res.fileCount)
+      shuffleCommittedInfo.currentShuffleFileCount.add(res.fileCount)
+    }
+  }
+
+  private def requestCommitFilesWithRetry(
+      endpoint: RpcEndpointRef,
+      message: CommitFiles): CommitFilesResponse = {
+    val maxRetries = conf.requestCommitFilesMaxRetries
+    var retryTimes = 0
+    while (retryTimes < maxRetries) {
+      try {
+        if (testRetryCommitFiles && retryTimes < maxRetries - 1) {
+          endpoint.ask[CommitFilesResponse](message)
+          Thread.sleep(1000)
+          throw new Exception("Mock fail for CommitFiles")
+        } else {
+          return endpoint.askSync[CommitFilesResponse](message)
+        }
+      } catch {
+        case e: Throwable =>
+          retryTimes += 1
+          logError(
+            s"AskSync CommitFiles for ${message.shuffleId} failed (attempt $retryTimes/$maxRetries).",
+            e)
+      }
+    }
+
+    CommitFilesResponse(
+      StatusCode.FAILED,
+      List.empty.asJava,
+      List.empty.asJava,
+      message.masterIds,
+      message.slaveIds)
+  }
+
+  def finalCommit(
+      applicationId: String,
+      shuffleId: Int,
+      fileGroups: Array[Array[PartitionLocation]]): Unit = {
+    if (stageEndShuffleSet.contains(shuffleId)) {
+      logInfo(s"[handleStageEnd] Shuffle $shuffleId already ended!")
+      return
+    }
+    inProcessStageEndShuffleSet.synchronized {
+      if (inProcessStageEndShuffleSet.contains(shuffleId)) {
+        logWarning(s"[handleStageEnd] Shuffle $shuffleId is in process!")
+        return
+      }
+      inProcessStageEndShuffleSet.add(shuffleId)
+    }
+    // ask allLocations workers holding partitions to commit files
+    val masterPartMap = new ConcurrentHashMap[String, PartitionLocation]
+    val slavePartMap = new ConcurrentHashMap[String, PartitionLocation]
+
+    val allocatedWorkers = lifecycleManager.shuffleAllocatedWorkers.get(shuffleId)
+    val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
+    val commitFilesFailedWorkers = new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]()
+    val commitFileStartTime = System.nanoTime()
+
+    val parallelism = Math.min(allocatedWorkers.size(), conf.rpcMaxParallelism)
+    ThreadUtils.parmap(
+      allocatedWorkers.asScala.to,
+      "CommitFiles",
+      parallelism) { case (worker, partitionLocationInfo) =>
+      if (partitionLocationInfo.containsShuffle(shuffleId.toString)) {
+        val masterParts = partitionLocationInfo.getAllMasterLocations(shuffleId.toString)
+        val slaveParts = partitionLocationInfo.getAllSlaveLocations(shuffleId.toString)
+        masterParts.asScala.foreach { p =>
+          val partition = new PartitionLocation(p)
+          partition.setFetchPort(worker.fetchPort)
+          partition.setPeer(null)
+          masterPartMap.put(partition.getUniqueId, partition)
+        }
+        slaveParts.asScala.foreach { p =>
+          val partition = new PartitionLocation(p)
+          partition.setFetchPort(worker.fetchPort)
+          partition.setPeer(null)
+          slavePartMap.put(partition.getUniqueId, partition)
+        }
+
+        val (masterIds, slaveIds) = shuffleCommittedInfo.synchronized {
+          (
+            masterParts.asScala
+              .filterNot(shuffleCommittedInfo.handledCommitPartitionRequests.contains)
+              .map(_.getUniqueId).asJava,
+            slaveParts.asScala
+              .filterNot(shuffleCommittedInfo.handledCommitPartitionRequests.contains)
+              .map(_.getUniqueId).asJava)
+        }
+
+        commitFiles(
+          applicationId,
+          shuffleId,
+          shuffleCommittedInfo,
+          worker,
+          masterIds,
+          slaveIds,
+          commitFilesFailedWorkers)
+      }
+    }
+
+    def hasCommitFailedIds: Boolean = {
+      val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
+      if (!pushReplicateEnabled && shuffleCommittedInfo.failedMasterPartitionIds.size() != 0) {
+        val msg =
+          shuffleCommittedInfo.failedMasterPartitionIds.asScala.map {
+            case (partitionId, workerInfo) =>
+              s"Lost partition $partitionId in worker [${workerInfo.readableAddress()}]"
+          }.mkString("\n")
+        logError(
+          s"""
+             |For shuffle $shuffleKey partition data lost:
+             |$msg
+             |""".stripMargin)
+        true
+      } else {
+        val failedBothPartitionIdsToWorker =
+          shuffleCommittedInfo.failedMasterPartitionIds.asScala.flatMap {
+            case (partitionId, worker) =>
+              if (shuffleCommittedInfo.failedSlavePartitionIds.contains(partitionId)) {
+                Some(partitionId -> (worker, shuffleCommittedInfo.failedSlavePartitionIds.get(
+                  partitionId)))
+              } else {
+                None
+              }
+          }
+        if (failedBothPartitionIdsToWorker.nonEmpty) {
+          val msg = failedBothPartitionIdsToWorker.map {
+            case (partitionId, (masterWorker, slaveWorker)) =>
+              s"Lost partition $partitionId " +
+                s"in master worker [${masterWorker.readableAddress()}] and slave worker [$slaveWorker]"
+          }.mkString("\n")
+          logError(
+            s"""
+               |For shuffle $shuffleKey partition data lost:
+               |$msg
+               |""".stripMargin)
+          true
+        } else {
+          false
+        }
+      }
+    }
+
+    while (shuffleCommittedInfo.inFlightCommitRequest.get() > 0) {
+      Thread.sleep(1000)
+    }
+
+    val dataLost = hasCommitFailedIds
+
+    if (!dataLost) {
+      val committedPartitions = new util.HashMap[String, PartitionLocation]
+      shuffleCommittedInfo.committedMasterIds.asScala.foreach { id =>
+        if (shuffleCommittedInfo.committedMasterStorageInfos.get(id) == null) {
+          logDebug(s"$applicationId-$shuffleId $id storage hint was not returned")
+        } else {
+          masterPartMap.get(id).setStorageInfo(
+            shuffleCommittedInfo.committedMasterStorageInfos.get(id))
+          masterPartMap.get(id).setMapIdBitMap(shuffleCommittedInfo.committedMapIdBitmap.get(id))
+          committedPartitions.put(id, masterPartMap.get(id))
+        }
+      }
+
+      shuffleCommittedInfo.committedSlaveIds.asScala.foreach { id =>
+        val slavePartition = slavePartMap.get(id)
+        if (shuffleCommittedInfo.committedSlaveStorageInfos.get(id) == null) {
+          logDebug(s"$applicationId-$shuffleId $id storage hint was not returned")
+        } else {
+          slavePartition.setStorageInfo(shuffleCommittedInfo.committedSlaveStorageInfos.get(id))
+          val masterPartition = committedPartitions.get(id)
+          if (masterPartition ne null) {
+            masterPartition.setPeer(slavePartition)
+            slavePartition.setPeer(masterPartition)
+          } else {
+            logInfo(s"Shuffle $shuffleId partition $id: master lost, " +
+              s"use slave $slavePartition.")
+            slavePartition.setMapIdBitMap(shuffleCommittedInfo.committedMapIdBitmap.get(id))
+            committedPartitions.put(id, slavePartition)
+          }
+        }
+      }
+
+      val sets = Array.fill(fileGroups.length)(new util.HashSet[PartitionLocation]())
+      committedPartitions.values().asScala.foreach { partition =>
+        sets(partition.getId).add(partition)
+      }
+      var i = 0
+      while (i < fileGroups.length) {
+        fileGroups(i) = sets(i).toArray(new Array[PartitionLocation](0))
+        i += 1
+      }
+
+      logInfo(s"Shuffle $shuffleId " +
+        s"commit files complete. File count ${shuffleCommittedInfo.currentShuffleFileCount.sum()} " +
+        s"using ${(System.nanoTime() - commitFileStartTime) / 1000000} ms")
+    }
+
+    // reply
+    if (!dataLost) {
+      logInfo(s"Succeed to handle stageEnd for $shuffleId.")
+      // record in stageEndShuffleSet
+      stageEndShuffleSet.add(shuffleId)
+    } else {
+      logError(s"Failed to handle stageEnd for $shuffleId, lost file!")
+      dataLostShuffleSet.add(shuffleId)
+      // record in stageEndShuffleSet
+      stageEndShuffleSet.add(shuffleId)
+    }
+    inProcessStageEndShuffleSet.remove(shuffleId)
+    lifecycleManager.recordWorkerFailure(commitFilesFailedWorkers)
+  }
+
+  def removeExpiredShuffle(shuffleId: String): Unit = {
+    stageEndShuffleSet.remove(shuffleId)
+    dataLostShuffleSet.remove(shuffleId)
+    committedPartitionInfo.remove(shuffleId)
+  }
+
+  def commitMetrics(): (Long, Long) = (totalWritten.sumThenReset(), fileCount.sumThenReset())
+}

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -64,16 +64,12 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   private val rpcCacheExpireTime = conf.rpcCacheExpireTime
 
   val registeredShuffle = ConcurrentHashMap.newKeySet[Int]()
-  private val shuffleMapperAttempts = new ConcurrentHashMap[Int, Array[Int]]()
+  val shuffleMapperAttempts = new ConcurrentHashMap[Int, Array[Int]]()
   private val reducerFileGroupsMap =
     new ConcurrentHashMap[Int, Array[Array[PartitionLocation]]]()
-  private val dataLostShuffleSet = ConcurrentHashMap.newKeySet[Int]()
-  val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
-  private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   // maintain each shuffle's map relation of WorkerInfo and partition location
-  private val shuffleAllocatedWorkers = {
+  val shuffleAllocatedWorkers =
     new ConcurrentHashMap[Int, ConcurrentHashMap[WorkerInfo, PartitionLocationInfo]]()
-  }
   // shuffle id -> (partitionId -> newest PartitionLocation)
   val latestPartitionLocation =
     new ConcurrentHashMap[Int, ConcurrentHashMap[Int, PartitionLocation]]()
@@ -84,9 +80,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     .expireAfterWrite(rpcCacheExpireTime, TimeUnit.MILLISECONDS)
     .maximumSize(rpcCacheSize)
     .build().asInstanceOf[Cache[Int, ByteBuffer]]
-
-  private val testRetryCommitFiles = conf.testRetryCommitFiles
-  private val commitEpoch = new AtomicLong()
 
   @VisibleForTesting
   def workerSnapshots(shuffleId: Int): util.Map[WorkerInfo, PartitionLocationInfo] =
@@ -112,41 +105,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     }
   }
 
-  case class CommitPartitionRequest(
-      applicationId: String,
-      shuffleId: Int,
-      partition: PartitionLocation)
-
-  case class ShuffleCommittedInfo(
-      committedMasterIds: util.List[String],
-      committedSlaveIds: util.List[String],
-      failedMasterPartitionIds: ConcurrentHashMap[String, WorkerInfo],
-      failedSlavePartitionIds: ConcurrentHashMap[String, WorkerInfo],
-      committedMasterStorageInfos: ConcurrentHashMap[String, StorageInfo],
-      committedSlaveStorageInfos: ConcurrentHashMap[String, StorageInfo],
-      committedMapIdBitmap: ConcurrentHashMap[String, RoaringBitmap],
-      currentShuffleFileCount: LongAdder,
-      commitPartitionRequests: util.Set[CommitPartitionRequest],
-      handledCommitPartitionRequests: util.Set[PartitionLocation],
-      inFlightCommitRequest: AtomicInteger)
-
-  // shuffle id -> ShuffleCommittedInfo
-  private val committedPartitionInfo = new ConcurrentHashMap[Int, ShuffleCommittedInfo]()
-  def registerCommitPartition(
-      applicationId: String,
-      shuffleId: Int,
-      partition: PartitionLocation,
-      cause: Option[StatusCode]): Unit = {
-    // handle hard split
-    if (batchHandleCommitPartitionEnabled && cause.isDefined && cause.get == StatusCode.HARD_SPLIT) {
-      val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
-      shuffleCommittedInfo.synchronized {
-        shuffleCommittedInfo.commitPartitionRequests
-          .add(CommitPartitionRequest(applicationId, shuffleId, partition))
-      }
-    }
-  }
-
   // register shuffle request waiting for response
   private val registeringShuffleRequest =
     new ConcurrentHashMap[Int, util.Set[RegisterCallContext]]()
@@ -160,20 +118,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   private var checkForShuffleRemoval: ScheduledFuture[_] = _
   private var getBlacklist: ScheduledFuture[_] = _
 
-  private val batchHandleCommitPartitionEnabled = conf.batchHandleCommitPartitionEnabled
-  private val batchHandleCommitPartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(
-    "rss-lifecycle-manager-commit-partition-executor",
-    conf.batchHandleCommitPartitionNumThreads)
-  private val batchHandleCommitPartitionRequestInterval =
-    conf.batchHandleCommitPartitionRequestInterval
-  private val batchHandleCommitPartitionSchedulerThread: Option[ScheduledExecutorService] =
-    if (batchHandleCommitPartitionEnabled) {
-      Some(ThreadUtils.newDaemonSingleThreadScheduledExecutor(
-        "rss-lifecycle-manager-commit-partition-scheduler"))
-    } else {
-      None
-    }
-
   // init driver rss meta rpc service
   override val rpcEnv: RpcEnv = RpcEnv.create(
     RpcNameConstants.RSS_METASERVICE_SYS,
@@ -185,14 +129,9 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   logInfo(s"Starting LifecycleManager on ${rpcEnv.address}")
 
   private val rssHARetryClient = new RssHARetryClient(rpcEnv, conf)
-  private val totalWritten = new LongAdder
-  private val fileCount = new LongAdder
+  val commitManager = new CommitManager(appId, conf, this)
   private val heartbeater =
-    new ApplicationHeartbeater(
-      appId,
-      conf,
-      rssHARetryClient,
-      () => (totalWritten.sumThenReset(), fileCount.sumThenReset()))
+    new ApplicationHeartbeater(appId, conf, rssHARetryClient, () => commitManager.commitMetrics())
   private val changePartitionManager = new ChangePartitionManager(conf, this)
 
   // Since method `onStart` is executed when `rpcEnv.setupEndpoint` is executed, and
@@ -202,117 +141,9 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   // method at the end of the construction of the class to perform the initialization operations.
   private def initialize(): Unit = {
     // noinspection ConvertExpressionToSAM
+    commitManager.start()
     heartbeater.start()
     changePartitionManager.start()
-
-    batchHandleCommitPartitionSchedulerThread.foreach {
-      _.scheduleAtFixedRate(
-        new Runnable {
-          override def run(): Unit = {
-            committedPartitionInfo.asScala.foreach { case (shuffleId, shuffleCommittedInfo) =>
-              batchHandleCommitPartitionExecutors.submit {
-                new Runnable {
-                  override def run(): Unit = {
-                    val workerToRequests = shuffleCommittedInfo.synchronized {
-                      // When running to here, if handleStageEnd got lock first and commitFiles,
-                      // then this batch get this lock, commitPartitionRequests may contains
-                      // partitions which are already committed by stageEnd process.
-                      // But inProcessStageEndShuffleSet should have contain this shuffle id,
-                      // can directly return.
-                      if (inProcessStageEndShuffleSet.contains(shuffleId) ||
-                        stageEndShuffleSet.contains(shuffleId)) {
-                        logWarning(s"Shuffle $shuffleId ended or during processing stage end.")
-                        shuffleCommittedInfo.commitPartitionRequests.clear()
-                        Map.empty[WorkerInfo, Set[PartitionLocation]]
-                      } else {
-                        val batch = new util.HashSet[CommitPartitionRequest]()
-                        batch.addAll(shuffleCommittedInfo.commitPartitionRequests)
-                        val currentBatch = batch.asScala.filterNot { request =>
-                          shuffleCommittedInfo.handledCommitPartitionRequests
-                            .contains(request.partition)
-                        }
-                        shuffleCommittedInfo.commitPartitionRequests.clear()
-                        currentBatch.foreach { commitPartitionRequest =>
-                          shuffleCommittedInfo.handledCommitPartitionRequests
-                            .add(commitPartitionRequest.partition)
-                          if (commitPartitionRequest.partition.getPeer != null) {
-                            shuffleCommittedInfo.handledCommitPartitionRequests
-                              .add(commitPartitionRequest.partition.getPeer)
-                          }
-                        }
-
-                        if (currentBatch.nonEmpty) {
-                          logWarning(s"Commit current batch HARD_SPLIT partitions for $shuffleId: " +
-                            s"${currentBatch.map(_.partition.getUniqueId).mkString("[", ",", "]")}")
-                          val workerToRequests = currentBatch.flatMap { request =>
-                            if (request.partition.getPeer != null) {
-                              Seq(request.partition, request.partition.getPeer)
-                            } else {
-                              Seq(request.partition)
-                            }
-                          }.groupBy(_.getWorker)
-                          shuffleCommittedInfo.inFlightCommitRequest.addAndGet(
-                            workerToRequests.size)
-                          workerToRequests
-                        } else {
-                          Map.empty[WorkerInfo, Set[PartitionLocation]]
-                        }
-                      }
-                    }
-                    if (workerToRequests.nonEmpty) {
-                      val commitFilesFailedWorkers =
-                        new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]()
-                      val parallelism = workerToRequests.size
-                      try {
-                        ThreadUtils.parmap(
-                          workerToRequests.to,
-                          "CommitFiles",
-                          parallelism) {
-                          case (worker, requests) =>
-                            val workerInfo =
-                              shuffleAllocatedWorkers
-                                .get(shuffleId)
-                                .asScala
-                                .find(_._1.equals(worker))
-                                .get
-                                ._1
-                            val mastersIds =
-                              requests
-                                .filter(_.getMode == PartitionLocation.Mode.MASTER)
-                                .map(_.getUniqueId)
-                                .toList
-                                .asJava
-                            val slaveIds =
-                              requests
-                                .filter(_.getMode == PartitionLocation.Mode.SLAVE)
-                                .map(_.getUniqueId)
-                                .toList
-                                .asJava
-
-                            commitFiles(
-                              appId,
-                              shuffleId,
-                              shuffleCommittedInfo,
-                              workerInfo,
-                              mastersIds,
-                              slaveIds,
-                              commitFilesFailedWorkers)
-                        }
-                        recordWorkerFailure(commitFilesFailedWorkers)
-                      } finally {
-                        shuffleCommittedInfo.inFlightCommitRequest.addAndGet(-workerToRequests.size)
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        0,
-        batchHandleCommitPartitionRequestInterval,
-        TimeUnit.MILLISECONDS)
-    }
   }
 
   override def onStart(): Unit = {
@@ -346,6 +177,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     getBlacklist.cancel(true)
     ThreadUtils.shutdown(forwardMessageThread, 800.millis)
 
+    commitManager.stop()
     changePartitionManager.stop()
     heartbeater.stop()
 
@@ -638,20 +470,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
       // Fifth, reply the allocated partition location to ShuffleClient.
       logInfo(s"Handle RegisterShuffle Success for $shuffleId.")
-      committedPartitionInfo.put(
-        shuffleId,
-        ShuffleCommittedInfo(
-          new util.ArrayList[String](),
-          new util.ArrayList[String](),
-          new ConcurrentHashMap[String, WorkerInfo](),
-          new ConcurrentHashMap[String, WorkerInfo](),
-          new ConcurrentHashMap[String, StorageInfo](),
-          new ConcurrentHashMap[String, StorageInfo](),
-          new ConcurrentHashMap[String, RoaringBitmap](),
-          new LongAdder,
-          new util.HashSet[CommitPartitionRequest](),
-          new util.HashSet[PartitionLocation](),
-          new AtomicInteger()))
+      commitManager.registerShuffle(shuffleId)
       val allMasterPartitionLocations = slots.asScala.flatMap(_._2._1.asScala).toArray
       reply(RegisterShuffleResponse(StatusCode.SUCCESS, allMasterPartitionLocations))
     }
@@ -784,7 +603,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       shuffleId: Int): Unit = {
     var timeout = stageEndTimeout
     val delta = 100
-    while (!stageEndShuffleSet.contains(shuffleId)) {
+    while (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
       Thread.sleep(delta)
       if (timeout <= 0) {
         logError(s"[handleGetReducerFileGroup] Wait for handleStageEnd Timeout! $shuffleId.")
@@ -797,7 +616,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     logDebug("[handleGetReducerFileGroup] Wait for handleStageEnd complete cost" +
       s" ${stageEndTimeout - timeout}ms")
 
-    if (dataLostShuffleSet.contains(shuffleId)) {
+    if (commitManager.dataLostShuffleSet.contains(shuffleId)) {
       context.reply(
         GetReducerFileGroupResponse(StatusCode.SHUFFLE_DATA_LOST, Array.empty, Array.empty))
     } else {
@@ -830,182 +649,13 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       logInfo(s"[handleStageEnd]" +
         s"$shuffleId not registered, maybe no shuffle data within this stage.")
       // record in stageEndShuffleSet
-      stageEndShuffleSet.add(shuffleId)
+      commitManager.stageEndShuffleSet.add(shuffleId)
       return
     }
-    if (stageEndShuffleSet.contains(shuffleId)) {
-      logInfo(s"[handleStageEnd] Shuffle $shuffleId already ended!")
-      return
-    }
-    inProcessStageEndShuffleSet.synchronized {
-      if (inProcessStageEndShuffleSet.contains(shuffleId)) {
-        logWarning(s"[handleStageEnd] Shuffle $shuffleId is in process!")
-        return
-      }
-      inProcessStageEndShuffleSet.add(shuffleId)
-    }
-
-    // ask allLocations workers holding partitions to commit files
-    val masterPartMap = new ConcurrentHashMap[String, PartitionLocation]
-    val slavePartMap = new ConcurrentHashMap[String, PartitionLocation]
-
-    val allocatedWorkers = shuffleAllocatedWorkers.get(shuffleId)
-    val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
-    val commitFilesFailedWorkers = new ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]()
-    val commitFileStartTime = System.nanoTime()
-
-    val parallelism = Math.min(workerSnapshots(shuffleId).size(), conf.rpcMaxParallelism)
-    ThreadUtils.parmap(
-      allocatedWorkers.asScala.to,
-      "CommitFiles",
-      parallelism) { case (worker, partitionLocationInfo) =>
-      if (partitionLocationInfo.containsShuffle(shuffleId.toString)) {
-        val masterParts = partitionLocationInfo.getAllMasterLocations(shuffleId.toString)
-        val slaveParts = partitionLocationInfo.getAllSlaveLocations(shuffleId.toString)
-        masterParts.asScala.foreach { p =>
-          val partition = new PartitionLocation(p)
-          partition.setFetchPort(worker.fetchPort)
-          partition.setPeer(null)
-          masterPartMap.put(partition.getUniqueId, partition)
-        }
-        slaveParts.asScala.foreach { p =>
-          val partition = new PartitionLocation(p)
-          partition.setFetchPort(worker.fetchPort)
-          partition.setPeer(null)
-          slavePartMap.put(partition.getUniqueId, partition)
-        }
-
-        val (masterIds, slaveIds) = shuffleCommittedInfo.synchronized {
-          (
-            masterParts.asScala
-              .filterNot(shuffleCommittedInfo.handledCommitPartitionRequests.contains)
-              .map(_.getUniqueId).asJava,
-            slaveParts.asScala
-              .filterNot(shuffleCommittedInfo.handledCommitPartitionRequests.contains)
-              .map(_.getUniqueId).asJava)
-        }
-
-        commitFiles(
-          applicationId,
-          shuffleId,
-          shuffleCommittedInfo,
-          worker,
-          masterIds,
-          slaveIds,
-          commitFilesFailedWorkers)
-      }
-    }
-
-    def hasCommitFailedIds: Boolean = {
-      val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
-      if (!pushReplicateEnabled && shuffleCommittedInfo.failedMasterPartitionIds.size() != 0) {
-        val msg =
-          shuffleCommittedInfo.failedMasterPartitionIds.asScala.map {
-            case (partitionId, workerInfo) =>
-              s"Lost partition $partitionId in worker [${workerInfo.readableAddress()}]"
-          }.mkString("\n")
-        logError(
-          s"""
-             |For shuffle $shuffleKey partition data lost:
-             |$msg
-             |""".stripMargin)
-        true
-      } else {
-        val failedBothPartitionIdsToWorker =
-          shuffleCommittedInfo.failedMasterPartitionIds.asScala.flatMap {
-            case (partitionId, worker) =>
-              if (shuffleCommittedInfo.failedSlavePartitionIds.contains(partitionId)) {
-                Some(partitionId -> (worker, shuffleCommittedInfo.failedSlavePartitionIds.get(
-                  partitionId)))
-              } else {
-                None
-              }
-          }
-        if (failedBothPartitionIdsToWorker.nonEmpty) {
-          val msg = failedBothPartitionIdsToWorker.map {
-            case (partitionId, (masterWorker, slaveWorker)) =>
-              s"Lost partition $partitionId " +
-                s"in master worker [${masterWorker.readableAddress()}] and slave worker [$slaveWorker]"
-          }.mkString("\n")
-          logError(
-            s"""
-               |For shuffle $shuffleKey partition data lost:
-               |$msg
-               |""".stripMargin)
-          true
-        } else {
-          false
-        }
-      }
-    }
-
-    while (shuffleCommittedInfo.inFlightCommitRequest.get() > 0) {
-      Thread.sleep(1000)
-    }
-
-    val dataLost = hasCommitFailedIds
-
-    if (!dataLost) {
-      val committedPartitions = new util.HashMap[String, PartitionLocation]
-      shuffleCommittedInfo.committedMasterIds.asScala.foreach { id =>
-        if (shuffleCommittedInfo.committedMasterStorageInfos.get(id) == null) {
-          logDebug(s"$applicationId-$shuffleId $id storage hint was not returned")
-        } else {
-          masterPartMap.get(id).setStorageInfo(
-            shuffleCommittedInfo.committedMasterStorageInfos.get(id))
-          masterPartMap.get(id).setMapIdBitMap(shuffleCommittedInfo.committedMapIdBitmap.get(id))
-          committedPartitions.put(id, masterPartMap.get(id))
-        }
-      }
-
-      shuffleCommittedInfo.committedSlaveIds.asScala.foreach { id =>
-        val slavePartition = slavePartMap.get(id)
-        if (shuffleCommittedInfo.committedSlaveStorageInfos.get(id) == null) {
-          logDebug(s"$applicationId-$shuffleId $id storage hint was not returned")
-        } else {
-          slavePartition.setStorageInfo(shuffleCommittedInfo.committedSlaveStorageInfos.get(id))
-          val masterPartition = committedPartitions.get(id)
-          if (masterPartition ne null) {
-            masterPartition.setPeer(slavePartition)
-            slavePartition.setPeer(masterPartition)
-          } else {
-            logInfo(s"Shuffle $shuffleId partition $id: master lost, " +
-              s"use slave $slavePartition.")
-            slavePartition.setMapIdBitMap(shuffleCommittedInfo.committedMapIdBitmap.get(id))
-            committedPartitions.put(id, slavePartition)
-          }
-        }
-      }
-
-      val fileGroups = reducerFileGroupsMap.get(shuffleId)
-      val sets = Array.fill(fileGroups.length)(new util.HashSet[PartitionLocation]())
-      committedPartitions.values().asScala.foreach { partition =>
-        sets(partition.getId).add(partition)
-      }
-      var i = 0
-      while (i < fileGroups.length) {
-        fileGroups(i) = sets(i).toArray(new Array[PartitionLocation](0))
-        i += 1
-      }
-
-      logInfo(s"Shuffle $shuffleId " +
-        s"commit files complete. File count ${shuffleCommittedInfo.currentShuffleFileCount.sum()} " +
-        s"using ${(System.nanoTime() - commitFileStartTime) / 1000000} ms")
-    }
-
-    // reply
-    if (!dataLost) {
-      logInfo(s"Succeed to handle stageEnd for $shuffleId.")
-      // record in stageEndShuffleSet
-      stageEndShuffleSet.add(shuffleId)
-    } else {
-      logError(s"Failed to handle stageEnd for $shuffleId, lost file!")
-      dataLostShuffleSet.add(shuffleId)
-      // record in stageEndShuffleSet
-      stageEndShuffleSet.add(shuffleId)
-    }
-    inProcessStageEndShuffleSet.remove(shuffleId)
-    recordWorkerFailure(commitFilesFailedWorkers)
+    commitManager.finalCommit(
+      applicationId,
+      shuffleId,
+      reducerFileGroupsMap.get(shuffleId))
     // release resources and clear worker info
     workerSnapshots(shuffleId).asScala.foreach { case (_, partitionLocationInfo) =>
       partitionLocationInfo.removeMasterPartitions(shuffleId.toString)
@@ -1016,103 +666,16 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       ReleaseSlots(applicationId, shuffleId, List.empty.asJava, List.empty.asJava))
   }
 
-  private def commitFiles(
-      applicationId: String,
-      shuffleId: Int,
-      shuffleCommittedInfo: ShuffleCommittedInfo,
-      worker: WorkerInfo,
-      masterIds: util.List[String],
-      slaveIds: util.List[String],
-      commitFilesFailedWorkers: ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]): Unit = {
-
-    val res =
-      if (!testRetryCommitFiles) {
-        val commitFiles = CommitFiles(
-          applicationId,
-          shuffleId,
-          masterIds,
-          slaveIds,
-          shuffleMapperAttempts.get(shuffleId),
-          commitEpoch.incrementAndGet())
-        val res = requestCommitFilesWithRetry(worker.endpoint, commitFiles)
-        res.status match {
-          case StatusCode.SUCCESS => // do nothing
-          case StatusCode.PARTIAL_SUCCESS | StatusCode.SHUFFLE_NOT_REGISTERED | StatusCode.FAILED =>
-            logDebug(s"Request $commitFiles return ${res.status} for " +
-              s"${Utils.makeShuffleKey(applicationId, shuffleId)}")
-            commitFilesFailedWorkers.put(worker, (res.status, System.currentTimeMillis()))
-          case _ => // won't happen
-        }
-        res
-      } else {
-        // for test
-        val commitFiles1 = CommitFiles(
-          applicationId,
-          shuffleId,
-          masterIds.subList(0, masterIds.size() / 2),
-          slaveIds.subList(0, slaveIds.size() / 2),
-          shuffleMapperAttempts.get(shuffleId),
-          commitEpoch.incrementAndGet())
-        val res1 = requestCommitFilesWithRetry(worker.endpoint, commitFiles1)
-
-        val commitFiles = CommitFiles(
-          applicationId,
-          shuffleId,
-          masterIds.subList(masterIds.size() / 2, masterIds.size()),
-          slaveIds.subList(slaveIds.size() / 2, slaveIds.size()),
-          shuffleMapperAttempts.get(shuffleId),
-          commitEpoch.incrementAndGet())
-        val res2 = requestCommitFilesWithRetry(worker.endpoint, commitFiles)
-
-        res1.committedMasterStorageInfos.putAll(res2.committedMasterStorageInfos)
-        res1.committedSlaveStorageInfos.putAll(res2.committedSlaveStorageInfos)
-        res1.committedMapIdBitMap.putAll(res2.committedMapIdBitMap)
-        CommitFilesResponse(
-          status = if (res1.status == StatusCode.SUCCESS) res2.status else res1.status,
-          (res1.committedMasterIds.asScala ++ res2.committedMasterIds.asScala).toList.asJava,
-          (res1.committedSlaveIds.asScala ++ res1.committedSlaveIds.asScala).toList.asJava,
-          (res1.failedMasterIds.asScala ++ res1.failedMasterIds.asScala).toList.asJava,
-          (res1.failedSlaveIds.asScala ++ res2.failedSlaveIds.asScala).toList.asJava,
-          res1.committedMasterStorageInfos,
-          res1.committedSlaveStorageInfos,
-          res1.committedMapIdBitMap,
-          res1.totalWritten + res2.totalWritten,
-          res1.fileCount + res2.fileCount)
-      }
-
-    shuffleCommittedInfo.synchronized {
-      // record committed partitionIds
-      shuffleCommittedInfo.committedMasterIds.addAll(res.committedMasterIds)
-      shuffleCommittedInfo.committedSlaveIds.addAll(res.committedSlaveIds)
-
-      // record committed partitions storage hint and disk hint
-      shuffleCommittedInfo.committedMasterStorageInfos.putAll(res.committedMasterStorageInfos)
-      shuffleCommittedInfo.committedSlaveStorageInfos.putAll(res.committedSlaveStorageInfos)
-
-      // record failed partitions
-      shuffleCommittedInfo.failedMasterPartitionIds.putAll(
-        res.failedMasterIds.asScala.map((_, worker)).toMap.asJava)
-      shuffleCommittedInfo.failedSlavePartitionIds.putAll(
-        res.failedSlaveIds.asScala.map((_, worker)).toMap.asJava)
-
-      shuffleCommittedInfo.committedMapIdBitmap.putAll(res.committedMapIdBitMap)
-
-      totalWritten.add(res.totalWritten)
-      fileCount.add(res.fileCount)
-      shuffleCommittedInfo.currentShuffleFileCount.add(res.fileCount)
-    }
-  }
-
   private def handleUnregisterShuffle(
       appId: String,
       shuffleId: Int): Unit = {
     // if StageEnd has not been handled, trigger StageEnd
-    if (!stageEndShuffleSet.contains(shuffleId)) {
+    if (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
       logInfo(s"Call StageEnd before Unregister Shuffle $shuffleId.")
       handleStageEnd(appId, shuffleId)
       var timeout = stageEndTimeout
       val delta = 100
-      while (!stageEndShuffleSet.contains(shuffleId) && timeout > 0) {
+      while (!commitManager.stageEndShuffleSet.contains(shuffleId) && timeout > 0) {
         Thread.sleep(delta)
         timeout = timeout - delta
       }
@@ -1496,13 +1059,11 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         registeredShuffle.remove(shuffleId)
         registeringShuffleRequest.remove(shuffleId)
         reducerFileGroupsMap.remove(shuffleId)
-        dataLostShuffleSet.remove(shuffleId)
         shuffleMapperAttempts.remove(shuffleId)
-        stageEndShuffleSet.remove(shuffleId)
-        committedPartitionInfo.remove(shuffleId)
         unregisterShuffleTime.remove(shuffleId)
         shuffleAllocatedWorkers.remove(shuffleId)
         latestPartitionLocation.remove(shuffleId)
+        commitManager.removeExpiredShuffle(shuffleId)
         changePartitionManager.removeExpiredShuffle(shuffleId)
 
         requestUnregisterShuffle(
@@ -1597,37 +1158,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         logError(s"AskSync Destroy for ${message.shuffleKey} failed.", e)
         DestroyResponse(StatusCode.FAILED, message.masterLocations, message.slaveLocations)
     }
-  }
-
-  private def requestCommitFilesWithRetry(
-      endpoint: RpcEndpointRef,
-      message: CommitFiles): CommitFilesResponse = {
-    val maxRetries = conf.requestCommitFilesMaxRetries
-    var retryTimes = 0
-    while (retryTimes < maxRetries) {
-      try {
-        if (testRetryCommitFiles && retryTimes < maxRetries - 1) {
-          endpoint.ask[CommitFilesResponse](message)
-          Thread.sleep(1000)
-          throw new Exception("Mock fail for CommitFiles")
-        } else {
-          return endpoint.askSync[CommitFilesResponse](message)
-        }
-      } catch {
-        case e: Throwable =>
-          retryTimes += 1
-          logError(
-            s"AskSync CommitFiles for ${message.shuffleId} failed (attempt $retryTimes/$maxRetries).",
-            e)
-      }
-    }
-
-    CommitFilesResponse(
-      StatusCode.FAILED,
-      List.empty.asJava,
-      List.empty.asJava,
-      message.masterIds,
-      message.slaveIds)
   }
 
   private def requestReleaseSlots(

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -20,8 +20,7 @@ package org.apache.celeborn.client
 import java.nio.ByteBuffer
 import java.util
 import java.util.{function, List => JList}
-import java.util.concurrent.{Callable, ConcurrentHashMap, ScheduledExecutorService, ScheduledFuture, TimeUnit}
-import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, LongAdder}
+import java.util.concurrent.{Callable, ConcurrentHashMap, ScheduledFuture, TimeUnit}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -29,7 +28,6 @@ import scala.util.Random
 
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.cache.{Cache, CacheBuilder}
-import org.roaringbitmap.RoaringBitmap
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.haclient.RssHARetryClient
@@ -43,6 +41,7 @@ import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc._
 import org.apache.celeborn.common.rpc.netty.{LocalNettyRpcCallContext, RemoteNettyRpcCallContext}
 import org.apache.celeborn.common.util.{PbSerDeUtils, ThreadUtils, Utils}
+import org.apache.celeborn.common.util.FunctionConverter._
 
 class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoint with Logging {
 
@@ -66,7 +65,8 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   val registeredShuffle = ConcurrentHashMap.newKeySet[Int]()
   val shuffleMapperAttempts = new ConcurrentHashMap[Int, Array[Int]]()
   private val reducerFileGroupsMap =
-    new ConcurrentHashMap[Int, Array[Array[PartitionLocation]]]()
+    new ConcurrentHashMap[Int, ConcurrentHashMap[Integer, util.Set[PartitionLocation]]]()
+  private val shuffleTaskInfo = new ShuffleTaskInfo()
   // maintain each shuffle's map relation of WorkerInfo and partition location
   val shuffleAllocatedWorkers =
     new ConcurrentHashMap[Int, ConcurrentHashMap[WorkerInfo, PartitionLocationInfo]]()
@@ -104,6 +104,11 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       context.reply(response)
     }
   }
+
+  case class ShuffleTask(
+      shuffleId: Int,
+      mapId: Int,
+      attemptId: Int)
 
   // register shuffle request waiting for response
   private val registeringShuffleRequest =
@@ -204,6 +209,18 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     shufflePartitionType.getOrDefault(shuffleId, conf.shufflePartitionType)
   }
 
+  def encodeExternalShuffleTask(
+      taskShuffleId: String,
+      mapId: Int,
+      taskAttemptId: String): ShuffleTask = {
+    val shuffleId = shuffleTaskInfo.getShuffleId(taskShuffleId)
+    val attemptId = shuffleTaskInfo.getAttemptId(taskShuffleId, mapId, taskAttemptId)
+    logInfo(
+      s"encode task from " + s"($taskShuffleId, $mapId, $taskAttemptId) to ($shuffleId, $mapId, " +
+        s"$attemptId)")
+    ShuffleTask(shuffleId, mapId, attemptId)
+  }
+
   override def receive: PartialFunction[Any, Unit] = {
     case RemoveExpiredShuffle =>
       removeExpiredShuffle()
@@ -292,10 +309,16 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         epoch,
         oldPartition)
 
-    case MapperEnd(applicationId, shuffleId, mapId, attemptId, numMappers) =>
-      logTrace(s"Received MapperEnd request, " +
-        s"${Utils.makeMapKey(applicationId, shuffleId, mapId, attemptId)}.")
-      handleMapperEnd(context, applicationId, shuffleId, mapId, attemptId, numMappers)
+    case MapperEnd(applicationId, shuffleId, mapId, attemptId, numMappers, partitionId) =>
+      logTrace(s"Received MapperEnd TaskEnd request, " +
+        s"${Utils.makeMapKey(applicationId, shuffleId, mapId, attemptId)}")
+      val partitionType = getPartitionType(shuffleId)
+      partitionType match {
+        case PartitionType.REDUCE =>
+          handleMapperEnd(context, applicationId, shuffleId, mapId, attemptId, numMappers)
+        case PartitionType.MAP =>
+          handleMapPartitionEnd(context, applicationId, shuffleId, mapId, attemptId, partitionId)
+      }
 
     case GetReducerFileGroup(applicationId: String, shuffleId: Int) =>
       logDebug(s"Received GetShuffleFileGroup request," +
@@ -465,8 +488,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
           }
         }
       }
-
-      reducerFileGroupsMap.put(shuffleId, new Array[Array[PartitionLocation]](numReducers))
+      reducerFileGroupsMap.put(shuffleId, new ConcurrentHashMap())
 
       // Fifth, reply the allocated partition location to ShuffleClient.
       logInfo(s"Handle RegisterShuffle Success for $shuffleId.")
@@ -533,13 +555,15 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       return
     }
 
-    // If shuffle registered and corresponding map finished, reply MapEnd and return.
-    if (shuffleMapperAttempts.containsKey(shuffleId)
-      && shuffleMapperAttempts.get(shuffleId)(mapId) != -1) {
-      logWarning(s"[handleRevive] Mapper ended, mapId $mapId, current attemptId $attemptId, " +
-        s"ended attemptId ${shuffleMapperAttempts.get(shuffleId)(mapId)}, shuffleId $shuffleId.")
-      context.reply(ChangeLocationResponse(StatusCode.MAP_ENDED, None))
-      return
+    // If shuffle registered and corresponding map finished, reply MapEnd and return. Only for reduce partition type
+    if (getPartitionType(shuffleId) == PartitionType.REDUCE) {
+      if (shuffleMapperAttempts.containsKey(shuffleId) && shuffleMapperAttempts.get(shuffleId)(
+          mapId) != -1) {
+        logWarning(s"[handleRevive] Mapper ended, mapId $mapId, current attemptId $attemptId, " +
+          s"ended attemptId ${shuffleMapperAttempts.get(shuffleId)(mapId)}, shuffleId $shuffleId.")
+        context.reply(ChangeLocationResponse(StatusCode.MAP_ENDED, None))
+        return
+      }
     }
 
     logWarning(s"Do Revive for shuffle ${Utils.makeShuffleKey(applicationId, shuffleId)}, " +
@@ -603,28 +627,39 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       shuffleId: Int): Unit = {
     var timeout = stageEndTimeout
     val delta = 100
-    while (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
-      Thread.sleep(delta)
-      if (timeout <= 0) {
-        logError(s"[handleGetReducerFileGroup] Wait for handleStageEnd Timeout! $shuffleId.")
-        context.reply(
-          GetReducerFileGroupResponse(StatusCode.STAGE_END_TIME_OUT, Array.empty, Array.empty))
-        return
+    // reduce partition need wait stage end. While map partition Would commit every partition synchronously.
+    if (getPartitionType(shuffleId) == PartitionType.REDUCE) {
+      while (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
+        Thread.sleep(delta)
+        if (timeout <= 0) {
+          logError(s"[handleGetReducerFileGroup] Wait for handleStageEnd Timeout! $shuffleId.")
+          context.reply(
+            GetReducerFileGroupResponse(
+              StatusCode.STAGE_END_TIME_OUT,
+              new ConcurrentHashMap(),
+              Array.empty))
+          return
+        }
+        timeout = timeout - delta
       }
-      timeout = timeout - delta
+      logDebug("[handleGetReducerFileGroup] Wait for handleStageEnd complete cost" +
+        s" ${stageEndTimeout - timeout}ms")
     }
-    logDebug("[handleGetReducerFileGroup] Wait for handleStageEnd complete cost" +
-      s" ${stageEndTimeout - timeout}ms")
 
     if (commitManager.dataLostShuffleSet.contains(shuffleId)) {
       context.reply(
-        GetReducerFileGroupResponse(StatusCode.SHUFFLE_DATA_LOST, Array.empty, Array.empty))
+        GetReducerFileGroupResponse(
+          StatusCode.SHUFFLE_DATA_LOST,
+          new ConcurrentHashMap(),
+          Array.empty))
     } else {
       if (context.isInstanceOf[LocalNettyRpcCallContext]) {
         // This branch is for the UTs
         context.reply(GetReducerFileGroupResponse(
           StatusCode.SUCCESS,
-          reducerFileGroupsMap.getOrDefault(shuffleId, Array.empty),
+          reducerFileGroupsMap.getOrDefault(
+            shuffleId,
+            new ConcurrentHashMap()),
           shuffleMapperAttempts.getOrDefault(shuffleId, Array.empty)))
       } else {
         val cachedMsg = getReducerFileGroupRpcCache.get(
@@ -633,7 +668,9 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
             override def call(): ByteBuffer = {
               val returnedMsg = GetReducerFileGroupResponse(
                 StatusCode.SUCCESS,
-                reducerFileGroupsMap.getOrDefault(shuffleId, Array.empty),
+                reducerFileGroupsMap.getOrDefault(
+                  shuffleId,
+                  new ConcurrentHashMap()),
                 shuffleMapperAttempts.getOrDefault(shuffleId, Array.empty))
               context.asInstanceOf[RemoteNettyRpcCallContext].nettyEnv.serialize(returnedMsg)
             }
@@ -666,24 +703,55 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       ReleaseSlots(applicationId, shuffleId, List.empty.asJava, List.empty.asJava))
   }
 
+  private def handleMapPartitionEnd(
+      context: RpcCallContext,
+      applicationId: String,
+      shuffleId: Int,
+      mapId: Int,
+      attemptId: Int,
+      partitionId: Int): Unit = {
+    def reply(result: Boolean): Unit = {
+      val message =
+        s"to handle MapPartitionEnd for ${Utils.makeMapKey(appId, shuffleId, mapId, attemptId)}, " +
+          s"$partitionId.";
+      result match {
+        case true => // if already committed by another try
+          logDebug(s"Succeed $message")
+          context.reply(MapperEndResponse(StatusCode.SUCCESS))
+        case false =>
+          logError(s"Failed $message")
+          context.reply(MapperEndResponse(StatusCode.SHUFFLE_DATA_LOST))
+      }
+    }
+
+    val dataCommitSuccess = commitManager.finalPartitionCommit(
+      applicationId,
+      shuffleId,
+      reducerFileGroupsMap.get(shuffleId),
+      partitionId)
+    reply(dataCommitSuccess)
+  }
+
   private def handleUnregisterShuffle(
       appId: String,
       shuffleId: Int): Unit = {
-    // if StageEnd has not been handled, trigger StageEnd
-    if (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
-      logInfo(s"Call StageEnd before Unregister Shuffle $shuffleId.")
-      handleStageEnd(appId, shuffleId)
-      var timeout = stageEndTimeout
-      val delta = 100
-      while (!commitManager.stageEndShuffleSet.contains(shuffleId) && timeout > 0) {
-        Thread.sleep(delta)
-        timeout = timeout - delta
-      }
-      if (timeout <= 0) {
-        logError(s"StageEnd Timeout! $shuffleId.")
-      } else {
-        logInfo("[handleUnregisterShuffle] Wait for handleStageEnd complete cost" +
-          s" ${stageEndTimeout - timeout}ms")
+    if (getPartitionType(shuffleId) == PartitionType.REDUCE) {
+      // if StageEnd has not been handled, trigger StageEnd
+      if (!commitManager.stageEndShuffleSet.contains(shuffleId)) {
+        logInfo(s"Call StageEnd before Unregister Shuffle $shuffleId.")
+        handleStageEnd(appId, shuffleId)
+        var timeout = stageEndTimeout
+        val delta = 100
+        while (!commitManager.stageEndShuffleSet.contains(shuffleId) && timeout > 0) {
+          Thread.sleep(delta)
+          timeout = timeout - delta
+        }
+        if (timeout <= 0) {
+          logError(s"StageEnd Timeout! $shuffleId.")
+        } else {
+          logInfo("[handleUnregisterShuffle] Wait for handleStageEnd complete cost" +
+            s" ${stageEndTimeout - timeout}ms")
+        }
       }
     }
 
@@ -1065,7 +1133,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         latestPartitionLocation.remove(shuffleId)
         commitManager.removeExpiredShuffle(shuffleId)
         changePartitionManager.removeExpiredShuffle(shuffleId)
-
+        shuffleTaskInfo.remove(shuffleId)
         requestUnregisterShuffle(
           rssHARetryClient,
           UnregisterShuffle(appId, shuffleId, RssHARetryClient.genRequestId()))

--- a/client/src/main/scala/org/apache/celeborn/client/ShuffleTaskInfo.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ShuffleTaskInfo.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function
+import javax.annotation.concurrent.ThreadSafe
+
+@ThreadSafe
+class ShuffleTaskInfo {
+
+  private var currentShuffleIndex: Int = 0
+  // task shuffle id -> mapId_taskAttemptId -> attemptIdx
+  private val taskShuffleAttemptIdToAttemptId =
+    new ConcurrentHashMap[String, ConcurrentHashMap[String, Int]]
+  // map attemptId index
+  private val taskShuffleAttemptIdIndex =
+    new ConcurrentHashMap[String, ConcurrentHashMap[Int, Int]]
+  // task shuffle id -> celeborn shuffle id
+  private val taskShuffleIdToShuffleId = new ConcurrentHashMap[String, Int]
+  // celeborn shuffle id -> task shuffle id
+  private val shuffleIdToTaskShuffleId = new ConcurrentHashMap[Int, String]
+
+  val newMapFunc: function.Function[String, ConcurrentHashMap[Int, Int]] =
+    new function.Function[String, ConcurrentHashMap[Int, Int]]() {
+      override def apply(s: String): ConcurrentHashMap[Int, Int] = {
+        new ConcurrentHashMap[Int, Int]()
+      }
+    }
+
+  val newMapFunc2: function.Function[String, ConcurrentHashMap[String, Int]] =
+    new function.Function[String, ConcurrentHashMap[String, Int]]() {
+      override def apply(s: String): ConcurrentHashMap[String, Int] = {
+        new ConcurrentHashMap[String, Int]()
+      }
+    }
+
+  def getShuffleId(taskShuffleId: String): Int = {
+    taskShuffleIdToShuffleId.synchronized {
+      if (taskShuffleIdToShuffleId.containsKey(taskShuffleId)) {
+        taskShuffleIdToShuffleId.get(taskShuffleId)
+      } else {
+        taskShuffleIdToShuffleId.put(taskShuffleId, currentShuffleIndex)
+        shuffleIdToTaskShuffleId.put(currentShuffleIndex, taskShuffleId)
+        val tempShuffleIndex = currentShuffleIndex
+        currentShuffleIndex = currentShuffleIndex + 1
+        tempShuffleIndex
+      }
+    }
+  }
+
+  def getAttemptId(taskShuffleId: String, mapId: Int, attemptId: String): Int = {
+    val attemptIndex = taskShuffleAttemptIdIndex.computeIfAbsent(taskShuffleId, newMapFunc)
+    val attemptIdMap =
+      taskShuffleAttemptIdToAttemptId.computeIfAbsent(taskShuffleId, newMapFunc2)
+    val mapAttemptId = mapId + "_" + attemptId
+    attemptIndex.synchronized {
+      if (!attemptIdMap.containsKey(mapAttemptId)) {
+        if (attemptIndex.containsKey(mapId)) {
+          val index = attemptIndex.get(mapId)
+          attemptIdMap.put(mapAttemptId, index + 1)
+          attemptIndex.put(mapId, index + 1)
+        } else {
+          attemptIdMap.put(mapAttemptId, 0)
+          attemptIndex.put(mapId, 0)
+        }
+      }
+    }
+
+    attemptIdMap.get(mapAttemptId)
+  }
+
+  def remove(shuffleId: Int): Unit = {
+    val taskShuffleId = shuffleIdToTaskShuffleId.remove(shuffleId)
+    taskShuffleIdToShuffleId.remove(taskShuffleId)
+    taskShuffleAttemptIdIndex.remove(shuffleId)
+    taskShuffleAttemptIdToAttemptId.remove(taskShuffleId)
+  }
+}

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -23,7 +23,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 
+import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,6 +94,16 @@ public class DummyShuffleClient extends ShuffleClient {
       String applicationId, int shuffleId, int mapId, int attemptId, int numMappers) {}
 
   @Override
+  public void mapPartitionMapperEnd(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int numMappers,
+      int partitionId)
+      throws IOException {}
+
+  @Override
   public void cleanup(String applicationId, int shuffleId, int mapId, int attemptId) {}
 
   @Override
@@ -126,6 +138,19 @@ public class DummyShuffleClient extends ShuffleClient {
   }
 
   @Override
+  public int pushDataToLocation(
+      String applicationId,
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int partitionId,
+      ByteBuf data,
+      PartitionLocation location,
+      BooleanSupplier closeCallBack) {
+    return 0;
+  }
+
+  @Override
   public Optional<PartitionLocation> regionStart(
       String applicationId,
       int shuffleId,
@@ -153,4 +178,10 @@ public class DummyShuffleClient extends ShuffleClient {
       int bufferSize,
       PartitionLocation location)
       throws IOException {}
+
+  @Override
+  public PartitionLocation registerMapPartitionTask(
+      String appId, int shuffleId, int numMappers, int mapId, int attemptId) {
+    return null;
+  }
 }

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import scala.reflect.ClassTag$;
+
+import io.netty.channel.ChannelFuture;
+
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
+import org.apache.celeborn.common.network.client.TransportClient;
+import org.apache.celeborn.common.network.client.TransportClientFactory;
+import org.apache.celeborn.common.protocol.CompressionCodec;
+import org.apache.celeborn.common.protocol.PartitionLocation;
+import org.apache.celeborn.common.protocol.PbRegisterShuffleResponse;
+import org.apache.celeborn.common.protocol.message.ControlMessages;
+import org.apache.celeborn.common.protocol.message.StatusCode;
+import org.apache.celeborn.common.rpc.RpcEndpointRef;
+
+public abstract class ShuffleClientBaseSuiteJ {
+  protected ShuffleClientImpl shuffleClient = null;
+  protected static final RpcEndpointRef endpointRef = mock(RpcEndpointRef.class);
+  protected static final TransportClientFactory clientFactory = mock(TransportClientFactory.class);
+  protected final TransportClient client = mock(TransportClient.class);
+
+  protected static final String TEST_APPLICATION_ID = "testapp1";
+  protected static final int TEST_SHUFFLE_ID = 1;
+  protected static final int TEST_ATTEMPT_ID = 0;
+  protected static final int TEST_REDUCRE_ID = 0;
+
+  protected static final int MASTER_RPC_PORT = 1234;
+  protected static final int MASTER_PUSH_PORT = 1235;
+  protected static final int MASTER_FETCH_PORT = 1236;
+  protected static final int MASTER_REPLICATE_PORT = 1237;
+  protected static final int SLAVE_RPC_PORT = 4321;
+  protected static final int SLAVE_PUSH_PORT = 4322;
+  protected static final int SLAVE_FETCH_PORT = 4323;
+  protected static final int SLAVE_REPLICATE_PORT = 4324;
+  protected static final PartitionLocation masterLocation =
+      new PartitionLocation(
+          0,
+          1,
+          "localhost",
+          MASTER_RPC_PORT,
+          MASTER_PUSH_PORT,
+          MASTER_FETCH_PORT,
+          MASTER_REPLICATE_PORT,
+          PartitionLocation.Mode.MASTER);
+  protected static final PartitionLocation slaveLocation =
+      new PartitionLocation(
+          0,
+          1,
+          "localhost",
+          SLAVE_RPC_PORT,
+          SLAVE_PUSH_PORT,
+          SLAVE_FETCH_PORT,
+          SLAVE_REPLICATE_PORT,
+          PartitionLocation.Mode.SLAVE);
+
+  protected final int BATCH_HEADER_SIZE = 4 * 4;
+  protected ChannelFuture mockedFuture = mock(ChannelFuture.class);
+
+  protected CelebornConf setupEnv(CompressionCodec codec) throws IOException, InterruptedException {
+    CelebornConf conf = new CelebornConf();
+    conf.set("celeborn.shuffle.compression.codec", codec.name());
+    conf.set("celeborn.push.retry.threads", "1");
+    conf.set("celeborn.push.buffer.size", "1K");
+    shuffleClient = new ShuffleClientImpl(conf, new UserIdentifier("mock", "mock"));
+    masterLocation.setPeer(slaveLocation);
+
+    when(endpointRef.askSync(
+            ControlMessages.RegisterShuffle$.MODULE$.apply(
+                TEST_APPLICATION_ID, TEST_SHUFFLE_ID, 1, 1),
+            ClassTag$.MODULE$.apply(PbRegisterShuffleResponse.class)))
+        .thenAnswer(
+            t ->
+                ControlMessages.RegisterShuffleResponse$.MODULE$.apply(
+                    StatusCode.SUCCESS, new PartitionLocation[] {masterLocation}));
+
+    shuffleClient.setupMetaServiceRef(endpointRef);
+    when(clientFactory.createClient(
+            masterLocation.getHost(), masterLocation.getPushPort(), TEST_REDUCRE_ID))
+        .thenAnswer(t -> client);
+
+    shuffleClient.dataClientFactory = clientFactory;
+    return conf;
+  }
+}

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.network.client.RpcResponseCallback;
+import org.apache.celeborn.common.protocol.CompressionCodec;
+import org.apache.celeborn.common.protocol.message.StatusCode;
+
+public class ShuffleClientImplSuiteJ extends ShuffleClientBaseSuiteJ {
+  static int BufferSize = 64;
+  static byte[] TEST_BUF1 = new byte[BufferSize];
+  static CelebornConf conf;
+
+  @Before
+  public void setup() throws IOException, InterruptedException {
+    conf = setupEnv(CompressionCodec.LZ4);
+  }
+
+  public ByteBuf createByteBuf() {
+    for (int i = BATCH_HEADER_SIZE; i < BufferSize; i++) {
+      TEST_BUF1[i] = 1;
+    }
+    ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
+    byteBuf.writerIndex(BufferSize);
+    return byteBuf;
+  }
+
+  @Test
+  public void testPushDataByteBufSuccess() throws IOException {
+    ByteBuf byteBuf = createByteBuf();
+    when(client.pushData(any(), any()))
+        .thenAnswer(
+            t -> {
+              RpcResponseCallback rpcResponseCallback =
+                  t.getArgumentAt(1, RpcResponseCallback.class);
+              ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[0]);
+              rpcResponseCallback.onSuccess(byteBuffer);
+              return mockedFuture;
+            });
+
+    int pushDataLen =
+        shuffleClient.pushDataToLocation(
+            TEST_APPLICATION_ID,
+            TEST_SHUFFLE_ID,
+            TEST_ATTEMPT_ID,
+            TEST_ATTEMPT_ID,
+            TEST_REDUCRE_ID,
+            byteBuf,
+            masterLocation,
+            () -> true);
+    Assert.assertEquals(BufferSize, pushDataLen);
+  }
+
+  @Test
+  public void testPushDataByteBufHardSplit() throws IOException {
+    ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
+    when(client.pushData(any(), any()))
+        .thenAnswer(
+            t -> {
+              RpcResponseCallback rpcResponseCallback =
+                  t.getArgumentAt(1, RpcResponseCallback.class);
+              ByteBuffer byteBuffer =
+                  ByteBuffer.wrap(new byte[] {StatusCode.HARD_SPLIT.getValue()});
+              rpcResponseCallback.onSuccess(byteBuffer);
+              return mockedFuture;
+            });
+    int pushDataLen =
+        shuffleClient.pushDataToLocation(
+            TEST_APPLICATION_ID,
+            TEST_SHUFFLE_ID,
+            TEST_ATTEMPT_ID,
+            TEST_ATTEMPT_ID,
+            TEST_REDUCRE_ID,
+            byteBuf,
+            masterLocation,
+            () -> true);
+  }
+
+  @Test
+  public void testPushDataByteBufFail() throws IOException {
+    ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
+    when(client.pushData(any(), any()))
+        .thenAnswer(
+            t -> {
+              RpcResponseCallback rpcResponseCallback =
+                  t.getArgumentAt(1, RpcResponseCallback.class);
+              rpcResponseCallback.onFailure(new Exception("pushDataFailed"));
+              return mockedFuture;
+            });
+    // first push just  set pushdata.exception
+    shuffleClient.pushDataToLocation(
+        TEST_APPLICATION_ID,
+        TEST_SHUFFLE_ID,
+        TEST_ATTEMPT_ID,
+        TEST_ATTEMPT_ID,
+        TEST_REDUCRE_ID,
+        byteBuf,
+        masterLocation,
+        () -> true);
+
+    boolean isFailed = false;
+    // second push will throw exception
+    try {
+      shuffleClient.pushDataToLocation(
+          TEST_APPLICATION_ID,
+          TEST_SHUFFLE_ID,
+          TEST_ATTEMPT_ID,
+          TEST_ATTEMPT_ID,
+          TEST_REDUCRE_ID,
+          byteBuf,
+          masterLocation,
+          () -> true);
+    } catch (IOException e) {
+      isFailed = true;
+    } finally {
+      Assert.assertTrue("should failed", isFailed);
+    }
+  }
+}

--- a/client/src/test/scala/org/apache/celeborn/client/ShuffleTaskInfoSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/ShuffleTaskInfoSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class ShuffleTaskInfoSuite extends AnyFunSuite {
+
+  test("encode shuffle id & map attemptId") {
+    val shuffleTaskInfo = new ShuffleTaskInfo
+    val encodeShuffleId = shuffleTaskInfo.getShuffleId("shuffleId")
+    assert(encodeShuffleId == 0)
+
+    // another shuffle
+    val encodeShuffleId1 = shuffleTaskInfo.getShuffleId("shuffleId1")
+    assert(encodeShuffleId1 == 1)
+
+    val encodeShuffleId0 = shuffleTaskInfo.getShuffleId("shuffleId")
+    assert(encodeShuffleId0 == 0)
+
+    val encodeAttemptId011 = shuffleTaskInfo.getAttemptId("shuffleId", 1, "attempt1")
+    val encodeAttemptId112 = shuffleTaskInfo.getAttemptId("shuffleId1", 1, "attempt2")
+    val encodeAttemptId021 = shuffleTaskInfo.getAttemptId("shuffleId", 2, "attempt1")
+    val encodeAttemptId012 = shuffleTaskInfo.getAttemptId("shuffleId", 1, "attempt2")
+    assert(encodeAttemptId011 == 0)
+    assert(encodeAttemptId112 == 0)
+    assert(encodeAttemptId021 == 0)
+    assert(encodeAttemptId012 == 1)
+
+    // remove shuffleId and reEncode
+    shuffleTaskInfo.remove(encodeShuffleId)
+    val encodeShuffleIdNew = shuffleTaskInfo.getShuffleId("shuffleId")
+    assert(encodeShuffleIdNew == 2)
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/meta/DiskStatus.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/DiskStatus.java
@@ -21,7 +21,8 @@ public enum DiskStatus {
   HEALTHY(0),
   READ_OR_WRITE_FAILURE(1),
   IO_HANG(2),
-  HIGH_DISK_USAGE(3);
+  HIGH_DISK_USAGE(3),
+  CRITICAL_ERROR(4);
 
   private final byte value;
 

--- a/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
@@ -18,7 +18,6 @@
 package org.apache.celeborn.common.meta;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -126,12 +125,16 @@ public class FileInfo {
     return userIdentifier;
   }
 
-  public void deleteAllFiles(FileSystem hdfsFs) throws IOException {
+  public void deleteAllFiles(FileSystem hdfsFs) {
     if (isHdfs()) {
-      hdfsFs.delete(getHdfsPath(), false);
-      hdfsFs.delete(getHdfsWriterSuccessPath(), false);
-      hdfsFs.delete(getHdfsIndexPath(), false);
-      hdfsFs.delete(getHdfsSortedPath(), false);
+      try {
+        hdfsFs.delete(getHdfsPath(), false);
+        hdfsFs.delete(getHdfsWriterSuccessPath(), false);
+        hdfsFs.delete(getHdfsIndexPath(), false);
+        hdfsFs.delete(getHdfsSortedPath(), false);
+      } catch (Exception e) {
+        // ignore delete exceptions because some other workers might be deleting the directory
+      }
     } else {
       getFile().delete();
       new File(getIndexPath()).delete();

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -232,6 +232,7 @@ message PbMapperEnd {
   int32 mapId = 3;
   int32 attemptId = 4;
   int32 numMappers = 5;
+  int32 partitionId = 6;
 }
 
 message PbMapperEndResponse {
@@ -245,7 +246,10 @@ message PbGetReducerFileGroup {
 
 message PbGetReducerFileGroupResponse {
   int32 status = 1;
-  repeated PbFileGroup fileGroup = 2;
+  // PartitionId -> Partition FileGroup
+  map<int32, PbFileGroup> fileGroups = 2;
+
+  // only reduce partition mode need know valid attempts
   repeated int32 attempts = 3;
 }
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/FunctionConverter.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/FunctionConverter.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.util
+
+/**
+ * Implicit conversion for scala(2.11) function to java function
+ */
+object FunctionConverter {
+
+  implicit def scalaFunctionToJava[From, To](function: (From) => To)
+      : java.util.function.Function[From, To] = {
+    new java.util.function.Function[From, To] {
+      override def apply(input: From): To = function(input)
+    }
+  }
+
+}

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -926,6 +926,7 @@ object Utils extends Logging {
       case 1 => DiskStatus.READ_OR_WRITE_FAILURE
       case 2 => DiskStatus.IO_HANG
       case 3 => DiskStatus.HIGH_DISK_USAGE
+      case 4 => DiskStatus.CRITICAL_ERROR
       case _ => null
     }
   }

--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -33,9 +33,13 @@
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
         </Console>
     </Appenders>
+
     <Loggers>
         <Root level="INFO">
             <AppenderRef ref="stdout"/>
         </Root>
+        <Logger name="org.apache.hadoop.hdfs" level="WARN" additivity="false">
+                    <Appender-ref ref="stdout" level="WARN" />
+        </Logger>
     </Loggers>
 </Configuration>

--- a/dev/reformat
+++ b/dev/reformat
@@ -23,3 +23,5 @@ RSS_HOME="$(cd "`dirname "$0"`/.."; pwd)"
 ${RSS_HOME}/build/mvn spotless:apply -Pspark-2.4
 
 ${RSS_HOME}/build/mvn spotless:apply -Pspark-3.1
+
+${RSS_HOME}/build/mvn spotless:apply -Pflink-1.14

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <module>service</module>
     <module>master</module>
     <module>worker</module>
-    <module>tests/spark-it</module>
   </modules>
 
   <distributionManagement>
@@ -84,6 +83,9 @@
     <slf4j.version>1.7.36</slf4j.version>
     <roaringbitmap.version>0.9.32</roaringbitmap.version>
     <snakeyaml.version>1.30</snakeyaml.version>
+    <!--  default flink version  -->
+    <flink.version>1.14.0</flink.version>
+
     <!--  default hadoop version  -->
     <hadoop.version>3.2.1</hadoop.version>
     <shading.prefix>org.apache.celeborn.shaded</shading.prefix>
@@ -101,6 +103,7 @@
     <maven.plugin.shade.version>3.4.0</maven.plugin.shade.version>
     <maven.plugin.spotless.version>2.24.1</maven.plugin.spotless.version>
     <maven.plugin.surefire.version>3.0.0-M7</maven.plugin.surefire.version>
+    <maven.plugin.jacoco-maven-plugin.version>0.8.7</maven.plugin.jacoco-maven-plugin.version>
 
     <!-- Allow modules to enable / disable certain build plugins easily. -->
     <testJarPhase>prepare-package</testJarPhase>
@@ -140,6 +143,25 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-runtime</artifactId>
+        <version>${flink.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.tysafe</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -577,7 +599,7 @@
               <include>**/*Test*.*</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=128m ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
+            <argLine>${argLine} -ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=128m ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
             <systemProperties>
               <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
               <log4j2.configurationFile>src/test/resources/log4j2-test.xml</log4j2.configurationFile>
@@ -803,6 +825,31 @@
             </execution>
           </executions>
         </plugin>
+
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${maven.plugin.jacoco-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>pre-test</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>report</id>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <phase>test</phase>
+              <configuration>
+                <outputDirectory>${project.build.directory}/codecov</outputDirectory>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
       </plugins>
     </pluginManagement>
 
@@ -841,6 +888,11 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 
@@ -851,6 +903,7 @@
         <module>client-spark/common</module>
         <module>client-spark/spark-2</module>
         <module>client-spark/spark-2-shaded</module>
+        <module>tests/spark-it</module>
       </modules>
       <properties>
         <jackson.version>2.6.7</jackson.version>
@@ -881,6 +934,7 @@
         <module>client-spark/common</module>
         <module>client-spark/spark-3</module>
         <module>client-spark/spark-3-shaded</module>
+        <module>tests/spark-it</module>
       </modules>
       <properties>
         <jackson.version>2.10.0</jackson.version>
@@ -899,6 +953,7 @@
         <module>client-spark/common</module>
         <module>client-spark/spark-3</module>
         <module>client-spark/spark-3-shaded</module>
+        <module>tests/spark-it</module>
       </modules>
       <properties>
         <jackson.version>2.10.0</jackson.version>
@@ -917,6 +972,7 @@
         <module>client-spark/common</module>
         <module>client-spark/spark-3</module>
         <module>client-spark/spark-3-shaded</module>
+        <module>tests/spark-it</module>
       </modules>
       <properties>
         <jackson.version>2.12.3</jackson.version>
@@ -935,6 +991,7 @@
         <module>client-spark/common</module>
         <module>client-spark/spark-3</module>
         <module>client-spark/spark-3-shaded</module>
+        <module>tests/spark-it</module>
       </modules>
       <properties>
         <jackson.version>2.13.4</jackson.version>
@@ -944,6 +1001,24 @@
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.3.1</spark.version>
         <zstd-jni.version>1.5.2-1</zstd-jni.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>flink-1.14</id>
+      <modules>
+        <module>client-flink/flink-1.14</module>
+        <module>client-flink/flink-common</module>
+        <module>client-flink/flink-shaded</module>
+      </modules>
+      <properties>
+        <jackson.version>2.6.7</jackson.version>
+        <jackson.databind.version>2.6.7.3</jackson.databind.version>
+        <lz4-java.version>1.4.0</lz4-java.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <zstd-jni.version>1.4.4-3</zstd-jni.version>
+        <scala.version>2.12.15</scala.version>
+        <flink.version>1.14.0</flink.version>
       </properties>
     </profile>
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
@@ -24,7 +24,7 @@ import org.junit.Assert
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.celeborn.client.{LifecycleManager, ShuffleClient, ShuffleClientImpl}
+import org.apache.celeborn.client.{LifecycleManager, ShuffleClientImpl}
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.util.PackedPartitionId
@@ -36,6 +36,9 @@ class ShuffleClientSuite extends AnyFunSuite with MiniClusterFeature
   val APP = "app-1"
   var shuffleClient: ShuffleClientImpl = _
   var lifecycleManager: LifecycleManager = _
+  val numMappers = 8
+  val mapId = 1
+  val attemptId = 0
 
   override def beforeAll(): Unit = {
     val masterConf = Map(
@@ -54,11 +57,8 @@ class ShuffleClientSuite extends AnyFunSuite with MiniClusterFeature
     shuffleClient.setupMetaServiceRef(lifecycleManager.self)
   }
 
-  test(s"test register map partition task with first attemptId") {
+  test(s"test register map partition task") {
     val shuffleId = 1
-    val numMappers = 8
-    val mapId = 1
-    val attemptId = 0
     var location =
       shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId)
     Assert.assertEquals(location.getId, PackedPartitionId.packedPartitionId(mapId, attemptId))
@@ -91,6 +91,39 @@ class ShuffleClientSuite extends AnyFunSuite with MiniClusterFeature
     count =
       partitionLocationInfos.map(r => r.getAllMasterLocations(shuffleId.toString).size()).sum
     Assert.assertEquals(count, numMappers + 1)
+  }
+
+  test(s"test map end & get reducer file group") {
+    val shuffleId = 2
+    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId)
+    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId + 1, attemptId)
+    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId + 2, attemptId)
+    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId + 1)
+    shuffleClient.mapPartitionMapperEnd(APP, shuffleId, numMappers, mapId, attemptId, mapId)
+    // retry
+    shuffleClient.mapPartitionMapperEnd(APP, shuffleId, numMappers, mapId, attemptId, mapId)
+    // another attempt
+    shuffleClient.mapPartitionMapperEnd(
+      APP,
+      shuffleId,
+      numMappers,
+      mapId,
+      attemptId + 1,
+      PackedPartitionId
+        .packedPartitionId(mapId, attemptId + 1))
+    // another mapper
+    shuffleClient.mapPartitionMapperEnd(APP, shuffleId, numMappers, mapId + 1, attemptId, mapId + 1)
+
+    // reduce file group size (for empty partitions)
+    Assert.assertEquals(shuffleClient.getReduceFileGroupsMap.size(), 0)
+
+    // reduce normal empty RssInputStream
+    var stream = shuffleClient.readPartition(APP, shuffleId, 1, 1)
+    Assert.assertEquals(stream.read(), -1)
+
+    // reduce normal null partition for RssInputStream
+    stream = shuffleClient.readPartition(APP, shuffleId, 3, 1)
+    Assert.assertEquals(stream.read(), -1)
   }
 
   override def afterAll(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HugeDataTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HugeDataTest.scala
@@ -50,8 +50,16 @@ class HugeDataTest extends AnyFunSuite
   test("celeborn spark integration test - huge data") {
     val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[4]")
     val ss = SparkSession.builder().config(updateSparkConf(sparkConf, false)).getOrCreate()
-    ss.sparkContext.parallelize(1 to 10000, 2)
-      .map { i => (i, Range(1, 10000).mkString(",")) }.groupByKey(16).collect()
+    val value = Range(1, 10000).mkString(",")
+    val tuples = ss.sparkContext.parallelize(1 to 10000, 2)
+      .map { i => (i, value) }.groupByKey(16).collect()
+
+    // verify result
+    assert(tuples.length == 10000)
+    for (elem <- tuples) {
+      assert(elem._2.mkString(",").equals(value))
+    }
+
     ss.stop()
   }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.storage;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import io.netty.buffer.CompositeByteBuf;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.metrics.source.AbstractSource;
+import org.apache.celeborn.common.protocol.PartitionSplitMode;
+import org.apache.celeborn.common.protocol.PartitionType;
+
+/*
+ * map partition file writer, it will create index for each partition
+ */
+public final class MapPartitionFileWriter extends FileWriter {
+  private static final Logger logger = LoggerFactory.getLogger(MapPartitionFileWriter.class);
+
+  private int numReducePartitions;
+  private int currentDataRegionIndex;
+  private boolean isBroadcastRegion;
+  private long[] numReducePartitionBytes;
+  private ByteBuffer indexBuffer;
+  private int currentReducePartition;
+  private long totalBytes;
+  private long regionStartingOffset;
+  private long numDataRegions;
+  private FileChannel channelIndex;
+  private FSDataOutputStream streamIndex;
+  private CompositeByteBuf flushBufferIndex;
+
+  public MapPartitionFileWriter(
+      FileInfo fileInfo,
+      Flusher flusher,
+      AbstractSource workerSource,
+      CelebornConf conf,
+      DeviceMonitor deviceMonitor,
+      long splitThreshold,
+      PartitionSplitMode splitMode,
+      boolean rangeReadFilter)
+      throws IOException {
+    super(
+        fileInfo,
+        flusher,
+        workerSource,
+        conf,
+        deviceMonitor,
+        splitThreshold,
+        splitMode,
+        PartitionType.MAP,
+        rangeReadFilter);
+    if (!fileInfo.isHdfs()) {
+      channelIndex = new FileOutputStream(fileInfo.getIndexPath()).getChannel();
+    } else {
+      streamIndex = StorageManager.hdfsFs().create(fileInfo.getHdfsIndexPath(), true);
+    }
+  }
+
+  @Override
+  public long close() throws IOException {
+    return 0;
+  }
+
+  public void pushDataHandShake(int numReducePartitions) {
+    this.numReducePartitions = numReducePartitions;
+  }
+
+  public void regionStart(int currentDataRegionIndex, boolean isBroadcastRegion) {
+    this.currentDataRegionIndex = currentDataRegionIndex;
+    this.isBroadcastRegion = isBroadcastRegion;
+  }
+
+  public void regionFinish() throws IOException {}
+}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionFileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ReducePartitionFileWriter.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.storage;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.metrics.source.AbstractSource;
+import org.apache.celeborn.common.protocol.PartitionSplitMode;
+import org.apache.celeborn.common.protocol.PartitionType;
+
+/*
+ * reduce partition file writer, it will create chunkindex
+ */
+public final class ReducePartitionFileWriter extends FileWriter {
+  private static final Logger logger = LoggerFactory.getLogger(ReducePartitionFileWriter.class);
+
+  private long nextBoundary;
+  private final long shuffleChunkSize;
+
+  public ReducePartitionFileWriter(
+      FileInfo fileInfo,
+      Flusher flusher,
+      AbstractSource workerSource,
+      CelebornConf conf,
+      DeviceMonitor deviceMonitor,
+      long splitThreshold,
+      PartitionSplitMode splitMode,
+      boolean rangeReadFilter)
+      throws IOException {
+    super(
+        fileInfo,
+        flusher,
+        workerSource,
+        conf,
+        deviceMonitor,
+        splitThreshold,
+        splitMode,
+        PartitionType.REDUCE,
+        rangeReadFilter);
+    this.shuffleChunkSize = conf.shuffleChunkSize();
+    this.nextBoundary = this.shuffleChunkSize;
+  }
+
+  protected void flush(boolean finalFlush) throws IOException {
+    super.flush(finalFlush);
+    maybeSetChunkOffsets(finalFlush);
+  }
+
+  private void maybeSetChunkOffsets(boolean forceSet) {
+    if (bytesFlushed >= nextBoundary || forceSet) {
+      fileInfo.addChunkOffset(bytesFlushed);
+      nextBoundary = bytesFlushed + shuffleChunkSize;
+    }
+  }
+
+  private boolean isChunkOffsetValid() {
+    // Consider a scenario where some bytes have been flushed
+    // but the chunk offset boundary has not yet been updated.
+    // we should check if the chunk offset boundary equals
+    // bytesFlush or not. For example:
+    // The last record is a giant record and it has been flushed
+    // but its size is smaller than the nextBoundary, then the
+    // chunk offset will not be set after flushing. we should
+    // set it during FileWriter close.
+    return fileInfo.getLastChunkOffset() == bytesFlushed;
+  }
+
+  public synchronized long close() throws IOException {
+    return super.close(
+        () -> {
+          if (!isChunkOffsetValid()) {
+            maybeSetChunkOffsets(true);
+          }
+        },
+        () -> {
+          if (StorageManager.hdfsFs().exists(fileInfo.getHdfsPeerWriterSuccessPath())) {
+            StorageManager.hdfsFs().delete(fileInfo.getHdfsPath(), false);
+            deleted = true;
+          } else {
+            StorageManager.hdfsFs().create(fileInfo.getHdfsWriterSuccessPath()).close();
+            FSDataOutputStream indexOutputStream =
+                StorageManager.hdfsFs().create(fileInfo.getHdfsIndexPath());
+            indexOutputStream.writeInt(fileInfo.getChunkOffsets().size());
+            for (Long offset : fileInfo.getChunkOffsets()) {
+              indexOutputStream.writeLong(offset);
+            }
+            indexOutputStream.close();
+          }
+        },
+        () -> {});
+  }
+}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -37,7 +37,7 @@ import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMod
 import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.unsafe.Platform
 import org.apache.celeborn.common.util.PackedPartitionId
-import org.apache.celeborn.service.deploy.worker.storage.{FileWriter, LocalFlusher, StorageManager}
+import org.apache.celeborn.service.deploy.worker.storage.{FileWriter, HdfsFlusher, LocalFlusher, StorageManager}
 
 class PushDataHandler extends BaseMessageHandler with Logging {
 
@@ -217,9 +217,14 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       callback.onFailure(new Exception(message, exception))
       return
     }
-    val diskFull = workerInfo.diskInfos
-      .get(fileWriter.flusher.asInstanceOf[LocalFlusher].mountPoint)
-      .actualUsableSpace < diskReserveSize
+    val diskFull =
+      if (fileWriter.flusher.isInstanceOf[LocalFlusher]) {
+        workerInfo.diskInfos
+          .get(fileWriter.flusher.asInstanceOf[LocalFlusher].mountPoint)
+          .actualUsableSpace < diskReserveSize
+      } else {
+        false
+      }
     if ((diskFull && fileWriter.getFileInfo.getFileLength > partitionSplitMinimumSize) ||
       (isMaster && fileWriter.getFileInfo.getFileLength > fileWriter.getSplitThreshold())) {
       if (fileWriter.getSplitMode == PartitionSplitMode.SOFT) {
@@ -766,6 +771,9 @@ class PushDataHandler extends BaseMessageHandler with Logging {
   }
 
   private def checkDiskFull(fileWriter: FileWriter): Boolean = {
+    if (fileWriter.flusher.isInstanceOf[HdfsFlusher]) {
+      return false
+    }
     val diskFull = workerInfo.diskInfos
       .get(fileWriter.flusher.asInstanceOf[LocalFlusher].mountPoint)
       .actualUsableSpace < diskReserveSize

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -37,7 +37,7 @@ import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMod
 import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.unsafe.Platform
 import org.apache.celeborn.common.util.PackedPartitionId
-import org.apache.celeborn.service.deploy.worker.storage.{FileWriter, HdfsFlusher, LocalFlusher, StorageManager}
+import org.apache.celeborn.service.deploy.worker.storage.{FileWriter, HdfsFlusher, LocalFlusher, MapPartitionFileWriter, StorageManager}
 
 class PushDataHandler extends BaseMessageHandler with Logging {
 
@@ -82,15 +82,22 @@ class PushDataHandler extends BaseMessageHandler with Logging {
           client,
           pushData,
           pushData.requestId,
-          () =>
-            handlePushData(
-              pushData,
-              new SimpleRpcResponseCallback(
-                Type.PUSH_DATA,
-                client,
-                pushData.requestId,
-                pushData.shuffleKey,
-                pushData.partitionUniqueId)))
+          () => {
+            val callback = new SimpleRpcResponseCallback(
+              Type.PUSH_DATA,
+              client,
+              pushData.requestId,
+              pushData.shuffleKey,
+              pushData.partitionUniqueId)
+            shufflePartitionType.getOrDefault(pushData.shuffleKey, PartitionType.REDUCE) match {
+              case PartitionType.REDUCE => handlePushData(
+                  pushData,
+                  callback)
+              case PartitionType.MAP => handleMapPartitionPushData(
+                  pushData,
+                  callback)
+            }
+          })
       case pushMergedData: PushMergedData => {
         handleCore(
           client,
@@ -537,6 +544,90 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     }
   }
 
+  def handleMapPartitionPushData(pushData: PushData, callback: RpcResponseCallback): Unit = {
+    val shuffleKey = pushData.shuffleKey
+    val mode = PartitionLocation.getMode(pushData.mode)
+    val body = pushData.body.asInstanceOf[NettyManagedBuffer].getBuf
+    val isMaster = mode == PartitionLocation.Mode.MASTER
+
+    val key = s"${pushData.requestId}"
+    if (isMaster) {
+      workerSource.startTimer(WorkerSource.MasterPushDataTime, key)
+    } else {
+      workerSource.startTimer(WorkerSource.SlavePushDataTime, key)
+    }
+
+    // find FileWriter responsible for the data
+    val location =
+      if (isMaster) {
+        partitionLocationInfo.getMasterLocation(shuffleKey, pushData.partitionUniqueId)
+      } else {
+        partitionLocationInfo.getSlaveLocation(shuffleKey, pushData.partitionUniqueId)
+      }
+
+    val wrappedCallback =
+      new WrappedRpcResponseCallback(
+        pushData.`type`(),
+        isMaster,
+        pushData.requestId,
+        null,
+        location,
+        if (isMaster) WorkerSource.MasterPushDataTime else WorkerSource.SlavePushDataTime,
+        callback)
+
+    if (checkLocationNull(
+        pushData.`type`(),
+        shuffleKey,
+        pushData.partitionUniqueId,
+        null,
+        location,
+        callback,
+        wrappedCallback)) return
+
+    // During worker shutdown, worker will return HARD_SPLIT for all existed partition.
+    // This should before return exception to make current push data can revive and retry.
+    if (shutdown.get()) {
+      logInfo(s"Push data return HARD_SPLIT for shuffle $shuffleKey since worker shutdown.")
+      callback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
+      return
+    }
+
+    val fileWriter =
+      getFileWriterAndCheck(pushData.`type`(), location, isMaster, callback) match {
+        case (true, _) => return
+        case (false, f: FileWriter) => f
+      }
+
+    // for mappartition we will not check whether disk full or split partition
+
+    fileWriter.incrementPendingWrites()
+
+    // for master, send data to slave
+    if (location.getPeer != null && isMaster) {
+      // to do
+      wrappedCallback.onSuccess(ByteBuffer.wrap(Array[Byte]()))
+    } else {
+      wrappedCallback.onSuccess(ByteBuffer.wrap(Array[Byte]()))
+    }
+
+    try {
+      fileWriter.write(body)
+    } catch {
+      case e: AlreadyClosedException =>
+        fileWriter.decrementPendingWrites()
+        val (mapId, attemptId) = getMapAttempt(body)
+        val endedAttempt =
+          if (shuffleMapperAttempts.containsKey(shuffleKey)) {
+            shuffleMapperAttempts.get(shuffleKey).get(mapId)
+          } else -1
+        // TODO just info log for ended attempt
+        logWarning(s"Append data failed for task(shuffle $shuffleKey, map $mapId, attempt" +
+          s" $attemptId), caused by ${e.getMessage}")
+      case e: Exception =>
+        logError("Exception encountered when write.", e)
+    }
+  }
+
   private def handleRpcRequest(client: TransportClient, rpcRequest: RpcRequest): Unit = {
     val msg = Message.decode(rpcRequest.body().nioByteBuffer())
     val requestId = rpcRequest.requestId
@@ -574,7 +665,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       requestId: Long,
       isCheckSplit: Boolean,
       callback: RpcResponseCallback): Unit = {
-    val isMaster = mode == PartitionLocation.Mode.MASTER
+    val isMaster = PartitionLocation.getMode(mode) == PartitionLocation.Mode.MASTER
     val messageType = message.`type`()
     log.info(s"requestId:$requestId, pushdata rpc:$messageType, mode:$mode, shuffleKey:$shuffleKey, partitionUniqueId:$partitionUniqueId")
     val (workerSourceMaster, workerSourceSlave) =
@@ -622,15 +713,16 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     try {
       messageType match {
         case Type.PUSH_DATA_HAND_SHAKE => {
-          fileWriter.pushDataHandShake(message.asInstanceOf[PushDataHandShake].numPartitions)
+          fileWriter.asInstanceOf[MapPartitionFileWriter].pushDataHandShake(
+            message.asInstanceOf[PushDataHandShake].numPartitions)
         }
         case Type.REGION_START => {
-          fileWriter.regionStart(
+          fileWriter.asInstanceOf[MapPartitionFileWriter].regionStart(
             message.asInstanceOf[RegionStart].currentRegionIndex,
             message.asInstanceOf[RegionStart].isBroadcast)
         }
         case Type.REGION_FINISH => {
-          fileWriter.regionFinish()
+          fileWriter.asInstanceOf[MapPartitionFileWriter].regionFinish()
         }
       }
       // for master, send data to slave
@@ -705,7 +797,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       callback: RpcResponseCallback,
       wrappedCallback: RpcResponseCallback): Boolean = {
     if (location == null) {
-      val (mapId, attemptId) = getMapAttempt(body, shuffleKey, partitionUniqueId)
+      val (mapId, attemptId) = getMapAttempt(partitionUniqueId)
       if (shuffleMapperAttempts.containsKey(shuffleKey) &&
         -1 != shuffleMapperAttempts.get(shuffleKey).get(mapId)) {
         // partition data has already been committed
@@ -799,15 +891,8 @@ class PushDataHandler extends BaseMessageHandler with Logging {
   }
 
   private def getMapAttempt(
-      body: ByteBuf,
-      shuffleKey: String,
       partitionUniqueId: String): (Int, Int) = {
-    shufflePartitionType.get(shuffleKey) match {
-      case PartitionType.MAP => {
-        val id = partitionUniqueId.split("-")(0).toInt
-        (PackedPartitionId.getRawPartitionId(id), PackedPartitionId.getAttemptId(id))
-      }
-      case PartitionType.REDUCE => getMapAttempt(body)
-    }
+    val id = partitionUniqueId.split("-")(0).toInt
+    (PackedPartitionId.getRawPartitionId(id), PackedPartitionId.getAttemptId(id))
   }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -74,6 +74,7 @@ object WorkerSource {
 
   // flush
   val TakeBufferTime = "TakeBufferTime"
+  val TakeBufferTimeIndex = "TakeBufferTimeIndex"
 
   val RegisteredShuffleCount = "RegisteredShuffleCount"
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -212,6 +212,7 @@ private[worker] class LocalFlusher(
   override def toString(): String = {
     s"LocalFlusher@$flusherId-$mountPoint"
   }
+
 }
 
 final private[worker] class HdfsFlusher(
@@ -223,11 +224,11 @@ final private[worker] class HdfsFlusher(
     hdfsFlusherThreads,
     flushAvgTimeWindowSize,
     avgFlushTimeSlidingWindowMinCount) with Logging {
-
   override def toString: String = s"HdfsFlusher@$flusherId"
 
   override def processIOException(e: IOException, deviceErrorType: DiskStatus): Unit = {
     stopAndCleanFlusher()
     logError(s"$this write failed, reason $deviceErrorType ,exception: $e")
   }
+
 }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -238,7 +238,7 @@ public class FileWriterSuiteJ {
     final int threadsNum = 8;
     File file = getTemporaryFile();
     FileWriter fileWriter =
-        new FileWriter(
+        new ReducePartitionFileWriter(
             new FileInfo(file, userIdentifier),
             localFlusher,
             source,
@@ -246,7 +246,6 @@ public class FileWriterSuiteJ {
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             SPLIT_THRESHOLD,
             splitMode,
-            partitionType,
             false);
 
     List<Future<?>> futures = new ArrayList<>();
@@ -283,7 +282,7 @@ public class FileWriterSuiteJ {
     final int threadsNum = Runtime.getRuntime().availableProcessors();
     File file = getTemporaryFile();
     FileWriter fileWriter =
-        new FileWriter(
+        new ReducePartitionFileWriter(
             new FileInfo(file, userIdentifier),
             localFlusher,
             source,
@@ -291,7 +290,6 @@ public class FileWriterSuiteJ {
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             SPLIT_THRESHOLD,
             splitMode,
-            partitionType,
             false);
 
     List<Future<?>> futures = new ArrayList<>();
@@ -337,7 +335,7 @@ public class FileWriterSuiteJ {
     File file = getTemporaryFile();
     FileInfo fileInfo = new FileInfo(file, userIdentifier);
     FileWriter fileWriter =
-        new FileWriter(
+        new ReducePartitionFileWriter(
             fileInfo,
             localFlusher,
             source,
@@ -345,7 +343,6 @@ public class FileWriterSuiteJ {
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             SPLIT_THRESHOLD,
             splitMode,
-            partitionType,
             false);
 
     List<Future<?>> futures = new ArrayList<>();


### PR DESCRIPTION
# [CELEBORN-83][FOLLOWUP] Fix various bugs when using HDFS as storage.

### What changes were proposed in this pull request?
1.Fix class cast exception.
2.Fix clean hdfs expired app dir.
3.Fix npe when destroy file writers.
4.Adjust disk not usable log level.
5.Close hdfs output streams.
6.Change hdfs log level to reduce log size.
7.Add instructions for buffer size using HDFS.
8.Fix data loss when reading from HDFS.

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
