### PR TITLE
[CELEBORN-182][BUG] StorageManager should not delete shuffle file when enable graceful shutdown

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -579,7 +579,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       }
     }
     if (null != diskOperators) {
-      cleanupExpiredShuffleKey(shuffleKeySet())
+      if (!conf.workerGracefulShutdown) {
+        cleanupExpiredShuffleKey(shuffleKeySet())
+      }
       ThreadUtils.parmap(
         diskOperators.asScala.toMap,
         "ShutdownDiskOperators",


### PR DESCRIPTION
### What changes were proposed in this pull request?
StorageManager should not delete shuffle file when enable graceful shutdown


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

