### PR TITLE
[CELEBORN-296] fix map partition commit using wrong partitionId and result

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -670,8 +670,8 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       shuffleId,
       mapId,
       attemptId,
-      partitionId,
-      numMappers)
+      numMappers,
+      partitionId)
     reply(mapperAttemptFinishedSuccess)
   }
 

--- a/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
@@ -194,13 +194,13 @@ class MapPartitionCommitHandler(
 
     var dataCommitSuccess = true
     if (!partitionAllocatedWorkers.isEmpty) {
-      val result =
+      val (dataLost, commitFailedWorkers) =
         handleFinalPartitionCommitFiles(
           shuffleId,
           partitionAllocatedWorkers,
           partitionId)
-      dataCommitSuccess = result._1
-      recordWorkerFailure(result._2)
+      dataCommitSuccess = !dataLost
+      recordWorkerFailure(commitFailedWorkers)
     }
 
     // release resources and clear related info


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. for map partition, correct the right partitionId would be committed.
2. for map partition, correct the final result in finishMapperAttempt. 

### Why are the changes needed?
Use wrong partitionId and result will cause shuffle data lost in next stage. And because of the above two interrelated issues, the test just passed.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
UT
