### PR TITLE
[CELEBORN-138] Respect users' configurations which are set in values.yaml

### DIFF
--- a/docker/helm/templates/configmap.yaml
+++ b/docker/helm/templates/configmap.yaml
@@ -23,15 +23,15 @@ metadata:
     {{- include "celeborn.labels" . | nindent 4 }}
 data:
   celeborn-defaults.conf: |-
-    {{- range $key, $val := .Values.celeborn }}
-    {{ $key }}={{ $val }}
-    {{- end -}} 
     {{- $namespace := .Release.Namespace }}
     celeborn.ha.enabled=true
     celeborn.master.endpoints={{ range until (.Values.masterReplicas |int) }}celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.cluster.local,{{ end }}
     {{- range until (.Values.masterReplicas |int) }}
     celeborn.ha.master.node.{{ . }}.host=celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.cluster.local
     {{- end }}
+    {{- range $key, $val := .Values.celeborn }}
+    {{ $key }}={{ $val }}
+    {{- end -}} 
     
   rss-env.sh: |
     {{- range $key, $val := .Values.environments }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Configurations in values.yaml will override those in celeborn-defaults.conf.


### Why are the changes needed?
Values.yaml this should be the user facing the most front-end configuration file.

We should respect configurations which set by user in values.yaml

For example, user explicitly set `celeborn.ha.enabled: false` in values.yaml will be override by `celeborn.ha.enabled=false` in celeborn-defaults.conf. We don't want to see this happen.


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?

