### PR TITLE
[CELEBORN-291] optimize shuffleclientimpl creating client and pushdata for mappartition

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
@@ -203,6 +203,7 @@ public class RemoteShuffleOutputGate {
       bufferPool.lazyDestroy();
     }
     bufferPacker.close();
+    shuffleWriteClient.cleanup(applicationId, shuffleId, mapId, attemptId);
   }
 
   /** Returns shuffle descriptor. */

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -20,7 +20,6 @@ package org.apache.celeborn.client;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BooleanSupplier;
 
 import io.netty.buffer.ByteBuf;
 import org.apache.hadoop.conf.Configuration;
@@ -208,7 +207,7 @@ public abstract class ShuffleClient {
       int partitionId,
       ByteBuf data,
       PartitionLocation location,
-      BooleanSupplier closeCallBack)
+      Runnable closeCallBack)
       throws IOException;
 
   public abstract Optional<PartitionLocation> regionStart(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1510,9 +1510,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     // do push data
     try {
       TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
-      ChannelFuture future = client.pushDataWithCompleteCallback(pushData, callback, closeCallBack);
-      pushState.pushStarted(
-          nextBatchId, future, callback, location.hostAndPushPort(), pushDataTimeout);
+      client.pushDataWithCompleteCallback(pushData, callback, closeCallBack);
     } catch (Exception e) {
       logger.warn("PushData byteBuf failed", e);
       callback.onFailure(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1510,7 +1510,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     // do push data
     try {
       TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
-      client.pushDataWithCompleteCallback(pushData, pushDataTimeout, callback, closeCallBack);
+      client.pushData(pushData, pushDataTimeout, callback, closeCallBack);
     } catch (Exception e) {
       logger.warn("PushData byteBuf failed", e);
       callback.onFailure(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1510,7 +1510,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     // do push data
     try {
       TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
-      client.pushDataWithCompleteCallback(pushData, callback, closeCallBack);
+      client.pushDataWithCompleteCallback(pushData, pushDataTimeout, callback, closeCallBack);
     } catch (Exception e) {
       logger.warn("PushData byteBuf failed", e);
       callback.onFailure(

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BooleanSupplier;
 
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -160,7 +160,7 @@ public class DummyShuffleClient extends ShuffleClient {
       int partitionId,
       ByteBuf data,
       PartitionLocation location,
-      BooleanSupplier closeCallBack) {
+      Runnable closeCallBack) {
     return 0;
   }
 

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
@@ -138,7 +138,7 @@ public class ShuffleClientImplSuiteJ extends ShuffleClientBaseSuiteJ {
           TEST_REDUCRE_ID,
           byteBuf,
           masterLocation,
-          () -> { });
+          () -> {});
     } catch (IOException e) {
       isFailed = true;
     } finally {

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
@@ -108,7 +108,7 @@ public class ShuffleClientImplSuiteJ extends ShuffleClientBaseSuiteJ {
   @Test
   public void testPushDataByteBufFail() throws IOException {
     ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
-    when(client.pushDataWithCompleteCallback(any(), any(), any()))
+    when(client.pushDataWithCompleteCallback(any(), anyLong(), any(), any()))
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback =

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
@@ -108,7 +108,7 @@ public class ShuffleClientImplSuiteJ extends ShuffleClientBaseSuiteJ {
   @Test
   public void testPushDataByteBufFail() throws IOException {
     ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
-    when(client.pushData(any(), anyLong(), any()))
+    when(client.pushDataWithCompleteCallback(any(), any(), any()))
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback =

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
@@ -108,7 +108,7 @@ public class ShuffleClientImplSuiteJ extends ShuffleClientBaseSuiteJ {
   @Test
   public void testPushDataByteBufFail() throws IOException {
     ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
-    when(client.pushDataWithCompleteCallback(any(), anyLong(), any(), any()))
+    when(client.pushData(any(), anyLong(), any(), any()))
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback =

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientImplSuiteJ.java
@@ -76,7 +76,7 @@ public class ShuffleClientImplSuiteJ extends ShuffleClientBaseSuiteJ {
             TEST_REDUCRE_ID,
             byteBuf,
             masterLocation,
-            () -> true);
+            () -> {});
     Assert.assertEquals(BufferSize, pushDataLen);
   }
 
@@ -102,7 +102,7 @@ public class ShuffleClientImplSuiteJ extends ShuffleClientBaseSuiteJ {
             TEST_REDUCRE_ID,
             byteBuf,
             masterLocation,
-            () -> true);
+            () -> {});
   }
 
   @Test
@@ -125,7 +125,7 @@ public class ShuffleClientImplSuiteJ extends ShuffleClientBaseSuiteJ {
         TEST_REDUCRE_ID,
         byteBuf,
         masterLocation,
-        () -> true);
+        () -> {});
 
     boolean isFailed = false;
     // second push will throw exception
@@ -138,7 +138,7 @@ public class ShuffleClientImplSuiteJ extends ShuffleClientBaseSuiteJ {
           TEST_REDUCRE_ID,
           byteBuf,
           masterLocation,
-          () -> true);
+          () -> { });
     } catch (IOException e) {
       isFailed = true;
     } finally {

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -188,7 +188,8 @@ public class TransportClient implements Closeable {
     return channel.writeAndFlush(pushData).addListener(listener);
   }
 
-  public ChannelFuture pushMergedData(PushMergedData pushMergedData, long pushDataTimeout, RpcResponseCallback callback) {
+  public ChannelFuture pushMergedData(
+      PushMergedData pushMergedData, long pushDataTimeout, RpcResponseCallback callback) {
     if (logger.isTraceEnabled()) {
       logger.trace("Pushing merged data to {}", NettyUtils.getRemoteAddress(channel));
     }


### PR DESCRIPTION
…appartition

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
optimize  currentClient to concurrentmap to avoid that different maptask use the same currentclient
the first int of data header in mappartition should be partitionid(subpartitionid) rather than mappid
closefunction is called while successfullly writeandflush insteading of get successfull response


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

