### PR TITLE
[CELEBORN-203] Fix NPE when removeExpiredShuffle in LifecycleManager.

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1053,7 +1053,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         latestPartitionLocation.remove(shuffleId)
         commitManager.removeExpiredShuffle(shuffleId)
         changePartitionManager.removeExpiredShuffle(shuffleId)
-        shuffleTaskInfo.remove(shuffleId)
+        shuffleTaskInfo.removeExpiredShuffle(shuffleId)
         requestUnregisterShuffle(
           rssHARetryClient,
           UnregisterShuffle(appId, shuffleId, RssHARetryClient.genRequestId()))

--- a/client/src/main/scala/org/apache/celeborn/client/ShuffleTaskInfo.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ShuffleTaskInfo.scala
@@ -86,10 +86,12 @@ class ShuffleTaskInfo {
     attemptIdMap.get(mapAttemptId)
   }
 
-  def remove(shuffleId: Int): Unit = {
-    val taskShuffleId = shuffleIdToTaskShuffleId.remove(shuffleId)
-    taskShuffleIdToShuffleId.remove(taskShuffleId)
-    taskShuffleAttemptIdIndex.remove(shuffleId)
-    taskShuffleAttemptIdToAttemptId.remove(taskShuffleId)
+  def removeExpiredShuffle(shuffleId: Int): Unit = {
+    if (shuffleIdToTaskShuffleId.containsKey(shuffleId)) {
+      val taskShuffleId = shuffleIdToTaskShuffleId.remove(shuffleId)
+      taskShuffleIdToShuffleId.remove(taskShuffleId)
+      taskShuffleAttemptIdIndex.remove(shuffleId)
+      taskShuffleAttemptIdToAttemptId.remove(taskShuffleId)
+    }
   }
 }

--- a/client/src/test/scala/org/apache/celeborn/client/ShuffleTaskInfoSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/ShuffleTaskInfoSuite.scala
@@ -43,8 +43,14 @@ class ShuffleTaskInfoSuite extends AnyFunSuite {
     assert(encodeAttemptId012 == 1)
 
     // remove shuffleId and reEncode
-    shuffleTaskInfo.remove(encodeShuffleId)
+    shuffleTaskInfo.removeExpiredShuffle(encodeShuffleId)
     val encodeShuffleIdNew = shuffleTaskInfo.getShuffleId("shuffleId")
     assert(encodeShuffleIdNew == 2)
+  }
+
+  test("remove none exist shuffle") {
+    val shuffleTaskInfo = new ShuffleTaskInfo
+    // remove none exist shuffle
+    shuffleTaskInfo.removeExpiredShuffle(0)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
as title

### Why are the changes needed?
if lifecycleManager doesn't encode shuffle task, then there is no shuffle taskInfo

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
ut
