### PR TITLE
[CELEBORN-333] [Flink]bypass unexpected backlog message when stream already closed

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
@@ -66,10 +66,11 @@ public class ReadClientHandler extends BaseMessageHandler {
       case BACKLOG_ANNOUNCEMENT:
         BacklogAnnouncement backlogAnnouncement = (BacklogAnnouncement) msg;
         streamId = backlogAnnouncement.getStreamId();
-        if (streamHandlers.containsKey(streamId)) {
+        Consumer<RequestMessage> consumer = streamHandlers.get(streamId);
+        if (consumer != null) {
           logger.debug(
               "received streamId: {}, backlog: {}", streamId, backlogAnnouncement.getBacklog());
-          streamHandlers.get(streamId).accept(msg);
+          consumer.accept(msg);
         } else {
           logger.warn("Unexpected streamId received: {}", streamId);
         }


### PR DESCRIPTION
…losed.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
bypass backlog message if stream reader already closed


### Why are the changes needed?
if stream reader already closed, stream handler will be removed from ReadClientHandler. But backlog message would still can received from server, this will cause consumer of the handler NPE and then the channel will be closed.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
UT & manual test
