### PR TITLE
[CELEBORN-197][Flink] In mappartition new client should wait until old client has sent out all the messages

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -132,6 +132,8 @@ public class ShuffleClientImpl extends ShuffleClient {
   // key: shuffleId
   private final Map<Integer, ReduceFileGroups> reduceFileGroupsMap = new ConcurrentHashMap<>();
 
+  private TransportClient currentClient;
+
   public ShuffleClientImpl(CelebornConf conf, UserIdentifier userIdentifier) {
     super();
     this.conf = conf;
@@ -1460,8 +1462,7 @@ public class ShuffleClientImpl extends ShuffleClient {
         };
     // do push data
     try {
-      TransportClient client =
-          dataClientFactory.createClient(location.getHost(), location.getPushPort(), partitionId);
+      TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
       ChannelFuture future = client.pushData(pushData, callback);
       pushState.pushStarted(nextBatchId, future, callback);
     } catch (Exception e) {
@@ -1469,6 +1470,23 @@ public class ShuffleClientImpl extends ShuffleClient {
       callback.onFailure(new Exception(getPushDataFailCause(e.getMessage()).toString(), e));
     }
     return totalLength;
+  }
+
+  private TransportClient createClientWaitingInFlightRequest(
+      PartitionLocation location, String mapKey, PushState pushState)
+      throws IOException, InterruptedException {
+    TransportClient client =
+        dataClientFactory.createClient(
+            location.getHost(), location.getPushPort(), location.getId());
+    if (currentClient != client) {
+      // makesure that messages have been sent by old client, in order to keep receiving data
+      // orderly
+      if (currentClient != null) {
+        limitMaxInFlight(mapKey, pushState, 0);
+      }
+      currentClient = client;
+    }
+    return currentClient;
   }
 
   @Override
@@ -1481,10 +1499,13 @@ public class ShuffleClientImpl extends ShuffleClient {
       int bufferSize,
       PartitionLocation location)
       throws IOException {
+    final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+    final PushState pushState = pushStates.computeIfAbsent(mapKey, (s) -> new PushState(conf));
     sendMessageInternal(
         shuffleId,
         mapId,
         attemptId,
+        pushState,
         () -> {
           String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
           logger.info(
@@ -1493,8 +1514,7 @@ public class ShuffleClientImpl extends ShuffleClient {
               attemptId,
               location.getUniqueId());
           logger.debug("pushDataHandShake location:{}", location.toString());
-          TransportClient client =
-              dataClientFactory.createClient(location.getHost(), location.getPushPort());
+          TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
           PushDataHandShake handShake =
               new PushDataHandShake(
                   MASTER_MODE,
@@ -1518,10 +1538,13 @@ public class ShuffleClientImpl extends ShuffleClient {
       int currentRegionIdx,
       boolean isBroadcast)
       throws IOException {
+    final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+    final PushState pushState = pushStates.computeIfAbsent(mapKey, (s) -> new PushState(conf));
     return sendMessageInternal(
         shuffleId,
         mapId,
         attemptId,
+        pushState,
         () -> {
           String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
           logger.info(
@@ -1530,8 +1553,7 @@ public class ShuffleClientImpl extends ShuffleClient {
               attemptId,
               location.getUniqueId());
           logger.debug("regionStart location:{}", location.toString());
-          TransportClient client =
-              dataClientFactory.createClient(location.getHost(), location.getPushPort());
+          TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
           RegionStart regionStart =
               new RegionStart(
                   MASTER_MODE,
@@ -1563,7 +1585,6 @@ public class ShuffleClientImpl extends ShuffleClient {
             if (StatusCode.SUCCESS.equals(respStatus)) {
               return Optional.of(PbSerDeUtils.fromPbPartitionLocation(response.getLocation()));
             } else if (StatusCode.MAP_ENDED.equals(respStatus)) {
-              final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
               mapperEndMap
                   .computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet())
                   .add(mapKey);
@@ -1586,10 +1607,13 @@ public class ShuffleClientImpl extends ShuffleClient {
   public void regionFinish(
       String applicationId, int shuffleId, int mapId, int attemptId, PartitionLocation location)
       throws IOException {
+    final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
+    final PushState pushState = pushStates.computeIfAbsent(mapKey, (s) -> new PushState(conf));
     sendMessageInternal(
         shuffleId,
         mapId,
         attemptId,
+        pushState,
         () -> {
           final String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
           logger.info(
@@ -1598,8 +1622,7 @@ public class ShuffleClientImpl extends ShuffleClient {
               attemptId,
               location.getUniqueId());
           logger.debug("regionFinish location:{}", location.toString());
-          TransportClient client =
-              dataClientFactory.createClient(location.getHost(), location.getPushPort());
+          TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
           RegionFinish regionFinish =
               new RegionFinish(MASTER_MODE, shuffleKey, location.getUniqueId(), attemptId);
           client.sendRpcSync(regionFinish.toByteBuffer(), conf.pushDataTimeoutMs());
@@ -1608,9 +1631,12 @@ public class ShuffleClientImpl extends ShuffleClient {
   }
 
   private <R> R sendMessageInternal(
-      int shuffleId, int mapId, int attemptId, ThrowingExceptionSupplier<R, Exception> supplier)
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      PushState pushState,
+      ThrowingExceptionSupplier<R, Exception> supplier)
       throws IOException {
-    PushState pushState = null;
     int batchId = 0;
     try {
       // mapKey
@@ -1624,7 +1650,6 @@ public class ShuffleClientImpl extends ShuffleClient {
             attemptId);
         return null;
       }
-      pushState = pushStates.computeIfAbsent(mapKey, (s) -> new PushState(conf));
       // force data has been send
       limitMaxInFlight(mapKey, pushState, 0);
 


### PR DESCRIPTION
… while sending messages

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Currently, While Sending MapPartitiion's Message like PushData/HandShake/RegionStart/RegionFinish, transportClient is got from clientPool which may create new transportClient.
In MapPartition, the key important thing is to keep the data orderly. 
so if new transportClient is created, it should wait that old transportClient has sent out all the messages before sending message by current transportClient.



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?

@waitinfuture @FMX @RexXiong 

### How was this patch tested?

