### PR TITLE
[CELEBORN-308] Fix flusher will exit unexpectedly if flush task write failed.

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -193,7 +193,6 @@ private[worker] class LocalFlusher(
   deviceMonitor.registerFlusher(this)
 
   override def processIOException(e: IOException, deviceErrorType: DiskStatus): Unit = {
-    stopFlag.set(true)
     logError(s"$this write failed, report to DeviceMonitor, exception: $e")
     deviceMonitor.reportNonCriticalError(mountPoint, e, deviceErrorType)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
If a flush task fails, the flusher should not stop. If a flusher stopped, related file writers would be left with unflushed data in memory and the worker will be stuck because of high memory usage or commit files failed.


### Why are the changes needed?
To make sure that workers with unstable disks can work well.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT and cluster.
