### PR TITLE
[CELEBORN-239][FOLLOWUP] PUSH_DATA_TIMEOUT_MASTER/SLAVE should support convert through  RPC

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -902,6 +902,10 @@ object Utils extends Logging {
         StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_MASTER
       case 41 =>
         StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_SLAVE
+      case 42 =>
+        StatusCode.PUSH_DATA_TIMEOUT_MASTER
+      case 43 =>
+        StatusCode.PUSH_DATA_TIMEOUT_SLAVE
       case _ =>
         null
     }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
@@ -78,7 +78,6 @@ class PushDataTimeoutTest extends AnyFunSuite
     }
   }
 
-
   test("celeborn spark integration test - pushdata timeout will add to balcklist") {
     val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[4]")
       .set("spark.celeborn.push.data.timeout", "5s")

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
@@ -50,6 +50,7 @@ class PushDataTimeoutTest extends AnyFunSuite
       val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[4]")
         .set("spark.celeborn.push.data.timeout", "5s")
         .set("spark.celeborn.push.replicate.enabled", enabled)
+        .set("spark.celeborn.client.blacklistSlave.enabled", "false")
       val sparkSession = SparkSession.builder().config(sparkConf).getOrCreate()
       val combineResult = combine(sparkSession)
       val groupbyResult = groupBy(sparkSession)
@@ -75,5 +76,25 @@ class PushDataTimeoutTest extends AnyFunSuite
       rssSparkSession.stop()
       ShuffleClient.reset()
     }
+  }
+
+
+  test("celeborn spark integration test - pushdata timeout will add to balcklist") {
+    val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[4]")
+      .set("spark.celeborn.push.data.timeout", "5s")
+      .set("spark.celeborn.push.replicate.enabled", "true")
+      .set("spark.celeborn.client.blacklistSlave.enabled", "true")
+    val rssSparkSession = SparkSession.builder()
+      .config(updateSparkConf(sparkConf, false)).getOrCreate()
+    try {
+      combine(rssSparkSession)
+    } catch {
+      case e: Exception =>
+        e.printStackTrace()
+        e.getMessage.concat("Revive Failed in retry push merged data for location")
+    }
+
+    rssSparkSession.stop()
+    ShuffleClient.reset()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
PUSH_DATA_TIMEOUT_MASTER/SLAVE should support convert through  RPC， without this LifecycleManager side will revive null status code, now is 
```
Received Revive request, local-1675825716934, 0, 3, 0, ,1, 0, PartitionLocation[
  id(rawId-attemptId)-epoch:1(1-0)-0
  host-rpcPort-pushPort-fetchPort-replicatePort:10.53.37.111-53650-53651-53653-53652
  mode:MASTER
  peer:(empty)
  storage hint:StorageInfo{type=MEMORY, mountPoint='/', finalResult=false, filePath=}
  mapIdBitMap:null], StatusCode{value=PUSH_DATA_TIMEOUT_MASTER}.
Received Revive request, local-1675825729662, 0, 2, 0, ,0, 0, PartitionLocation[
  id(rawId-attemptId)-epoch:0(0-0)-0
  host-rpcPort-pushPort-fetchPort-replicatePort:10.53.37.111-53650-53651-53653-53652
  mode:MASTER
  peer:(host-rpcPort-pushPort-fetchPort-replicatePort:10.53.37.111-53654-53655-53657-53656)
  storage hint:StorageInfo{type=MEMORY, mountPoint='/', finalResult=false, filePath=}
  mapIdBitMap:null], StatusCode{value=PUSH_DATA_TIMEOUT_SLAVE}.
```


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

