### PR TITLE
[CELEBORN-325] After worker restart, throw NPE when receive not found partition

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -491,7 +491,8 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       return
     }
 
-    val fileWriters = partitionIdToLocations.map(_.asInstanceOf[WorkingPartition].getFileWriter)
+    val fileWriters =
+      partitionIdToLocations.map(_._2).map(_.asInstanceOf[WorkingPartition].getFileWriter)
     val fileWriterWithException = fileWriters.find(_.getException != null)
     if (fileWriterWithException.nonEmpty) {
       val exception = fileWriterWithException.get.getException

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -505,7 +505,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
           StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage()
         }
       callbackWithTimer.onFailure(new Exception(
-        s"$message! ${partitionIdToLocations.head}",
+        s"$message! ${partitionIdToLocations.head._2}",
         exception))
       return
     }
@@ -567,12 +567,12 @@ class PushDataHandler extends BaseMessageHandler with Logging {
                 callbackWithTimer.onFailure(e)
               } else if (e.getMessage.startsWith(StatusCode.PUSH_DATA_TIMEOUT_SLAVE.getMessage)) {
                 callbackWithTimer.onFailure(new Exception(
-                  s"${StatusCode.PUSH_DATA_TIMEOUT_SLAVE.getMessage}! Push data to peer of ${partitionIdToLocations.head} timeout: ${e.getMessage}",
+                  s"${StatusCode.PUSH_DATA_TIMEOUT_SLAVE.getMessage}! Push data to peer of ${partitionIdToLocations.head._2} timeout: ${e.getMessage}",
                   e))
               } else {
                 // Throw by connection
                 callbackWithTimer.onFailure(new Exception(
-                  s"${StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_SLAVE.getMessage}! Push data to peer of ${partitionIdToLocations.head} failed: ${e.getMessage}",
+                  s"${StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_SLAVE.getMessage}! Push data to peer of ${partitionIdToLocations.head._2} failed: ${e.getMessage}",
                   e))
               }
             }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -427,19 +427,20 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       return
     }
 
