### PR TITLE
[CELEBORN-198] Fix the wrong configuration path of plugin protobuf-maven-plugin and …

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -144,6 +144,12 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${maven.plugin.protobuf.version}</version>
         <extensions>true</extensions>
+        <configuration>
+          <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+        </configuration>
         <executions>
           <execution>
             <id>compile-protoc</id>
@@ -151,12 +157,6 @@
               <goal>compile</goal>
               <goal>compile-custom</goal>
             </goals>
-            <configuration>
-              <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
-              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
-              <pluginId>grpc-java</pluginId>
-              <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -102,6 +102,12 @@
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${maven.plugin.protobuf.version}</version>
+        <configuration>
+          <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+        </configuration>
         <extensions>true</extensions>
         <executions>
           <execution>
@@ -110,12 +116,6 @@
               <goal>compile</goal>
               <goal>compile-custom</goal>
             </goals>
-            <configuration>
-              <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
-              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
-              <pluginId>grpc-java</pluginId>
-              <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <maven.plugin.jacoco.version>0.8.7</maven.plugin.jacoco.version>
     <maven.plugin.jar.version>3.0.2</maven.plugin.jar.version>
     <maven.plugin.os.version>1.7.0</maven.plugin.os.version>
-    <maven.plugin.protobuf.version>0.5.1</maven.plugin.protobuf.version>
+    <maven.plugin.protobuf.version>0.6.1</maven.plugin.protobuf.version>
     <maven.plugin.rat.version>0.13</maven.plugin.rat.version>
     <maven.plugin.scala.version>4.7.2</maven.plugin.scala.version>
     <maven.plugin.scalatest.version>2.1.0</maven.plugin.scalatest.version>


### PR DESCRIPTION
…bump it from 0.5.1 to version 0.6.1

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

this PR 

1. correct the configuration path of plugin protobuf-maven-plugin to make it effective
2. bump protobuf-maven-plugin from version 0.5.1 to version 0.6.1


### Why are the changes needed?

before this PR, an error is thrown when the user generates the protobuf related source code by running 

```
mvn protobuf:compile -pl common
```

Output:
```

[WARNING] No 'protocExecutable' parameter is configured, using the default: 'protoc'
[INFO] Compiling 1 proto file(s) to /Users/fchen/Project/bigdata/celeborn/common/target/generated-sources/protobuf/java
[WARNING] [PROTOC] Unable to invoke protoc, will retry 2 time(s)
...

Caused by: java.io.IOException: Cannot run program "protoc": error=2, No such file or directory
    at java.lang.ProcessBuilder.start (ProcessBuilder.java:1048)
    at java.lang.Runtime.exec (Runtime.java:620)
```


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

tested locally.
