### PR TITLE
[CELEBORN-275] WrappedCallback should only handle response from replica

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -148,9 +148,17 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     val key = s"${pushData.requestId}"
     val callbackWithTimer =
       if (isMaster) {
-        new RpcResponseCallbackWithTimer(workerSource, WorkerSource.MasterPushDataTime, key, callback)
+        new RpcResponseCallbackWithTimer(
+          workerSource,
+          WorkerSource.MasterPushDataTime,
+          key,
+          callback)
       } else {
-        new RpcResponseCallbackWithTimer(workerSource, WorkerSource.SlavePushDataTime, key, callback)
+        new RpcResponseCallbackWithTimer(
+          workerSource,
+          WorkerSource.SlavePushDataTime,
+          key,
+          callback)
       }
 
     // find FileWriter responsible for the data
@@ -381,9 +389,17 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     val key = s"${pushMergedData.requestId}"
     val callbackWithTimer =
       if (isMaster) {
-        new RpcResponseCallbackWithTimer(workerSource, WorkerSource.MasterPushDataTime, key, callback)
+        new RpcResponseCallbackWithTimer(
+          workerSource,
+          WorkerSource.MasterPushDataTime,
+          key,
+          callback)
       } else {
-        new RpcResponseCallbackWithTimer(workerSource, WorkerSource.SlavePushDataTime, key, callback)
+        new RpcResponseCallbackWithTimer(
+          workerSource,
+          WorkerSource.SlavePushDataTime,
+          key,
+          callback)
       }
 
     // For test

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -148,9 +148,9 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     val key = s"${pushData.requestId}"
     val callbackWithTimer =
       if (isMaster) {
-        new WrappedTimeMetric(workerSource, WorkerSource.MasterPushDataTime, key, callback)
+        new RpcResponseCallbackWithTimer(workerSource, WorkerSource.MasterPushDataTime, key, callback)
       } else {
-        new WrappedTimeMetric(workerSource, WorkerSource.SlavePushDataTime, key, callback)
+        new RpcResponseCallbackWithTimer(workerSource, WorkerSource.SlavePushDataTime, key, callback)
       }
 
     // find FileWriter responsible for the data
@@ -381,9 +381,9 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     val key = s"${pushMergedData.requestId}"
     val callbackWithTimer =
       if (isMaster) {
-        new WrappedTimeMetric(workerSource, WorkerSource.MasterPushDataTime, key, callback)
+        new RpcResponseCallbackWithTimer(workerSource, WorkerSource.MasterPushDataTime, key, callback)
       } else {
-        new WrappedTimeMetric(workerSource, WorkerSource.SlavePushDataTime, key, callback)
+        new RpcResponseCallbackWithTimer(workerSource, WorkerSource.SlavePushDataTime, key, callback)
       }
 
     // For test
@@ -635,7 +635,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
 
   override def checkRegistered(): Boolean = registered.get()
 
-  class WrappedTimeMetric(
+  class RpcResponseCallbackWithTimer(
       source: Source,
       metricName: String,
       key: String,

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -383,7 +383,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       if (isMaster) {
         new WrappedTimeMetric(workerSource, WorkerSource.MasterPushDataTime, key, callback)
       } else {
-        new WrappedTimeMetric(workerSource, WorkerSource.MasterPushDataTime, key, callback)
+        new WrappedTimeMetric(workerSource, WorkerSource.SlavePushDataTime, key, callback)
       }
 
     // For test
@@ -653,6 +653,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       source.stopTimer(metricName, key)
     }
   }
+
   class SimpleRpcResponseCallback(
       messageType: Message.Type,
       client: TransportClient,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. Move `WrappedCallback` in the `doReplicate` block
2. Remove unnecessary check in the wrappedCallback
3. Currently slave push data timer metric is not well calculated, need to fix it


### Why are the changes needed?
Clean the codes and fix the bug of calculating slave push data timer


### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?
MT. and existing UT.
