### PR TITLE
[CELEBORN-330] [Flink] fix pollNext deadlock when process data recevied while open stream

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/server/BufferStreamManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/BufferStreamManager.java
@@ -21,7 +21,16 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -97,7 +106,12 @@ public class BufferStreamManager {
   }
 
   public long registerStream(
-      Channel channel, int initialCredit, int startSubIndex, int endSubIndex, FileInfo fileInfo)
+      Consumer<Long> callback,
+      Channel channel,
+      int initialCredit,
+      int startSubIndex,
+      int endSubIndex,
+      FileInfo fileInfo)
       throws IOException {
     long streamId = nextStreamId.getAndIncrement();
     streams.put(streamId, new StreamState(channel, fileInfo.getBufferSize()));
@@ -109,6 +123,8 @@ public class BufferStreamManager {
       mapDataPartition.addStream(streamId);
       addCredit(initialCredit, streamId);
       servingStreams.put(streamId, mapDataPartition);
+      // response streamId to channel first
+      callback.accept(streamId);
       mapDataPartition.setupDataPartitionReader(startSubIndex, endSubIndex, streamId);
     }
 


### PR DESCRIPTION
…e data while other thread wait the response

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
No need wait the open stream rpc response, just use async way and celeborn server need guarantee response the streamId before send back backlog/data in the same channel.

### Why are the changes needed?
stream will opened when Flink streamTask processInput and  this operation(open stream) will hold the object lock inputGatesWithData(for all inputGates),  but at the same time the same channel which wait this open stream response possibly received other inputGate data and also need inputGatesWithData(for all inputGates) lock. That's how the deadlock happened.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
TPCDS
