### PR TITLE
[CELEBORN-247][FOLLOWUP] Fix NPE issue

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -145,6 +145,7 @@ private[celeborn] class Master(
   masterSource.addGauge(MasterSource.IsActiveMaster, _ => isMasterActive)
 
   metricsSystem.registerSource(rpcSource)
+  metricsSystem.registerSource(resourceConsumptionSource)
   metricsSystem.registerSource(masterSource)
   metricsSystem.registerSource(new JVMSource(conf, MetricsSystem.ROLE_MASTER))
   metricsSystem.registerSource(new JVMCPUSource(conf, MetricsSystem.ROLE_MASTER))

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -638,7 +638,7 @@ private[celeborn] class Master(
         val newResourceConsumption = statusSystem.workers.asScala.flatMap { workerInfo =>
           workerInfo.userResourceConsumption.asScala.get(userIdentifier)
         }.foldRight(ResourceConsumption(0, 0, 0, 0))(_ add _)
-        userResourceConsumptions.put(userIdentifier, (newResourceConsumption, current))._1
+        userResourceConsumptions.put(userIdentifier, (newResourceConsumption, current))
         newResourceConsumption
       } else {
         resourceConsumptionAndUpdateTime._1
@@ -647,7 +647,7 @@ private[celeborn] class Master(
       val newResourceConsumption = statusSystem.workers.asScala.flatMap { workerInfo =>
         workerInfo.userResourceConsumption.asScala.get(userIdentifier)
       }.foldRight(ResourceConsumption(0, 0, 0, 0))(_ add _)
-      userResourceConsumptions.put(userIdentifier, (newResourceConsumption, current))._1
+      userResourceConsumptions.put(userIdentifier, (newResourceConsumption, current))
       newResourceConsumption
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Fix NPE of 
```
[INFO] Running com.aliyun.emr.rss.service.deploy.integration.HugeDataTest
23/02/06 06:35:26,272 ERROR [dispatcher-event-loop-2] Inbox: Ignoring error
java.lang.NullPointerException
	at com.aliyun.emr.rss.service.deploy.master.Master.computeUserResourceConsumption(Master.scala:482)
	at com.aliyun.emr.rss.service.deploy.master.Master.com$aliyun$emr$rss$service$deploy$master$Master$$handleCheckQuota(Master.scala:507)
	at com.aliyun.emr.rss.service.deploy.master.Master$$anonfun$receiveAndReply$1.$anonfun$applyOrElse$24(Master.scala:229)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at com.aliyun.emr.rss.service.deploy.master.Master.executeWithLeaderChecker(Master.scala:163)
	at com.aliyun.emr.rss.service.deploy.master.Master$$anonfun$receiveAndReply$1.applyOrElse(Master.scala:229)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:110)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.safelyCall(Inbox.scala:214)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.process(Inbox.scala:107)
	at com.aliyun.emr.rss.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:222)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
23/02/06 06:35:26,275 ERROR [dag-scheduler-event-loop] RssHARetryClient: Send rpc with failure, has tried 0, max try 15!
com.aliyun.emr.rss.common.exception.RssException: Exception thrown in awaitResult: 
	at com.aliyun.emr.rss.common.util.ThreadUtils$.awaitResult(ThreadUtils.scala:224)
	at com.aliyun.emr.rss.common.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:74)
	at com.aliyun.emr.rss.common.haclient.RssHARetryClient.sendMessageInner(RssHARetryClient.java:148)
	at com.aliyun.emr.rss.common.haclient.RssHARetryClient.askSync(RssHARetryClient.java:120)
	at com.aliyun.emr.rss.client.write.LifecycleManager.checkQuota(LifecycleManager.scala:1699)
	at org.apache.spark.shuffle.rss.RssShuffleFallbackPolicyRunner.checkQuota(RssShuffleFallbackPolicyRunner.scala:65)
	at org.apache.spark.shuffle.rss.RssShuffleFallbackPolicyRunner.applyAllFallbackPolicy(RssShuffleFallbackPolicyRunner.scala:31)
	at org.apache.spark.shuffle.rss.RssShuffleManager.registerShuffle(RssShuffleManager.scala:85)
	at org.apache.spark.ShuffleDependency.<init>(Dependency.scala:96)
	at org.apache.spark.rdd.ShuffledRDD.getDependencies(ShuffledRDD.scala:87)
	at org.apache.spark.rdd.RDD.$anonfun$dependencies$2(RDD.scala:259)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.rdd.RDD.dependencies(RDD.scala:255)
	at org.apache.spark.scheduler.DAGScheduler.getShuffleDependencies(DAGScheduler.scala:541)
	at org.apache.spark.scheduler.DAGScheduler.getOrCreateParentStages(DAGScheduler.scala:490)
	at org.apache.spark.scheduler.DAGScheduler.createResultStage(DAGScheduler.scala:477)
	at org.apache.spark.scheduler.DAGScheduler.handleJobSubmitted(DAGScheduler.scala:1009)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:2196)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2188)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2177)
	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)
Caused by: java.lang.NullPointerException
	at com.aliyun.emr.rss.service.deploy.master.Master.computeUserResourceConsumption(Master.scala:482)
	at com.aliyun.emr.rss.service.deploy.master.Master.com$aliyun$emr$rss$service$deploy$master$Master$$handleCheckQuota(Master.scala:507)
	at com.aliyun.emr.rss.service.deploy.master.Master$$anonfun$receiveAndReply$1.$anonfun$applyOrElse$24(Master.scala:229)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at com.aliyun.emr.rss.service.deploy.master.Master.executeWithLeaderChecker(Master.scala:163)
	at com.aliyun.emr.rss.service.deploy.master.Master$$anonfun$receiveAndReply$1.applyOrElse(Master.scala:229)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:110)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.safelyCall(Inbox.scala:214)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.process(Inbox.scala:107)
	at com.aliyun.emr.rss.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:222)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

