### PR TITLE
[CELEBORN-319][FLINK] FlinkTransportClient should not reuse connection.

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/FlinkTransportClientFactory.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/FlinkTransportClientFactory.java
@@ -18,6 +18,7 @@
 package org.apache.celeborn.plugin.flink.network;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.function.Supplier;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
@@ -31,10 +32,10 @@ public class FlinkTransportClientFactory extends TransportClientFactory {
     super(context);
   }
 
-  public TransportClient createClient(
-      String remoteHost, int remotePort, int partitionId, Supplier<ByteBuf> supplier)
+  public TransportClient createClient(String remoteHost, int remotePort, Supplier<ByteBuf> supplier)
       throws IOException, InterruptedException {
-    return createClient(
-        remoteHost, remotePort, partitionId, new TransportFrameDecoderWithBufferSupplier(supplier));
+    final InetSocketAddress resolvedAddress = new InetSocketAddress(remoteHost, remotePort);
+    return internalCreateClient(
+        resolvedAddress, new TransportFrameDecoderWithBufferSupplier(supplier));
   }
 }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/RssBufferStream.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/RssBufferStream.java
@@ -75,7 +75,6 @@ public class RssBufferStream {
         clientFactory.createClient(
             locations[currentLocationIndex].getHost(),
             locations[currentLocationIndex].getFetchPort(),
-            -1,
             supplier);
     OpenStreamWithCredit openBufferStream =
         new OpenStreamWithCredit(
@@ -155,5 +154,11 @@ public class RssBufferStream {
 
   public TransportClient getClient() {
     return client;
+  }
+
+  public void close() {
+    if (client != null) {
+      client.close();
+    }
   }
 }

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
@@ -92,6 +92,7 @@ public class RemoteBufferStreamReader extends CreditListener {
   public void close() {
     isOpen = false;
     client.getReadClientHandler().removeHandler(this.bufferStream.getStreamId());
+    bufferStream.close();
   }
 
   public boolean isOpened() {

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -188,7 +188,7 @@ public class TransportClientFactory implements Closeable {
    *
    * <p>As with {@link #createClient(String, int)}, this method is blocking.
    */
-  private TransportClient internalCreateClient(
+  protected TransportClient internalCreateClient(
       InetSocketAddress address, ChannelInboundHandlerAdapter decoder)
       throws IOException, InterruptedException {
     Bootstrap bootstrap = new Bootstrap();

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -56,7 +56,7 @@ public abstract class Message implements Encodable {
 
   /** Whether the body should be copied out in frame decoder. */
   public boolean needCopyOut() {
-    return false;
+    return true;
   }
 
   protected boolean equals(Message other) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Do not reuse the transport client in flink plugin.


### Why are the changes needed?
1. Flink channels have different buffer suppliers so we can not reuse transport clients.
2. Readdata message needs to copy out from the netty stack to the flink memory stack.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT.
