### PR TITLE
[CELEBORN-272][BUG] Non-replication should use callback instead of wrappedCallback

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -337,7 +337,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
         }
       })
     } else {
-      wrappedCallback.onSuccess(ByteBuffer.wrap(Array[Byte]()))
+      callback.onSuccess(ByteBuffer.wrap(Array[Byte]()))
     }
 
     try {
@@ -559,7 +559,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
         }
       })
     } else {
-      wrappedCallback.onSuccess(ByteBuffer.wrap(Array[Byte]()))
+      callback.onSuccess(ByteBuffer.wrap(Array[Byte]()))
     }
 
     var index = 0


### PR DESCRIPTION
### What changes were proposed in this pull request?
Don't do replication should directly use callback not wrappedCallback


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

