### PR TITLE
[CELEBORN-258] `sbin/restart-worker.sh` should respect CELEBORN_WORKER_MEMORY and CELEBORN_WORKER_OFFHEAP_MEMORY

### DIFF
--- a/sbin/restart-worker.sh
+++ b/sbin/restart-worker.sh
@@ -22,6 +22,20 @@ if [ -z "${CELEBORN_HOME}" ]; then
   export CELEBORN_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 fi
 
+if [ "$CELEBORN_WORKER_MEMORY" = "" ]; then
+  CELEBORN_WORKER_MEMORY="1g"
+fi
+
+if [ "$CELEBORN_WORKER_OFFHEAP_MEMORY" = "" ]; then
+  CELEBORN_WORKER_OFFHEAP_MEMORY="1g"
+fi
+
+export CELEBORN_JAVA_OPTS="-Xmx$CELEBORN_WORKER_MEMORY -XX:MaxDirectMemorySize=$CELEBORN_WORKER_OFFHEAP_MEMORY $CELEBORN_WORKER_JAVA_OPTS"
+JAVA_VERSION=$(java -version 2>&1 | grep " version " | head -1 | awk '{print $3}' | tr -d '"')
+if [[ ! "$JAVA_VERSION" == 1.8.* ]]; then
+  export CELEBORN_JAVA_OPTS="${CELEBORN_JAVA_OPTS} --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --illegal-access=warn -Dio.netty.tryReflectionSetAccessible=true"
+fi
+
 if [ "$WORKER_INSTANCE" = "" ]; then
   WORKER_INSTANCE=1
 fi


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

`sbin/restart-worker.sh` should respect `CELEBORN_WORKER_OFFHEAP_MEMORY` and `CELEBORN_WORKER_MEMORY`

### Why are the changes needed?

If we restart the worker using `sbin/restart-worker.sh`, `CELEBORN_WORKER_OFFHEAP_MEMORY` and `CELEBORN_WORKER_MEMORY` will not take effect, this pr fixes this.

### Does this PR introduce _any_ user-facing change?

Yes, bug fix.

### How was this patch tested?

MT.