### PR TITLE
[CELEBORN-176][BUG] Fix wrong alternative conf of celeborn.worker.flusher.ssd.threads

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1904,7 +1904,7 @@ object CelebornConf extends Logging {
 
   val WORKER_FLUSHER_SSD_THREADS: ConfigEntry[Int] =
     buildConf("celeborn.worker.flusher.ssd.threads")
-      .withAlternative("rss.flusher.hdd.thread.count")
+      .withAlternative("rss.flusher.ssd.thread.count")
       .categories("worker")
       .doc("Flusher's thread count per disk used for write data to SSD disks.")
       .version("0.2.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix wrong conf mapping of  `celeborn.worker.flusher.ssd.threads`


### Why are the changes needed?
Fix bug


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Not need
