### PR TITLE
[CELEBORN-258][FOLLOW UP] `sbin/restart-worker.sh` should also import the `sbin/celeborn-config.sh`

### DIFF
--- a/sbin/restart-worker.sh
+++ b/sbin/restart-worker.sh
@@ -22,6 +22,8 @@ if [ -z "${CELEBORN_HOME}" ]; then
   export CELEBORN_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 fi
 
+. "${CELEBORN_HOME}/sbin/celeborn-config.sh"
+
 if [ "$CELEBORN_WORKER_MEMORY" = "" ]; then
   CELEBORN_WORKER_MEMORY="1g"
 fi


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Follow up the pr #1192 to read the `sbin/celeborn-config.sh` firstly, otherwise `CELEBORN_WORKER_MEMORY` and `CELEBORN_WORKER_OFFHEAP_MEMORY ` set in the `celeborn-env.sh` will not take effect 

### Why are the changes needed?

If users set `CELEBORN_WORKER_MEMORY` and `CELEBORN_WORKER_OFFHEAP_MEMORY ` in the `celeborn-env.sh`, calling `sbin/restart-worker.sh` actually omit these settings.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

MT.