### PR TITLE
[CELEBORN-253][MINOR] Fix the wrongly resolve celeborn.ha.master.node.id issue if enable HA

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -574,6 +574,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     val nodeConfPrefix = extractPrefix(HA_MASTER_NODE_HOST.key, "<id>")
     getAllWithPrefix(nodeConfPrefix)
       .map(_._1)
+      .filterNot(_.startsWith("id"))
       .map(k => extractPrefix(k, "."))
       .distinct
   }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -574,7 +574,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     val nodeConfPrefix = extractPrefix(HA_MASTER_NODE_HOST.key, "<id>")
     getAllWithPrefix(nodeConfPrefix)
       .map(_._1)
-      .filterNot(_.startsWith("id"))
+      .filterNot(_.equals("id"))
       .map(k => extractPrefix(k, "."))
       .distinct
   }

--- a/common/src/test/scala/org/apache/celeborn/common/CelebornConfSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/CelebornConfSuite.scala
@@ -152,6 +152,7 @@ class CelebornConfSuite extends CelebornFunSuite {
 
   test("extract masterNodeIds") {
     val conf = new CelebornConf()
+      .set("celeborn.ha.master.node.id", "1")
       .set("celeborn.ha.master.node.1.host", "clb-1")
       .set("celeborn.ha.master.node.2.host", "clb-1")
       .set("celeborn.ha.master.node.3.host", "clb-1")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

`haMasterNodeIds` could resolve the `celeborn.ha.master.node.id` if we set it,

```java
assertion failed: id does not contain .
java.lang.AssertionError: assertion failed: id does not contain .
	at scala.Predef$.assert(Predef.scala:223)
	at org.apache.celeborn.common.CelebornConf.extractPrefix$1(CelebornConf.scala:570)
	at org.apache.celeborn.common.CelebornConf.$anonfun$haMasterNodeIds$3(CelebornConf.scala:577)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238)
	at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
	at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
	at scala.collection.TraversableLike.map(TraversableLike.scala:238)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:231)
	at scala.collection.mutable.ArrayOps$ofRef.map(ArrayOps.scala:198)
	at org.apache.celeborn.common.CelebornConf.haMasterNodeIds(CelebornConf.scala:577)
	at org.apache.celeborn.common.CelebornConfSuite.$anonfun$new$16(CelebornConfSuite.scala:159)
```

we should not contains `celeborn.ha.master.node.id` if we want to resolve the `MasterNodeIds`

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?
Added tests
