### PR TITLE
[CELEBORN-332] Unify the log of ShuffleClientImpl

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -193,8 +193,10 @@ public class ShuffleClientImpl extends ShuffleClient {
               + mapId
               + " attempt "
               + attemptId
-              + " partitionId "
+              + " partition "
               + partitionId
+              + " batch "
+              + batchId
               + ".");
       pushState.removeBatch(batchId, loc.hostAndPushPort());
     } else {
@@ -206,8 +208,10 @@ public class ShuffleClientImpl extends ShuffleClient {
               + mapId
               + " attempt "
               + attemptId
-              + " partitionId "
+              + " partition "
               + partitionId
+              + " batch "
+              + batchId
               + " is location "
               + newLoc
               + ".");
@@ -233,7 +237,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                 + mapId
                 + " attempt "
                 + attemptId
-                + " partitionId "
+                + " partition "
                 + partitionId
                 + " batch "
                 + batchId
@@ -293,8 +297,10 @@ public class ShuffleClientImpl extends ShuffleClient {
                 + mapId
                 + " attempt "
                 + attemptId
-                + " partitionId "
+                + " partition "
                 + partitionId
+                + " batch "
+                + oldGroupedBatchId
                 + ".");
       } else {
         PartitionLocation newLoc = reducePartitionMap.get(shuffleId).get(partitionId);
@@ -305,8 +311,10 @@ public class ShuffleClientImpl extends ShuffleClient {
                 + mapId
                 + " attempt "
                 + attemptId
-                + " partitionId "
+                + " partition "
                 + partitionId
+                + " batch "
+                + oldGroupedBatchId
                 + " is location "
                 + newLoc
                 + ".");
@@ -380,11 +388,13 @@ public class ShuffleClientImpl extends ShuffleClient {
             + shuffleId
             + " map "
             + mapId
-            + " attemptId "
+            + " attempt "
             + attemptId
-            + " partitionId "
+            + " partition  "
             + partitionId
-            + ".");
+            + " with "
+            + numMappers
+            + " mapper.");
     ConcurrentHashMap<Integer, PartitionLocation> partitionLocationMap =
         registerShuffleInternal(
             shuffleId,
@@ -533,7 +543,7 @@ public class ShuffleClientImpl extends ShuffleClient {
               + mapId
               + " attempt "
               + attemptId
-              + " partitionId "
+              + " partition "
               + partitionId
               + " epoch "
               + epoch
@@ -549,7 +559,7 @@ public class ShuffleClientImpl extends ShuffleClient {
               + mapId
               + " attempt "
               + attemptId
-              + " partitionId "
+              + " partition "
               + partitionId
               + ", just return (Assume revive successfully).");
       return true;
@@ -623,6 +633,8 @@ public class ShuffleClientImpl extends ShuffleClient {
               + mapId
               + " attempt "
               + attemptId
+              + " partition "
+              + partitionId
               + ".");
       PushState pushState = pushStates.get(mapKey);
       if (pushState != null) {
@@ -651,7 +663,7 @@ public class ShuffleClientImpl extends ShuffleClient {
           null,
           StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE)) {
         throw new CelebornIOException(
-            "Revive for shuffle " + shuffleKey + " partitionId " + partitionId + " failed.");
+            "Revive for shuffle " + shuffleKey + " partition " + partitionId + " failed.");
       }
     }
 
@@ -663,6 +675,8 @@ public class ShuffleClientImpl extends ShuffleClient {
               + mapId
               + " attempt "
               + attemptId
+              + " partition "
+              + partitionId
               + ".");
       PushState pushState = pushStates.get(mapKey);
       if (pushState != null) {
@@ -733,6 +747,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                       + mapId
                       + " attempt "
                       + attemptId
+                      + " partition "
+                      + partitionId
                       + " batch "
                       + nextBatchId
                       + ".");
@@ -751,6 +767,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                       + mapId
                       + " attempt "
                       + attemptId
+                      + " partition "
+                      + partitionId
                       + " batch "
                       + nextBatchId
                       + ".",
@@ -776,6 +794,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                           + mapId
                           + " attempt "
                           + attemptId
+                          + " partition "
+                          + partitionId
                           + " batch "
                           + nextBatchId
                           + ".");
@@ -792,6 +812,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                           + mapId
                           + " attempt "
                           + attemptId
+                          + " partition "
+                          + partitionId
                           + " batch "
                           + nextBatchId
                           + ".");
@@ -819,6 +841,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                           + mapId
                           + " attempt "
                           + attemptId
+                          + " partition "
+                          + partitionId
                           + " batch "
                           + nextBatchId
                           + ".");
@@ -834,6 +858,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                           + mapId
                           + " attempt "
                           + attemptId
+                          + " partition "
+                          + partitionId
                           + " batch "
                           + nextBatchId
                           + ".");
@@ -880,6 +906,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                       + mapId
                       + " attempt "
                       + attemptId
+                      + " partition "
+                      + partitionId
                       + " batch "
                       + nextBatchId
                       + ".",
@@ -912,6 +940,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                         + mapId
                         + " attempt "
                         + attemptId
+                        + " partition "
+                        + partitionId
                         + " batch "
                         + nextBatchId
                         + ".");
@@ -939,6 +969,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                 + mapId
                 + " attempt "
                 + attemptId
+                + " partition "
+                + partitionId
                 + " batch "
                 + nextBatchId
                 + " location "
