### PR TITLE
[CELEBORN-161][BUILD] Disable scaladocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -718,6 +718,9 @@
               </goals>
               <phase>process-test-resources</phase>
             </execution>
+            <!--
+              CELEBORN-161: we must disable scaladocs to recover building for Spark 2.4
+              `build/mvn clean install -DskipTests -Pspark-2.4`
             <execution>
               <id>attach-scaladocs</id>
               <goals>
@@ -725,6 +728,7 @@
               </goals>
               <phase>verify</phase>
             </execution>
+            -->
           </executions>
         </plugin>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Disable `attach-scaladocs`.

### Why are the changes needed?

To recover the following building command
```
build/mvn clean install -DskipTests -Pspark-2.4
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Run `build/mvn clean install -DskipTests -Pspark-2.4`.

Before
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Celeborn Project Parent POM 0.2.0-SNAPSHOT:
[INFO]
[INFO] Celeborn Project Parent POM ........................ SUCCESS [  4.156 s]
[INFO] Celeborn Common .................................... FAILURE [ 32.095 s]
[INFO] Celeborn Client .................................... SKIPPED
[INFO] Celeborn Service ................................... SKIPPED
[INFO] Celeborn Master .................................... SKIPPED
[INFO] Celeborn Worker .................................... SKIPPED
[INFO] Celeborn Client for Spark Common ................... SKIPPED
[INFO] Celeborn Client for Spark 2 ........................ SKIPPED
[INFO] Celeborn Shaded Client for Spark 2 ................. SKIPPED
[INFO] Celeborn Spark Integration Test .................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.629 s
[INFO] Finished at: 2022-12-21T22:33:41+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.7.2:doc-jar (attach-scaladocs) on project celeborn-common_2.11: MavenReportException: Error while creating archive: wrap: Process exited with an error: 1 (Exit value: 1) -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :celeborn-common_2.11
```

After

```
[INFO] Reactor Summary for Celeborn Project Parent POM 0.2.0-SNAPSHOT:
[INFO]
[INFO] Celeborn Project Parent POM ........................ SUCCESS [  3.002 s]
[INFO] Celeborn Common .................................... SUCCESS [ 31.506 s]
[INFO] Celeborn Client .................................... SUCCESS [ 13.180 s]
[INFO] Celeborn Service ................................... SUCCESS [  2.638 s]
[INFO] Celeborn Master .................................... SUCCESS [ 15.160 s]
[INFO] Celeborn Worker .................................... SUCCESS [ 18.356 s]
[INFO] Celeborn Client for Spark Common ................... SUCCESS [  2.759 s]
[INFO] Celeborn Client for Spark 2 ........................ SUCCESS [  8.191 s]
[INFO] Celeborn Shaded Client for Spark 2 ................. SUCCESS [  5.428 s]
[INFO] Celeborn Spark Integration Test .................... SUCCESS [  7.739 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:48 min
[INFO] Finished at: 2022-12-21T22:42:58+08:00
[INFO] ------------------------------------------------------------------------
```