### PR TITLE
[CELEBORN-168][FEATURE] Add disk usage related metrics for Worker

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -91,4 +91,8 @@ object WorkerSource {
   val DiskBuffer = "DiskBuffer"
   val PausePushDataCount = "PausePushData"
   val PausePushDataAndReplicateCount = "PausePushDataAndReplicate"
+
+  // local device
+  val DeviceOSFreeCapacity = "DeviceOSFreeCapacity"
+  val DeviceOSTotalCapacity = "DeviceOSTotalCapacity"
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -95,4 +95,6 @@ object WorkerSource {
   // local device
   val DeviceOSFreeCapacity = "DeviceOSFreeCapacity"
   val DeviceOSTotalCapacity = "DeviceOSTotalCapacity"
+  val DeviceCelebornFreeCapacity = "DeviceCelebornFreeCapacity"
+  val DeviceCelebornTotalCapacity = "DeviceCelebornTotalCapacity"
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -33,7 +33,6 @@ import org.apache.celeborn.common.metrics.source.AbstractSource
 import org.apache.celeborn.common.util.{ThreadUtils, Utils}
 import org.apache.celeborn.common.util.Utils._
 import org.apache.celeborn.service.deploy.worker.WorkerSource
-import org.apache.celeborn.service.deploy.worker.storage.DeviceMonitor.deviceCheckThreadPool
 
 trait DeviceMonitor {
   def startCheck() {}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -203,6 +203,10 @@ object DeviceMonitor {
     }
   }
 
+  def getDiskUsageInfos(diskInfo: DiskInfo): Array[String] = {
+    runCommand(s"df -B 1G ${diskInfo.mountPoint}").trim.split("[ \t]+")
+  }
+
   /**
    * check if the disk is high usage
    *
@@ -212,7 +216,7 @@ object DeviceMonitor {
    */
   def highDiskUsage(conf: CelebornConf, diskInfo: DiskInfo): Boolean = {
     tryWithTimeoutAndCallback({
-      val usage = runCommand(s"df -B 1G ${diskInfo.mountPoint}").trim.split("[ \t]+")
+      val usage = getDiskUsageInfos(diskInfo)
       val totalSpace = usage(usage.length - 5)
       val freeSpace = usage(usage.length - 3)
       val used_percent = usage(usage.length - 2)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -32,6 +32,8 @@ import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus}
 import org.apache.celeborn.common.metrics.source.AbstractSource
 import org.apache.celeborn.common.util.{ThreadUtils, Utils}
 import org.apache.celeborn.common.util.Utils._
+import org.apache.celeborn.service.deploy.worker.WorkerSource
+import org.apache.celeborn.service.deploy.worker.storage.DeviceMonitor.deviceCheckThreadPool
 
 trait DeviceMonitor {
   def startCheck() {}
@@ -78,6 +80,26 @@ class LocalDeviceMonitor(
       observedDevice.addObserver(observer)
       observedDevices.put(entry._2, observedDevice)
     })
+    diskInfos
+      .asScala
+      .values
+      .toList
+      .groupBy(_.deviceInfo)
+      .foreach { case (deviceInfo: DeviceInfo, diskInfos: List[DiskInfo]) =>
+        def usage = DeviceMonitor.getDiskUsageInfos(diskInfos.head)
+        workerSource.addGauge(
+          s"${WorkerSource.DeviceOSTotalCapacity}_${deviceInfo.name}",
+          _ => usage(usage.length - 5))
+        workerSource.addGauge(
+          s"${WorkerSource.DeviceOSFreeCapacity}_${deviceInfo.name}",
+          _ => usage(usage.length - 3))
+        workerSource.addGauge(
+          s"${WorkerSource.DeviceCelebornTotalCapacity}_${deviceInfo.name}",
+          _ => diskInfos.map(_.configuredUsableSpace).sum)
+        workerSource.addGauge(
+          s"${WorkerSource.DeviceCelebornFreeCapacity}_${deviceInfo.name}",
+          _ => diskInfos.map(_.actualUsableSpace).sum)
+      }
   }
 
   override def startCheck(): Unit = {
@@ -204,6 +226,7 @@ object DeviceMonitor {
   }
 
   def getDiskUsageInfos(diskInfo: DiskInfo): Array[String] = {
+    // TODO: will it be more flexible if return as Bytes?
     runCommand(s"df -B 1G ${diskInfo.mountPoint}").trim.split("[ \t]+")
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -45,7 +45,6 @@ import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMod
 import org.apache.celeborn.common.quota.ResourceConsumption
 import org.apache.celeborn.common.util.{PbSerDeUtils, ThreadUtils, Utils}
 import org.apache.celeborn.service.deploy.worker._
-import org.apache.celeborn.service.deploy.worker.storage.DeviceMonitor.deviceCheckThreadPool
 import org.apache.celeborn.service.deploy.worker.storage.StorageManager.hadoopFs
 
 final private[worker] class StorageManager(conf: CelebornConf, workerSource: AbstractSource)
@@ -73,24 +72,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       disks.asScala.toList
     }
   }
-
-  disksSnapshot()
-    .groupBy(_.deviceInfo)
-    .foreach { case (deviceInfo: DeviceInfo, diskInfos: List[DiskInfo]) =>
-      val dumbArray = Array("none", "0", "0", "0", "0%", "none")
-      def usage: Array[String] =
-        Utils.tryWithTimeoutAndCallback(DeviceMonitor.getDiskUsageInfos(diskInfos.head))(dumbArray)(
-          deviceCheckThreadPool,
-          conf.workerDeviceStatusCheckTimeout,
-          s"Disk: ${diskInfos.head.mountPoint} Usage Check Timeout")
-
-      workerSource.addGauge(
-        s"${WorkerSource.DeviceOSTotalCapacity}_${deviceInfo.name}",
-        _ => usage(usage.length - 5))
-      workerSource.addGauge(
-        s"${WorkerSource.DeviceOSFreeCapacity}_${deviceInfo.name}",
-        _ => usage(usage.length - 3))
-    }
 
   def healthyWorkingDirs(): List[File] =
     disksSnapshot().filter(_.status == DiskStatus.HEALTHY).flatMap(_.dirs)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add disk usage related metrics for Worker.
BTW, shall we modify the PromServlet to support add customized label for Prom metrics, such as `device_type` or `mount_point` for disk related metrics?
And do we need to add metrics to monitor the hdfs capacity usage of each Worker, not sure if it is necessary.

### Why are the changes needed?
Better display current OS device's (not disk's) capacity of each Worker on monitor.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UTs

cc: @AngersZhuuuu 