### PR TITLE
[CELEBORN-297] don't cache file groups for map partition shuffle type

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
@@ -32,6 +32,9 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{ShufflePartitionLocationInfo, WorkerInfo}
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionType}
+import org.apache.celeborn.common.protocol.message.ControlMessages.GetReducerFileGroupResponse
+import org.apache.celeborn.common.protocol.message.StatusCode
+import org.apache.celeborn.common.rpc.RpcCallContext
 // Can Remove this if celeborn don't support scala211 in future
 import org.apache.celeborn.common.util.FunctionConverter._
 import org.apache.celeborn.common.util.Utils
@@ -210,5 +213,12 @@ class MapPartitionCommitHandler(
 
     inProcessingPartitionIds.remove(partitionId)
     (dataCommitSuccess, false)
+  }
+
+  override def handleGetReducerFileGroup(context: RpcCallContext, shuffleId: Int): Unit = {
+    context.reply(GetReducerFileGroupResponse(
+      StatusCode.SUCCESS,
+      reducerFileGroupsMap.getOrDefault(shuffleId, new ConcurrentHashMap()),
+      getMapperAttempts(shuffleId)))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
 With this patch celeborn lifecycleManager don't cache file groups for map partition shuffle type. But would do best effort cache at client-side if map partition already finished, this will be done in following pr.

### Why are the changes needed?
Only Reduce partition mode supports cache all file groups for reducer. Map partition doesn't guarantee that all partitions are complete by the time the method is called, as downstream tasks may start early before all tasks are completed.So map partition may need refresh reducer file group if needed.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
