### PR TITLE
[CELEBORN-189][IMPROVEMENT] PushDataFailedSlave should add slave worker to blacklist

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -514,7 +514,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       shuffleId: Int,
       oldPartition: PartitionLocation,
       cause: StatusCode): Unit = {
-
     val failedWorker = new ShuffleFailedWorkers()
 
     def blacklistPartitionWorker(

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -526,7 +526,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
               (StatusCode.PUSH_DATA_FAIL_MASTER, System.currentTimeMillis()))
           }
         case StatusCode.PUSH_DATA_FAIL_SLAVE
-            if oldPartition.getPeer != null && conf.workerExcludedSlaveEnabled =>
+            if oldPartition.getPeer != null && conf.blacklistSlaveEnabled =>
           val tmpWorker = oldPartition.getPeer.getWorker
           val worker = workerSnapshots(shuffleId).keySet().asScala.find(_.equals(tmpWorker))
           if (worker.isDefined) {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -516,12 +516,27 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       cause: StatusCode): Unit = {
     // only blacklist if cause is PushDataFailMain
     val failedWorker = new ShuffleFailedWorkers()
-    if (cause == StatusCode.PUSH_DATA_FAIL_MASTER && oldPartition != null) {
-      val tmpWorker = oldPartition.getWorker
-      val worker = workerSnapshots(shuffleId).keySet().asScala
-        .find(_.equals(tmpWorker))
-      if (worker.isDefined) {
-        failedWorker.put(worker.get, (StatusCode.PUSH_DATA_FAIL_MASTER, System.currentTimeMillis()))
+    if (oldPartition != null) {
+      cause match {
+        case StatusCode.PUSH_DATA_FAIL_MASTER =>
+          val tmpWorker = oldPartition.getWorker
+          val worker = workerSnapshots(shuffleId).keySet().asScala.find(_.equals(tmpWorker))
+          if (worker.isDefined) {
+            failedWorker.put(
+              worker.get,
+              (StatusCode.PUSH_DATA_FAIL_MASTER, System.currentTimeMillis()))
+          }
+        case StatusCode.PUSH_DATA_FAIL_SLAVE
+            if oldPartition.getPeer != null && conf.workerExcludedSlaveEnabled =>
+          val tmpWorker = oldPartition.getPeer.getWorker
+          val worker = workerSnapshots(shuffleId).keySet().asScala.find(_.equals(tmpWorker))
+          if (worker.isDefined) {
+            failedWorker.put(
+              worker.get,
+              (StatusCode.PUSH_DATA_FAIL_SLAVE, System.currentTimeMillis()))
+          }
+        case _ =>
+
       }
     }
     if (!failedWorker.isEmpty) {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -514,7 +514,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       shuffleId: Int,
       oldPartition: PartitionLocation,
       cause: StatusCode): Unit = {
-    // only blacklist if cause is PushDataFailMain
     val failedWorker = new ShuffleFailedWorkers()
     if (oldPartition != null) {
       cause match {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -529,7 +529,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def shuffleExpiredCheckIntervalMs: Long = get(SHUFFLE_EXPIRED_CHECK_INTERVAL)
   def workerExcludedCheckIntervalMs: Long = get(WORKER_EXCLUDED_INTERVAL)
   def workerExcludedExpireTimeout: Long = get(WORKER_EXCLUDED_EXPIRE_TIMEOUT)
-  def workerExcludedSlaveEnabled: Boolean = get(WORKER_EXCLUDE_SLAVE_ENABLED)
+  def blacklistSlaveEnabled: Boolean = get(BLACKLIST_SLAVE_ENABLED)
   def shuffleRangeReadFilterEnabled: Boolean = get(SHUFFLE_RANGE_READ_FILTER_ENABLED)
   def shufflePartitionType: PartitionType = PartitionType.valueOf(get(SHUFFLE_PARTITION_TYPE))
   def requestCommitFilesMaxRetries: Int = get(COMMIT_FILE_REQUEST_MAX_RETRY)
@@ -1355,8 +1355,8 @@ object CelebornConf extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("600s")
 
-  val WORKER_EXCLUDE_SLAVE_ENABLED: ConfigEntry[Boolean] =
-    buildConf("celeborn.worker.excluded.slave.enabled")
+  val BLACKLIST_SLAVE_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.client.blacklistSlave.enabled")
       .categories("client")
       .version("0.3.0")
       .doc("When true, Celeborn will add partition's peer worker into blacklist " +

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -529,6 +529,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def shuffleExpiredCheckIntervalMs: Long = get(SHUFFLE_EXPIRED_CHECK_INTERVAL)
   def workerExcludedCheckIntervalMs: Long = get(WORKER_EXCLUDED_INTERVAL)
   def workerExcludedExpireTimeout: Long = get(WORKER_EXCLUDED_EXPIRE_TIMEOUT)
+  def workerExcludedSlaveEnabled: Boolean = get(WORKER_EXCLUDE_SLAVE_ENABLED)
   def shuffleRangeReadFilterEnabled: Boolean = get(SHUFFLE_RANGE_READ_FILTER_ENABLED)
   def shufflePartitionType: PartitionType = PartitionType.valueOf(get(SHUFFLE_PARTITION_TYPE))
   def requestCommitFilesMaxRetries: Int = get(COMMIT_FILE_REQUEST_MAX_RETRY)
@@ -1353,6 +1354,15 @@ object CelebornConf extends Logging {
       .doc("Timeout time for LifecycleManager to clear reserved excluded worker.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("600s")
+
+  val WORKER_EXCLUDE_SLAVE_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.worker.excluded.slave.enabled")
+      .categories("client")
+      .version("0.3.0")
+      .doc("When true, Celeborn will add partition's peer worker into blacklist " +
+        "when push data to slave failed.")
+      .booleanConf
+      .createWithDefault(true)
 
   val SHUFFLE_CHUCK_SIZE: ConfigEntry[Long] =
     buildConf("celeborn.shuffle.chuck.size")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -73,4 +73,5 @@ license: |
 | celeborn.test.retryCommitFiles | false | Fail commitFile request for test | 0.2.0 | 
 | celeborn.worker.excluded.checkInterval | 30s | Interval for client to refresh excluded worker list. | 0.2.0 | 
 | celeborn.worker.excluded.expireTimeout | 600s | Timeout time for LifecycleManager to clear reserved excluded worker. | 0.2.0 | 
+| celeborn.worker.excluded.slave.enabled | true | When true, Celeborn will add partition's peer worker into blacklist when push data to slave failed. | 0.3.0 | 
 <!--end-include-->

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -20,6 +20,7 @@ license: |
 | Key | Default | Description | Since |
 | --- | ------- | ----------- | ----- |
 | celeborn.application.heartbeatInterval | 10s | Interval for client to send heartbeat message to master. | 0.2.0 | 
+| celeborn.client.blacklistSlave.enabled | true | When true, Celeborn will add partition's peer worker into blacklist when push data to slave failed. | 0.3.0 | 
 | celeborn.client.maxRetries | 15 | Max retry times for client to connect master endpoint | 0.2.0 | 
 | celeborn.fetch.maxReqsInFlight | 3 | Amount of in-flight chunk fetch request. | 0.2.0 | 
 | celeborn.fetch.maxRetries | 3 | Max retries of fetch chunk | 0.2.0 | 
@@ -73,5 +74,4 @@ license: |
 | celeborn.test.retryCommitFiles | false | Fail commitFile request for test | 0.2.0 | 
 | celeborn.worker.excluded.checkInterval | 30s | Interval for client to refresh excluded worker list. | 0.2.0 | 
 | celeborn.worker.excluded.expireTimeout | 600s | Timeout time for LifecycleManager to clear reserved excluded worker. | 0.2.0 | 
-| celeborn.worker.excluded.slave.enabled | true | When true, Celeborn will add partition's peer worker into blacklist when push data to slave failed. | 0.3.0 | 
 <!--end-include-->


### PR DESCRIPTION
### What changes were proposed in this pull request?
In our cluster, we meet a case that some worker is stuck, but if it's a slave partition, celeborn won't add it to blacklist, when revive, it may be offered as another partition, cause push data stuck again.

But for some small cluster, this policy is too strict, so I add a configuration to control if we should add peer partition into blacklist.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

