### PR TITLE
[CELEBORN-55][FOLLOWUP] Code refine

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
@@ -109,7 +109,6 @@ public class SortBasedPusher extends MemoryConsumer {
             rssShuffleClient,
             afterPush,
             mapStatusLengths);
-    dataPusher.startPushThread();
 
     pushBufferMaxSize = conf.pushBufferMaxSize();
     pushSortMemoryThreshold = conf.pushSortMemoryThreshold();

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -153,7 +153,6 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             rssShuffleClient,
             writeMetrics::incBytesWritten,
             mapStatusLengths);
-    dataPusher.startPushThread();
   }
 
   @Override

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -161,7 +161,6 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             rssShuffleClient,
             writeMetrics::incBytesWritten,
             mapStatusLengths);
-    dataPusher.startPushThread();
 
     if (conf.columnarShuffleEnabled()) {
       this.schema = SparkUtils.getSchema(dep);

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -29,8 +29,12 @@ import java.util.function.Consumer;
 
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.CelebornConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DataPusher {
+  private static final Logger logger = LoggerFactory.getLogger(DataPusher.class);
+
   private final long WAIT_TIME_NANOS = TimeUnit.MILLISECONDS.toNanos(500);
 
   private final LinkedBlockingQueue<PushTask> idleQueue;
@@ -130,9 +134,6 @@ public class DataPusher {
           }
         };
     pushThread.setDaemon(true);
-  }
-
-  public void startPushThread() {
     pushThread.start();
   }
 
@@ -170,6 +171,7 @@ public class DataPusher {
     try {
       pushThread.join();
     } catch (InterruptedException ignored) {
+      logger.info("Thread interrupted while joining pushThread");
     }
     idleQueue.clear();
     dataPushQueue.clear();
@@ -218,9 +220,5 @@ public class DataPusher {
 
   public DataPushQueue getDataPushQueue() {
     return dataPushQueue;
-  }
-
-  public Thread getPushThread() {
-    return pushThread;
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -27,10 +27,11 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
-import org.apache.celeborn.client.ShuffleClient;
-import org.apache.celeborn.common.CelebornConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.client.ShuffleClient;
+import org.apache.celeborn.common.CelebornConf;
 
 public class DataPusher {
   private static final Logger logger = LoggerFactory.getLogger(DataPusher.class);

--- a/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
@@ -53,13 +53,13 @@ public class InFlightRequestTracker {
     this.pushState = pushState;
   }
 
-  public void addFlightBatch(int batchId, String hostAndPushPort) {
+  public void addBatch(int batchId, String hostAndPushPort) {
     ConcurrentHashMap<Integer, BatchInfo> batchIdSetPerPair =
         inflightBatchesPerAddress.computeIfAbsent(hostAndPushPort, id -> new ConcurrentHashMap<>());
     batchIdSetPerPair.computeIfAbsent(batchId, id -> new BatchInfo());
   }
 
-  public void removeFlightBatch(int batchId, String hostAndPushPort) {
+  public void removeBatch(int batchId, String hostAndPushPort) {
     ConcurrentHashMap<Integer, BatchInfo> batchIdMap =
         inflightBatchesPerAddress.get(hostAndPushPort);
     BatchInfo info = batchIdMap.remove(batchId);

--- a/client/src/main/java/org/apache/celeborn/client/write/PushState.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/PushState.java
@@ -87,11 +87,11 @@ public class PushState {
   }
 
   public void addBatch(int batchId, String hostAndPushPort) {
-    inFlightRequestTracker.addFlightBatch(batchId, hostAndPushPort);
+    inFlightRequestTracker.addBatch(batchId, hostAndPushPort);
   }
 
   public void removeBatch(int batchId, String hostAndPushPort) {
-    inFlightRequestTracker.removeFlightBatch(batchId, hostAndPushPort);
+    inFlightRequestTracker.removeBatch(batchId, hostAndPushPort);
   }
 
   public boolean limitMaxInFlight(String hostAndPushPort, int maxInFlight) throws IOException {

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -60,6 +60,7 @@ public class PartitionLocation implements Serializable {
   private PartitionLocation peer;
   private StorageInfo storageInfo;
   private RoaringBitmap mapIdBitMap;
+  private transient String _hostPushPort;
 
   public PartitionLocation(PartitionLocation loc) {
     this.id = loc.id;
@@ -73,6 +74,7 @@ public class PartitionLocation implements Serializable {
     this.peer = loc.peer;
     this.storageInfo = loc.storageInfo;
     this.mapIdBitMap = loc.mapIdBitMap;
+    this._hostPushPort = host + ":" + pushPort;
   }
 
   public PartitionLocation(
@@ -201,7 +203,7 @@ public class PartitionLocation implements Serializable {
   }
 
   public String hostAndPushPort() {
-    return host + ":" + pushPort;
+    return _hostPushPort;
   }
 
   public Mode getMode() {

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -147,6 +147,7 @@ public class PartitionLocation implements Serializable {
     this.peer = peer;
     this.storageInfo = hint;
     this.mapIdBitMap = mapIdBitMap;
+    this._hostPushPort = host + ":" + pushPort;
   }
 
   public int getId() {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HugeDataTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HugeDataTest.scala
@@ -38,7 +38,6 @@ class HugeDataTest extends AnyFunSuite
 
   test("celeborn spark integration test - huge data") {
     val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[4]")
-      .set("spark.celeborn.shuffle.register.maxRetries", "10")
     val ss = SparkSession.builder().config(updateSparkConf(sparkConf, false)).getOrCreate()
     val value = Range(1, 10000).mkString(",")
     val tuples = ss.sparkContext.parallelize(1 to 10000, 2)

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushdataTimeoutTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushdataTimeoutTest.scala
@@ -46,7 +46,6 @@ class PushdataTimeoutTest extends AnyFunSuite
   test("celeborn spark integration test - pushdata timeout") {
     val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[4]")
       .set("spark.celeborn.push.data.timeout", "10s")
-      .set("spark.celeborn.shuffle.register.maxRetries", "10")
     val sparkSession = SparkSession.builder().config(sparkConf).getOrCreate()
     val combineResult = combine(sparkSession)
     val groupbyResult = groupBy(sparkSession)

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SkewJoinSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SkewJoinSuite.scala
@@ -58,7 +58,6 @@ class SkewJoinSuite extends AnyFunSuite
         .set("spark.sql.autoBroadcastJoinThreshold", "-1")
         .set("spark.sql.parquet.compression.codec", "gzip")
         .set("spark.celeborn.shuffle.compression.codec", codec.name)
-        .set("spark.celeborn.shuffle.register.maxRetries", "10")
 
       enableRss(sparkConf)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This is a follow-up of [CELEBORN-55](https://github.com/apache/incubator-celeborn/pull/1102) , which has some code refinement.
1. make _hostPushPort a transient member of PartitionLocation
2. remove the configuration spark.celeborn.shuffle.register.maxRetries in HugeDataTest, PushdataTimeoutTest, SkewJoinSuite
3. start dataPusher after construction


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

