### PR TITLE
[CELEBORN-213]  Add  configuration for whether to close idle connections in client side

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -155,7 +155,8 @@ public class ShuffleClientImpl extends ShuffleClient {
     TransportConf dataTransportConf =
         Utils.fromCelebornConf(conf, module, conf.getInt("celeborn" + module + ".io.threads", 8));
     TransportContext context =
-        new TransportContext(dataTransportConf, new BaseMessageHandler(), true);
+        new TransportContext(
+            dataTransportConf, new BaseMessageHandler(), conf.clientCloseIdleConnections());
     dataClientFactory = context.createClientFactory();
 
     int pushDataRetryThreads = conf.pushRetryThreads();

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -514,6 +514,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   //                      Client                         //
   // //////////////////////////////////////////////////////
   def clientMaxTries: Int = get(CLIENT_MAX_RETRIES)
+  def clientCloseIdleConnections: Boolean = get(CLIENT_CLOSE_IDLE_CONNECTIONS)
   def shuffleWriterMode: ShuffleMode = ShuffleMode.valueOf(get(SHUFFLE_WRITER_MODE))
   def shuffleForceFallbackEnabled: Boolean = get(SHUFFLE_FORCE_FALLBACK_ENABLED)
   def shuffleForceFallbackPartitionThreshold: Long = get(SHUFFLE_FORCE_FALLBACK_PARTITION_THRESHOLD)
@@ -2282,6 +2283,14 @@ object CelebornConf extends Logging {
       .version("0.2.0")
       .intConf
       .createWithDefault(15)
+
+  val CLIENT_CLOSE_IDLE_CONNECTIONS: ConfigEntry[Boolean] =
+    buildConf("celeborn.client.closeIdleConnections")
+      .categories("client")
+      .doc("Whether client will close idle connections.")
+      .version("0.3.0")
+      .booleanConf
+      .createWithDefault(true)
 
   val METRICS_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.metrics.enabled")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -21,6 +21,7 @@ license: |
 | --- | ------- | ----------- | ----- |
 | celeborn.application.heartbeatInterval | 10s | Interval for client to send heartbeat message to master. | 0.2.0 | 
 | celeborn.client.blacklistSlave.enabled | true | When true, Celeborn will add partition's peer worker into blacklist when push data to slave failed. | 0.3.0 | 
+| celeborn.client.closeIdleConnections | true | Whether client will close idle connections. | 0.3.0 | 
 | celeborn.client.maxRetries | 15 | Max retry times for client to connect master endpoint | 0.2.0 | 
 | celeborn.fetch.maxReqsInFlight | 3 | Amount of in-flight chunk fetch request. | 0.2.0 | 
 | celeborn.fetch.maxRetries | 3 | Max retries of fetch chunk | 0.2.0 | 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title.

### Why are the changes needed?
CloseIdleConnections is hard-coded to true when new TransportContext in ShuffleClientImpl , It would be better to support configuration to control this behavior as needed.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual.
