### PR TITLE
[CELEBORN-155] Wrong TimeUnit for registerShuffleRetryWait in Shuffle…

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -82,7 +82,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   private final UserIdentifier userIdentifier;
 
   private final int registerShuffleMaxRetries;
-  private final long registerShuffleRetryWait;
+  private final long registerShuffleRetryWaitMs;
   private int maxInFlight;
   private Integer currentMaxReqsInFlight = 1;
   private int congestionAvoidanceFlag = 0;
@@ -136,7 +136,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     this.conf = conf;
     this.userIdentifier = userIdentifier;
     registerShuffleMaxRetries = conf.registerShuffleMaxRetry();
-    registerShuffleRetryWait = conf.registerShuffleRetryWait();
+    registerShuffleRetryWaitMs = conf.registerShuffleRetryWaitMs();
     maxInFlight = conf.pushMaxReqsInFlight();
     pushBufferMaxSize = conf.pushBufferMaxSize();
 
@@ -345,7 +345,7 @@ public class ShuffleClientImpl extends ShuffleClient {
       }
 
       try {
-        TimeUnit.SECONDS.sleep(registerShuffleRetryWait);
+        TimeUnit.MILLISECONDS.sleep(registerShuffleRetryWaitMs);
       } catch (InterruptedException e) {
         break;
       }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -520,7 +520,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def shuffleManagerPort: Int = get(SHUFFLE_MANAGER_PORT)
   def shuffleChunkSize: Long = get(SHUFFLE_CHUCK_SIZE)
   def registerShuffleMaxRetry: Int = get(SHUFFLE_REGISTER_MAX_RETRIES)
-  def registerShuffleRetryWait: Long = get(SHUFFLE_REGISTER_RETRY_WAIT)
+  def registerShuffleRetryWaitMs: Long = get(SHUFFLE_REGISTER_RETRY_WAIT)
   def reserveSlotsMaxRetries: Int = get(RESERVE_SLOTS_MAX_RETRIES)
   def reserveSlotsRetryWait: Long = get(RESERVE_SLOTS_RETRY_WAIT)
   def rpcMaxParallelism: Int = get(CLIENT_RPC_MAX_PARALLELISM)
@@ -1351,7 +1351,7 @@ object CelebornConf extends Logging {
       .version("0.2.0")
       .doc("Timeout time for LifecycleManager to clear reserved excluded worker.")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("600s")
+      .createWithDefaultString("60s")
 
   val SHUFFLE_CHUCK_SIZE: ConfigEntry[Long] =
     buildConf("celeborn.shuffle.chuck.size")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1351,7 +1351,7 @@ object CelebornConf extends Logging {
       .version("0.2.0")
       .doc("Timeout time for LifecycleManager to clear reserved excluded worker.")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("60s")
+      .createWithDefaultString("600s")
 
   val SHUFFLE_CHUCK_SIZE: ConfigEntry[Long] =
     buildConf("celeborn.shuffle.chuck.size")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -71,5 +71,5 @@ license: |
 | celeborn.test.fetchFailure | false | Wheter to test fetch chunk failure | 0.2.0 | 
 | celeborn.test.retryCommitFiles | false | Fail commitFile request for test | 0.2.0 | 
 | celeborn.worker.excluded.checkInterval | 30s | Interval for client to refresh excluded worker list. | 0.2.0 | 
-| celeborn.worker.excluded.expireTimeout | 600s | Timeout time for LifecycleManager to clear reserved excluded worker. | 0.2.0 | 
+| celeborn.worker.excluded.expireTimeout | 60s | Timeout time for LifecycleManager to clear reserved excluded worker. | 0.2.0 | 
 <!--end-include-->

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -71,5 +71,5 @@ license: |
 | celeborn.test.fetchFailure | false | Wheter to test fetch chunk failure | 0.2.0 | 
 | celeborn.test.retryCommitFiles | false | Fail commitFile request for test | 0.2.0 | 
 | celeborn.worker.excluded.checkInterval | 30s | Interval for client to refresh excluded worker list. | 0.2.0 | 
-| celeborn.worker.excluded.expireTimeout | 60s | Timeout time for LifecycleManager to clear reserved excluded worker. | 0.2.0 | 
+| celeborn.worker.excluded.expireTimeout | 600s | Timeout time for LifecycleManager to clear reserved excluded worker. | 0.2.0 | 
 <!--end-include-->


### PR DESCRIPTION
…ClientImpl

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
In CelebornConf the time unit of celeborn.shuffle.register.retryWait is milliseconds, while ShuffleClientImpl treats it as SECONDS, so it will sleep for too long.
![image](https://user-images.githubusercontent.com/948245/208388740-a5e84752-7828-491e-ae11-f95f46eca277.png)



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

