### PR TITLE
[CELEBORN-264] InFlight requests should not be expired if it's not pushed yet

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
@@ -182,8 +182,6 @@ public class InFlightRequestTracker {
                     .forEach(
                         info -> {
                           if (info.pushTime != -1 && (currentTime - info.pushTime > pushTimeoutMs)) {
-                            logger.info("Fail request since it is timeout, pushTime is {}, maxTime is {}",
-                                info.pushTime, pushTimeoutMs);
                             if (info.callback != null) {
                               info.channelFuture.cancel(true);
                               info.callback.onFailure(

--- a/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
@@ -181,7 +181,9 @@ public class InFlightRequestTracker {
                     .values()
                     .forEach(
                         info -> {
-                          if (currentTime - info.pushTime > pushTimeoutMs) {
+                          if (info.pushTime != -1 && (currentTime - info.pushTime > pushTimeoutMs)) {
+                            logger.info("Fail request since it is timeout, pushTime is {}, maxTime is {}",
+                                info.pushTime, pushTimeoutMs);
                             if (info.callback != null) {
                               info.channelFuture.cancel(true);
                               info.callback.onFailure(
@@ -214,7 +216,7 @@ public class InFlightRequestTracker {
 
   static class BatchInfo {
     ChannelFuture channelFuture;
-    long pushTime;
+    long pushTime = -1;
     RpcResponseCallback callback;
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
@@ -181,7 +181,8 @@ public class InFlightRequestTracker {
                     .values()
                     .forEach(
                         info -> {
-                          if (info.pushTime != -1 && (currentTime - info.pushTime > pushTimeoutMs)) {
+                          if (info.pushTime != -1
+                              && (currentTime - info.pushTime > pushTimeoutMs)) {
                             if (info.callback != null) {
                               info.channelFuture.cancel(true);
                               info.callback.onFailure(

--- a/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
@@ -181,7 +181,7 @@ public class InFlightRequestTracker {
                     .values()
                     .forEach(
                         info -> {
-                          if (info.pushTime > 0 && (currentTime - info.pushTime > pushTimeoutMs)) {
+                          if (info.pushTime != -1 && (currentTime - info.pushTime > pushTimeoutMs)) {
                             if (info.callback != null) {
                               info.channelFuture.cancel(true);
                               info.callback.onFailure(

--- a/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/InFlightRequestTracker.java
@@ -181,7 +181,7 @@ public class InFlightRequestTracker {
                     .values()
                     .forEach(
                         info -> {
-                          if (info.pushTime != -1 && (currentTime - info.pushTime > pushTimeoutMs)) {
+                          if (info.pushTime > 0 && (currentTime - info.pushTime > pushTimeoutMs)) {
                             if (info.callback != null) {
                               info.channelFuture.cancel(true);
                               info.callback.onFailure(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Give inFlightRequest's `pushTime` an initial negative value, and `InFlightRequestsTracker` will only expire requests if it's `pushTime` is not negative


### Why are the changes needed?

`ShuffleClientImpl` first add batch to the `pushState`, and `pushTime` is assigned value in `pushState.pushStarted`, which is after the method `pushState.addBatch`, so it's possible to wrongly throw the exception `PushDataTimeout`.

For example,
1. pushState add batch 1, whose `pushTime` is initialized by 0 (Long)
2. Another push request calls `limitMaxInFlight` to check the limit, and batch 1 will be expired (since currentTime - 0 usually is larger than pushTimeoutMs)
![SeaTalk_IMG_1675235878](https://user-images.githubusercontent.com/10115332/216007808-e07edb73-1854-4907-9d92-00b96c67bb9d.png)


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

MT. After add the patch, the issue doesn't occur anymore.