### PR TITLE
[CELEBORN-171][FOLLOWUP] Auto activate jdk-8 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1013,6 +1013,9 @@
 
     <profile>
       <id>jdk-8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
       <properties>
         <java.version>8</java.version>
       </properties>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Auto activate `jdk-8` maven profile when using JDK 8.

### Why are the changes needed?

The `jdk-*` profile should be activate based on the JDK version automatically.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass CI.