### PR TITLE
[CELEBORN-140][FOLLOWUP] quota.yaml file not support default value -1 no2

### DIFF
--- a/conf/quota.yaml.template
+++ b/conf/quota.yaml.template
@@ -18,15 +18,15 @@
 -  tenantId: AAA
    name: Tom
    quota:
-     diskBytesWritten: 10000
+     diskBytesWritten: 100m
      diskFileCount: 200
-     hdfsBytesWritten: -1
-     hdfsFileCount: -1
+     hdfsBytesWritten: 200m
+     hdfsFileCount: 100
 
 -  tenantId: BBB
    name: Jerry
    quota:
-     diskBytesWritten: -1
-     diskFileCount: -1
-     hdfsBytesWritten: 10000
+     diskBytesWritten: 1G
+     diskFileCount: 1000
+     hdfsBytesWritten: 3G
      hdfsFileCount: 200


### PR DESCRIPTION
### What changes were proposed in this pull request?
After #1085 , yaml file not support default quota value -1, if we don't want to set this quota, can just not set the value, default will be -1, means no limit.


### Why are the changes needed?
Fix incorrect template quota.yaml


### Does this PR introduce _any_ user-facing change?
Yea, quota.yaml file setting should not use -1 to set default value.


### How was this patch tested?

