### PR TITLE
[CELEBORN-208][IMPROVEMENT] Make flink default scala version to 2.12.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <java.version>8</java.version>
-    <scala211.version>2.11.12</scala211.version>
-    <scala211.binary.version>2.11</scala211.binary.version>
     <scala.version>2.12.15</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -1022,8 +1020,8 @@
       </modules>
       <properties>
         <flink.version>1.14.6</flink.version>
-        <scala.version>${scala211.version}</scala.version>
-        <scala.binary.version>${scala211.binary.version}</scala.binary.version>
+        <scala.version>2.12.7</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title.


### Why are the changes needed?
For dynamic artifactId(with scala-binary-version), IDE support is not very friendly，for Flink current default version(2.11), It would still use 2.12 for other module, then we can't find the correct module dependencies, so we need align to 2.12. When Flink becomes ready for release we should document this.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test
