### PR TITLE
[CELEBORN-307] fix ArrayComparisonFailure while running lz4 ut

### DIFF
--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
@@ -59,7 +59,7 @@ trait ReadWriteTestBase extends AnyFunSuite
       .set("celeborn.shuffle.compression.codec", codec.name)
       .set("celeborn.push.replicate.enabled", "true")
       .set("celeborn.push.buffer.size", "256K")
-        .set("celeborn.data.io.numConnectionsPerPeer", "1")
+      .set("celeborn.data.io.numConnectionsPerPeer", "1")
     val lifecycleManager = new LifecycleManager(APP, clientConf)
     val shuffleClient = new ShuffleClientImpl(clientConf, UserIdentifier("mock", "mock"))
     shuffleClient.setupMetaServiceRef(lifecycleManager.self)

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
@@ -59,6 +59,7 @@ trait ReadWriteTestBase extends AnyFunSuite
       .set("celeborn.shuffle.compression.codec", codec.name)
       .set("celeborn.push.replicate.enabled", "true")
       .set("celeborn.push.buffer.size", "256K")
+        .set("celeborn.data.io.numConnectionsPerPeer", "1")
     val lifecycleManager = new LifecycleManager(APP, clientConf)
     val shuffleClient = new ShuffleClientImpl(clientConf, UserIdentifier("mock", "mock"))
     shuffleClient.setupMetaServiceRef(lifecycleManager.self)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
pushmergedata  chooses a random TransportClient ,but pushdata only choose a specfic TransportClient. 
the defaut value of celeborn.data.io.numConnectionsPerPeer is 2, so the client maybe different between pushdata and  pushmergedata.
Two TransportClient means two threads to send message and worker server will has two threads to flush data, so the data in the file maybe unorder. lastly, Assert.assertArrayEquals(targetArr, readBytes) will occur error because the data is unorder.

so set celeborn.data.io.numConnectionsPerPeer to 1 to slove the problem above



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

