### PR TITLE
[CELEBORN-244][IMPROVEMENT] Separate outstandingPushes from outstandingRpcs

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -162,11 +162,11 @@ public class TransportClient implements Closeable {
     }
 
     long requestId = requestId();
-    handler.addRpcRequest(requestId, callback);
+    handler.addPushRequest(requestId, callback);
 
     pushData.requestId = requestId;
 
-    RpcChannelListener listener = new RpcChannelListener(requestId, callback);
+    PushChannelListener listener = new PushChannelListener(requestId, callback);
     return channel.writeAndFlush(pushData).addListener(listener);
   }
 
@@ -176,11 +176,11 @@ public class TransportClient implements Closeable {
     }
 
     long requestId = requestId();
-    handler.addRpcRequest(requestId, callback);
+    handler.addPushRequest(requestId, callback);
 
     pushMergedData.requestId = requestId;
 
-    RpcChannelListener listener = new RpcChannelListener(requestId, callback);
+    PushChannelListener listener = new PushChannelListener(requestId, callback);
     return channel.writeAndFlush(pushMergedData).addListener(listener);
   }
 
@@ -318,6 +318,23 @@ public class TransportClient implements Closeable {
     @Override
     protected void handleFailure(String errorMsg, Throwable cause) {
       handler.removeRpcRequest(rpcRequestId);
+      callback.onFailure(new IOException(errorMsg, cause));
+    }
+  }
+
+  private class PushChannelListener extends StdChannelListener {
+    final long rpcRequestId;
+    final RpcResponseCallback callback;
+
+    PushChannelListener(long rpcRequestId, RpcResponseCallback callback) {
+      super("PUSH " + rpcRequestId);
+      this.rpcRequestId = rpcRequestId;
+      this.callback = callback;
+    }
+
+    @Override
+    protected void handleFailure(String errorMsg, Throwable cause) {
+      handler.removePushRequest(rpcRequestId);
       callback.onFailure(new IOException(errorMsg, cause));
     }
   }

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -323,18 +323,18 @@ public class TransportClient implements Closeable {
   }
 
   private class PushChannelListener extends StdChannelListener {
-    final long rpcRequestId;
+    final long pushRequestId;
     final RpcResponseCallback callback;
 
-    PushChannelListener(long rpcRequestId, RpcResponseCallback callback) {
-      super("PUSH " + rpcRequestId);
-      this.rpcRequestId = rpcRequestId;
+    PushChannelListener(long pushRequestId, RpcResponseCallback callback) {
+      super("PUSH " + pushRequestId);
+      this.pushRequestId = pushRequestId;
       this.callback = callback;
     }
 
     @Override
     protected void handleFailure(String errorMsg, Throwable cause) {
-      handler.removePushRequest(rpcRequestId);
+      handler.removePushRequest(pushRequestId);
       callback.onFailure(new IOException(errorMsg, cause));
     }
   }

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -226,11 +226,11 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
               NettyUtils.getRemoteAddress(channel),
               resp.errorString);
         } else {
-          outstandingPushes.remove(resp.requestId);
+          outstandingRpcs.remove(resp.requestId);
           listener.onFailure(new RuntimeException(resp.errorString));
         }
       } else {
-        outstandingRpcs.remove(resp.requestId);
+        outstandingPushes.remove(resp.requestId);
         listener.onFailure(new RuntimeException(resp.errorString));
       }
     } else {

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -44,6 +44,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
   private final Map<StreamChunkSlice, ChunkReceivedCallback> outstandingFetches;
 
   private final Map<Long, RpcResponseCallback> outstandingRpcs;
+  private final Map<Long, RpcResponseCallback> outstandingPushs;
 
   /** Records the time (in system nanoseconds) that the last fetch or RPC request was sent. */
   private final AtomicLong timeOfLastRequestNs;
@@ -52,6 +53,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
     this.channel = channel;
     this.outstandingFetches = new ConcurrentHashMap<>();
     this.outstandingRpcs = new ConcurrentHashMap<>();
+    this.outstandingPushs = new ConcurrentHashMap<>();
     this.timeOfLastRequestNs = new AtomicLong(0);
   }
 
@@ -79,6 +81,18 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
     outstandingRpcs.remove(requestId);
   }
 
+  public void addPushRequest(long requestId, RpcResponseCallback callback) {
+    updateTimeOfLastRequest();
+    if (outstandingPushs.containsKey(requestId)) {
+      logger.warn("[addPushRequest] requestId {} already exists!", requestId);
+    }
+    outstandingPushs.put(requestId, callback);
+  }
+
+  public void removePushRequest(long requestId) {
+    outstandingPushs.remove(requestId);
+  }
+
   /**
    * Fire the failure callback for all outstanding requests. This is called when we have an uncaught
    * exception or pre-mature connection termination.
@@ -98,10 +112,18 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
         logger.warn("RpcResponseCallback.onFailure throws exception", e);
       }
     }
+    for (Map.Entry<Long, RpcResponseCallback> entry : outstandingPushs.entrySet()) {
+      try {
+        entry.getValue().onFailure(cause);
+      } catch (Exception e) {
+        logger.warn("RpcResponseCallback.onFailure throws exception", e);
+      }
+    }
 
     // It's OK if new fetches appear, as they will fail immediately.
     outstandingFetches.clear();
     outstandingRpcs.clear();
+    outstandingPushs.clear();
   }
 
   @Override
@@ -196,13 +218,14 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
         listener.onFailure(new RuntimeException(resp.errorString));
       }
     } else {
+      // TODO: Add PushDataResponse
       throw new IllegalStateException("Unknown response type: " + message.type());
     }
   }
 
   /** Returns total number of outstanding requests (fetch requests + rpcs) */
   public int numOutstandingRequests() {
-    return outstandingFetches.size() + outstandingRpcs.size();
+    return outstandingFetches.size() + outstandingRpcs.size() + outstandingPushs.size();
   }
 
   /** Returns the time in nanoseconds of when the last request was sent out. */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Separate outstandingPushes from outstandingRpcs so that we can timeout PushData requests in both client side and worker side.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

