### PR TITLE
[CELEBORN-212] Refresh client if current client is inactive for WorkerPartitionReader

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.util;
+
+import java.io.IOException;
+
+public class ExceptionUtils {
+
+  public static void wrapAndThrowIOException(Exception exception) throws IOException {
+    if (exception instanceof IOException) {
+      throw (IOException) exception;
+    } else {
+      throw new IOException(exception.getMessage(), exception);
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Refresh client when WorkerPartitionReader fetches trunks.

### Why are the changes needed?
After WorkerPartitionReader fetches trunks normally, transportClient would be inactive If the reader takes too long to process the results between two fetch trunks request(such as exceeds 240s as channel will be idle and timeout to close), when the reader tries to fetches the next trunk use the inactive transportClient, netty channel StacklessClosedChannelException will be raised up. So here need refresh client when fetch trunks. 


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT
