### PR TITLE
[CELEBORN-178][BUG] Default registered flag should be false, not null

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -42,7 +42,7 @@ class FetchHandler(val conf: TransportConf) extends BaseMessageHandler with Logg
   var rpcSource: RPCSource = _
   var storageManager: StorageManager = _
   var partitionsSorter: PartitionFilesSorter = _
-  var registered: AtomicBoolean = _
+  var registered: AtomicBoolean = new AtomicBoolean(false)
 
   def init(worker: Worker): Unit = {
     this.workerSource = worker.workerSource

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -50,7 +50,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
   var replicateThreadPool: ThreadPoolExecutor = _
   var unavailablePeers: ConcurrentHashMap[WorkerInfo, Long] = _
   var pushClientFactory: TransportClientFactory = _
-  var registered: AtomicBoolean = _
+  var registered: AtomicBoolean = new AtomicBoolean(false)
   var workerInfo: WorkerInfo = _
   var diskReserveSize: Long = _
   var partitionSplitMinimumSize: Long = _

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -415,22 +415,24 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   def cleanupExpiredShuffleKey(expiredShuffleKeys: util.HashSet[String]): Unit = {
     expiredShuffleKeys.asScala.foreach { shuffleKey =>
       logInfo(s"Cleanup expired shuffle $shuffleKey.")
-      val hdfsInfos = fileInfos.remove(shuffleKey).asScala.filter(_._2.isHdfs)
-      val (appId, shuffleId) = Utils.splitShuffleKey(shuffleKey)
-      disksSnapshot().filter(_.status != DiskStatus.IO_HANG).foreach { diskInfo =>
-        diskInfo.dirs.foreach { dir =>
-          val file = new File(dir, s"$appId/$shuffleId")
-          deleteDirectory(file, diskOperators.get(diskInfo.mountPoint))
+      if (fileInfos.containsKey(shuffleKey)) {
+        val hdfsInfos = fileInfos.remove(shuffleKey).asScala.filter(_._2.isHdfs)
+        val (appId, shuffleId) = Utils.splitShuffleKey(shuffleKey)
+        disksSnapshot().filter(_.status != DiskStatus.IO_HANG).foreach { diskInfo =>
+          diskInfo.dirs.foreach { dir =>
+            val file = new File(dir, s"$appId/$shuffleId")
+            deleteDirectory(file, diskOperators.get(diskInfo.mountPoint))
+          }
         }
-      }
-      hdfsInfos.foreach(item => item._2.deleteAllFiles(StorageManager.hadoopFs))
-      if (!hdfsInfos.isEmpty) {
-        try {
-          StorageManager.hadoopFs.delete(
-            new Path(new Path(hdfsDir, conf.workerWorkingDir), s"$appId/$shuffleId"),
-            true)
-        } catch {
-          case e: Exception => logWarning("Clean expired hdfs shuffle failed.", e)
+        hdfsInfos.foreach(item => item._2.deleteAllFiles(StorageManager.hadoopFs))
+        if (!hdfsInfos.isEmpty) {
+          try {
+            StorageManager.hadoopFs.delete(
+              new Path(new Path(hdfsDir, conf.workerWorkingDir), s"$appId/$shuffleId"),
+              true)
+          } catch {
+            case e: Exception => logWarning("Clean expired hdfs shuffle failed.", e)
+          }
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When restart worker, throw NPE, caused by default registered flag is null before attach value
```
22/12/29 13:28:06,355 WARN [push-server-6-43] TransportChannelHandler: Exception in connection from /10.169.41.1:29528
java.lang.NullPointerException
        at org.apache.celeborn.service.deploy.worker.PushDataHandler.checkRegistered(PushDataHandler.scala:509)
        at org.apache.celeborn.common.network.server.TransportRequestHandler.checkRegistered(TransportRequestHandler.java:82)
        at org.apache.celeborn.common.network.server.TransportRequestHandler.handle(TransportRequestHandler.java:76)
        at org.apache.celeborn.common.network.server.TransportChannelHandler.channelRead(TransportChannelHandler.java:117)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at org.apache.celeborn.common.network.util.TransportFrameDecoder.channelRead(TransportFrameDecoder.java:74)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:748)
```


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

