### PR TITLE
[CELEBORN-300] fix a bug about non-leader master try to update partition size.

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -120,8 +120,11 @@ private[celeborn] class Master(
   partitionSizeUpdateService.scheduleAtFixedRate(
     new Runnable {
       override def run(): Unit = {
-        statusSystem.handleUpdatePartitionSize()
-        logInfo(s"Cluster estimate partition size ${Utils.bytesToString(statusSystem.estimatedPartitionSize)}")
+        executeWithLeaderChecker(
+          null, {
+            statusSystem.handleUpdatePartitionSize()
+            logInfo(s"Cluster estimate partition size ${Utils.bytesToString(statusSystem.estimatedPartitionSize)}")
+          })
       }
     },
     estimatedPartitionSizeUpdaterInitialDelay,


### PR DESCRIPTION
### What changes were proposed in this pull request?
If a master is not a leader, it won't try to update the partition size.


### Why are the changes needed?
To reduce log size.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT.
