### PR TITLE
[CELEBORN-339][Flink] Should ignore readdata's backlog.

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
@@ -134,10 +134,6 @@ public class RemoteBufferStreamReader extends CreditListener {
       readData.body().release();
       return;
     }
-    int backLogInData = readData.getBacklog();
-    if (backLogInData > 0) {
-      backlogReceived(backLogInData);
-    }
     dataListener.accept(readData.getFlinkBuffer());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Ignore backlog in ReadData structure.


### Why are the changes needed?
It will reserve backlog repeatedly if not ignore the backlog.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT and Cluster Test.
