### PR TITLE
[CELEBORN-139][BUG] Fix read wrong yaml file format when loading config

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2362,7 +2362,8 @@ object CelebornConf extends Logging {
     buildConf("celeborn.quota.configuration.path")
       .withAlternative("rss.quota.configuration.path")
       .categories("quota")
-      .doc("Quota configuration file path.")
+      .doc("Quota configuration file path. The file format should be yaml. Quota configuration file template can be " +
+        "found under conf directory.")
       .version("0.2.0")
       .stringConf
       .createOptional

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -561,7 +561,7 @@ object Utils extends Logging {
   def getDefaultQuotaConfigurationFile(env: Map[String, String] = sys.env): String = {
     env.get("CELEBORN_CONF_DIR")
       .orElse(env.get("CELEBORN_HOME").map { t => s"$t${File.separator}conf" })
-      .map { t => new File(s"$t${File.separator}quota.yml") }
+      .map { t => new File(s"$t${File.separator}quota.yaml") }
       .filter(_.isFile)
       .map(_.getAbsolutePath)
       .orNull

--- a/docs/configuration/quota.md
+++ b/docs/configuration/quota.md
@@ -19,7 +19,7 @@ license: |
 <!--begin-include-->
 | Key | Default | Description | Since |
 | --- | ------- | ----------- | ----- |
-| celeborn.quota.configuration.path | &lt;undefined&gt; | Quota configuration file path. | 0.2.0 | 
+| celeborn.quota.configuration.path | &lt;undefined&gt; | Quota configuration file path. The file format should be yaml. Quota configuration file template can be found under conf directory. | 0.2.0 | 
 | celeborn.quota.enabled | true | When true, before registering shuffle, LifecycleManager should check if current user have enough quota space, if cluster don't have enough quota space for current user, fallback to Spark's default shuffle | 0.2.0 | 
 | celeborn.quota.identity.provider | org.apache.celeborn.common.identity.DefaultIdentityProvider | IdentityProvider class name. Default class is `org.apache.celeborn.common.identity.DefaultIdentityProvider`, return `org.apache.celeborn.common.identity.UserIdentifier` with default tenant id and username from `org.apache.hadoop.security.UserGroupInformation`.  | 0.2.0 | 
 | celeborn.quota.manager | org.apache.celeborn.common.quota.DefaultQuotaManager | QuotaManger class name. Default class is `org.apache.celeborn.common.quota.DefaultQuotaManager`. | 0.2.0 | 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix read wrong yaml file format when loading config


### Why are the changes needed?
its file format should be yaml rather than yml when creating quota config file.

### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?

