### PR TITLE
[CELEBORN-301] Refactor PartitionLocationInfo to use ConcurrentHashMap

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
@@ -52,6 +52,7 @@ public class SortBasedPusher extends MemoryConsumer {
   private final int pushBufferMaxSize;
   private final long pushSortMemoryThreshold;
   final int uaoSize = UnsafeAlignedOffset.getUaoSize();
+  static final long size8k = Utils.byteStringAsBytes("8k");
 
   String appId;
   int shuffleId;
@@ -182,7 +183,7 @@ public class SortBasedPusher extends MemoryConsumer {
       throws IOException {
 
     if (getUsed() > pushSortMemoryThreshold
-        && pageCursor + Utils.byteStringAsBytes("8k")
+        && pageCursor + size8k
             > currentPage.getBaseOffset() + currentPage.size()) {
       logger.info(
           "Memory Used across threshold, trigger push. Memory: "

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -224,6 +224,10 @@ public class PartitionLocation implements Serializable {
     return id + "-" + epoch;
   }
 
+  public long encodeUniqueId() {
+    return ((long) id) << 32 | epoch;
+  }
+
   public String getFileName() {
     return id + "-" + epoch + "-" + mode.mode;
   }

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -224,10 +224,6 @@ public class PartitionLocation implements Serializable {
     return id + "-" + epoch;
   }
 
-  public long encodeUniqueId() {
-    return ((long) id) << 32 | epoch;
-  }
-
   public String getFileName() {
     return id + "-" + epoch + "-" + mode.mode;
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -413,6 +413,7 @@ private[celeborn] class Worker(
     expiredShuffleKeys.asScala.foreach { shuffleKey =>
       partitionLocationInfo.removeMasterPartitions(shuffleKey)
       partitionLocationInfo.removeSlavePartitions(shuffleKey)
+      partitionLocationInfo.removeShuffle(shuffleKey)
       shufflePartitionType.remove(shuffleKey)
       shuffleMapperAttempts.remove(shuffleKey)
       shuffleCommitInfos.remove(shuffleKey)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Refactor PartitionLocationInfo, replace HashMap with ConcurrentHashMap and removed synchronized blocks. Also change the core data structure from ```(shuffleKey  -> (partitionId -> List[PartitionLocation]))``` to ```(shuffleKey -> (encodedUniqueId -> partitionLocation))```, where ```encodedUniqueId``` is ```partitionId.toLong << 32 | epoch```


### Why are the changes needed?
For very large test case, say 300T terasort with 30w * 15w parallelism with sort pusher, the synchronization lock becomes the bottleneck. Tried with ReentrantReadWriteLock, task duration decreases from 7min to 5.6min. The PR further uses ConcurrentHashMap to avoid lock.

I tested the following with sort pusher
```
spark.sparkContext.parallelize(1 to 3000).repartition(2000).flatMap( _ => (1 to 15000000).iterator.map(num => num)).repartition(150000).count
```
Before this PR the shuffle write stage takes 6.7 min
After this PR the shuffle write stage takes 5.3 min

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Integration test.