-    val locations = pushMergedData.partitionUniqueIds.map { id =>
+    val partitionIdToLocations = pushMergedData.partitionUniqueIds.map { id =>
       if (isMaster) {
-        partitionLocationInfo.getMasterLocation(shuffleKey, id)
+        id -> partitionLocationInfo.getMasterLocation(shuffleKey, id)
       } else {
-        partitionLocationInfo.getSlaveLocation(shuffleKey, id)
+        id -> partitionLocationInfo.getSlaveLocation(shuffleKey, id)
       }
     }
 
     // Fetch real batchId from body will add more cost and no meaning for replicate.
-    val doReplicate = locations.head != null && locations.head.getPeer != null && isMaster
+    val doReplicate =
+      partitionIdToLocations.head._2 != null && partitionIdToLocations.head._2.getPeer != null && isMaster
 
     // find FileWriters responsible for the data
-    locations.foreach { loc =>
+    partitionIdToLocations.foreach { case (id, loc) =>
       if (loc == null) {
         val (mapId, attemptId) = getMapAttempt(body)
         // MapperAttempts for a shuffle exists after any CommitFiles request succeeds.
@@ -473,7 +474,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
               ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
           } else {
             val msg = s"Partition location wasn't found for task(shuffle $shuffleKey, map $mapId," +
-              s" attempt $attemptId, uniqueId ${loc.getUniqueId})."
+              s" attempt $attemptId, uniqueId $id)."
             logWarning(s"[handlePushMergedData] $msg")
             callbackWithTimer.onFailure(
               new Exception(StatusCode.PUSH_DATA_FAIL_PARTITION_NOT_FOUND.getMessage()))
@@ -490,7 +491,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       return
     }
 
-    val fileWriters = locations.map(_.asInstanceOf[WorkingPartition].getFileWriter)
+    val fileWriters = partitionIdToLocations.map(_.asInstanceOf[WorkingPartition].getFileWriter)
     val fileWriterWithException = fileWriters.find(_.getException != null)
     if (fileWriterWithException.nonEmpty) {
       val exception = fileWriterWithException.get.getException
@@ -502,7 +503,9 @@ class PushDataHandler extends BaseMessageHandler with Logging {
         } else {
           StatusCode.PUSH_DATA_FAIL_SLAVE.getMessage()
         }
-      callbackWithTimer.onFailure(new Exception(s"$message! ${locations.head}", exception))
+      callbackWithTimer.onFailure(new Exception(
+        s"$message! ${partitionIdToLocations.head}",
+        exception))
       return
     }
     fileWriters.foreach(_.incrementPendingWrites())
@@ -512,7 +515,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       pushMergedData.body().retain()
       replicateThreadPool.submit(new Runnable {
         override def run(): Unit = {
-          val location = locations.head
+          val location = partitionIdToLocations.head._2
           val peer = location.getPeer
           val peerWorker = new WorkerInfo(
             peer.getHost,
@@ -563,12 +566,12 @@ class PushDataHandler extends BaseMessageHandler with Logging {
                 callbackWithTimer.onFailure(e)
               } else if (e.getMessage.startsWith(StatusCode.PUSH_DATA_TIMEOUT_SLAVE.getMessage)) {
                 callbackWithTimer.onFailure(new Exception(
-                  s"${StatusCode.PUSH_DATA_TIMEOUT_SLAVE.getMessage}! Push data to peer of ${locations.head} timeout: ${e.getMessage}",
+                  s"${StatusCode.PUSH_DATA_TIMEOUT_SLAVE.getMessage}! Push data to peer of ${partitionIdToLocations.head} timeout: ${e.getMessage}",
                   e))
               } else {
                 // Throw by connection
                 callbackWithTimer.onFailure(new Exception(
-                  s"${StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_SLAVE.getMessage}! Push data to peer of ${locations.head} failed: ${e.getMessage}",
+                  s"${StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_SLAVE.getMessage}! Push data to peer of ${partitionIdToLocations.head} failed: ${e.getMessage}",
                   e))
               }
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?
```
23/02/22 12:11:57,048 ERROR [push-server-6-8] TransportRequestHandler: Error while invoking RpcHandler#receive() on PushMergedData PushMergedData{requestId=7305, mode=0, shuffleKey=application_1676010707928_2449604-0, partitionIds=[188-0, 191-0, 194-0, 197-0], batchOffsets=[0, 3720, 7800, 11991], body size=15979}
java.lang.NullPointerException
    at com.aliyun.emr.rss.service.deploy.worker.Worker.$anonfun$handlePushMergedData$2(Worker.scala:984)
    at com.aliyun.emr.rss.service.deploy.worker.Worker.$anonfun$handlePushMergedData$2$adapted(Worker.scala:960)
    at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
    at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
    at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
    at com.aliyun.emr.rss.service.deploy.worker.Worker.handlePushMergedData(Worker.scala:960)
    at com.aliyun.emr.rss.service.deploy.worker.PushDataRpcHandler.receivePushMergedData(PushDataRpcHandler.java:62)
    at com.aliyun.emr.rss.common.network.server.TransportRequestHandler.processPushMergedData(TransportRequestHandler.java:249)
    at com.aliyun.emr.rss.common.network.server.TransportRequestHandler.handle(TransportRequestHandler.java:141)
    at com.aliyun.emr.rss.common.network.server.TransportChannelHandler.channelRead(TransportChannelHandler.java:118)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
    at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
    at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
    at com.aliyun.emr.rss.common.network.util.TransportFrameDecoder.channelRead(TransportFrameDecoder.java:85)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
    at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
    at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
    at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
    at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
    at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
    at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995)
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
    at java.lang.Thread.run(Thread.java:748) 
```


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

