### PR TITLE
[CELEBORN-191][BUG] ShuffleClient registerShuffle return RESERVE_SLOTS_FAILED should also been print out

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -336,6 +336,11 @@ public class ShuffleClientImpl extends ShuffleClient {
               "LifecycleManager request slots return {}, retry again, remain retry times {}",
               StatusCode.SLOT_NOT_AVAILABLE,
               numRetries - 1);
+        } else if (StatusCode.RESERVE_SLOTS_FAILED.equals(respStatus)) {
+          logger.error(
+              "LifecycleManager request slots return {}, retry again, remain retry times {}",
+              StatusCode.RESERVE_SLOTS_FAILED,
+              numRetries - 1);
         } else {
           logger.error(
               "LifecycleManager request slots return {}, retry again, remain retry times {}",


### PR DESCRIPTION
### What changes were proposed in this pull request?
When ShuffleClient print put why registerShuffle failed, miss RESERVE_SLOTS_FAILED


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

