### PR TITLE
[CELEBORN-305] Change the parameter passed in the registerShuffle method to numPartitions instead of numMappers

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -313,7 +313,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     return registerShuffleInternal(
         shuffleId,
         numMappers,
-        numMappers,
+        numPartitions,
         () ->
             driverRssMetaService.askSync(
                 RegisterShuffle$.MODULE$.apply(appId, shuffleId, numMappers, numPartitions),


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Change the parameter passed in the registerShuffle method to numPartitions instead of numMappers

### Why are the changes needed?

ShuffleClientImpl's registerShuffle method should pass numPartitions instead of numMappers

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

