### PR TITLE
[CELEBORN-311] not retry when register for map partition occurs exception 

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
@@ -233,7 +233,7 @@ public class RemoteShuffleOutputGate {
     }
   }
 
-  public void handshake(boolean isFirstHandShake) {
+  public void handshake(boolean isFirstHandShake) throws IOException {
     if (partitionLocation == null) {
       partitionLocation =
           shuffleWriteClient.registerMapPartitionTask(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -235,7 +235,7 @@ public abstract class ShuffleClient {
       throws IOException;
 
   public abstract PartitionLocation registerMapPartitionTask(
-      String appId, int shuffleId, int numMappers, int mapId, int attemptId);
+      String appId, int shuffleId, int numMappers, int mapId, int attemptId) throws IOException;
 
   public abstract ConcurrentHashMap<Integer, PartitionLocation> getPartitionLocation(
       String applicationId, int shuffleId, int numMappers, int numPartitions);

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -320,7 +320,7 @@ public class ShuffleClientImpl extends ShuffleClient {
 
   @VisibleForTesting
   public PartitionLocation registerMapPartitionTask(
-      String appId, int shuffleId, int numMappers, int mapId, int attemptId) {
+      String appId, int shuffleId, int numMappers, int mapId, int attemptId) throws IOException {
     int partitionId = PackedPartitionId.packedPartitionId(mapId, attemptId);
     logger.info(
         "register mapPartitionTask, mapId: {}, attemptId: {}, partitionId: {}",
@@ -338,6 +338,12 @@ public class ShuffleClientImpl extends ShuffleClient {
                         appId, shuffleId, numMappers, mapId, attemptId, partitionId),
                     conf.registerShuffleRpcAskTimeout(),
                     ClassTag$.MODULE$.apply(PbRegisterShuffleResponse.class)));
+
+    if (partitionLocationMap == null) {
+      String shuffleKey = Utils.makeShuffleKey(appId, shuffleId);
+      throw new IOException("Register shuffle failed for shuffle " + shuffleKey);
+    }
+
     return partitionLocationMap.get(partitionId);
   }
 

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -383,9 +383,9 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
               case PartitionType.MAP =>
                 if (response.getStatus == 0) {
                   val partitionLocations =
-                    response.getPartitionLocationsList.asScala.filter(_.getId == context.partitionId).map(
-                      r =>
-                        PbSerDeUtils.fromPbPartitionLocation(r)).toArray
+                    response.getPartitionLocationsList.asScala.filter(
+                      _.getId == context.partitionId).map(r =>
+                      PbSerDeUtils.fromPbPartitionLocation(r)).toArray
                   processMapTaskReply(
                     applicationId,
                     shuffleId,

--- a/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
@@ -44,7 +44,7 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
   private val mapId = 1
   private val attemptId = 0
 
-  test(s"test register map partition task") {
+  test("test register map partition task") {
     Assert.assertNotNull(lifecycleManager)
     Assert.assertNotNull(shuffleClient)
     val shuffleId = 1
@@ -82,7 +82,7 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
     Assert.assertEquals(count, numMappers + 1)
   }
 
-  test(s"test map end & get reducer file group") {
+  test("test map end & get reducer file group") {
     val shuffleId = 2
     shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId)
     shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId + 1, attemptId)

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
@@ -42,8 +42,8 @@ class ShuffleClientSuite extends WithShuffleClientSuite with MiniClusterFeature 
 
   test("test register when master not available") {
     val celebornConf: CelebornConf = new CelebornConf()
-    celebornConf.set("celeborn.master.endpoints", s"localhost:19098")
-    celebornConf.set("celeborn.client.maxRetries", s"0")
+    celebornConf.set("celeborn.master.endpoints", "localhost:19098")
+    celebornConf.set("celeborn.client.maxRetries", "0")
 
     val lifecycleManager: LifecycleManager = new LifecycleManager(APP, celebornConf)
     val shuffleClient: ShuffleClientImpl = {
@@ -55,6 +55,8 @@ class ShuffleClientSuite extends WithShuffleClientSuite with MiniClusterFeature 
     assertThrows[IOException] {
       () -> shuffleClient.registerMapPartitionTask(APP, 1, 1, 0, 0)
     }
+
+    lifecycleManager.stop()
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
not retry when register occurs exception and response original status to client


### Why are the changes needed?
1. No need for another retry when register shuffle for map partition occurs exception.
2.Retry will cause lose original response message, and it is impossible to succeed.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
UT
