### PR TITLE
[CELEBORN-113][FEATURE] Add metrics to monitor non-critical error number on local device

### DIFF
--- a/common/src/test/java/org/apache/celeborn/common/meta/DiskStatusSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/meta/DiskStatusSuiteJ.java
@@ -17,34 +17,19 @@
 
 package org.apache.celeborn.common.meta;
 
-public enum DiskStatus {
-  HEALTHY(0),
-  READ_OR_WRITE_FAILURE(1),
-  IO_HANG(2),
-  HIGH_DISK_USAGE(3),
-  CRITICAL_ERROR(4);
+import static org.junit.Assert.*;
 
-  private final byte value;
+import org.junit.Test;
 
-  DiskStatus(int value) {
-    assert (value >= 0 && value < 256);
-    this.value = (byte) value;
-  }
+public class DiskStatusSuiteJ {
 
-  public final byte getValue() {
-    return value;
-  }
-
-  public final String toMetric() {
-    String[] fragments = this.name().split("_");
-    String metric = "";
-    for (String fragment : fragments) {
-      int len = fragment.length();
-      if (len >= 1) {
-        metric += fragment.substring(0, 1).toUpperCase();
-        metric += fragment.substring(1, len).toLowerCase();
-      }
-    }
-    return metric;
+  @Test
+  public void testDiskStatusToMetric() throws Exception {
+    assertEquals(DiskStatus.values().length, 5);
+    assertEquals(DiskStatus.HEALTHY.toMetric(), "Healthy");
+    assertEquals(DiskStatus.READ_OR_WRITE_FAILURE.toMetric(), "ReadOrWriteFailure");
+    assertEquals(DiskStatus.IO_HANG.toMetric(), "IoHang");
+    assertEquals(DiskStatus.HIGH_DISK_USAGE.toMetric(), "HighDiskUsage");
+    assertEquals(DiskStatus.CRITICAL_ERROR.toMetric(), "CriticalError");
   }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -92,7 +92,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     tmpDiskInfos.put(diskInfo.mountPoint, diskInfo)
   }
   private val deviceMonitor =
-    DeviceMonitor.createDeviceMonitor(conf, this, deviceInfos, tmpDiskInfos)
+    DeviceMonitor.createDeviceMonitor(conf, this, deviceInfos, tmpDiskInfos, workerSource)
 
   // (mountPoint -> LocalFlusher)
   private val localFlushers: ConcurrentHashMap[String, LocalFlusher] = {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
@@ -34,6 +34,7 @@ import org.apache.celeborn.common.CelebornConf.WORKER_DISK_MONITOR_CHECK_INTERVA
 import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus}
 import org.apache.celeborn.common.protocol.StorageInfo
 import org.apache.celeborn.common.util.Utils
+import org.apache.celeborn.service.deploy.worker.WorkerSource
 
 class DeviceMonitorSuite extends AnyFunSuite {
   val dfCmd = "df -ah"
@@ -66,6 +67,7 @@ class DeviceMonitorSuite extends AnyFunSuite {
 
   val conf = new CelebornConf()
   conf.set(WORKER_DISK_MONITOR_CHECK_INTERVAL.key, "3600s")
+  val workerSource = new WorkerSource(conf)
 
   val storageManager = mock[DeviceObserver]
   var (deviceInfos, diskInfos, workingDirDiskInfos): (
@@ -82,7 +84,7 @@ class DeviceMonitorSuite extends AnyFunSuite {
     diskInfos = tdiskInfos
   }
   val deviceMonitor =
-    new LocalDeviceMonitor(conf, storageManager, deviceInfos, diskInfos)
+    new LocalDeviceMonitor(conf, storageManager, deviceInfos, diskInfos, workerSource)
 
   val vdaDeviceInfo = new DeviceInfo("vda")
   val vdbDeviceInfo = new DeviceInfo("vdb")
@@ -272,5 +274,32 @@ class DeviceMonitorSuite extends AnyFunSuite {
       assert(!result)
     })
     DeviceMonitor.deviceCheckThreadPool.shutdownNow()
+  }
+
+  test("monitor non-critical error metrics") {
+    withObjectMocked[org.apache.celeborn.common.util.Utils.type] {
+      when(Utils.runCommand(dfCmd)) thenReturn dfOut
+      when(Utils.runCommand(lsCmd)) thenReturn lsOut
+
+      deviceMonitor.init()
+
+      val device1 = deviceMonitor.observedDevices.values().asScala.head
+      val mountPoints1 = device1.diskInfos.keySet().asScala.toList
+
+      device1.notifyObserversOnNonCriticalError(mountPoints1, DiskStatus.READ_OR_WRITE_FAILURE)
+      device1.notifyObserversOnNonCriticalError(mountPoints1, DiskStatus.IO_HANG)
+      val deviceMonitorMetrics =
+        workerSource.gauges().filter(_.name.startsWith("Device")).sortBy(_.name)
+
+      assertEquals("Device_vda_IoHang_Count", deviceMonitorMetrics.head.name)
+      assertEquals("Device_vda_ReadOrWriteFailure_Count", deviceMonitorMetrics.last.name)
+      assertEquals(1, deviceMonitorMetrics.head.gauge.getValue)
+      assertEquals(1, deviceMonitorMetrics.last.gauge.getValue)
+
+      device1.notifyObserversOnNonCriticalError(mountPoints1, DiskStatus.READ_OR_WRITE_FAILURE)
+      device1.notifyObserversOnNonCriticalError(mountPoints1, DiskStatus.IO_HANG)
+      assertEquals(2, deviceMonitorMetrics.head.gauge.getValue)
+      assertEquals(2, deviceMonitorMetrics.last.gauge.getValue)
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add metrics to monitor non-critical error number on local device. The metrics will looks like below
<img width="344" alt="image" src="https://user-images.githubusercontent.com/30563796/208389823-401711d9-45f4-4d48-8462-f12bebe8e4cc.png">


### Why are the changes needed?
In order to better add metrics to trace the current valid non-critical error number(differentiate based on DiskStatus) when local device has issue.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
unit test
