### PR TITLE
[CELEBORN-316] Wrap Celeborn exception with CelebornIOException

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.client.compress.Decompressor;
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.network.client.TransportClientFactory;
 import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.protocol.PartitionLocation;
@@ -242,7 +243,7 @@ public abstract class RssInputStream extends InputStream {
           }
         }
       }
-      throw new IOException("createPartitionReader failed!");
+      throw new CelebornIOException("createPartitionReader failed!");
     }
 
     private ByteBuf getNextChunk() throws IOException {
@@ -254,7 +255,8 @@ public abstract class RssInputStream extends InputStream {
           currentReader.close();
           if (fetchChunkRetryCnt == fetchChunkMaxRetry) {
             logger.warn("Fetch chunk fail exceeds max retry {}", fetchChunkRetryCnt);
-            throw new IOException("Fetch chunk failed for " + fetchChunkRetryCnt + " times");
+            throw new CelebornIOException(
+                "Fetch chunk failed for " + fetchChunkRetryCnt + " times");
           } else {
             if (currentReader.getLocation().getPeer() != null) {
               logger.warn(
@@ -270,7 +272,7 @@ public abstract class RssInputStream extends InputStream {
           }
         }
       }
-      throw new IOException("Fetch chunk failed!");
+      throw new CelebornIOException("Fetch chunk failed!");
     }
 
     private PartitionReader createReader(
@@ -304,7 +306,7 @@ public abstract class RssInputStream extends InputStream {
             conf, shuffleKey, location, clientFactory, startMapIndex, endMapIndex);
       }
 
-      throw new IOException(
+      throw new CelebornIOException(
           "Unknown storage info " + storageInfo + " to read location " + location);
     }
 

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -24,10 +24,10 @@ import org.apache.celeborn.common.exception.CelebornIOException;
 public class ExceptionUtils {
 
   public static void wrapAndThrowIOException(Exception exception) throws IOException {
-    if (exception instanceof IOException) {
-      throw new CelebornIOException(exception);
-    } else if (exception instanceof CelebornIOException) {
+    if (exception instanceof CelebornIOException) {
       throw (CelebornIOException) exception;
+    } else if (exception instanceof IOException) {
+      throw new CelebornIOException(exception);
     } else {
       throw new CelebornIOException(exception.getMessage(), exception);
     }

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -17,9 +17,9 @@
 
 package org.apache.celeborn.common.util;
 
-import org.apache.celeborn.common.exception.CelebornIOException;
-
 import java.io.IOException;
+
+import org.apache.celeborn.common.exception.CelebornIOException;
 
 public class ExceptionUtils {
 

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -17,15 +17,19 @@
 
 package org.apache.celeborn.common.util;
 
+import org.apache.celeborn.common.exception.CelebornIOException;
+
 import java.io.IOException;
 
 public class ExceptionUtils {
 
   public static void wrapAndThrowIOException(Exception exception) throws IOException {
     if (exception instanceof IOException) {
-      throw (IOException) exception;
+      throw new CelebornIOException(exception);
+    } else if (exception instanceof CelebornIOException) {
+      throw (CelebornIOException) exception;
     } else {
-      throw new IOException(exception.getMessage(), exception);
+      throw new CelebornIOException(exception.getMessage(), exception);
     }
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/write/InFlightRequestTracker.java
+++ b/common/src/main/java/org/apache/celeborn/common/write/InFlightRequestTracker.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.exception.CelebornIOException;
 
 /*
  * This class is for track in flight request and limit request.
@@ -97,7 +98,7 @@ public class InFlightRequestTracker {
         times--;
       }
     } catch (InterruptedException e) {
-      pushState.exception.set(new IOException(e));
+      pushState.exception.set(new CelebornIOException(e));
     }
 
     if (times <= 0) {
@@ -141,7 +142,7 @@ public class InFlightRequestTracker {
         times--;
       }
     } catch (InterruptedException e) {
-      pushState.exception.set(new IOException(e));
+      pushState.exception.set(new CelebornIOException(e));
     }
 
     if (times <= 0) {

--- a/common/src/main/java/org/apache/celeborn/common/write/SlowStartPushStrategy.java
+++ b/common/src/main/java/org/apache/celeborn/common/write/SlowStartPushStrategy.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.exception.CelebornIOException;
 
 public class SlowStartPushStrategy extends PushStrategy {
 
@@ -153,7 +154,7 @@ public class SlowStartPushStrategy extends PushStrategy {
         logger.debug("Will sleep {} ms to control the push speed.", sleepInterval);
         Thread.sleep(sleepInterval);
       } catch (InterruptedException e) {
-        pushState.exception.set(new IOException(e));
+        pushState.exception.set(new CelebornIOException(e));
       }
     }
   }

--- a/common/src/main/scala/org/apache/celeborn/common/exception/CelebornIOException.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/exception/CelebornIOException.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.exception
+
+import java.io.IOException
+
+class CelebornIOException(message: String, cause: Throwable)
+  extends IOException(message, cause) {
+
+  def this(message: String) = this(message, null)
+
+  def this(cause: Throwable) = this(cause.getMessage, cause)
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
When we enable spark blacklist mechanism, many executor was excluded from current stage caused by RSS exception, but for all RSS exception we should not been excluded and this mechanism caused less and less executor to return the task, caused job slower. 

We should wrap RSS exception with CelebonrIOException then we can do something in spark side


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