@@ -984,7 +1016,11 @@ public class ShuffleClientImpl extends ShuffleClient {
     synchronized (splittingSet) {
       if (splittingSet.contains(partitionId)) {
         logger.debug(
-            "shuffle {} partitionId {} is splitting, skip split request ", shuffleId, partitionId);
+            "Splitting for shuffle "
+                + shuffleId
+                + " partition "
+                + partitionId
+                + ", skip split request.");
         return;
       }
       splittingSet.add(partitionId);
@@ -1113,6 +1149,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     pushState.addBatch(groupedBatchId, hostPort);
 
     final int numBatches = batches.size();
+    final Integer[] partitionIds = new Integer[numBatches];
     final String[] partitionUniqueIds = new String[numBatches];
     final int[] offsets = new int[numBatches];
     final int[] batchIds = new int[numBatches];
@@ -1120,6 +1157,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     CompositeByteBuf byteBuf = Unpooled.compositeBuffer();
     for (int i = 0; i < numBatches; i++) {
       DataBatches.DataBatch batch = batches.get(i);
+      partitionIds[i] = batch.loc.getId();
       partitionUniqueIds[i] = batch.loc.getUniqueId();
       offsets[i] = currentSize;
       batchIds[i] = batch.batchId;
@@ -1144,7 +1182,9 @@ public class ShuffleClientImpl extends ShuffleClient {
                     + mapId
                     + " attempt "
                     + attemptId
-                    + " grouped batch "
+                    + " partition "
+                    + Arrays.toString(partitionIds)
+                    + " batch "
                     + groupedBatchId
                     + ".");
             pushState.removeBatch(groupedBatchId, hostPort);
@@ -1166,12 +1206,14 @@ public class ShuffleClientImpl extends ShuffleClient {
                     + mapId
                     + " attempt "
                     + attemptId
-                    + " batches "
+                    + " partition "
+                    + Arrays.toString(partitionIds)
+                    + " batche "
                     + Arrays.toString(batchIds)
                     + ".";
             pushState.exception.compareAndSet(null, new CelebornIOException(errorMsg, e));
             if (logger.isDebugEnabled()) {
-              for (int batchId : batchIds) {
+              for (int i = 0; i < numBatches; i++) {
                 logger.debug(
                     "Push merged data to "
                         + hostPort
@@ -1181,8 +1223,11 @@ public class ShuffleClientImpl extends ShuffleClient {
                         + mapId
                         + " attempt "
                         + attemptId
-                        + " grouped batch "
-                        + batchId
+                        + " partition "
+                        + partitionIds[i]
+                        + Arrays.toString(partitionIds)
+                        + " batch "
+                        + batchIds[i]
                         + ".");
               }
             }
@@ -1205,7 +1250,9 @@ public class ShuffleClientImpl extends ShuffleClient {
                         + mapId
                         + " attempt "
                         + attemptId
-                        + " batches "
+                        + " partition "
+                        + Arrays.toString(partitionIds)
+                        + " batche "
                         + Arrays.toString(batchIds)
                         + ".");
                 pushDataRetryPool.submit(
@@ -1230,7 +1277,9 @@ public class ShuffleClientImpl extends ShuffleClient {
                         + mapId
                         + " attempt "
                         + attemptId
-                        + " batches "
+                        + " partition "
+                        + Arrays.toString(partitionIds)
+                        + " batche "
                         + Arrays.toString(batchIds)
                         + ".");
                 pushState.onCongestControl(hostPort);
@@ -1245,7 +1294,9 @@ public class ShuffleClientImpl extends ShuffleClient {
                         + mapId
                         + " attempt "
                         + attemptId
-                        + " batches "
+                        + " partition "
+                        + Arrays.toString(partitionIds)
+                        + " batche "
                         + Arrays.toString(batchIds)
                         + ".");
                 pushState.onCongestControl(hostPort);
@@ -1289,7 +1340,9 @@ public class ShuffleClientImpl extends ShuffleClient {
                     + mapId
                     + " attempt "
                     + attemptId
-                    + " batches "
+                    + " partition "
+                    + Arrays.toString(partitionIds)
+                    + " batche "
                     + Arrays.toString(batchIds)
                     + ".",
                 e);
@@ -1329,7 +1382,9 @@ public class ShuffleClientImpl extends ShuffleClient {
               + mapId
               + " attempt "
               + attemptId
-              + " batchIds "
+              + " partition "
+              + Arrays.toString(partitionIds)
+              + " batch  "
               + Arrays.toString(batchIds)
               + " location "
               + hostPort
@@ -1681,12 +1736,17 @@ public class ShuffleClientImpl extends ShuffleClient {
               }
             }
             logger.debug(
-                "Push data byteBuf to {}:{} success for map {} attempt {} batch {}.",
-                location.getHost(),
-                location.getPushPort(),
-                mapId,
-                attemptId,
-                nextBatchId);
+                "Push data byteBuf to "
+                    + location.hostAndPushPort()
+                    + " success for shuffle "
+                    + shuffleId
+                    + " map "
+                    + mapId
+                    + " attemptId "
+                    + attemptId
+                    + " batch "
+                    + nextBatchId
+                    + ".");
           }
 
           @Override
@@ -1732,7 +1792,21 @@ public class ShuffleClientImpl extends ShuffleClient {
       TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
       client.pushData(pushData, pushDataTimeout, callback, closeCallBack);
     } catch (Exception e) {
-      logger.warn("PushData byteBuf failed", e);
+      logger.error(
+          "Exception raised while pushing data byteBuf for shuffle "
+              + shuffleId
+              + " map "
+              + mapId
+              + " attempt "
+              + attemptId
+              + " partitionId "
+              + partitionId
+              + " batch "
+              + nextBatchId
+              + " location "
+              + location
+              + ".",
+          e);
       callback.onFailure(
           new Exception(
               StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_MASTER.getMessage()
@@ -1822,12 +1896,16 @@ public class ShuffleClientImpl extends ShuffleClient {
         () -> {
           String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
           logger.info(
-              "regionStart regionId:{}, shuffleKey:{}, attemptId:{}, locationId:{}",
-              currentRegionIdx,
-              shuffleKey,
-              attemptId,
-              location.getUniqueId());
-          logger.debug("regionStart location:{}", location.toString());
+              "RegionStart for shuffle "
+                  + shuffleId
+                  + " regionId "
+                  + currentRegionIdx
+                  + " attemptId "
+                  + attemptId
+                  + " locationId "
+                  + location.getUniqueId()
+                  + ".");
+          logger.debug("RegionStart  for location " + location.toString() + ".");
           TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
           RegionStart regionStart =
               new RegionStart(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -187,34 +187,23 @@ public class ShuffleClientImpl extends ShuffleClient {
           new CelebornIOException("Revive Failed, remain revive times " + remainReviveTimes));
     } else if (mapperEnded(shuffleId, mapId, attemptId)) {
       logger.debug(
-          "Revive for push data success, but the mapper already ended for shuffle "
-              + shuffleId
-              + " map "
-              + mapId
-              + " attempt "
-              + attemptId
-              + " partition "
-              + partitionId
-              + " batch "
-              + batchId
-              + ".");
+          "Revive for push data success, but the mapper already ended for shuffle {} map {} attempt {} partition {} batch {}.",
+          shuffleId,
+          mapId,
+          attemptId,
+          partitionId,
+          batchId);
       pushState.removeBatch(batchId, loc.hostAndPushPort());
     } else {
       PartitionLocation newLoc = reducePartitionMap.get(shuffleId).get(partitionId);
       logger.info(
-          "Revive for push data success, new location for shuffle "
-              + shuffleId
-              + " map "
-              + mapId
-              + " attempt "
-              + attemptId
-              + " partition "
-              + partitionId
-              + " batch "
-              + batchId
-              + " is location "
-              + newLoc
-              + ".");
+          "Revive for push data success, new location for shuffle {} map {} attempt {} partition {} batch {} is location {}.",
+          shuffleId,
+          mapId,
+          attemptId,
+          partitionId,
+          batchId,
+          newLoc);
       try {
         if (!testRetryRevive || remainReviveTimes < 1) {
           TransportClient client =
@@ -231,19 +220,13 @@ public class ShuffleClientImpl extends ShuffleClient {
         }
       } catch (Exception e) {
         logger.error(
-            "Exception raised while pushing data for shuffle "
-                + shuffleId
-                + " map "
-                + mapId
-                + " attempt "
-                + attemptId
-                + " partition "
-                + partitionId
-                + " batch "
-                + batchId
-                + " location "
-                + newLoc
-                + ".",
+            "Exception raised while pushing data for shuffle {} map {} attempt {} partition {} batch {} location {}.",
+            shuffleId,
+            mapId,
+            attemptId,
+            partitionId,
+            batchId,
+            newLoc,
             e);
         wrappedCallback.onFailure(
             new Exception(
@@ -291,33 +274,22 @@ public class ShuffleClientImpl extends ShuffleClient {
         }
       } else if (mapperEnded(shuffleId, mapId, attemptId)) {
         logger.debug(
-            "Revive for push merged data success, but the mapper already ended for shuffle "
-                + shuffleId
-                + " map "
-                + mapId
-                + " attempt "
-                + attemptId
-                + " partition "
-                + partitionId
-                + " batch "
-                + oldGroupedBatchId
-                + ".");
+            "Revive for push merged data success, but the mapper already ended for shuffle {} map {} attempt {} partition {} batch {}.",
+            shuffleId,
+            mapId,
+            attemptId,
+            partitionId,
+            oldGroupedBatchId);
       } else {
         PartitionLocation newLoc = reducePartitionMap.get(shuffleId).get(partitionId);
         logger.info(
-            "Revive for push merged data success, new location for shuffle "
-                + shuffleId
-                + " map "
-                + mapId
-                + " attempt "
-                + attemptId
-                + " partition "
-                + partitionId
-                + " batch "
-                + oldGroupedBatchId
-                + " is location "
-                + newLoc
-                + ".");
+            "Revive for push merged data success, new location for shuffle {} map {} attempt {} partition {} batch {} is location {}.",
+            shuffleId,
+            mapId,
+            attemptId,
+            partitionId,
+            oldGroupedBatchId,
+            newLoc);
         DataBatches newDataBatches =
             newDataBatchesMap.computeIfAbsent(genAddressPair(newLoc), (s) -> new DataBatches());
         newDataBatches.addDataBatch(newLoc, batch.batchId, batch.body);
@@ -384,17 +356,12 @@ public class ShuffleClientImpl extends ShuffleClient {
       String appId, int shuffleId, int numMappers, int mapId, int attemptId) throws IOException {
     int partitionId = PackedPartitionId.packedPartitionId(mapId, attemptId);
     logger.info(
-        "Register MapPartition task for shuffle "
-            + shuffleId
-            + " map "
-            + mapId
-            + " attempt "
-            + attemptId
-            + " partition  "
-            + partitionId
-            + " with "
-            + numMappers
-            + " mapper.");
+        "Register MapPartition task for shuffle {} map {} attempt {} partition {} with {} mapper.",
+        shuffleId,
+        mapId,
+        attemptId,
+        partitionId,
+        numMappers);
     ConcurrentHashMap<Integer, PartitionLocation> partitionLocationMap =
         registerShuffleInternal(
             shuffleId,
@@ -463,13 +430,10 @@ public class ShuffleClientImpl extends ShuffleClient {
         }
       } catch (Exception e) {
         logger.error(
-            "Exception raised while registering shuffle "
-                + shuffleId
-                + " with "
-                + numMappers
-                + " mapper and "
-                + numPartitions
-                + " partitions.",
+            "Exception raised while registering shuffle {} with {} mapper and {} partitions.",
+            shuffleId,
+            numMappers,
+            numPartitions,
             e);
         break;
       }
@@ -537,31 +501,22 @@ public class ShuffleClientImpl extends ShuffleClient {
     ConcurrentHashMap<Integer, PartitionLocation> map = reducePartitionMap.get(shuffleId);
     if (waitRevivedLocation(map, partitionId, epoch)) {
       logger.debug(
-          "Revive already success for shuffle "
-              + shuffleId
-              + " map "
-              + mapId
-              + " attempt "
-              + attemptId
-              + " partition "
-              + partitionId
-              + " epoch "
-              + epoch
-              + ", just return(Assume revive successfully).");
+          "Revive already success for shuffle {} map {} attempt {} partition {} epoch {}, just return(Assume revive successfully).",
+          shuffleId,
+          mapId,
+          attemptId,
+          partitionId,
+          epoch);
       return true;
     }
     String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
     if (mapperEnded(shuffleId, mapId, attemptId)) {
       logger.debug(
-          "Revive success, but the mapper ended for shuffle "
-              + shuffleId
-              + " map "
-              + mapId
-              + " attempt "
-              + attemptId
-              + " partition "
-              + partitionId
-              + ", just return (Assume revive successfully).");
+          "Revive success, but the mapper ended for shuffle {} map {} attempt {} partition {}, just return (Assume revive successfully).",
+          shuffleId,
+          mapId,
+          attemptId,
+          partitionId);
       return true;
     }
 
@@ -592,17 +547,12 @@ public class ShuffleClientImpl extends ShuffleClient {
       }
     } catch (Exception e) {
       logger.error(
-          "Exception raised while reviving for shuffle "
-              + shuffleId
-              + " map "
-              + mapId
-              + " attempt "
-              + attemptId
-              + " partition "
-              + partitionId
-              + " epoch "
-              + epoch
-              + ".",
+          "Exception raised while reviving for shuffle {} map {} attempt {} partition {} epoch {}.",
+          shuffleId,
+          mapId,
+          attemptId,
+          partitionId,
+          epoch,
           e);
       return false;
     }
@@ -627,15 +577,11 @@ public class ShuffleClientImpl extends ShuffleClient {
     // return if shuffle stage already ended
     if (mapperEnded(shuffleId, mapId, attemptId)) {
       logger.debug(
-          "Push or merge data ignored because mapper already ended for shuffle "
-              + shuffleId
-              + " map "
-              + mapId
-              + " attempt "
-              + attemptId
-              + " partition "
-              + partitionId
-              + ".");
+          "Push or merge data ignored because mapper already ended for shuffle {} map {} attempt {} partition {}.",
+          shuffleId,
+          mapId,
+          attemptId,
+          partitionId);
       PushState pushState = pushStates.get(mapKey);
       if (pushState != null) {
         pushState.cleanup();
@@ -669,15 +615,11 @@ public class ShuffleClientImpl extends ShuffleClient {
 
     if (mapperEnded(shuffleId, mapId, attemptId)) {
       logger.debug(
-          "Push or merge data ignored because mapper already ended for shuffle "
-              + shuffleId
-              + " map "
-              + mapId
-              + " attempt "
-              + attemptId
-              + " partition "
-              + partitionId
-              + ".");
+          "Push or merge data ignored because mapper already ended for shuffle {} map {} attempt {} partition {}.",
+          shuffleId,
+          mapId,
+          attemptId,
+          partitionId);
       PushState pushState = pushStates.get(mapKey);
       if (pushState != null) {
         pushState.cleanup();
@@ -739,19 +681,13 @@ public class ShuffleClientImpl extends ShuffleClient {
                     .add(mapKey);
               }
               logger.debug(
-                  "Push data to "
-                      + loc.hostAndPushPort()
-                      + " success for shuffle "
-                      + shuffleId
-                      + " map "
-                      + mapId
-                      + " attempt "
-                      + attemptId
-                      + " partition "
-                      + partitionId
-                      + " batch "
-                      + nextBatchId
-                      + ".");
+                  "Push data to {} success for shuffle {} map {} attempt {} partition {} batch {}.",
+                  loc.hostAndPushPort(),
+                  shuffleId,
+                  mapId,
+                  attemptId,
+                  partitionId,
+                  nextBatchId);
             }
 
             @Override
@@ -759,19 +695,13 @@ public class ShuffleClientImpl extends ShuffleClient {
               pushState.exception.compareAndSet(
                   null, new CelebornIOException("Revived PushData failed!", e));
               logger.error(
-                  "Push data to "
-                      + loc.hostAndPushPort()
-                      + " failed for shuffle "
-                      + shuffleId
-                      + " map "
-                      + mapId
-                      + " attempt "
-                      + attemptId
-                      + " partition "
-                      + partitionId
-                      + " batch "
-                      + nextBatchId
-                      + ".",
+                  "Push data to {} failed for shuffle {} map {} attempt {} partition {} batch {}.",
+                  loc.hostAndPushPort(),
+                  shuffleId,
+                  mapId,
+                  attemptId,
+                  partitionId,
+                  nextBatchId,
                   e);
             }
           };
@@ -786,37 +716,25 @@ public class ShuffleClientImpl extends ShuffleClient {
                 byte reason = response.get();
                 if (reason == StatusCode.SOFT_SPLIT.getValue()) {
                   logger.debug(
-                      "Push data to "
-                          + loc.hostAndPushPort()
-                          + " soft split required for shuffle "
-                          + shuffleId
-                          + " map "
-                          + mapId
-                          + " attempt "
-                          + attemptId
-                          + " partition "
-                          + partitionId
-                          + " batch "
-                          + nextBatchId
-                          + ".");
+                      "Push data to {} soft split required for shuffle {} map {} attempt {} partition {} batch {}.",
+                      loc.hostAndPushPort(),
+                      shuffleId,
+                      mapId,
+                      attemptId,
+                      partitionId,
+                      nextBatchId);
                   splitPartition(shuffleId, partitionId, applicationId, loc);
                   pushState.onSuccess(loc.hostAndPushPort());
                   callback.onSuccess(response);
                 } else if (reason == StatusCode.HARD_SPLIT.getValue()) {
                   logger.debug(
-                      "Push data to "
-                          + loc.hostAndPushPort()
-                          + " hard split required for shuffle "
-                          + shuffleId
-                          + " map "
-                          + mapId
-                          + " attempt "
-                          + attemptId
-                          + " partition "
-                          + partitionId
-                          + " batch "
-                          + nextBatchId
-                          + ".");
+                      "Push data to {} hard split required for shuffle {} map {} attempt {} partition {} batch {}.",
+                      loc.hostAndPushPort(),
+                      shuffleId,
+                      mapId,
+                      attemptId,
+                      partitionId,
+                      nextBatchId);
                   pushDataRetryPool.submit(
                       () ->
                           submitRetryPushData(
@@ -833,36 +751,24 @@ public class ShuffleClientImpl extends ShuffleClient {
                               remainReviveTimes));
                 } else if (reason == StatusCode.PUSH_DATA_SUCCESS_MASTER_CONGESTED.getValue()) {
                   logger.debug(
-                      "Push data to "
-                          + loc.hostAndPushPort()
-                          + " master congestion required for shuffle "
-                          + shuffleId
-                          + " map "
-                          + mapId
-                          + " attempt "
-                          + attemptId
-                          + " partition "
-                          + partitionId
-                          + " batch "
-                          + nextBatchId
-                          + ".");
+                      "Push data to {} master congestion required for shuffle {} map {} attempt {} partition {} batch {}.",
+                      loc.hostAndPushPort(),
+                      shuffleId,
+                      mapId,
+                      attemptId,
+                      partitionId,
+                      nextBatchId);
                   pushState.onCongestControl(loc.hostAndPushPort());
                   callback.onSuccess(response);
                 } else if (reason == StatusCode.PUSH_DATA_SUCCESS_SLAVE_CONGESTED.getValue()) {
                   logger.debug(
-                      "Push data to "
-                          + loc.hostAndPushPort()
-                          + " slave congestion required for shuffle "
-                          + shuffleId
-                          + " map "
-                          + mapId
-                          + " attempt "
-                          + attemptId
-                          + " partition "
-                          + partitionId
-                          + " batch "
-                          + nextBatchId
-                          + ".");
+                      "Push data to {} slave congestion required for shuffle {} map {} attempt {} partition {} batch {}.",
+                      loc.hostAndPushPort(),
+                      shuffleId,
+                      mapId,
+                      attemptId,
+                      partitionId,
+                      nextBatchId);
                   pushState.onCongestControl(loc.hostAndPushPort());
                   callback.onSuccess(response);
                 } else {
@@ -898,19 +804,13 @@ public class ShuffleClientImpl extends ShuffleClient {
               }
 
               logger.error(
-                  "Push data to "
-                      + loc.hostAndPushPort()
-                      + " failed for shuffle "
-                      + shuffleId
-                      + " map "
-                      + mapId
-                      + " attempt "
-                      + attemptId
-                      + " partition "
-                      + partitionId
-                      + " batch "
-                      + nextBatchId
-                      + ".",
+                  "Push data to {} failed for shuffle {} map {} attempt {} partition {} batch {}.",
+                  loc.hostAndPushPort(),
+                  shuffleId,
+                  mapId,
+                  attemptId,
+                  partitionId,
+                  nextBatchId,
                   e);
               // async retry push data
               if (!mapperEnded(shuffleId, mapId, attemptId)) {
@@ -932,19 +832,13 @@ public class ShuffleClientImpl extends ShuffleClient {
               } else {
                 pushState.removeBatch(nextBatchId, loc.hostAndPushPort());
                 logger.info(
-                    "Push data to "
-                        + loc.hostAndPushPort()
-                        + " failed but mapper already ended for shuffle "
-                        + shuffleId
-                        + " map "
-                        + mapId
-                        + " attempt "
-                        + attemptId
-                        + " partition "
-                        + partitionId
-                        + " batch "
-                        + nextBatchId
-                        + ".");
+                    "Push data to {} failed but mapper already ended for shuffle {} map {} attempt {} partition {} batch {}.",
+                    loc.hostAndPushPort(),
+                    shuffleId,
+                    mapId,
+                    attemptId,
+                    partitionId,
+                    nextBatchId);
               }
             }
           };
@@ -963,19 +857,13 @@ public class ShuffleClientImpl extends ShuffleClient {
         }
       } catch (Exception e) {
         logger.error(
-            "Exception raised while pushing data for shuffle "
-                + shuffleId
-                + " map "
-                + mapId
-                + " attempt "
-                + attemptId
-                + " partition "
-                + partitionId
-                + " batch "
-                + nextBatchId
-                + " location "
-                + loc
-                + ".",
+            "Exception raised while pushing data for shuffle {} map {} attempt {} partition {} batch {} location {}.",
+            shuffleId,
+            mapId,
+            attemptId,
+            partitionId,
+            nextBatchId,
+            loc,
             e);
         wrappedCallback.onFailure(
             new Exception(
@@ -1016,11 +904,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     synchronized (splittingSet) {
       if (splittingSet.contains(partitionId)) {
         logger.debug(
-            "Splitting for shuffle "
-                + shuffleId
-                + " partition "
-                + partitionId
-                + ", skip split request.");
+            "Splitting for shuffle {} partition {}, skip split request.", shuffleId, partitionId);
         return;
       }
       splittingSet.add(partitionId);
@@ -1174,19 +1058,13 @@ public class ShuffleClientImpl extends ShuffleClient {
           @Override
           public void onSuccess(ByteBuffer response) {
             logger.debug(
-                "Push merged data to "
-                    + hostPort
-                    + " success for shuffle "
-                    + shuffleId
-                    + " map "
-                    + mapId
-                    + " attempt "
-                    + attemptId
-                    + " partition "
-                    + Arrays.toString(partitionIds)
-                    + " batch "
-                    + groupedBatchId
-                    + ".");
+                "Push merged data to {} success for shuffle {} map {} attempt {} partition {} batch {}.",
+                hostPort,
+                shuffleId,
+                mapId,
+                attemptId,
+                Arrays.toString(partitionIds),
+                groupedBatchId);
             pushState.removeBatch(groupedBatchId, hostPort);
             // TODO Need to adjust maxReqsInFlight if server response is congested, see CELEBORN-62
             if (response.remaining() > 0 && response.get() == StatusCode.STAGE_ENDED.getValue()) {
@@ -1208,27 +1086,20 @@ public class ShuffleClientImpl extends ShuffleClient {
                     + attemptId
                     + " partition "
                     + Arrays.toString(partitionIds)
-                    + " batche "
+                    + " batch "
                     + Arrays.toString(batchIds)
                     + ".";
             pushState.exception.compareAndSet(null, new CelebornIOException(errorMsg, e));
             if (logger.isDebugEnabled()) {
               for (int i = 0; i < numBatches; i++) {
                 logger.debug(
-                    "Push merged data to "
-                        + hostPort
-                        + " failed for shuffle "
-                        + shuffleId
-                        + " map "
-                        + mapId
-                        + " attempt "
-                        + attemptId
-                        + " partition "
-                        + partitionIds[i]
-                        + Arrays.toString(partitionIds)
-                        + " batch "
-                        + batchIds[i]
-                        + ".");
+                    "Push merged data to {} failed for shuffle {} map {} attempt {} partition {} batch {}.",
+                    hostPort,
+                    shuffleId,
+                    mapId,
+                    attemptId,
+                    partitionIds[i],
+                    batchIds[i]);
               }
             }
           }
@@ -1242,19 +1113,13 @@ public class ShuffleClientImpl extends ShuffleClient {
               byte reason = response.get();
               if (reason == StatusCode.HARD_SPLIT.getValue()) {
                 logger.info(
-                    "Push merged data to "
-                        + hostPort
-                        + " hard split required for shuffle "
-                        + shuffleId
-                        + " map "
-                        + mapId
-                        + " attempt "
-                        + attemptId
-                        + " partition "
-                        + Arrays.toString(partitionIds)
-                        + " batche "
-                        + Arrays.toString(batchIds)
-                        + ".");
+                    "Push merged data to {} hard split required for shuffle {} map {} attempt {} partition {} batch {}.",
+                    hostPort,
+                    shuffleId,
+                    mapId,
+                    attemptId,
+                    Arrays.toString(partitionIds),
+                    Arrays.toString(batchIds));
                 pushDataRetryPool.submit(
                     () ->
                         submitRetryPushMergedData(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -874,7 +874,7 @@ public class ShuffleClientImpl extends ShuffleClient {
               logger.error(
                   "Push data to "
                       + loc.hostAndPushPort()
-                      + "  failed for shuffle "
+                      + " failed for shuffle "
                       + shuffleId
                       + " map "
                       + mapId
@@ -1161,9 +1161,7 @@ public class ShuffleClientImpl extends ShuffleClient {
             String errorMsg =
                 (remainReviveTimes < maxReviveTimes ? "Revived push" : "Push")
                     + " merged data to "
-                    + host
-                    + ":"
-                    + port
+                    + hostPort
                     + " failed for map "
                     + mapId
                     + " attempt "
@@ -1491,7 +1489,8 @@ public class ShuffleClientImpl extends ShuffleClient {
       String applicationId, String shuffleKey, int shuffleId, int partitionId) throws IOException {
     ReduceFileGroups reduceFileGroups = updateFileGroup(applicationId, shuffleKey, shuffleId);
     if (reduceFileGroups == null) {
-      String msg = "Shuffle data lost for shuffle " + shuffleId + " partition " + partitionId + "!";
+      String msg =
+          "Shuffle data lost for shuffle " + shuffleId + " partitionId " + partitionId + "!";
       logger.error(msg);
       throw new CelebornIOException(msg);
     }
@@ -1700,7 +1699,7 @@ public class ShuffleClientImpl extends ShuffleClient {
               pushState.exception.compareAndSet(
                   null, new CelebornIOException("PushData byteBuf failed!", e));
               logger.error(
-                  "Push data to "
+                  "Push data byteBuf to "
                       + location.hostAndPushPort()
                       + " failed for shuffle "
                       + shuffleId
@@ -1870,6 +1869,10 @@ public class ShuffleClientImpl extends ShuffleClient {
               logger.error(
                   "Exception raised while reviving for shuffle "
                       + shuffleId
+                      + " map "
+                      + mapId
+                      + " attemptId "
+                      + attemptId
                       + " partition "
                       + location.getId()
                       + " epoch "
@@ -1897,11 +1900,16 @@ public class ShuffleClientImpl extends ShuffleClient {
         () -> {
           final String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
           logger.info(
-              "regionFinish shuffleKey:{}, attemptId:{}, locationId:{}",
-              shuffleKey,
-              attemptId,
-              location.getUniqueId());
-          logger.debug("regionFinish location:{}", location.toString());
+              "RegionFinish for shuffle "
+                  + shuffleId
+                  + " map "
+                  + mapId
+                  + " attemptId "
+                  + attemptId
+                  + " locationId "
+                  + location.getUniqueId()
+                  + ".");
+          logger.debug("RegionFinish for location " + location.toString() + ".");
           TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
           RegionFinish regionFinish =
               new RegionFinish(MASTER_MODE, shuffleKey, location.getUniqueId(), attemptId);
@@ -1924,7 +1932,7 @@ public class ShuffleClientImpl extends ShuffleClient {
       final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
       // return if shuffle stage already ended
       if (mapperEnded(shuffleId, mapId, attemptId)) {
-        logger.info(
+        logger.debug(
             "Send message to "
                 + location.hostAndPushPort()
                 + " ignored because mapper already ended for shuffle "

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -414,17 +414,17 @@ public class ShuffleClientImpl extends ShuffleClient {
           return result;
         } else if (StatusCode.SLOT_NOT_AVAILABLE.equals(respStatus)) {
           logger.error(
-              "LifecycleManager request slots return {}, retry again, remain retry times {}",
+              "LifecycleManager request slots return {}, retry again, remain retry times {}.",
               StatusCode.SLOT_NOT_AVAILABLE,
               numRetries - 1);
         } else if (StatusCode.RESERVE_SLOTS_FAILED.equals(respStatus)) {
           logger.error(
-              "LifecycleManager request slots return {}, retry again, remain retry times {}",
+              "LifecycleManager request slots return {}, retry again, remain retry times {}.",
               StatusCode.RESERVE_SLOTS_FAILED,
               numRetries - 1);
         } else {
           logger.error(
-              "LifecycleManager request slots return {}, retry again, remain retry times {}",
+              "LifecycleManager request slots return {}, retry again, remain retry times {}.",
               StatusCode.REQUEST_FAILED,
               numRetries - 1);
         }
@@ -501,7 +501,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     ConcurrentHashMap<Integer, PartitionLocation> map = reducePartitionMap.get(shuffleId);
     if (waitRevivedLocation(map, partitionId, epoch)) {
       logger.debug(
-          "Revive already success for shuffle {} map {} attempt {} partition {} epoch {}, just return(Assume revive successfully).",
+          "Revive already success for shuffle {} map {} attempt {} partition {} epoch {}, just return true(Assume revive successfully).",
           shuffleId,
           mapId,
           attemptId,
@@ -512,7 +512,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
     if (mapperEnded(shuffleId, mapId, attemptId)) {
       logger.debug(
-          "Revive success, but the mapper ended for shuffle {} map {} attempt {} partition {}, just return (Assume revive successfully).",
+          "Revive success, but the mapper ended for shuffle {} map {} attempt {} partition {}, just return true(Assume revive successfully).",
           shuffleId,
           mapId,
           attemptId,
@@ -540,6 +540,12 @@ public class ShuffleClientImpl extends ShuffleClient {
         map.put(partitionId, PbSerDeUtils.fromPbPartitionLocation(response.getLocation()));
         return true;
       } else if (StatusCode.MAP_ENDED.equals(respStatus)) {
+        logger.debug(
+            "Revive success, but the mapper ended for shuffle {} map {} attempt {} partition {}, just return true(Assume revive successfully).",
+            shuffleId,
+            mapId,
+            attemptId,
+            partitionId);
         mapperEndMap.computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet()).add(mapKey);
         return true;
       } else {
@@ -1164,7 +1170,7 @@ public class ShuffleClientImpl extends ShuffleClient {
               } else {
                 // Should not happen in current architecture.
                 response.rewind();
-                logger.error("Push merged data should not receive this response");
+                logger.error("Push merged data should not receive this response.");
                 pushState.onSuccess(hostPort);
                 callback.onSuccess(response);
               }
@@ -1359,26 +1365,26 @@ public class ShuffleClientImpl extends ShuffleClient {
 
         if (response.status() == StatusCode.SUCCESS) {
           logger.info(
-              "Shuffle {} request reducer file group success using time:{} ms, result partition ids: {}",
+              "Shuffle {} request reducer file group success using {} ms, result partition ids {}.",
               shuffleId,
               (System.nanoTime() - getReducerFileGroupStartTime) / 1000_000,
               response.fileGroup().keySet());
           return new ReduceFileGroups(response.fileGroup(), response.attempts());
         } else if (response.status() == StatusCode.STAGE_END_TIME_OUT) {
           logger.warn(
-              "Request {} return {} for {}",
+              "Request {} return {} for {}.",
               getReducerFileGroup,
               StatusCode.STAGE_END_TIME_OUT.toString(),
               shuffleKey);
         } else if (response.status() == StatusCode.SHUFFLE_DATA_LOST) {
           logger.warn(
-              "Request {} return {} for {}",
+              "Request {} return {} for {}.",
               getReducerFileGroup,
               StatusCode.SHUFFLE_DATA_LOST.toString(),
               shuffleKey);
         }
       } catch (Exception e) {
-        logger.error("Exception raised while call GetReducerFileGroup for " + shuffleKey + ".", e);
+        logger.error("Exception raised while call GetReducerFileGroup for {}.", shuffleKey, e);
       }
       return null;
     }
@@ -1416,8 +1422,7 @@ public class ShuffleClientImpl extends ShuffleClient {
 
     if (fileGroups.partitionGroups.size() == 0
         || !fileGroups.partitionGroups.containsKey(partitionId)) {
-      logger.warn(
-          "Shuffle data is empty for shuffle " + shuffleId + " partitionId " + partitionId + ".");
+      logger.warn("Shuffle data is empty for shuffle {} partition {}.", shuffleId, partitionId);
       return RssInputStream.empty();
     } else {
       return RssInputStream.create(
@@ -1681,11 +1686,11 @@ public class ShuffleClientImpl extends ShuffleClient {
         () -> {
           String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
           logger.info(
-              "pushDataHandShake shuffleKey:{}, attemptId:{}, locationId:{}",
+              "PushDataHandShake shuffleKey {} attemptId {} locationId {}",
               shuffleKey,
               attemptId,
               location.getUniqueId());
-          logger.debug("pushDataHandShake location:{}", location.toString());
+          logger.debug("PushDataHandShake location {}", location.toString());
           TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
           PushDataHandShake handShake =
               new PushDataHandShake(
@@ -1772,7 +1777,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                   attemptId,
                   location.getId(),
                   location.getEpoch());
-              throw new CelebornIOException("regiontstart revive failed");
+              throw new CelebornIOException("RegionStart revive failed");
             }
           }
           return Optional.empty();
@@ -1799,7 +1804,7 @@ public class ShuffleClientImpl extends ShuffleClient {
               mapId,
               attemptId,
               location.getUniqueId());
-          logger.debug("RegionFinish for location " + location.toString() + ".");
+          logger.debug("RegionFinish for location {}.", location.toString());
           TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
           RegionFinish regionFinish =
               new RegionFinish(MASTER_MODE, shuffleKey, location.getUniqueId(), attemptId);
@@ -1860,7 +1865,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     while (!Thread.currentThread().isInterrupted()
         && !isSuccess
         && retryTimes < conf.networkIoMaxRetries(TransportModuleConstants.PUSH_MODULE)) {
-      logger.debug("retrySendMessage times: {}", retryTimes);
+      logger.debug("RetrySendMessage  retry times {}.", retryTimes);
       try {
         result = supplier.get();
         isSuccess = true;

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1134,36 +1134,24 @@ public class ShuffleClientImpl extends ShuffleClient {
                             remainReviveTimes));
               } else if (reason == StatusCode.PUSH_DATA_SUCCESS_MASTER_CONGESTED.getValue()) {
                 logger.debug(
-                    "Push merged data to "
-                        + hostPort
-                        + " master congestion required for shuffle "
-                        + shuffleId
-                        + " map "
-                        + mapId
-                        + " attempt "
-                        + attemptId
-                        + " partition "
-                        + Arrays.toString(partitionIds)
-                        + " batche "
-                        + Arrays.toString(batchIds)
-                        + ".");
+                    "Push merged data to {} master congestion required for shuffle {} map {} attempt {} partition {} batch {}.",
+                    hostPort,
+                    shuffleId,
+                    mapId,
+                    attemptId,
+                    Arrays.toString(partitionIds),
+                    Arrays.toString(batchIds));
                 pushState.onCongestControl(hostPort);
                 callback.onSuccess(response);
               } else if (reason == StatusCode.PUSH_DATA_SUCCESS_SLAVE_CONGESTED.getValue()) {
                 logger.debug(
-                    "Push merged data to "
-                        + hostPort
-                        + " slave congestion required for shuffle "
-                        + shuffleId
-                        + " map "
-                        + mapId
-                        + " attempt "
-                        + attemptId
-                        + " partition "
-                        + Arrays.toString(partitionIds)
-                        + " batche "
-                        + Arrays.toString(batchIds)
-                        + ".");
+                    "Push merged data to {} slave congestion required for shuffle {} map {} attempt {} partition {} batch {}.",
+                    hostPort,
+                    shuffleId,
+                    mapId,
+                    attemptId,
+                    Arrays.toString(partitionIds),
+                    Arrays.toString(batchIds));
                 pushState.onCongestControl(hostPort);
                 callback.onSuccess(response);
               } else {
@@ -1197,19 +1185,13 @@ public class ShuffleClientImpl extends ShuffleClient {
               return;
             }
             logger.error(
-                "Push merged data to "
-                    + hostPort
-                    + " failed for shuffle "
-                    + shuffleId
-                    + " map "
-                    + mapId
-                    + " attempt "
-                    + attemptId
-                    + " partition "
-                    + Arrays.toString(partitionIds)
-                    + " batche "
-                    + Arrays.toString(batchIds)
-                    + ".",
+                "Push merged data to {} failed for shuffle {} map {} attempt {} partition {} batch {}.",
+                hostPort,
+                shuffleId,
+                mapId,
+                attemptId,
+                Arrays.toString(partitionIds),
+                Arrays.toString(batchIds),
                 e);
             if (!mapperEnded(shuffleId, mapId, attemptId)) {
               pushDataRetryPool.submit(
@@ -1241,19 +1223,13 @@ public class ShuffleClientImpl extends ShuffleClient {
       }
     } catch (Exception e) {
       logger.error(
-          "Exception raised while pushing merged data for shuffle "
-              + shuffleId
-              + " map "
-              + mapId
-              + " attempt "
-              + attemptId
-              + " partition "
-              + Arrays.toString(partitionIds)
-              + " batch  "
-              + Arrays.toString(batchIds)
-              + " location "
-              + hostPort
-              + ".",
+          "Exception raised while pushing merged data for shuffle {} map {} attempt {} partition {} batch  {} location {}.",
+          shuffleId,
+          mapId,
+          attemptId,
+          Arrays.toString(partitionIds),
+          Arrays.toString(batchIds),
+          hostPort,
           e);
       wrappedCallback.onFailure(
           new Exception(
@@ -1539,15 +1515,11 @@ public class ShuffleClientImpl extends ShuffleClient {
     // return if shuffle stage already ended
     if (mapperEnded(shuffleId, mapId, attemptId)) {
       logger.info(
-          "Push data byteBuf to location "
-              + location.hostAndPushPort()
-              + " ignored because mapper already ended for shuffle "
-              + shuffleId
-              + " map "
-              + mapId
-              + " attempt "
-              + attemptId
-              + ".");
+          "Push data byteBuf to location {} ignored because mapper already ended for shuffle {} map {} attempt {}.",
+          location.hostAndPushPort(),
+          shuffleId,
+          mapId,
+          attemptId);
       PushState pushState = pushStates.get(mapKey);
       if (pushState != null) {
         pushState.cleanup();
@@ -1601,17 +1573,12 @@ public class ShuffleClientImpl extends ShuffleClient {
               }
             }
             logger.debug(
-                "Push data byteBuf to "
-                    + location.hostAndPushPort()
-                    + " success for shuffle "
-                    + shuffleId
-                    + " map "
-                    + mapId
-                    + " attemptId "
-                    + attemptId
-                    + " batch "
-                    + nextBatchId
-                    + ".");
+                "Push data byteBuf to {} success for shuffle {} map {} attemptId {} batch {}.",
+                location.hostAndPushPort(),
+                shuffleId,
+                mapId,
+                attemptId,
+                nextBatchId);
           }
 
           @Override
@@ -1624,31 +1591,21 @@ public class ShuffleClientImpl extends ShuffleClient {
               pushState.exception.compareAndSet(
                   null, new CelebornIOException("PushData byteBuf failed!", e));
               logger.error(
-                  "Push data byteBuf to "
-                      + location.hostAndPushPort()
-                      + " failed for shuffle "
-                      + shuffleId
-                      + " map "
-                      + mapId
-                      + " attempt "
-                      + attemptId
-                      + " batch "
-                      + nextBatchId
-                      + ".",
+                  "Push data byteBuf to {} failed for shuffle {} map {} attempt {} batch {}.",
+                  location.hostAndPushPort(),
+                  shuffleId,
+                  mapId,
+                  attemptId,
+                  nextBatchId,
                   e);
             } else {
               logger.warn(
-                  "Push data to "
-                      + location.hostAndPushPort()
-                      + " failed but mapper already ended for shuffle "
-                      + shuffleId
-                      + " map "
-                      + mapId
-                      + " attempt "
-                      + attemptId
-                      + " batch "
-                      + nextBatchId
-                      + ".");
+                  "Push data to {} failed but mapper already ended for shuffle {} map {} attempt {} batch {}.",
+                  location.hostAndPushPort(),
+                  shuffleId,
+                  mapId,
+                  attemptId,
+                  nextBatchId);
             }
           }
         };
@@ -1658,19 +1615,13 @@ public class ShuffleClientImpl extends ShuffleClient {
       client.pushData(pushData, pushDataTimeout, callback, closeCallBack);
     } catch (Exception e) {
       logger.error(
-          "Exception raised while pushing data byteBuf for shuffle "
-              + shuffleId
-              + " map "
-              + mapId
-              + " attempt "
-              + attemptId
-              + " partitionId "
-              + partitionId
-              + " batch "
-              + nextBatchId
-              + " location "
-              + location
-              + ".",
+          "Exception raised while pushing data byteBuf for shuffle {} map {} attempt {} partitionId {} batch {} location {}.",
+          shuffleId,
+          mapId,
+          attemptId,
+          partitionId,
+          nextBatchId,
+          location,
           e);
       callback.onFailure(
           new Exception(
@@ -1761,16 +1712,12 @@ public class ShuffleClientImpl extends ShuffleClient {
         () -> {
           String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
           logger.info(
-              "RegionStart for shuffle "
-                  + shuffleId
-                  + " regionId "
-                  + currentRegionIdx
-                  + " attemptId "
-                  + attemptId
-                  + " locationId "
-                  + location.getUniqueId()
-                  + ".");
-          logger.debug("RegionStart  for location " + location.toString() + ".");
+              "RegionStart for shuffle {} regionId {} attemptId {} locationId {}.",
+              shuffleId,
+              currentRegionIdx,
+              attemptId,
+              location.getUniqueId());
+          logger.debug("RegionStart  for location {}.", location.toString());
           TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
           RegionStart regionStart =
               new RegionStart(
@@ -1810,17 +1757,12 @@ public class ShuffleClientImpl extends ShuffleClient {
             } else {
               // throw exception
               logger.error(
-                  "Exception raised while reviving for shuffle "
-                      + shuffleId
-                      + " map "
-                      + mapId
-                      + " attemptId "
-                      + attemptId
-                      + " partition "
-                      + location.getId()
-                      + " epoch "
-                      + location.getEpoch()
-                      + ".");
+                  "Exception raised while reviving for shuffle {} map {} attemptId {} partition {} epoch {}.",
+                  shuffleId,
+                  mapId,
+                  attemptId,
+                  location.getId(),
+                  location.getEpoch());
               throw new CelebornIOException("regiontstart revive failed");
             }
           }
@@ -1843,15 +1785,11 @@ public class ShuffleClientImpl extends ShuffleClient {
         () -> {
           final String shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId);
           logger.info(
-              "RegionFinish for shuffle "
-                  + shuffleId
-                  + " map "
-                  + mapId
-                  + " attemptId "
-                  + attemptId
-                  + " locationId "
-                  + location.getUniqueId()
-                  + ".");
+              "RegionFinish for shuffle {} map {} attemptId {} locationId {}.",
+              shuffleId,
+              mapId,
+              attemptId,
+              location.getUniqueId());
           logger.debug("RegionFinish for location " + location.toString() + ".");
           TransportClient client = createClientWaitingInFlightRequest(location, mapKey, pushState);
           RegionFinish regionFinish =
@@ -1876,15 +1814,11 @@ public class ShuffleClientImpl extends ShuffleClient {
       // return if shuffle stage already ended
       if (mapperEnded(shuffleId, mapId, attemptId)) {
         logger.debug(
-            "Send message to "
-                + location.hostAndPushPort()
-                + " ignored because mapper already ended for shuffle "
-                + shuffleId
-                + " map "
-                + mapId
-                + " attempt "
-                + attemptId
-                + ".");
+            "Send message to {} ignored because mapper already ended for shuffle {} map {} attempt {}.",
+            location.hostAndPushPort(),
+            shuffleId,
+            mapId,
+            attemptId);
         return null;
       }
       pushState = getPushState(mapKey);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current log in `ShuffleClientImpl` have below problem:

1. Use `logger.error` but can't show error stack
2. Different format of log
3. Wrong log level of error type log

In this pr, I prefer to unify the log format


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

