### PR TITLE
[CELEBORN-241][IMPROVEMENT] limit inflight push timeout should >  push data timeout

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -683,10 +683,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def pushDataTimeoutMs: Long = {
     if (pushReplicateEnabled) {
       get(PUSH_DATA_TIMEOUT).getOrElse(
-        networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE).toLong * 2.5)
+        (networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE) * 2.5).toLong)
     } else {
       get(PUSH_DATA_TIMEOUT).getOrElse(
-        networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE).toLong * 1.5)
+        (networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE) * 1.5).toLong)
     }
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -680,15 +680,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def rpcCacheSize: Int = get(RPC_CACHE_SIZE)
   def rpcCacheConcurrencyLevel: Int = get(RPC_CACHE_CONCURRENCY_LEVEL)
   def rpcCacheExpireTime: Long = get(RPC_CACHE_EXPIRE_TIME)
-  def pushDataTimeoutMs: Long = {
-    if (pushReplicateEnabled) {
-      get(PUSH_DATA_TIMEOUT).getOrElse(
-        networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE).toLong * 2)
-    } else {
-      get(PUSH_DATA_TIMEOUT).getOrElse(
-        networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE).toLong * 1)
-    }
-  }
+  def pushDataTimeoutMs: Long = get(PUSH_DATA_TIMEOUT)
   def registerShuffleRpcAskTimeout: RpcTimeout =
     new RpcTimeout(
       get(REGISTER_SHUFFLE_RPC_ASK_TIMEOUT).map(_.milli)
@@ -2127,16 +2119,14 @@ object CelebornConf extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
-  val PUSH_DATA_TIMEOUT: OptionalConfigEntry[Long] =
+  val PUSH_DATA_TIMEOUT: ConfigEntry[Long] =
     buildConf("celeborn.push.data.timeout")
       .withAlternative("rss.push.data.rpc.timeout")
       .categories("client")
       .version("0.2.0")
-      .doc("Timeout for a task to push data rpc message." +
-        s"Default value should be `${NETWORK_IO_CONNECTION_TIMEOUT.key.replace("<module>", TransportModuleConstants.DATA_MODULE)} * 2` when enable replication and" +
-        s"the value should be `${NETWORK_IO_CONNECTION_TIMEOUT.key.replace("<module>", TransportModuleConstants.DATA_MODULE)}` when disable replication.")
+      .doc("Timeout for a task to push data rpc message.")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createOptional
+      .createWithDefaultString("120s")
 
   val TEST_PUSHDATA_TIMEOUT: ConfigEntry[Boolean] =
     buildConf("celeborn.test.pushdataTimeout")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -680,9 +680,15 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def rpcCacheSize: Int = get(RPC_CACHE_SIZE)
   def rpcCacheConcurrencyLevel: Int = get(RPC_CACHE_CONCURRENCY_LEVEL)
   def rpcCacheExpireTime: Long = get(RPC_CACHE_EXPIRE_TIME)
-  def pushDataTimeoutMs: Long =
-    get(PUSH_DATA_TIMEOUT).getOrElse(
-      networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE) * 2.5)
+  def pushDataTimeoutMs: Long = {
+    if (pushReplicateEnabled) {
+      get(PUSH_DATA_TIMEOUT).getOrElse(
+        networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE) * 2.5)
+    } else {
+      get(PUSH_DATA_TIMEOUT).getOrElse(
+        networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE) * 1.5)
+    }
+  }
 
   def registerShuffleRpcAskTimeout: RpcTimeout =
     new RpcTimeout(

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -683,10 +683,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def pushDataTimeoutMs: Long = {
     if (pushReplicateEnabled) {
       get(PUSH_DATA_TIMEOUT).getOrElse(
-        networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE) * 2.5)
+        networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE).toLong * 2.5)
     } else {
       get(PUSH_DATA_TIMEOUT).getOrElse(
-        networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE) * 1.5)
+        networkIoConnectionTimeoutMs(TransportModuleConstants.DATA_MODULE).toLong * 1.5)
     }
   }
 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -31,7 +31,7 @@ license: |
 | celeborn.push.buffer.initial.size | 8k |  | 0.2.0 | 
 | celeborn.push.buffer.max.size | 64k | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. | 0.2.0 | 
 | celeborn.push.data.slowStart | false | Whether to allow to slow increasing maxReqs to meet the max push capacity, worked when worker side enables rate limit mechanism | 0.3.0 | 
