### PR TITLE
[CELEBORN-316][FOLLOWUP] Should not wrap CelebornIOException with CelebornIOException

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -127,6 +127,8 @@ public class DataPusher {
                 }
                 pushData(task);
                 reclaimTask(task);
+              } catch (CelebornIOException e) {
+                exceptionRef.set(e);
               } catch (InterruptedException | IOException e) {
                 exceptionRef.set(new CelebornIOException(e));
               }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Should not wrap CelebornIOException with CelebornIOException


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

