### PR TITLE
[CELEBORN-237][IMPROVEMENT] push failed error message should show partition info

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1380,12 +1380,12 @@ public class ShuffleClientImpl extends ShuffleClient {
   private StatusCode getPushDataFailCause(String message) {
     logger.info("[getPushDataFailCause] message: " + message);
     StatusCode cause;
-    if (StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage().equals(message)) {
+    if (message.startsWith(StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage())) {
       cause = StatusCode.PUSH_DATA_FAIL_SLAVE;
-    } else if (StatusCode.PUSH_DATA_FAIL_MASTER.getMessage().equals(message)
+    } else if (message.startsWith(StatusCode.PUSH_DATA_FAIL_MASTER.getMessage())
         || connectFail(message)) {
       cause = StatusCode.PUSH_DATA_FAIL_MASTER;
-    } else if (StatusCode.PUSH_DATA_TIMEOUT.getMessage().equals(message)) {
+    } else if (message.startsWith(StatusCode.PUSH_DATA_TIMEOUT.getMessage())) {
       cause = StatusCode.PUSH_DATA_TIMEOUT;
     } else {
       cause = StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE;

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -169,9 +169,10 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       }
 
       override def onFailure(e: Throwable): Unit = {
-        logError(s"[handlePushData.onFailure] partitionLocation: $location")
+        logError(s"[handlePushData.onFailure] partitionLocation: $location", e)
         workerSource.incCounter(WorkerSource.PushDataFailCount)
-        callback.onFailure(new Exception(StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage(), e))
+        callback.onFailure(
+          new Exception(s"${StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage()}! ${e.getMessage}", e))
       }
     }
 
@@ -231,7 +232,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
         } else {
           StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage()
         }
-      callback.onFailure(new Exception(message, exception))
+      callback.onFailure(new Exception(s"$message! $location", exception))
       return
     }
     val diskFull =
@@ -267,7 +268,8 @@ class PushDataHandler extends BaseMessageHandler with Logging {
             peer.getReplicatePort)
           if (unavailablePeers.containsKey(peerWorker)) {
             pushData.body().release()
-            wrappedCallback.onFailure(new Exception(s"Peer $peerWorker unavailable!"))
+            wrappedCallback.onFailure(
+              new Exception(s"Peer $peerWorker unavailable for $location!"))
             return
           }
           try {
@@ -283,7 +285,8 @@ class PushDataHandler extends BaseMessageHandler with Logging {
             case e: Exception =>
               pushData.body().release()
               unavailablePeers.put(peerWorker, System.currentTimeMillis())
-              wrappedCallback.onFailure(e)
+              wrappedCallback.onFailure(
+                new Exception(s"Push data to peer $peerWorker failed for $location", e))
           }
         }
       })
@@ -351,7 +354,8 @@ class PushDataHandler extends BaseMessageHandler with Logging {
 
       override def onFailure(e: Throwable): Unit = {
         workerSource.incCounter(WorkerSource.PushDataFailCount)
-        callback.onFailure(new Exception(StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage, e))
+        callback.onFailure(
+          new Exception(s"${StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage()}! ${e.getMessage}", e))
       }
     }
 
@@ -423,7 +427,9 @@ class PushDataHandler extends BaseMessageHandler with Logging {
         } else {
           StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage()
         }
-      callback.onFailure(new Exception(message, exception))
+      callback.onFailure(new Exception(
+        s"$message! ${locations.map(_.toString).mkString("{", ", ", "}")}",
+        exception))
       return
     }
     fileWriters.foreach(_.incrementPendingWrites())
@@ -443,7 +449,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
             peer.getReplicatePort)
           if (unavailablePeers.containsKey(peerWorker)) {
             pushMergedData.body().release()
-            wrappedCallback.onFailure(new Exception(s"Peer $peerWorker unavailable!"))
+            wrappedCallback.onFailure(new Exception(s"Peer $peerWorker unavailable for $location!"))
             return
           }
           try {
@@ -462,7 +468,9 @@ class PushDataHandler extends BaseMessageHandler with Logging {
             case e: Exception =>
               pushMergedData.body().release()
               unavailablePeers.put(peerWorker, System.currentTimeMillis())
-              wrappedCallback.onFailure(e)
+              wrappedCallback.onFailure(new Exception(
+                s"Push data to peer $peerWorker failed for $location",
+                e))
           }
         }
       })

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -427,9 +427,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
         } else {
           StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage()
         }
-      callback.onFailure(new Exception(
-        s"$message! ${locations.map(_.toString).mkString("{", ", ", "}")}",
-        exception))
+      callback.onFailure(new Exception(s"$message! ${locations.head}", exception))
       return
     }
     fileWriters.foreach(_.incrementPendingWrites())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently push data failed only show failed reason, but don't have partition info. In this pr, we enable push failed error message both show the error type and show the partition location.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

