### PR TITLE
[CELEBORN-328][MPROVEMENT] Too much noisy log when reserve slot failed

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -379,7 +379,7 @@ public class ShuffleClientImpl extends ShuffleClient {
           }
           return result;
         } else if (StatusCode.SLOT_NOT_AVAILABLE.equals(respStatus)) {
-          logger.warn(
+          logger.error(
               "LifecycleManager request slots return {}, retry again, remain retry times {}",
               StatusCode.SLOT_NOT_AVAILABLE,
               numRetries - 1);

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -415,11 +415,11 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
     res.status match {
       case StatusCode.REQUEST_FAILED =>
-        logError(s"OfferSlots RPC request failed for $shuffleId!")
+        logDebug(s"OfferSlots RPC request failed for $shuffleId!")
         reply(RegisterShuffleResponse(StatusCode.REQUEST_FAILED, Array.empty))
         return
       case StatusCode.SLOT_NOT_AVAILABLE =>
-        logError(s"OfferSlots for $shuffleId failed!")
+        logDebug(s"OfferSlots for $shuffleId failed!")
         reply(RegisterShuffleResponse(StatusCode.SLOT_NOT_AVAILABLE, Array.empty))
         return
       case StatusCode.SUCCESS =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
```
23/02/22 16:38:47 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:47 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:47 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:47 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:48 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:48 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:48 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:48 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:48 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:48 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:49 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:49 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:49 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:49 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:49 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:49 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:49 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:49 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:49 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:49 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:50 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:50 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:50 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:50 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:51 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:51 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:52 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:52 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:52 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:52 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:52 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:52 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:52 ERROR LifecycleManager: OfferSlots for 0 failed!
23/02/22 16:38:53 ERROR LifecycleManager: OfferSlots for 0 failed!
```

Since this message will been print in client side, in driver side we don't need print too much noisy log.
<img width="1251" alt="截屏2023-02-22 下午4 59 15" src="https://user-images.githubusercontent.com/46485123/220571557-f78140d6-9b0c-4ea3-aca2-47519cbc090c.png">


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

