### PR TITLE
[CELEBORN-333][FLINK] Fix memory leak.

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
@@ -28,9 +28,12 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
 import org.apache.celeborn.common.network.protocol.Message;
 import org.apache.celeborn.common.network.util.FrameDecoder;
 import org.apache.celeborn.plugin.flink.protocol.ReadData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandlerAdapter
     implements FrameDecoder {
+  public static final Logger logger = LoggerFactory.getLogger(TransportFrameDecoderWithBufferSupplier.class);
   private int msgSize = -1;
   private int bodySize = -1;
   private Message.Type curType = Message.Type.UNKNOWN_TYPE;
@@ -144,7 +147,9 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
           }
         }
       }
-    } finally {
+    }catch (Exception e){
+      logger.error("decode msg failed type {} curMsg {} size {}", curType, curMsg, nettyBuf.readableBytes());
+    } finally{
       if (nettyBuf != null) {
         nettyBuf.release();
       }
@@ -156,6 +161,10 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
     curMsg = null;
     curType = Message.Type.UNKNOWN_TYPE;
     headerBuf.clear();
+    if (bodyBuf != null) {
+      bodyBuf.clear();
+      bodyBuf.release();
+    }
     bodyBuf = null;
     bodySize = -1;
   }

--- a/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferDispatcher.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferDispatcher.java
@@ -48,7 +48,7 @@ public class ReadBufferDispatcher extends Thread {
 
   public void recycle(ByteBuf buf) {
     int bufferSize = buf.capacity();
-    buf.release();
+    buf.release(buf.refCnt());
     memoryManager.changeReadBufferCounter(-1 * bufferSize);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Solve buffer dispatcher memory leak in worker.
2. Solve transportFrameDecoder memory leak in client.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT and cluster.
