### PR TITLE
[CELEBORN-133] Improve snapshot loading

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
@@ -211,6 +211,7 @@ public class StateMachine extends BaseStateMachine {
       return;
     }
     if (snapshot.getTermIndex().compareTo(getLastAppliedTermIndex()) <= 0) {
+      LOG.info("obsolete snapshot provided: " + snapshot.getTermIndex());
       return;
     }
     LOG.info("Loading Snapshot {}.", snapshot);
@@ -222,17 +223,18 @@ public class StateMachine extends BaseStateMachine {
     try {
       setLastAppliedTermIndex(snapshot.getTermIndex());
       install(snapshotFile);
-    } catch (IOException e) {
-      throw new IOException(String.format("Failed to load snapshot %s", snapshot), e.getCause());
+    } catch (IOException rethrow) {
+      LOG.error("Failed to load snapshot {}", snapshot);
+      throw rethrow;
     }
   }
 
   private void install(File snapshotFile) throws IOException {
     try {
       metaHandler.loadSnapShot(snapshotFile);
-    } catch (IOException e) {
-      LOG.warn("Failed to install snapshot!", e);
-      throw e;
+    } catch (IOException rethrow) {
+      LOG.warn("Failed to install snapshot!", rethrow);
+      throw rethrow;
     }
     LOG.info("Successfully installed snapshot!");
   }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
@@ -211,7 +211,7 @@ public class StateMachine extends BaseStateMachine {
       return;
     }
     if (snapshot.getTermIndex().compareTo(getLastAppliedTermIndex()) <= 0) {
-      LOG.info("obsolete snapshot provided: " + snapshot.getTermIndex());
+      LOG.info("obsolete snapshot provided: {}", snapshot.getTermIndex());
       return;
     }
     LOG.info("Loading Snapshot {}.", snapshot);


### PR DESCRIPTION
# [BUG]/[FEATURE] Improve snapshot loading

### What changes were proposed in this pull request?
1. add a pre-check to reject obsolete snapshots
2. throw exception and fail immediately when snapshot is not loaded

### Why are the changes needed?
Snapshot loading happens when:
1. A server restarts from crash.
2. A new Server joins the group.
In both situation, when snapshot loading is failed, the server is not able to service. We should throw exception and fails immediately.


/cc @related-reviewer

/assign @main-reviewer
