### PR TITLE
[CELEBORN-292] optimize mappartitionfilewriter flushing index and reading data header

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
@@ -40,6 +40,7 @@ public class FileInfo {
   private final UserIdentifier userIdentifier;
   private final PartitionType partitionType;
   private int bufferSize;
+  private int numReducerPartitions;
 
   public FileInfo(String filePath, List<Long> chunkOffsets, UserIdentifier userIdentifier) {
     this(filePath, chunkOffsets, userIdentifier, PartitionType.REDUCE);
@@ -185,5 +186,13 @@ public class FileInfo {
 
   public int getBufferSize() {
     return bufferSize;
+  }
+
+  public int getNumReducerPartitions() {
+    return numReducerPartitions;
+  }
+
+  public void setNumReducerPartitions(int numReducerPartitions) {
+    this.numReducerPartitions = numReducerPartitions;
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -42,7 +42,7 @@ import org.roaringbitmap.RoaringBitmap
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{DiskStatus, WorkerInfo}
+import org.apache.celeborn.common.meta.{DiskStatus, FileInfo, WorkerInfo}
 import org.apache.celeborn.common.network.protocol.TransportMessage
 import org.apache.celeborn.common.network.util.{ConfigProvider, JavaUtils, TransportConf}
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType}
@@ -992,6 +992,13 @@ object Utils extends Logging {
     } else {
       null
     }
+  }
+
+  def getShortFormattedFileName(fileInfo: FileInfo): String = {
+    val parentFile = fileInfo.getFile.getParent
+    parentFile.substring(
+      parentFile.lastIndexOf("/"),
+      parentFile.length) + "/" + fileInfo.getFile.getName
   }
 
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriter.java
@@ -277,7 +277,7 @@ public final class MapPartitionFileWriter extends FileWriter {
 
   private void flushIndex() throws IOException {
     if (indexBuffer != null) {
-      logger.debug("flushIndex start:" + fileInfo.getIndexPath());
+      logger.debug("flushIndex start:{}", fileInfo.getIndexPath());
       long startTime = System.currentTimeMillis();
       indexBuffer.flip();
       notifier.checkException();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriterSuiteJ.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -45,7 +47,6 @@ import org.apache.celeborn.common.network.server.memory.MemoryManager;
 import org.apache.celeborn.common.network.util.JavaUtils;
 import org.apache.celeborn.common.protocol.PartitionSplitMode;
 import org.apache.celeborn.common.protocol.StorageInfo;
-import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;
 
@@ -145,10 +146,11 @@ public class MapPartitionFileWriterSuiteJ {
     int len = (int) (Math.ceil(1.0 * tempLen / hello.length) * hello.length) + headerLength;
 
     byte[] data = new byte[len];
-    Platform.putInt(data, Platform.BYTE_ARRAY_OFFSET, partitionId);
-    Platform.putInt(data, Platform.BYTE_ARRAY_OFFSET + 4, 0);
-    Platform.putInt(data, Platform.BYTE_ARRAY_OFFSET + 8, rand.nextInt());
-    Platform.putInt(data, Platform.BYTE_ARRAY_OFFSET + 12, len);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN);
+    byteBuffer.putInt(0, partitionId);
+    byteBuffer.putInt(4, 0);
+    byteBuffer.putInt(8, rand.nextInt());
+    byteBuffer.putInt(12, len);
 
     for (int i = headerLength; i < len; i += hello.length) {
       System.arraycopy(hello, 0, data, i, hello.length);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?



### Why are the changes needed?

add logs
modify flushindex from async to sync
modify reading header from platform method to bytebuf read

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

