### PR TITLE
[CELEBORN-341][Flink] cache file group for map partition in Flink plugin

### DIFF
--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -252,6 +252,9 @@ message PbGetReducerFileGroupResponse {
 
   // only reduce partition mode need know valid attempts
   repeated int32 attempts = 3;
+
+  // only map partition mode has succeed partitionIds
+  repeated int32 partitionIds = 4;
 }
 
 message PbUnregisterShuffle {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. Provide finished partitionIds(only for map partition) in reducer file group as partition may be committed early when split. So we need know whether the partition is ready for reader.
2.Cache file group in task Manager and use cached file group if partition which needed is ready.

### Why are the changes needed?
Cache file group in Flink task manager will reduce useless/duplicate rpc call to jobManager.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
TPCDS
