### PR TITLE
[CELEBORN-179][BUG] Repeat remove expired shuffle throw NPE

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -415,22 +415,24 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   def cleanupExpiredShuffleKey(expiredShuffleKeys: util.HashSet[String]): Unit = {
     expiredShuffleKeys.asScala.foreach { shuffleKey =>
       logInfo(s"Cleanup expired shuffle $shuffleKey.")
-      val hdfsInfos = fileInfos.remove(shuffleKey).asScala.filter(_._2.isHdfs)
-      val (appId, shuffleId) = Utils.splitShuffleKey(shuffleKey)
-      disksSnapshot().filter(_.status != DiskStatus.IO_HANG).foreach { diskInfo =>
-        diskInfo.dirs.foreach { dir =>
-          val file = new File(dir, s"$appId/$shuffleId")
-          deleteDirectory(file, diskOperators.get(diskInfo.mountPoint))
+      if (fileInfos.containsKey(shuffleKey)) {
+        val hdfsInfos = fileInfos.remove(shuffleKey).asScala.filter(_._2.isHdfs)
+        val (appId, shuffleId) = Utils.splitShuffleKey(shuffleKey)
+        disksSnapshot().filter(_.status != DiskStatus.IO_HANG).foreach { diskInfo =>
+          diskInfo.dirs.foreach { dir =>
+            val file = new File(dir, s"$appId/$shuffleId")
+            deleteDirectory(file, diskOperators.get(diskInfo.mountPoint))
+          }
         }
-      }
-      hdfsInfos.foreach(item => item._2.deleteAllFiles(StorageManager.hadoopFs))
-      if (!hdfsInfos.isEmpty) {
-        try {
-          StorageManager.hadoopFs.delete(
-            new Path(new Path(hdfsDir, conf.workerWorkingDir), s"$appId/$shuffleId"),
-            true)
-        } catch {
-          case e: Exception => logWarning("Clean expired hdfs shuffle failed.", e)
+        hdfsInfos.foreach(item => item._2.deleteAllFiles(StorageManager.hadoopFs))
+        if (!hdfsInfos.isEmpty) {
+          try {
+            StorageManager.hadoopFs.delete(
+              new Path(new Path(hdfsDir, conf.workerWorkingDir), s"$appId/$shuffleId"),
+              true)
+          } catch {
+            case e: Exception => logWarning("Clean expired hdfs shuffle failed.", e)
+          }
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Repeat remove expired shuffle throw NPE

```


22/12/29 12:54:06,145 INFO [Cleaner] Worker: Cleaned up expired shuffle application_1670989463623_3306414-0
22/12/29 12:54:06,146 INFO [Cleaner] StorageManager: Cleanup expired shuffle application_1670989463623_3306414-0.
22/12/29 12:54:06,152 INFO [Cleaner] Worker: Cleaned up expired shuffle application_1670989463623_3306414-0
22/12/29 12:54:06,152 INFO [Cleaner] StorageManager: Cleanup expired shuffle application_1670989463623_3306414-0.
22/12/29 12:54:06,153 DEBUG [Disk-cleaner-/mnt/disk/0-0] StorageManager: Deleted expired shuffle file /mnt/disk/0/hadoop/rss-worker/shuffle_data/application_1670989463623_3306414/0.
22/12/29 12:54:06,153 ERROR [Cleaner] Worker: Cleanup failed
java.lang.NullPointerException
	at org.apache.celeborn.service.deploy.worker.storage.StorageManager.$anonfun$cleanupExpiredShuffleKey$1(StorageManager.scala:393)
	at org.apache.celeborn.service.deploy.worker.storage.StorageManager.$anonfun$cleanupExpiredShuffleKey$1$adapted(StorageManager.scala:391)
	at scala.collection.Iterator.foreach(Iterator.scala:941)
	at scala.collection.Iterator.foreach$(Iterator.scala:941)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at org.apache.celeborn.service.deploy.worker.storage.StorageManager.cleanupExpiredShuffleKey(StorageManager.scala:391)
	at org.apache.celeborn.service.deploy.worker.Worker.org$apache$celeborn$service$deploy$worker$Worker$$cleanup(Worker.scala:434)
	at org.apache.celeborn.service.deploy.worker.Worker$$anon$3.run(Worker.scala:316)
22/12/29 12:54:06,153 INFO [Cleaner] Worker: Cleaned up expired shuffle application_1670989463623_3306414-0
22/12/29 12:54:06,153 INFO [Cleaner] StorageManager: Cleanup expired shuffle application_1670989463623_3306414-0.
22/12/29 12:54:06,154 ERROR [Cleaner] Worker: Cleanup failed
java.lang.NullPointerException
	at org.apache.celeborn.service.deploy.worker.storage.StorageManager.$anonfun$cleanupExpiredShuffleKey$1(StorageManager.scala:393)
	at org.apache.celeborn.service.deploy.worker.storage.StorageManager.$anonfun$cleanupExpiredShuffleKey$1$adapted(StorageManager.scala:391)
	at scala.collection.Iterator.foreach(Iterator.scala:941)
	at scala.collection.Iterator.foreach$(Iterator.scala:941)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at org.apache.celeborn.service.deploy.worker.storage.StorageManager.cleanupExpiredShuffleKey(StorageManager.scala:391)
	at org.apache.celeborn.service.deploy.worker.Worker.org$apache$celeborn$service$deploy$worker$Worker$$cleanup(Worker.scala:434)
	at org.apache.celeborn.service.deploy.worker.Worker$$anon$3.run(Worker.scala:316)
```


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

