### PR TITLE
[CELEBORN-132] ShuffleClient should not implement Cloneable

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -141,7 +141,7 @@ public class RssShuffleManager implements ShuffleManager {
   @Override
   public void stop() {
     if (rssShuffleClient != null) {
-      rssShuffleClient.shutDown();
+      rssShuffleClient.shutdown();
     }
     if (lifecycleManager != null) {
       lifecycleManager.stop();

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
@@ -250,7 +250,7 @@ public class RssShuffleWriterSuiteJ {
 
       writer.write(iterator);
       Option<MapStatus> status = writer.stop(true);
-      client.shutDown();
+      client.shutdown();
 
       assertNotNull(status);
       assertTrue(status.isDefined());
@@ -315,7 +315,7 @@ public class RssShuffleWriterSuiteJ {
 
       writer.write(iterator);
       Option<MapStatus> status = writer.stop(true);
-      client.shutDown();
+      client.shutdown();
 
       assertNotNull(status);
       assertTrue(status.isDefined());

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -139,7 +139,7 @@ public class RssShuffleManager implements ShuffleManager {
   @Override
   public void stop() {
     if (rssShuffleClient != null) {
-      rssShuffleClient.shutDown();
+      rssShuffleClient.shutdown();
     }
     if (lifecycleManager != null) {
       lifecycleManager.stop();

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
@@ -232,7 +232,7 @@ public class RssShuffleWriterSuiteJ {
 
     writer.write(iterator);
     Option<MapStatus> status = writer.stop(true);
-    client.shutDown();
+    client.shutdown();
 
     assertNotNull(status);
     assertTrue(status.isDefined());

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -37,13 +37,13 @@ import org.apache.celeborn.common.rpc.RpcEndpointRef;
  */
 public abstract class ShuffleClient {
   private static volatile ShuffleClient _instance;
-  private static volatile boolean initFinished = false;
+  private static volatile boolean initialized = false;
   private static volatile FileSystem hdfsFs;
 
   // for testing
   public static void reset() {
     _instance = null;
-    initFinished = false;
+    initialized = false;
     hdfsFs = null;
   }
 
@@ -51,7 +51,7 @@ public abstract class ShuffleClient {
 
   public static ShuffleClient get(
       RpcEndpointRef driverRef, CelebornConf conf, UserIdentifier userIdentifier) {
-    if (null == _instance || !initFinished) {
+    if (null == _instance || !initialized) {
       synchronized (ShuffleClient.class) {
         if (null == _instance) {
           // During the execution of Spark tasks, each task may be interrupted due to speculative
@@ -61,12 +61,12 @@ public abstract class ShuffleClient {
           // when communicating with MetaService, it will cause a NullPointerException.
           _instance = new ShuffleClientImpl(conf, userIdentifier);
           _instance.setupMetaServiceRef(driverRef);
-          initFinished = true;
-        } else if (!initFinished) {
+          initialized = true;
+        } else if (!initialized) {
           _instance.shutdown();
           _instance = new ShuffleClientImpl(conf, userIdentifier);
           _instance.setupMetaServiceRef(driverRef);
-          initFinished = true;
+          initialized = true;
         }
       }
     }
@@ -75,7 +75,7 @@ public abstract class ShuffleClient {
 
   public static ShuffleClient get(
       String driverHost, int port, CelebornConf conf, UserIdentifier userIdentifier) {
-    if (null == _instance || !initFinished) {
+    if (null == _instance || !initialized) {
       synchronized (ShuffleClient.class) {
         if (null == _instance) {
           // During the execution of Spark tasks, each task may be interrupted due to speculative
@@ -85,12 +85,12 @@ public abstract class ShuffleClient {
           // when communicating with MetaService, it will cause a NullPointerException.
           _instance = new ShuffleClientImpl(conf, userIdentifier);
           _instance.setupMetaServiceRef(driverHost, port);
-          initFinished = true;
-        } else if (!initFinished) {
+          initialized = true;
+        } else if (!initialized) {
           _instance.shutdown();
           _instance = new ShuffleClientImpl(conf, userIdentifier);
           _instance.setupMetaServiceRef(driverHost, port);
-          initFinished = true;
+          initialized = true;
         }
       }
     }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -35,7 +35,7 @@ import org.apache.celeborn.common.rpc.RpcEndpointRef;
  * ShuffleClient may be a process singleton, the specific PartitionLocation should be hidden in the
  * implementation
  */
-public abstract class ShuffleClient implements Cloneable {
+public abstract class ShuffleClient {
   private static volatile ShuffleClient _instance;
   private static volatile boolean initFinished = false;
   private static volatile FileSystem hdfsFs;
@@ -63,7 +63,7 @@ public abstract class ShuffleClient implements Cloneable {
           _instance.setupMetaServiceRef(driverRef);
           initFinished = true;
         } else if (!initFinished) {
-          _instance.shutDown();
+          _instance.shutdown();
           _instance = new ShuffleClientImpl(conf, userIdentifier);
           _instance.setupMetaServiceRef(driverRef);
           initFinished = true;
@@ -87,7 +87,7 @@ public abstract class ShuffleClient implements Cloneable {
           _instance.setupMetaServiceRef(driverHost, port);
           initFinished = true;
         } else if (!initFinished) {
-          _instance.shutDown();
+          _instance.shutdown();
           _instance = new ShuffleClientImpl(conf, userIdentifier);
           _instance.setupMetaServiceRef(driverHost, port);
           initFinished = true;
@@ -185,7 +185,7 @@ public abstract class ShuffleClient implements Cloneable {
 
   public abstract boolean unregisterShuffle(String applicationId, int shuffleId, boolean isDriver);
 
-  public abstract void shutDown();
+  public abstract void shutdown();
 
   // Write data to a specific map partition, input data's type is Bytebuf.
   // data's type is Bytebuf to avoid copy between application and netty

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -75,7 +75,7 @@ public class ShuffleClientImpl extends ShuffleClient {
 
   private static final byte MASTER_MODE = PartitionLocation.Mode.MASTER.mode();
 
-  private static final Random rand = new Random();
+  private static final Random RND = new Random();
 
   private final CelebornConf conf;
 
@@ -143,9 +143,9 @@ public class ShuffleClientImpl extends ShuffleClient {
     // init rpc env and master endpointRef
     rpcEnv = RpcEnv.create("ShuffleClient", Utils.localHostName(), 0, conf);
 
+    String module = TransportModuleConstants.DATA_MODULE;
     TransportConf dataTransportConf =
-        Utils.fromCelebornConf(
-            conf, TransportModuleConstants.DATA_MODULE, conf.getInt("celeborn.data.io.threads", 8));
+        Utils.fromCelebornConf(conf, module, conf.getInt("celeborn" + module + ".io.threads", 8));
     TransportContext context =
         new TransportContext(dataTransportConf, new BaseMessageHandler(), true);
     dataClientFactory = context.createClientFactory();
@@ -402,7 +402,7 @@ public class ShuffleClientImpl extends ShuffleClient {
       return true;
     }
 
-    long sleepTimeMs = rand.nextInt(50);
+    long sleepTimeMs = RND.nextInt(50);
     if (sleepTimeMs > 30) {
       try {
         TimeUnit.MILLISECONDS.sleep(sleepTimeMs);
@@ -873,7 +873,7 @@ public class ShuffleClientImpl extends ShuffleClient {
         new ArrayList<>(pushState.batchesMap.entrySet());
     while (!batchesArr.isEmpty()) {
       limitMaxInFlight(mapKey, pushState, currentMaxReqsInFlight);
-      Map.Entry<String, DataBatches> entry = batchesArr.get(rand.nextInt(batchesArr.size()));
+      Map.Entry<String, DataBatches> entry = batchesArr.get(RND.nextInt(batchesArr.size()));
       ArrayList<DataBatches.DataBatch> batches = entry.getValue().requireBatches(pushBufferMaxSize);
       if (entry.getValue().getTotalSize() == 0) {
         batchesArr.remove(entry);
@@ -1233,7 +1233,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   }
 
   @Override
-  public void shutDown() {
+  public void shutdown() {
     if (null != rpcEnv) {
       rpcEnv.shutdown();
     }

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -129,7 +129,7 @@ public class DummyShuffleClient extends ShuffleClient {
   }
 
   @Override
-  public void shutDown() {
+  public void shutdown() {
     try {
       os.close();
     } catch (IOException e) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
@@ -88,7 +88,7 @@ trait ReadWriteTestBase extends Logging {
     Assert.assertArrayEquals(targetArr, readBytes)
 
     Thread.sleep(5000L)
-    shuffleClient.shutDown()
+    shuffleClient.shutdown()
     lifecycleManager.rpcEnv.shutdown()
 
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove interface `Cloneable` declaration from `ShuffleClient`, and minor code improvement.

### Why are the changes needed?

ShuffleClient should not implement Cloneable, the original intention here is Closeable, but the close method throws IOException (which is a checked exception, so catch or throw is necessary), to make the code clean and simple, here just remove the implement Cloneable.

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
