### PR TITLE
[CELEBORN-222][Flink] Flink plugin RemoteShuffleOutputGate adds ut about net…

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
@@ -212,7 +212,6 @@ public class RemoteShuffleOutputGate {
   /** Writes a piece of data to a subpartition. */
   public void write(ByteBuf byteBuf, int subIdx) throws InterruptedException {
     try {
-      byteBuf.retain();
       shuffleWriteClient.pushDataToLocation(
           applicationId,
           shuffleId,


### PR DESCRIPTION
…tybufferTransform

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Currently, flink netty package is different from celeborn's, so nettybuffer should be transformed from flink to celeborn before used by celeborn.
This pr adds ut to  check the correctness about transforming and buffer release


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?
@FMX @waitinfuture @RexXiong 
