### PR TITLE
[CELEBORN-229][FOLLOWUP] Support collect metrics with customized labels

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/MetricLabels.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/MetricLabels.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.metrics
+
+private[metrics] trait MetricLabels {
+  val labels: Map[String, String]
+
+  def labelString: String = MetricLabels.labelString(labels)
+}
+
+object MetricLabels {
+  def labelString(labels: Map[String, String]): String = {
+    "{" + labels.map { case (key: String, value: String) => s"""$key="$value"""" }.mkString(
+      " ") + "}"
+  }
+}

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/MetricLabels.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/MetricLabels.scala
@@ -25,7 +25,12 @@ private[metrics] trait MetricLabels {
 
 object MetricLabels {
   def labelString(labels: Map[String, String]): String = {
-    "{" + labels.map { case (key: String, value: String) => s"""$key="$value"""" }.mkString(
-      " ") + "}"
+    "{" +
+      labels
+        .map { case (key: String, value: String) => s"""$key="$value"""" }
+        .toList
+        .sorted
+        .mkString(" ") +
+      "}"
   }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
@@ -26,22 +26,32 @@ class CelebornSourceSuite extends CelebornFunSuite {
     val mockSource = new AbstractSource(new CelebornConf(), "mock") {
       override def sourceName: String = "mockSource"
     }
+    val user1 = Map("user" -> "user1")
+    val user2 = Map("user" -> "user2")
+    val user3 = Map("user" -> "user3")
     mockSource.addGauge("Gauge1", _ => 1000)
-    mockSource.addGauge("Gauge2", _ => 2000, Map("user" -> "user1"))
+    mockSource.addGauge("Gauge2", _ => 2000, user1)
     mockSource.addCounter("Counter1")
+    mockSource.addCounter("Counter2", user2)
+    // test operation with and without label
     mockSource.incCounter("Counter1", 3000)
-    mockSource.addCounter("Counter2", Map("user" -> "user2"))
-    mockSource.incCounter("Counter2", 4000)
+    mockSource.incCounter("Counter2", 4000, user2)
     mockSource.addTimer("Timer1")
-    mockSource.addTimer("Timer2", Map("user" -> "user3"))
+    mockSource.addTimer("Timer2", user3)
+    // ditto
+    mockSource.startTimer("Timer1", "key1")
+    mockSource.startTimer("Timer2", "key2", user3)
+    Thread.sleep(10)
+    mockSource.stopTimer("Timer1", "key1")
+    mockSource.stopTimer("Timer2", "key2", user3)
 
     val res = mockSource.getMetrics()
     val exp1 = "metrics_Gauge1_Value{role=\"mock\"} 1000"
     val exp2 = "metrics_Gauge2_Value{user=\"user1\" role=\"mock\"} 2000"
     val exp3 = "metrics_Counter1_Count{role=\"mock\"} 3000"
     val exp4 = "metrics_Counter2_Count{user=\"user2\" role=\"mock\"} 4000"
-    val exp5 = "metrics_Timer1_Count{role=\"mock\"} 0"
-    val exp6 = "metrics_Timer2_Count{user=\"user3\" role=\"mock\"} 0"
+    val exp5 = "metrics_Timer1_Count{role=\"mock\"} 1"
+    val exp6 = "metrics_Timer2_Count{user=\"user3\" role=\"mock\"} 1"
 
     assert(res.contains(exp1))
     assert(res.contains(exp2))

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/source/CelebornSourceSuite.scala
@@ -47,11 +47,11 @@ class CelebornSourceSuite extends CelebornFunSuite {
 
     val res = mockSource.getMetrics()
     val exp1 = "metrics_Gauge1_Value{role=\"mock\"} 1000"
-    val exp2 = "metrics_Gauge2_Value{user=\"user1\" role=\"mock\"} 2000"
+    val exp2 = "metrics_Gauge2_Value{role=\"mock\" user=\"user1\"} 2000"
     val exp3 = "metrics_Counter1_Count{role=\"mock\"} 3000"
-    val exp4 = "metrics_Counter2_Count{user=\"user2\" role=\"mock\"} 4000"
+    val exp4 = "metrics_Counter2_Count{role=\"mock\" user=\"user2\"} 4000"
     val exp5 = "metrics_Timer1_Count{role=\"mock\"} 1"
-    val exp6 = "metrics_Timer2_Count{user=\"user3\" role=\"mock\"} 1"
+    val exp6 = "metrics_Timer2_Count{role=\"mock\" user=\"user3\"} 1"
 
     assert(res.contains(exp1))
     assert(res.contains(exp2))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Modify API to ensure they can find metrics with labels.


### Why are the changes needed?
After supporting metrics with customized label, there will be some scenario that metrics has same name but their labels are different(such as user consumed quota), currently when storing NamedTimer, NamedCounter and NamedHistogram(not implemented yet) Celeborn only use metric name to deduplicate, we should keep the uniqueness of named  metrics based on both metrics name and label.

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ut
