### PR TITLE
[CELEBORN-281] Add metrics about buffer stream's read buffer.

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/server/memory/MemoryManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/memory/MemoryManager.java
@@ -67,7 +67,7 @@ public class MemoryManager {
   private boolean underPressure;
   private final AtomicBoolean trimInProcess = new AtomicBoolean(false);
 
-  // For read buffer
+  // For buffer stream
   private final AtomicLong readBufferCounter = new AtomicLong(0);
   private long readBufferThreshold = 0;
   private final ReadBufferDispatcher readBufferDispatcher;
@@ -340,6 +340,10 @@ public class MemoryManager {
 
   public AtomicLong getDiskBufferCounter() {
     return diskBufferCounter;
+  }
+
+  public AtomicLong getReadBufferCounter() {
+    return readBufferCounter;
   }
 
   public long getPausePushDataCounter() {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -243,6 +243,9 @@ private[celeborn] class Worker(
   workerSource.addGauge(
     WorkerSource.PausePushDataAndReplicateCount,
     _ => memoryTracker.getPausePushDataAndReplicateCounter)
+  workerSource.addGauge(
+    WorkerSource.BufferStreamReadBuffer,
+    _ => memoryTracker.getReadBufferCounter.get())
 
   private def heartBeatToMaster(): Unit = {
     val activeShuffleKeys = new JHashSet[String]()

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -91,6 +91,7 @@ object WorkerSource {
   val DiskBuffer = "DiskBuffer"
   val PausePushDataCount = "PausePushData"
   val PausePushDataAndReplicateCount = "PausePushDataAndReplicate"
+  val BufferStreamReadBuffer = "BufferStreamReadBuffer"
 
   // local device
   val DeviceOSFreeCapacity = "DeviceOSFreeCapacity(B)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Export usage about buffer stream's read buffer.


### Why are the changes needed?
Export buffer stream memory data to Prometheus.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?

