### PR TITLE
[CELEBORN-323] [FLINK] readBuffers of BufferStreamManager need synchronized

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/server/BufferStreamManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/BufferStreamManager.java
@@ -260,7 +260,7 @@ public class BufferStreamManager {
       readBuffers();
     }
 
-    public void readBuffers() {
+    public synchronized void readBuffers() {
       PriorityQueue<DataPartitionReader> sortedReaders = new PriorityQueue<>(readers);
       while (buffers.size() > 0 && !sortedReaders.isEmpty()) {
         DataPartitionReader reader = sortedReaders.poll();
@@ -279,9 +279,7 @@ public class BufferStreamManager {
       readExecutor.submit(
           () -> {
             // Key for IO schedule.
-            synchronized (MapDataPartition.this) {
-              readBuffers();
-            }
+            readBuffers();
           });
     }
 


### PR DESCRIPTION
…all readers in multiple threads

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
add synchronized on readBuffers

### Why are the changes needed?
recycle buffer will call readers in multiple threads

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
manual test
