### PR TITLE
[CELEBORN-302] Fix workers count out of sync in HA mode.

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -268,13 +268,12 @@ class WorkerInfo(
         rpcPort == that.rpcPort &&
         pushPort == that.pushPort &&
         fetchPort == that.fetchPort &&
-        replicatePort == that.replicatePort &&
-        userResourceConsumption == that.userResourceConsumption
+        replicatePort == that.replicatePort
     case _ => false
   }
 
   override def hashCode(): Int = {
-    val state = Seq(host, rpcPort, pushPort, fetchPort, replicatePort, userResourceConsumption)
+    val state = Seq(host, rpcPort, pushPort, fetchPort, replicatePort)
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -259,7 +259,6 @@ class WorkerInfo(
        |""".stripMargin
   }
 
-
   private def canEqual(other: Any): Boolean = other.isInstanceOf[WorkerInfo]
 
   override def equals(other: Any): Boolean = other match {

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -259,17 +259,24 @@ class WorkerInfo(
        |""".stripMargin
   }
 
-  override def equals(obj: Any): Boolean = {
-    val other = obj.asInstanceOf[WorkerInfo]
-    host == other.host &&
-    rpcPort == other.rpcPort &&
-    pushPort == other.pushPort &&
-    fetchPort == other.fetchPort &&
-    replicatePort == other.replicatePort
+
+  private def canEqual(other: Any): Boolean = other.isInstanceOf[WorkerInfo]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: WorkerInfo =>
+      that.canEqual(this) &&
+        host == that.host &&
+        rpcPort == that.rpcPort &&
+        pushPort == that.pushPort &&
+        fetchPort == that.fetchPort &&
+        replicatePort == that.replicatePort &&
+        userResourceConsumption == that.userResourceConsumption
+    case _ => false
   }
 
   override def hashCode(): Int = {
-    Objects.hashCode(host, rpcPort, pushPort, fetchPort, replicatePort)
+    val state = Seq(host, rpcPort, pushPort, fetchPort, replicatePort, userResourceConsumption)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
 }
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -259,12 +259,9 @@ class WorkerInfo(
        |""".stripMargin
   }
 
-  private def canEqual(other: Any): Boolean = other.isInstanceOf[WorkerInfo]
-
   override def equals(other: Any): Boolean = other match {
     case that: WorkerInfo =>
-      that.canEqual(this) &&
-        host == that.host &&
+      host == that.host &&
         rpcPort == that.rpcPort &&
         pushPort == that.pushPort &&
         fetchPort == that.fetchPort &&

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -363,7 +363,7 @@ object PbSerDeUtils {
       blacklist: java.util.Set[WorkerInfo],
       workerLostEvent: java.util.Set[WorkerInfo],
       appHeartbeatTime: java.util.Map[String, java.lang.Long],
-      workers: java.util.Set[WorkerInfo],
+      workers: java.util.ArrayList[WorkerInfo],
       partitionTotalWritten: java.lang.Long,
       partitionTotalFileCount: java.lang.Long,
       appDiskUsageMetricSnapshots: Array[AppDiskUsageSnapShot],

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -363,7 +363,7 @@ object PbSerDeUtils {
       blacklist: java.util.Set[WorkerInfo],
       workerLostEvent: java.util.Set[WorkerInfo],
       appHeartbeatTime: java.util.Map[String, java.lang.Long],
-      workers: java.util.ArrayList[WorkerInfo],
+      workers: java.util.Set[WorkerInfo],
       partitionTotalWritten: java.lang.Long,
       partitionTotalFileCount: java.lang.Long,
       appDiskUsageMetricSnapshots: Array[AppDiskUsageSnapShot],

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -235,7 +235,9 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
 
     workerInfo.updateDiskMaxSlots(estimatedPartitionSize);
     synchronized (workers) {
-      workers.add(workerInfo);
+      if (!workers.contains(workerInfo)) {
+        workers.add(workerInfo);
+      }
     }
   }
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -224,8 +224,13 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       // if some master failed, other master not, sync state will be broken.
       workerInfo.setupEndpoint(rpcEnv.setupEndpointRef(RpcAddress.apply(host, rpcPort), WORKER_EP));
     } catch (Exception e) {
-      LOG.error("Worker register failed", e);
-      return;
+      LOG.warn("Worker register setupEndpoint failed {}, will retry", e);
+      try {
+        workerInfo.setupEndpoint(
+            rpcEnv.setupEndpointRef(RpcAddress.apply(host, rpcPort), WORKER_EP));
+      } catch (Exception e1) {
+        workerInfo.setupEndpoint(null);
+      }
     }
 
     workerInfo.updateDiskMaxSlots(estimatedPartitionSize);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -47,7 +47,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   // Meta data for master service
   public final Set<String> registeredShuffle = ConcurrentHashMap.newKeySet();
   public final Set<String> hostnameSet = ConcurrentHashMap.newKeySet();
-  public final Set<WorkerInfo> workers = new HashSet<>();
+  public final ArrayList<WorkerInfo> workers = new ArrayList<>();
   public final ConcurrentHashMap<String, Long> appHeartbeatTime = new ConcurrentHashMap<>();
   // blacklist
   public final Set<WorkerInfo> blacklist = ConcurrentHashMap.newKeySet();

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -21,11 +21,7 @@ import static org.apache.celeborn.common.protocol.RpcNameConstants.WORKER_EP;
 
 import java.io.*;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -51,7 +47,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   // Meta data for master service
   public final Set<String> registeredShuffle = ConcurrentHashMap.newKeySet();
   public final Set<String> hostnameSet = ConcurrentHashMap.newKeySet();
-  public final ArrayList<WorkerInfo> workers = new ArrayList<>();
+  public final Set<WorkerInfo> workers = new HashSet<>();
   public final ConcurrentHashMap<String, Long> appHeartbeatTime = new ConcurrentHashMap<>();
   // blacklist
   public final Set<WorkerInfo> blacklist = ConcurrentHashMap.newKeySet();
@@ -225,6 +221,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     workerInfo.lastHeartbeat_$eq(System.currentTimeMillis());
 
     try {
+      // if some master failed, other master not, sync state will be broken.
       workerInfo.setupEndpoint(rpcEnv.setupEndpointRef(RpcAddress.apply(host, rpcPort), WORKER_EP));
     } catch (Exception e) {
       LOG.error("Worker register failed", e);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -221,7 +221,6 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     workerInfo.lastHeartbeat_$eq(System.currentTimeMillis());
 
     try {
-      // if some master failed, other master not, sync state will be broken.
       workerInfo.setupEndpoint(rpcEnv.setupEndpointRef(RpcAddress.apply(host, rpcPort), WORKER_EP));
     } catch (Exception e) {
       LOG.warn("Worker register setupEndpoint failed {}, will retry", e);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -21,7 +21,11 @@ import static org.apache.celeborn.common.protocol.RpcNameConstants.WORKER_EP;
 
 import java.io.*;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -748,32 +748,34 @@ private[celeborn] class Master(
 
   private def requestGetWorkerInfos(endpoint: RpcEndpointRef): GetWorkerInfosResponse = {
     try {
-      endpoint.askSync[GetWorkerInfosResponse](GetWorkerInfos)
+      if (endpoint != null) {
+        return endpoint.askSync[GetWorkerInfosResponse](GetWorkerInfos)
+      }
     } catch {
       case e: Exception =>
         logError(s"AskSync GetWorkerInfos failed.", e)
-        val result = new util.ArrayList[WorkerInfo]
-        result.add(new WorkerInfo(
-          "unknown",
-          -1,
-          -1,
-          -1,
-          -1,
-          new util.HashMap[String, DiskInfo](),
-          new ConcurrentHashMap[UserIdentifier, ResourceConsumption](),
-          null))
-        GetWorkerInfosResponse(StatusCode.REQUEST_FAILED, result.asScala: _*)
     }
+    val result = new util.ArrayList[WorkerInfo]
+    result.add(new WorkerInfo(
+      "unknown",
+      -1,
+      -1,
+      -1,
+      -1,
+      new util.HashMap[String, DiskInfo](),
+      new ConcurrentHashMap[UserIdentifier, ResourceConsumption](),
+      null))
+    GetWorkerInfosResponse(StatusCode.REQUEST_FAILED, result.asScala: _*)
   }
 
   private def requestThreadDump(endpoint: RpcEndpointRef): ThreadDumpResponse = {
     try {
-      endpoint.askSync[ThreadDumpResponse](ThreadDump)
+      return endpoint.askSync[ThreadDumpResponse](ThreadDump)
     } catch {
       case e: Exception =>
         logError(s"AskSync ThreadDump failed.", e)
-        ThreadDumpResponse("Unknown")
     }
+    ThreadDumpResponse("Unknown")
   }
 
   private def isMasterActive: Int = {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -770,7 +770,9 @@ private[celeborn] class Master(
 
   private def requestThreadDump(endpoint: RpcEndpointRef): ThreadDumpResponse = {
     try {
-      return endpoint.askSync[ThreadDumpResponse](ThreadDump)
+      if (endpoint != null) {
+        return endpoint.askSync[ThreadDumpResponse](ThreadDump)
+      }
     } catch {
       case e: Exception =>
         logError(s"AskSync ThreadDump failed.", e)


### PR DESCRIPTION
### What changes were proposed in this pull request?
The worker's list might add two identical workers if the masters failed to connect to the worker while setting up the endpoint.


### Why are the changes needed?
Change the worker's list to set to remove redundant workers.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT.
