### PR TITLE
[CELEBORN-185][SPARK] Can't release shuffle data if rss fallback to nss

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -172,7 +172,7 @@ public class RssShuffleManager implements ShuffleManager {
               "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());
         }
       } else {
-        sortShuffleIds.add(handle.shuffleId);
+        sortShuffleIds.add(handle.shuffleId());
         return sortShuffleManager().getWriter(handle, mapId, context);
       }
     } catch (IOException e) {

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -172,7 +172,7 @@ public class RssShuffleManager implements ShuffleManager {
               "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());
         }
       } else {
-        sortShuffleIds.add(shuffleId);
+        sortShuffleIds.add(handle.shuffleId);
         return sortShuffleManager().getWriter(handle, mapId, context);
       }
     } catch (IOException e) {

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -172,6 +172,7 @@ public class RssShuffleManager implements ShuffleManager {
               "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());
         }
       } else {
+        sortShuffleIds.add(shuffleId);
         return sortShuffleManager().getWriter(handle, mapId, context);
       }
     } catch (IOException e) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -170,7 +170,7 @@ public class RssShuffleManager implements ShuffleManager {
               "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());
         }
       } else {
-        sortShuffleIds.add(handle.shuffleId);
+        sortShuffleIds.add(handle.shuffleId());
         return sortShuffleManager().getWriter(handle, mapId, context, metrics);
       }
     } catch (IOException e) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -170,7 +170,7 @@ public class RssShuffleManager implements ShuffleManager {
               "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());
         }
       } else {
-        sortShuffleIds.add(shuffleId);
+        sortShuffleIds.add(handle.shuffleId);
         return sortShuffleManager().getWriter(handle, mapId, context, metrics);
       }
     } catch (IOException e) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -170,6 +170,7 @@ public class RssShuffleManager implements ShuffleManager {
               "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());
         }
       } else {
+        sortShuffleIds.add(shuffleId);
         return sortShuffleManager().getWriter(handle, mapId, context, metrics);
       }
     } catch (IOException e) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
add shuffle id to sortShuffleIds while getWriter if rss fallback to native shuffle service


### Why are the changes needed?
if rss fallback to native shuffle service, RssShuffleManager.unregisterShuffle won't call SortShuffleManager to release shuffle data on executor size


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

