### PR TITLE
[CELEBORN-128] Bump Log4j2 to 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <javaxservlet.version>3.1.0</javaxservlet.version>
     <junit.version>4.12</junit.version>
     <leveldb.version>1.8</leveldb.version>
-    <log4j2.version>2.17.1</log4j2.version>
+    <log4j2.version>2.17.2</log4j2.version>
     <mockito.version>1.10.19</mockito.version>
     <mockito-scalatest.version>1.16.37</mockito-scalatest.version>
     <netty.version>4.1.77.Final</netty.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Log4j2 from 2.17.1 to 2.17.2

### Why are the changes needed?

2.17.1 is a rushed version, and we'd better to use the latest patched version of 2.17

https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.2

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