-| celeborn.push.data.timeout | &lt;undefined&gt; | Timeout for a task to push data rpc message.Default value should be `celeborn.data.io.connectionTimeout * 2` when enable replication andthe value should be `celeborn.data.io.connectionTimeout` when disable replication. | 0.2.0 | 
+| celeborn.push.data.timeout | 120s | Timeout for a task to push data rpc message. | 0.2.0 | 
 | celeborn.push.limit.inFlight.sleepInterval | 50ms | Sleep interval when check netty in-flight requests to be done. | 0.2.0 | 
 | celeborn.push.limit.inFlight.timeout | &lt;undefined&gt; | Timeout for netty in-flight requests to be done.Default value should be `celeborn.push.data.timeout * 2`. | 0.2.0 | 
 | celeborn.push.maxReqsInFlight | 4 | Amount of Netty in-flight requests per worker. The maximum memory is `celeborn.push.maxReqsInFlight` * `celeborn.push.buffer.max.size` * compression ratio(1 in worst case), default: 64Kib * 32 = 2Mib | 0.2.0 | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -31,9 +31,9 @@ license: |
 | celeborn.push.buffer.initial.size | 8k |  | 0.2.0 | 
 | celeborn.push.buffer.max.size | 64k | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. | 0.2.0 | 
 | celeborn.push.data.slowStart | false | Whether to allow to slow increasing maxReqs to meet the max push capacity, worked when worker side enables rate limit mechanism | 0.3.0 | 
-| celeborn.push.data.timeout | 120s | Timeout for a task to push data rpc message. | 0.2.0 | 
+| celeborn.push.data.timeout | &lt;undefined&gt; | Timeout for a task to push data rpc message.Default value should be `celeborn.data.io.connectionTimeout * 2` when enable replication andthe value should be `celeborn.data.io.connectionTimeout` when disable replication. | 0.2.0 | 
 | celeborn.push.limit.inFlight.sleepInterval | 50ms | Sleep interval when check netty in-flight requests to be done. | 0.2.0 | 
-| celeborn.push.limit.inFlight.timeout | 240s | Timeout for netty in-flight requests to be done. | 0.2.0 | 
+| celeborn.push.limit.inFlight.timeout | &lt;undefined&gt; | Timeout for netty in-flight requests to be done.Default value should be `celeborn.push.data.timeout * 2`. | 0.2.0 | 
 | celeborn.push.maxReqsInFlight | 4 | Amount of Netty in-flight requests per worker. The maximum memory is `celeborn.push.maxReqsInFlight` * `celeborn.push.buffer.max.size` * compression ratio(1 in worst case), default: 64Kib * 32 = 2Mib | 0.2.0 | 
 | celeborn.push.queue.capacity | 512 | Push buffer queue size for a task. The maximum memory is `celeborn.push.buffer.max.size` * `celeborn.push.queue.capacity`, default: 64KiB * 512 = 32MiB | 0.2.0 | 
 | celeborn.push.replicate.enabled | true | When true, Celeborn worker will replicate shuffle data to another Celeborn worker asynchronously to ensure the pushed shuffle data won't be lost after the node failure. | 0.2.0 | 


### PR DESCRIPTION
### What changes were proposed in this pull request?
 PUSH_LIMIT_IN_FLIGHT_TIMEOUT must > PUSH_DATATIMEOUT

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

