### PR TITLE
[CELEBORN-201] Separate partitionLocationInfo in LifecycleManager and worker

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -293,9 +293,9 @@ class ChangePartitionManager(
           lifecycleManager.workerSnapshots(shuffleId).asScala
             .get(workInfo)
             .foreach { partitionLocationInfo =>
-              partitionLocationInfo.addMasterPartitions(shuffleId.toString, masterLocations)
+              partitionLocationInfo.addMasterPartitions(masterLocations)
               lifecycleManager.updateLatestPartitionLocations(shuffleId, masterLocations)
-              partitionLocationInfo.addSlavePartitions(shuffleId.toString, slaveLocations)
+              partitionLocationInfo.addSlavePartitions(slaveLocations)
             }
           // partition location can be null when call reserveSlotsWithRetry().
           val locations = (masterLocations.asScala ++ slaveLocations.asScala.map(_.getPeer))

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -32,7 +32,7 @@ import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, Shu
 import org.apache.celeborn.client.ShuffleCommittedInfo
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{PartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.meta.{ShufflePartitionLocationInfo, WorkerInfo}
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType}
 import org.apache.celeborn.common.protocol.message.ControlMessages.{CommitFiles, CommitFilesResponse, GetReducerFileGroupResponse}
 import org.apache.celeborn.common.protocol.message.StatusCode
@@ -211,7 +211,7 @@ abstract class CommitHandler(
 
   def parallelCommitFiles(
       shuffleId: Int,
-      allocatedWorkers: util.Map[WorkerInfo, PartitionLocationInfo],
+      allocatedWorkers: util.Map[WorkerInfo, ShufflePartitionLocationInfo],
       partitionIdOpt: Option[Int] = None): CommitResult = {
     val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
     val masterPartMap = new ConcurrentHashMap[String, PartitionLocation]
@@ -223,42 +223,41 @@ abstract class CommitHandler(
       allocatedWorkers.asScala.to,
       "CommitFiles",
       parallelism) { case (worker, partitionLocationInfo) =>
-      if (partitionLocationInfo.containsShuffle(shuffleId.toString)) {
-        val masterParts =
-          partitionLocationInfo.getMasterLocations(shuffleId.toString, partitionIdOpt)
-        val slaveParts = partitionLocationInfo.getSlaveLocations(shuffleId.toString, partitionIdOpt)
-        masterParts.asScala.foreach { p =>
-          val partition = new PartitionLocation(p)
-          partition.setFetchPort(worker.fetchPort)
-          partition.setPeer(null)
-          masterPartMap.put(partition.getUniqueId, partition)
-        }
-        slaveParts.asScala.foreach { p =>
-          val partition = new PartitionLocation(p)
-          partition.setFetchPort(worker.fetchPort)
-          partition.setPeer(null)
-          slavePartMap.put(partition.getUniqueId, partition)
-        }
-
-        val (masterIds, slaveIds) = shuffleCommittedInfo.synchronized {
-          (
-            masterParts.asScala
-              .filterNot(shuffleCommittedInfo.handledPartitionLocations.contains)
-              .map(_.getUniqueId).asJava,
-            slaveParts.asScala
-              .filterNot(shuffleCommittedInfo.handledPartitionLocations.contains)
-              .map(_.getUniqueId).asJava)
-        }
-
-        commitFiles(
-          appId,
-          shuffleId,
-          shuffleCommittedInfo,
-          worker,
-          masterIds,
-          slaveIds,
-          commitFilesFailedWorkers)
+      val masterParts =
+        partitionLocationInfo.getMasterPartitions(partitionIdOpt)
+      val slaveParts = partitionLocationInfo.getSlavePartitions(partitionIdOpt)
+      masterParts.asScala.foreach { p =>
+        val partition = new PartitionLocation(p)
+        partition.setFetchPort(worker.fetchPort)
+        partition.setPeer(null)
+        masterPartMap.put(partition.getUniqueId, partition)
       }
+      slaveParts.asScala.foreach { p =>
+        val partition = new PartitionLocation(p)
+        partition.setFetchPort(worker.fetchPort)
+        partition.setPeer(null)
+        slavePartMap.put(partition.getUniqueId, partition)
+      }
+
+      val (masterIds, slaveIds) = shuffleCommittedInfo.synchronized {
+        (
+          masterParts.asScala
+            .filterNot(shuffleCommittedInfo.handledPartitionLocations.contains)
+            .map(_.getUniqueId).asJava,
+          slaveParts.asScala
+            .filterNot(shuffleCommittedInfo.handledPartitionLocations.contains)
+            .map(_.getUniqueId).asJava)
+      }
+
+      commitFiles(
+        appId,
+        shuffleId,
+        shuffleCommittedInfo,
+        worker,
+        masterIds,
+        slaveIds,
+        commitFilesFailedWorkers)
+
     }
 
     logInfo(s"Shuffle $shuffleId " +

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -24,14 +24,14 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 import org.apache.celeborn.client.CommitManager.CommittedPartitionInfo
-import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, ShuffleFailedWorkers, ShuffleFileGroups}
+import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, ShuffleFailedWorkers}
 import org.apache.celeborn.client.ShuffleCommittedInfo
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{PartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.meta.{ShufflePartitionLocationInfo, WorkerInfo}
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType}
-import org.apache.celeborn.common.protocol.message.{ControlMessages, StatusCode}
 import org.apache.celeborn.common.protocol.message.ControlMessages.GetReducerFileGroupResponse
+import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc.RpcCallContext
 
 /**
@@ -126,7 +126,7 @@ class ReducePartitionCommitHandler(
 
   private def handleFinalCommitFiles(
       shuffleId: Int,
-      allocatedWorkers: util.Map[WorkerInfo, PartitionLocationInfo])
+      allocatedWorkers: util.Map[WorkerInfo, ShufflePartitionLocationInfo])
       : (Boolean, ShuffleFailedWorkers) = {
     val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
 

--- a/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
@@ -59,7 +59,7 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
     // check all allocated slots
     var partitionLocationInfos = lifecycleManager.workerSnapshots(shuffleId).values().asScala
     var count =
-      partitionLocationInfos.map(r => r.getAllMasterLocations(shuffleId.toString).size()).sum
+      partitionLocationInfos.map(r => r.getMasterPartitions().size()).sum
     Assert.assertEquals(count, numMappers)
 
     // another mapId
@@ -78,7 +78,7 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
     partitionLocationInfos = lifecycleManager.workerSnapshots(shuffleId).values().asScala
     logInfo(partitionLocationInfos.toString())
     count =
-      partitionLocationInfos.map(r => r.getAllMasterLocations(shuffleId.toString).size()).sum
+      partitionLocationInfos.map(r => r.getMasterPartitions().size()).sum
     Assert.assertEquals(count, numMappers + 1)
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
@@ -75,7 +75,7 @@ class ShufflePartitionLocationInfo {
       locations: util.List[PartitionLocation]): Unit = {
     if (locations != null && locations.size() > 0) {
       locations.asScala.foreach { loc =>
-        partitionInfo.putIfAbsent(loc.getId, new util.ArrayList[PartitionLocation]())
+        partitionInfo.putIfAbsent(loc.getId, new util.ArrayList)
         val locations = partitionInfo.get(loc.getId)
         locations.add(loc)
       }

--- a/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.meta
+
+import java.util
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters._
+
+import org.apache.celeborn.common.protocol.PartitionLocation
+
+class ShufflePartitionLocationInfo {
+
+  type PartitionInfo = ConcurrentHashMap[Int, util.List[PartitionLocation]]
+  private val masterPartitionLocations = new PartitionInfo
+  private val slavePartitionLocations = new PartitionInfo
+
+  def addMasterPartitions(masterLocations: util.List[PartitionLocation]) = {
+    addPartitions(masterPartitionLocations, masterLocations)
+  }
+
+  def addSlavePartitions(slaveLocations: util.List[PartitionLocation]) = {
+    addPartitions(slavePartitionLocations, slaveLocations)
+  }
+
+  def getMasterPartitions(partitionIdOpt: Option[Int] = None): util.List[PartitionLocation] = {
+    getPartitions(masterPartitionLocations, partitionIdOpt)
+  }
+
+  def getSlavePartitions(partitionIdOpt: Option[Int] = None): util.List[PartitionLocation] = {
+    getPartitions(slavePartitionLocations, partitionIdOpt)
+  }
+
+  def containsPartition(partitionId: Int): Boolean = {
+    masterPartitionLocations.containsKey(partitionId) ||
+    slavePartitionLocations.containsKey(partitionId)
+  }
+
+  def removePartitions(partitionId: Int): Unit = {
+    masterPartitionLocations.remove(partitionId)
+    slavePartitionLocations.remove(partitionId)
+  }
+
+  def getAllMasterLocationsWithMinEpoch(): util.List[PartitionLocation] = {
+    def order(a: Int, b: Int): Boolean = a < b
+
+    masterPartitionLocations.values().asScala.map { list =>
+      var loc = list.get(0)
+      1 until list.size() foreach (ind => {
+        if (order(list.get(ind).getEpoch, loc.getEpoch)) {
+          loc = list.get(ind)
+        }
+      })
+      loc
+    }.toList.asJava
+  }
+
+  private def addPartitions(
+      partitionInfo: PartitionInfo,
+      locations: util.List[PartitionLocation]): Unit = {
+    if (locations != null && locations.size() > 0) {
+      locations.asScala.foreach { loc =>
+        partitionInfo.putIfAbsent(loc.getId, new util.ArrayList[PartitionLocation]())
+        val locations = partitionInfo.get(loc.getId)
+        locations.add(loc)
+      }
+    }
+  }
+
+  private def getPartitions(
+      partitionInfo: PartitionInfo,
+      partitionIdOpt: Option[Int]): util.List[PartitionLocation] = {
+    partitionIdOpt match {
+      case Some(partitionId) =>
+        partitionInfo.getOrDefault(partitionId, new util.ArrayList)
+      case _ => partitionInfo.values().asScala.flatMap(_.asScala).toList.asJava
+    }
+  }
+}

--- a/common/src/main/scala/org/apache/celeborn/common/util/CollectionUtils.java
+++ b/common/src/main/scala/org/apache/celeborn/common/util/CollectionUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.util;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class CollectionUtils {
+
+  public static boolean isEmpty(Collection collection) {
+    return collection == null || collection.isEmpty();
+  }
+
+  public static boolean isNotEmpty(Collection collection) {
+    return !isEmpty(collection);
+  }
+
+  public static boolean isEmpty(Map map) {
+    return map == null || map.isEmpty();
+  }
+
+  public static boolean isNotEmpty(Map map) {
+    return !isEmpty(map);
+  }
+
+}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -31,7 +31,7 @@ import org.roaringbitmap.RoaringBitmap
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{PartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.meta.{WorkerInfo, WorkerPartitionLocationInfo}
 import org.apache.celeborn.common.metrics.MetricsSystem
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType, StorageInfo}
 import org.apache.celeborn.common.protocol.message.ControlMessages._
@@ -53,7 +53,7 @@ private[deploy] class Controller(
   var shuffleCommitInfos: ConcurrentHashMap[String, ConcurrentHashMap[Long, CommitInfo]] = _
   var shufflePartitionType: ConcurrentHashMap[String, PartitionType] = _
   var workerInfo: WorkerInfo = _
-  var partitionLocationInfo: PartitionLocationInfo = _
+  var partitionLocationInfo: WorkerPartitionLocationInfo = _
   var timer: HashedWheelTimer = _
   var commitThreadPool: ThreadPoolExecutor = _
   var asyncReplyPool: ScheduledExecutorService = _

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -27,7 +27,7 @@ import io.netty.buffer.ByteBuf
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.exception.AlreadyClosedException
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{PartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.meta.{WorkerInfo, WorkerPartitionLocationInfo}
 import org.apache.celeborn.common.metrics.source.RPCSource
 import org.apache.celeborn.common.network.buffer.{NettyManagedBuffer, NioManagedBuffer}
 import org.apache.celeborn.common.network.client.{RpcResponseCallback, TransportClient, TransportClientFactory}
@@ -44,7 +44,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
 
   var workerSource: WorkerSource = _
   var rpcSource: RPCSource = _
-  var partitionLocationInfo: PartitionLocationInfo = _
+  var partitionLocationInfo: WorkerPartitionLocationInfo = _
   var shuffleMapperAttempts: ConcurrentHashMap[String, AtomicIntegerArray] = _
   var shufflePartitionType: ConcurrentHashMap[String, PartitionType] = _
   var replicateThreadPool: ThreadPoolExecutor = _

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -35,7 +35,7 @@ import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.haclient.RssHARetryClient
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{DiskInfo, PartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.meta.{DiskInfo, WorkerInfo, WorkerPartitionLocationInfo}
 import org.apache.celeborn.common.metrics.MetricsSystem
 import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, RPCSource}
 import org.apache.celeborn.common.network.TransportContext
@@ -180,7 +180,7 @@ private[celeborn] class Worker(
   val registered = new AtomicBoolean(false)
   val shuffleMapperAttempts = new ConcurrentHashMap[String, AtomicIntegerArray]()
   val shufflePartitionType = new ConcurrentHashMap[String, PartitionType]
-  val partitionLocationInfo = new PartitionLocationInfo
+  val partitionLocationInfo = new WorkerPartitionLocationInfo
 
   val shuffleCommitInfos = new ConcurrentHashMap[String, ConcurrentHashMap[Long, CommitInfo]]()
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

as title

### Why are the changes needed?
PartitionLocationInfo in LifecycleManager is related to specific app shuffle but related to all app shuffle in worker. Seems It would be better to separate.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
ut & ft
