### PR TITLE
[CELEBORN-202][Flink] Flink plugin BuffPacker adds unpack implements for shu…

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/BufferUtils.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/BufferUtils.java
@@ -35,7 +35,7 @@ public class BufferUtils {
 
   // subpartitionid(4) + attemptId(4) + nextBatchId(4) + compressedsize
   public static final int HEADER_LENGTH_PREFIX = 4 * 4;
-  // dataType(1) + size(4)
+  // dataType(1) + isCompress(1) + size(4)
   public static final int HEADER_LENGTH = HEADER_LENGTH_PREFIX + 1 + 1 + 4;
 
   /**

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/BufferUtils.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/BufferUtils.java
@@ -36,7 +36,7 @@ public class BufferUtils {
   // subpartitionid(4) + attemptId(4) + nextBatchId(4) + compressedsize
   public static final int HEADER_LENGTH_PREFIX = 4 * 4;
   // dataType(1) + size(4)
-  public static final int HEADER_LENGTH = HEADER_LENGTH_PREFIX + 1 + 4;
+  public static final int HEADER_LENGTH = HEADER_LENGTH_PREFIX + 1 + 1 + 4;
 
   /**
    * Copies the data of the compressed buffer and the corresponding buffer header to the origin
@@ -77,7 +77,7 @@ public class BufferUtils {
   public static BufferHeader getBufferHeader(Buffer buffer, int position, boolean isFirst) {
     ByteBuf byteBuf = buffer.asByteBuf();
     byteBuf.readerIndex(position);
-    if (isFirst) {
+    if (!isFirst) {
       return new BufferHeader(
           Buffer.DataType.values()[byteBuf.readByte()], byteBuf.readBoolean(), byteBuf.readInt());
     } else {

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/UnpackSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/UnpackSuiteJ.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.io.IOException;
+import java.util.Queue;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.celeborn.plugin.flink.buffer.BufferPacker;
+
+public class UnpackSuiteJ {
+
+  private NetworkBufferPool networkBufferPool;
+  private BufferPool bufferPool;
+
+  @Before
+  public void setup() throws IOException {
+    networkBufferPool = new NetworkBufferPool(10, 128);
+    bufferPool = networkBufferPool.createBufferPool(10, 10);
+  }
+
+  @After
+  public void tearDown() {
+    bufferPool.lazyDestroy();
+    networkBufferPool.destroy();
+  }
+
+  @Test
+  public void testUnpack() throws IOException, InterruptedException {
+    Buffer buffer = bufferPool.requestBuffer();
+    ByteBuf byteBuf = buffer.asByteBuf();
+    byteBuf.writerIndex(0);
+    byteBuf.writeInt(0);
+    byteBuf.writeInt(1);
+    byteBuf.writeInt(2);
+    byteBuf.writeInt(3);
+    byteBuf.writeByte((byte) Buffer.DataType.DATA_BUFFER.ordinal());
+    byteBuf.writeBoolean(true);
+    byteBuf.writeInt(3);
+    byteBuf.writeBytes(new byte[] {1, 2, 3});
+    byteBuf.writeByte((byte) Buffer.DataType.EVENT_BUFFER.ordinal());
+    byteBuf.writeBoolean(false);
+    byteBuf.writeInt(5);
+    byteBuf.writeBytes(new byte[] {1, 2, 3, 4, 5});
+
+    Queue<Buffer> bufferQueue = BufferPacker.unpack(byteBuf);
+    Assert.assertEquals(2, bufferQueue.size());
+    Buffer buffer1 = bufferQueue.poll();
+    Assert.assertEquals(buffer1.getDataType(), Buffer.DataType.DATA_BUFFER);
+    Assert.assertEquals(buffer1.isCompressed(), true);
+    Assert.assertEquals(buffer1.getSize(), 3);
+
+    Buffer buffer2 = bufferQueue.poll();
+    Assert.assertEquals(buffer2.getDataType(), Buffer.DataType.EVENT_BUFFER);
+    Assert.assertEquals(buffer2.isCompressed(), false);
+    Assert.assertEquals(buffer2.getSize(), 5);
+  }
+}


### PR DESCRIPTION
…ffle read

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Currently, Flink plugin  shuffle write will pack buffers together before sending data. 
So, it must be unpacked by shuffle read.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
@waitinfuture @FMX @RexXiong 


### How was this patch tested?

