### PR TITLE
[CELEBORN-140][IMPROVEMENT] Quota yaml should support byte string

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/quota/DefaultQuotaManager.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/quota/DefaultQuotaManager.scala
@@ -49,7 +49,12 @@ class DefaultQuotaManager(conf: CelebornConf) extends QuotaManager(conf) {
             .asInstanceOf[java.util.HashMap[String, Object]]
             .asScala
             .foreach { case (key, value) =>
-              quota.update(userIdentifier, key, value.toString.toLong)
+              key match {
+                case "diskBytesWritten" | "hdfsBytesWritten" =>
+                  quota.update(userIdentifier, key, Utils.byteStringAsBytes(value.toString))
+                case _ =>
+                  quota.update(userIdentifier, key, value.toString.toLong)
+              }
             }
           userQuotas.put(userIdentifier, quota)
         }

--- a/common/src/test/resources/test-quota.yaml
+++ b/common/src/test/resources/test-quota.yaml
@@ -18,15 +18,11 @@
 -  tenantId: AAA
    name: Tom
    quota:
-     diskBytesWritten: 10000
+     diskBytesWritten: 100m
      diskFileCount: 200
-     hdfsBytesWritten: -1
-     hdfsFileCount: -1
 
 -  tenantId: BBB
    name: Jerry
    quota:
-     diskBytesWritten: -1
-     diskFileCount: -1
-     hdfsBytesWritten: 10000
+     hdfsBytesWritten: 200m
      hdfsFileCount: 200

--- a/common/src/test/scala/org/apache/celeborn/common/quota/DefaultQuotaManagerSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/quota/DefaultQuotaManagerSuite.scala
@@ -21,6 +21,7 @@ import org.junit.Assert.assertEquals
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.util.Utils
 
 class DefaultQuotaManagerSuite extends BaseQuotaManagerSuite {
 
@@ -39,9 +40,9 @@ class DefaultQuotaManagerSuite extends BaseQuotaManagerSuite {
   test("test rss quota conf") {
     assertEquals(
       quotaManager.getQuota(UserIdentifier("AAA", "Tom")),
-      Quota(10000, 200, -1, -1))
+      Quota(Utils.byteStringAsBytes("100m"), 200, -1, -1))
     assertEquals(
       quotaManager.getQuota(UserIdentifier("BBB", "Jerry")),
-      Quota(-1, -1, 10000, 200))
+      Quota(-1, -1, Utils.byteStringAsBytes("200m"), 200))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Bytes's setting support such as `1m`. `1G`


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

