### PR TITLE
[CELEBORN-146] refactor ShuffleMapperAttempts & GetReducerFileGroup

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -55,17 +55,16 @@ abstract class CommitHandler(
 
   private val pushReplicateEnabled = conf.pushReplicateEnabled
   private val testRetryCommitFiles = conf.testRetryCommitFiles
-  private val commitEpoch = new AtomicLong()
-  private val totalWritten = new LongAdder
-  private val fileCount = new LongAdder
   private val rpcCacheSize = conf.rpcCacheSize
   private val rpcCacheConcurrencyLevel = conf.rpcCacheConcurrencyLevel
   private val rpcCacheExpireTime = conf.rpcCacheExpireTime
 
-  protected val stageEndTimeout = conf.pushStageEndTimeout
-  protected val reducerFileGroupsMap = new ShuffleFileGroups
+  private val commitEpoch = new AtomicLong()
+  private val totalWritten = new LongAdder
+  private val fileCount = new LongAdder
+  private val reducerFileGroupsMap = new ShuffleFileGroups
   // noinspection UnstableApiUsage
-  protected val getReducerFileGroupRpcCache: Cache[Int, ByteBuffer] = CacheBuilder.newBuilder()
+  private val getReducerFileGroupRpcCache: Cache[Int, ByteBuffer] = CacheBuilder.newBuilder()
     .concurrencyLevel(rpcCacheConcurrencyLevel)
     .expireAfterWrite(rpcCacheExpireTime, TimeUnit.MILLISECONDS)
     .maximumSize(rpcCacheSize)

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -81,7 +81,7 @@ abstract class CommitHandler(
   def setStageEnd(shuffleId: Int): Unit
 
   /**
-   * return (waitStage isTimeOut, cost)
+   * return (waitStage isTimeOut, waitTime)
    */
   def waitStageEnd(shuffleId: Int): (Boolean, Long) = (true, 0)
 
@@ -152,7 +152,7 @@ abstract class CommitHandler(
       recordWorkerFailure: ShuffleFailedWorkers => Unit): Boolean
 
   def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int): Unit = {
-    if (this.isStageDataLost(shuffleId)) {
+    if (isStageDataLost(shuffleId)) {
       context.reply(
         GetReducerFileGroupResponse(
           StatusCode.SHUFFLE_DATA_LOST,
@@ -164,7 +164,7 @@ abstract class CommitHandler(
         context.reply(GetReducerFileGroupResponse(
           StatusCode.SUCCESS,
           reducerFileGroupsMap.getOrDefault(shuffleId, new ConcurrentHashMap()),
-          this.getMapperAttempts(shuffleId)))
+          getMapperAttempts(shuffleId)))
       } else {
         val cachedMsg = getReducerFileGroupRpcCache.get(
           shuffleId,

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -17,23 +17,27 @@
 
 package org.apache.celeborn.client.commit
 
+import java.nio.ByteBuffer
 import java.util
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.{Callable, ConcurrentHashMap, TimeUnit}
 import java.util.concurrent.atomic.{AtomicLong, LongAdder}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
+import com.google.common.cache.{Cache, CacheBuilder}
+
 import org.apache.celeborn.client.CommitManager.CommittedPartitionInfo
-import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, ShuffleFailedWorkers, ShuffleFileGroups, ShuffleMapperAttempts}
+import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, ShuffleFailedWorkers, ShuffleFileGroups}
 import org.apache.celeborn.client.ShuffleCommittedInfo
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{PartitionLocationInfo, WorkerInfo}
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType}
-import org.apache.celeborn.common.protocol.message.ControlMessages.{CommitFiles, CommitFilesResponse}
+import org.apache.celeborn.common.protocol.message.ControlMessages.{CommitFiles, CommitFilesResponse, GetReducerFileGroupResponse}
 import org.apache.celeborn.common.protocol.message.StatusCode
-import org.apache.celeborn.common.rpc.RpcEndpointRef
+import org.apache.celeborn.common.rpc.{RpcCallContext, RpcEndpointRef}
+import org.apache.celeborn.common.rpc.netty.{LocalNettyRpcCallContext, RemoteNettyRpcCallContext}
 import org.apache.celeborn.common.util.{ThreadUtils, Utils}
 // Can Remove this if celeborn don't support scala211 in future
 import org.apache.celeborn.common.util.FunctionConverter._
@@ -47,7 +51,6 @@ abstract class CommitHandler(
     appId: String,
     conf: CelebornConf,
     allocatedWorkers: ShuffleAllocatedWorkers,
-    reducerFileGroupsMap: ShuffleFileGroups,
     committedPartitionInfo: CommittedPartitionInfo) extends Logging {
 
   private val pushReplicateEnabled = conf.pushReplicateEnabled
@@ -55,6 +58,18 @@ abstract class CommitHandler(
   private val commitEpoch = new AtomicLong()
   private val totalWritten = new LongAdder
   private val fileCount = new LongAdder
+  private val rpcCacheSize = conf.rpcCacheSize
+  private val rpcCacheConcurrencyLevel = conf.rpcCacheConcurrencyLevel
+  private val rpcCacheExpireTime = conf.rpcCacheExpireTime
+
+  protected val stageEndTimeout = conf.pushStageEndTimeout
+  protected val reducerFileGroupsMap = new ShuffleFileGroups
+  // noinspection UnstableApiUsage
+  protected val getReducerFileGroupRpcCache: Cache[Int, ByteBuffer] = CacheBuilder.newBuilder()
+    .concurrencyLevel(rpcCacheConcurrencyLevel)
+    .expireAfterWrite(rpcCacheExpireTime, TimeUnit.MILLISECONDS)
+    .maximumSize(rpcCacheSize)
+    .build().asInstanceOf[Cache[Int, ByteBuffer]]
 
   def getPartitionType(): PartitionType
 
@@ -65,6 +80,11 @@ abstract class CommitHandler(
   def isStageDataLost(shuffleId: Int): Boolean = false
 
   def setStageEnd(shuffleId: Int): Unit
+
+  /**
+   * return (waitStage isTimeOut, cost)
+   */
+  def waitStageEnd(shuffleId: Int): (Boolean, Long) = (true, 0)
 
   def isPartitionInProcess(shuffleId: Int, partitionId: Int): Boolean = false
 
@@ -132,14 +152,63 @@ abstract class CommitHandler(
       shuffleId: Int,
       recordWorkerFailure: ShuffleFailedWorkers => Unit): Boolean
 
-  def finalPartitionCommit(
+  def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int): Unit = {
+    if (this.isStageDataLost(shuffleId)) {
+      context.reply(
+        GetReducerFileGroupResponse(
+          StatusCode.SHUFFLE_DATA_LOST,
+          new ConcurrentHashMap(),
+          Array.empty))
+    } else {
+      if (context.isInstanceOf[LocalNettyRpcCallContext]) {
+        // This branch is for the UTs
+        context.reply(GetReducerFileGroupResponse(
+          StatusCode.SUCCESS,
+          reducerFileGroupsMap.getOrDefault(shuffleId, new ConcurrentHashMap()),
+          this.getMapperAttempts(shuffleId)))
+      } else {
+        val cachedMsg = getReducerFileGroupRpcCache.get(
+          shuffleId,
+          new Callable[ByteBuffer]() {
+            override def call(): ByteBuffer = {
+              val returnedMsg = GetReducerFileGroupResponse(
+                StatusCode.SUCCESS,
+                reducerFileGroupsMap.getOrDefault(shuffleId, new ConcurrentHashMap()),
+                getMapperAttempts(shuffleId))
+              context.asInstanceOf[RemoteNettyRpcCallContext].nettyEnv.serialize(returnedMsg)
+            }
+          })
+        context.asInstanceOf[RemoteNettyRpcCallContext].callback.onSuccess(cachedMsg)
+      }
+    }
+  }
+
+  def removeExpiredShuffle(shuffleId: Int): Unit = {
+    reducerFileGroupsMap.remove(shuffleId)
+  }
+
+  /**
+   * For reduce partition if shuffle registered and corresponding map finished, reply true.
+   * For map partition would always return false, as one mapper attempt finished don't mean mapper ended.
+   */
+  def isMapperEnded(shuffleId: Int, mapId: Int): Boolean = false
+
+  def getMapperAttempts(shuffleId: Int): Array[Int]
+
+  /**
+   * return (thisMapperAttemptedFinishedSuccessOrNot, allMapperFinishedOrNot)
+   */
+  def finishMapperAttempt(
       shuffleId: Int,
+      mapId: Int,
+      attemptId: Int,
+      numMappers: Int,
       partitionId: Int,
-      recordWorkerFailure: ShuffleFailedWorkers => Unit): Boolean
+      recordWorkerFailure: ShuffleFailedWorkers => Unit): (Boolean, Boolean)
 
-  def removeExpiredShuffle(shuffleId: Int): Unit
-
-  def getShuffleMapperAttempts(shuffleId: Int): Array[Int]
+  def registerShuffle(shuffleId: Int, numMappers: Int): Unit = {
+    reducerFileGroupsMap.put(shuffleId, new ConcurrentHashMap())
+  }
 
   def parallelCommitFiles(
       shuffleId: Int,
@@ -216,7 +285,7 @@ abstract class CommitHandler(
           shuffleId,
           masterIds,
           slaveIds,
-          getShuffleMapperAttempts(shuffleId),
+          getMapperAttempts(shuffleId),
           commitEpoch.incrementAndGet())
         val res = requestCommitFilesWithRetry(worker.endpoint, commitFiles)
 
@@ -236,7 +305,7 @@ abstract class CommitHandler(
           shuffleId,
           masterIds.subList(0, masterIds.size() / 2),
           slaveIds.subList(0, slaveIds.size() / 2),
-          getShuffleMapperAttempts(shuffleId),
+          getMapperAttempts(shuffleId),
           commitEpoch.incrementAndGet())
         val res1 = requestCommitFilesWithRetry(worker.endpoint, commitFiles1)
 
@@ -245,7 +314,7 @@ abstract class CommitHandler(
           shuffleId,
           masterIds.subList(masterIds.size() / 2, masterIds.size()),
           slaveIds.subList(slaveIds.size() / 2, slaveIds.size()),
-          getShuffleMapperAttempts(shuffleId),
+          getMapperAttempts(shuffleId),
           commitEpoch.incrementAndGet())
         val res2 = requestCommitFilesWithRetry(worker.endpoint, commitFiles)
 

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -53,6 +53,7 @@ class ReducePartitionCommitHandler(
   private val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val shuffleMapperAttempts = new ConcurrentHashMap[Int, Array[Int]]()
+  private val stageEndTimeout = conf.pushStageEndTimeout
 
   override def getPartitionType(): PartitionType = {
     PartitionType.REDUCE

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -228,9 +228,7 @@ class ReducePartitionCommitHandler(
       if (!shuffleMapperAttempts.containsKey(shuffleId)) {
         val attempts = new Array[Int](numMappers)
         0 until numMappers foreach (idx => attempts(idx) = -1)
-        shuffleMapperAttempts.synchronized {
-          shuffleMapperAttempts.put(shuffleId, attempts)
-        }
+        shuffleMapperAttempts.put(shuffleId, attempts)
       }
     }
   }
@@ -253,7 +251,7 @@ class ReducePartitionCommitHandler(
   override def waitStageEnd(shuffleId: Int): (Boolean, Long) = {
     var timeout = stageEndTimeout
     val delta = 100
-    while (!this.isStageEnd(shuffleId) && timeout > 0) {
+    while (!isStageEnd(shuffleId) && timeout > 0) {
       Thread.sleep(delta)
       timeout = timeout - delta
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This is the third refactor step according to [CELEBORN-116](https://issues.apache.org/jira/browse/CELEBORN-116).
In this patch we move shuffleMapperAttempts and getReducerFileGroup to CommitManager.

### Why are the changes needed?
MapperAttemptsFinished process and final valid file groups are strongly related to commit，So move them to CommitManager.

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

