### PR TITLE
[CELEBORN-321] When register shuffle failed, DataPushQueue should directly take the task queue to avoid NPE

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -93,16 +93,19 @@ public class DataPushQueue {
         int partitionId = task.getPartitionId();
         Map<Integer, PartitionLocation> partitionLocationMap =
             client.getPartitionLocation(appId, shuffleId, numMappers, numPartitions);
-        PartitionLocation loc = partitionLocationMap.get(partitionId);
-
-        if (!reachLimitWorker.contains(loc.hostAndPushPort())) {
-          boolean reachLimit = pushState.reachLimit(loc.hostAndPushPort(), maxInFlight);
-          if (!reachLimit) {
-            iterator.remove();
-            return task;
-          } else {
-            reachLimitWorker.add(loc.hostAndPushPort());
+        if (partitionLocationMap != null) {
+          PartitionLocation loc = partitionLocationMap.get(partitionId);
+          if (!reachLimitWorker.contains(loc.hostAndPushPort())) {
+            boolean reachLimit = pushState.reachLimit(loc.hostAndPushPort(), maxInFlight);
+            if (!reachLimit) {
+              iterator.remove();
+              return task;
+            } else {
+              reachLimitWorker.add(loc.hostAndPushPort());
+            }
           }
+        } else {
+          return task;
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

ShuffleClientI side log when register shuffle failed
```
23/02/21 12:07:41 WARN ShuffleClientImpl: LifecycleManager request slots return StatusCode{value=ReserveSlotFailed}, retry again, remain retry times 2
23/02/21 12:07:44 WARN ShuffleClientImpl: LifecycleManager request slots return StatusCode{value=ReserveSlotFailed}, retry again, remain retry times 1
23/02/21 12:07:48 WARN ShuffleClientImpl: LifecycleManager request slots return StatusCode{value=ReserveSlotFailed}, retry again, remain retry times 0
23/02/21 12:07:51 ERROR SparkUncaughtExceptionHandler: Uncaught exception in thread Thread[DataPusher-458,5,main]
java.lang.NullPointerException
    at com.aliyun.emr.rss.client.write.DataPushQueue.takePushTask(DataPushQueue.java:97)
    at com.aliyun.emr.rss.client.write.DataPusher$1.run(DataPusher.java:123)
23/02/21 12:07:51 WARN ShuffleClientImpl: LifecycleManager request slots return StatusCode{value=ReserveSlotFailed}, retry again, remain retry times 2
23/02/21 12:07:51 INFO BlockManager: BlockManager stopped
23/02/21 12:07:51 INFO ShutdownHookManager: Shutdown hook called
```


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

