### PR TITLE
[CELEBORN-121] Refactor batchHandleCommitPartition

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -150,7 +150,6 @@ class ChangePartitionManager(
     inBatchPartitions.computeIfAbsent(shuffleId, inBatchShuffleIdRegisterFunc)
 
     lifecycleManager.commitManager.registerCommitPartitionRequest(
-      applicationId,
       shuffleId,
       oldPartition,
       cause)

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -47,8 +47,8 @@ case class ShuffleCommittedInfo(
     committedSlaveStorageInfos: ConcurrentHashMap[String, StorageInfo],
     committedMapIdBitmap: ConcurrentHashMap[String, RoaringBitmap],
     currentShuffleFileCount: LongAdder,
-    commitPartitionRequests: util.Set[PartitionLocation],
-    handledCommitPartitionRequests: util.Set[PartitionLocation],
+    unCommitPartitionLocations: util.Set[PartitionLocation],
+    handledCommitPartitionLocations: util.Set[PartitionLocation],
     allInFlightCommitRequestNum: AtomicInteger,
     partitionInFlightCommitRequestNum: ConcurrentHashMap[Int, AtomicInteger])
 
@@ -188,7 +188,7 @@ class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: Lif
     if (batchHandleCommitPartitionEnabled && cause.isDefined && cause.get == StatusCode.HARD_SPLIT) {
       val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
       shuffleCommittedInfo.synchronized {
-        shuffleCommittedInfo.commitPartitionRequests
+        shuffleCommittedInfo.unCommitPartitionLocations
           .add(partitionLocation)
       }
     }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -83,11 +83,9 @@ abstract class CommitHandler(
       val currentBatch = this.getUnHandledPartitionLocations(shuffleId, shuffleCommittedInfo)
       shuffleCommittedInfo.unHandledPartitionLocations.clear()
       currentBatch.foreach { partitionLocation =>
-        shuffleCommittedInfo.handledPartitionLocations
-          .add(partitionLocation)
+        shuffleCommittedInfo.handledPartitionLocations.add(partitionLocation)
         if (partitionLocation.getPeer != null) {
-          shuffleCommittedInfo.handledPartitionLocations
-            .add(partitionLocation.getPeer)
+          shuffleCommittedInfo.handledPartitionLocations.add(partitionLocation.getPeer)
         }
       }
 

--- a/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
@@ -109,11 +109,11 @@ class MapPartitionCommitHandler(
     dataCommitSuccess
   }
 
-  override def getUnCommitPartitionRequests(
+  override def getUnHandledPartitionLocations(
       shuffleId: Int,
       shuffleCommittedInfo: ShuffleCommittedInfo): mutable.Set[PartitionLocation] = {
-    shuffleCommittedInfo.unCommitPartitionLocations.asScala.filterNot { partitionLocation =>
-      shuffleCommittedInfo.handledCommitPartitionLocations.contains(partitionLocation) &&
+    shuffleCommittedInfo.unHandledPartitionLocations.asScala.filterNot { partitionLocation =>
+      shuffleCommittedInfo.handledPartitionLocations.contains(partitionLocation) &&
       this.isPartitionInProcess(shuffleId, partitionLocation.getId)
     }
   }
@@ -124,8 +124,7 @@ class MapPartitionCommitHandler(
     workerToRequests.foreach {
       case (_, partitions) =>
         partitions.groupBy(_.getId).foreach { case (id, _) =>
-          val atomicInteger = shuffleCommittedInfo
-            .partitionInFlightCommitRequestNum
+          val atomicInteger = shuffleCommittedInfo.partitionInFlightCommitRequestNum
             .computeIfAbsent(id, (k: Int) => new AtomicInteger(0))
           atomicInteger.incrementAndGet()
         }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -154,8 +154,8 @@ class ReducePartitionCommitHandler(
   override def getUnCommitPartitionRequests(
       shuffleId: Int,
       shuffleCommittedInfo: ShuffleCommittedInfo): mutable.Set[PartitionLocation] = {
-    shuffleCommittedInfo.commitPartitionRequests.asScala.filterNot { partitionLocation =>
-      shuffleCommittedInfo.handledCommitPartitionRequests
+    shuffleCommittedInfo.unCommitPartitionLocations.asScala.filterNot { partitionLocation =>
+      shuffleCommittedInfo.handledCommitPartitionLocations
         .contains(partitionLocation)
     }
   }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -151,12 +151,11 @@ class ReducePartitionCommitHandler(
     (dataLost, parallelCommitResult.commitFilesFailedWorkers)
   }
 
-  override def getUnCommitPartitionRequests(
+  override def getUnHandledPartitionLocations(
       shuffleId: Int,
       shuffleCommittedInfo: ShuffleCommittedInfo): mutable.Set[PartitionLocation] = {
-    shuffleCommittedInfo.unCommitPartitionLocations.asScala.filterNot { partitionLocation =>
-      shuffleCommittedInfo.handledCommitPartitionLocations
-        .contains(partitionLocation)
+    shuffleCommittedInfo.unHandledPartitionLocations.asScala.filterNot { partitionLocation =>
+      shuffleCommittedInfo.handledPartitionLocations.contains(partitionLocation)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is the second refactor step according to [CELEBORN-116](https://issues.apache.org/jira/browse/CELEBORN-116), follow up [CELEBORN-117](https://issues.apache.org/jira/browse/CELEBORN-117)
It's about refactor batchHandleCommitPartition, as we can use specific commit handler for the R/M shuffle type.

### Why are the changes needed?
Use specific commit handler  to do batchHandleCommitPartition for the R/M shuffle type,  will make the whole logic clearer and the code cleaner.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
trigger test
