### PR TITLE
[CELEBORN-168][FOLLOWUP] Device metrics should use long value and add size unit in metric name

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -93,8 +93,8 @@ object WorkerSource {
   val PausePushDataAndReplicateCount = "PausePushDataAndReplicate"
 
   // local device
-  val DeviceOSFreeCapacity = "DeviceOSFreeCapacity"
-  val DeviceOSTotalCapacity = "DeviceOSTotalCapacity"
-  val DeviceCelebornFreeCapacity = "DeviceCelebornFreeCapacity"
-  val DeviceCelebornTotalCapacity = "DeviceCelebornTotalCapacity"
+  val DeviceOSFreeCapacity = "DeviceOSFreeCapacity(GB)"
+  val DeviceOSTotalCapacity = "DeviceOSTotalCapacity(GB)"
+  val DeviceCelebornFreeCapacity = "DeviceCelebornFreeCapacity(GB)"
+  val DeviceCelebornTotalCapacity = "DeviceCelebornTotalCapacity(GB)"
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -95,6 +95,6 @@ object WorkerSource {
   // local device
   val DeviceOSFreeCapacity = "DeviceOSFreeCapacity(GB)"
   val DeviceOSTotalCapacity = "DeviceOSTotalCapacity(GB)"
-  val DeviceCelebornFreeCapacity = "DeviceCelebornFreeCapacity(GB)"
-  val DeviceCelebornTotalCapacity = "DeviceCelebornTotalCapacity(GB)"
+  val DeviceCelebornFreeCapacity = "DeviceCelebornFreeCapacity(B)"
+  val DeviceCelebornTotalCapacity = "DeviceCelebornTotalCapacity(B)"
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -88,10 +88,10 @@ class LocalDeviceMonitor(
         def usage = DeviceMonitor.getDiskUsageInfos(diskInfos.head)
         workerSource.addGauge(
           s"${WorkerSource.DeviceOSTotalCapacity}_${deviceInfo.name}",
-          _ => usage(usage.length - 5))
+          _ => usage(usage.length - 5).toLong)
         workerSource.addGauge(
           s"${WorkerSource.DeviceOSFreeCapacity}_${deviceInfo.name}",
-          _ => usage(usage.length - 3))
+          _ => usage(usage.length - 3).toLong)
         workerSource.addGauge(
           s"${WorkerSource.DeviceCelebornTotalCapacity}_${deviceInfo.name}",
           _ => diskInfos.map(_.configuredUsableSpace).sum)

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
@@ -396,14 +396,14 @@ class DeviceMonitorSuite extends AnyFunSuite {
         _.name.startsWith(WorkerSource.DeviceCelebornFreeCapacity)).sortBy(_.name)
 
       assertEquals(s"${WorkerSource.DeviceOSTotalCapacity}_vda", metrics1.head.name)
-      assertEquals("1300", metrics1.head.gauge.getValue)
+      assertEquals(1300L, metrics1.head.gauge.getValue)
       assertEquals(s"${WorkerSource.DeviceOSTotalCapacity}_vdb", metrics1.last.name)
-      assertEquals("1800", metrics1.last.gauge.getValue)
+      assertEquals(1800L, metrics1.last.gauge.getValue)
 
       assertEquals(s"${WorkerSource.DeviceOSFreeCapacity}_vda", metrics2.head.name)
-      assertEquals("1205", metrics2.head.gauge.getValue)
+      assertEquals(1205L, metrics2.head.gauge.getValue)
       assertEquals(s"${WorkerSource.DeviceOSFreeCapacity}_vdb", metrics2.last.name)
-      assertEquals("1709", metrics2.last.gauge.getValue)
+      assertEquals(1709L, metrics2.last.gauge.getValue)
 
       assertEquals(s"${WorkerSource.DeviceCelebornTotalCapacity}_vda", metrics3.head.name)
       assertEquals(Int.MaxValue.toLong * 2, metrics3.head.gauge.getValue)
@@ -418,7 +418,7 @@ class DeviceMonitorSuite extends AnyFunSuite {
 
       // test if metrics will change when disk usage change, here
       when(Utils.runCommand(dfBCmd1)).thenReturn(dfBOut6)
-      assertEquals("1178", metrics2.head.gauge.getValue)
+      assertEquals(1178L, metrics2.head.gauge.getValue)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Device metrics should use long value and add size unit in metric name


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

