### PR TITLE
[CELEBORN-342] Fix the wrong avg produce bytes in Congestion control

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
@@ -71,4 +71,12 @@ public class BufferStatusHub extends TimeSlidingHub<BufferStatusHub.BufferStatus
   protected BufferStatusNode newEmptyNode() {
     return new BufferStatusNode();
   }
+
+  public long avgBytes() {
+    long currentNumBytes = sum().numBytes();
+    if (currentNumBytes > 0) {
+      return currentNumBytes / (long) getCurrentTimeWindowsInMills();
+    }
+    return 0L;
+  }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
@@ -72,10 +72,10 @@ public class BufferStatusHub extends TimeSlidingHub<BufferStatusHub.BufferStatus
     return new BufferStatusNode();
   }
 
-  public long avgBytes() {
+  public long avgBytesPerSec() {
     long currentNumBytes = sum().numBytes();
     if (currentNumBytes > 0) {
-      return currentNumBytes / (long) getCurrentTimeWindowsInMills();
+      return currentNumBytes * 1000 / (long) getCurrentTimeWindowsInMills();
     }
     return 0L;
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
@@ -207,8 +207,8 @@ public class CongestionController {
   }
 
   /**
-   * Get avg consumed bytes in a configured time window, and divide with the
-   * number of active users to determine the potential consume speed.
+   * Get avg consumed bytes in a configured time window, and divide with the number of active users
+   * to determine the potential consume speed.
    */
   public long getPotentialConsumeSpeed() {
     if (userBufferStatuses.size() == 0) {
@@ -218,9 +218,7 @@ public class CongestionController {
     return consumedBufferStatusHub.avgBytesPerSec() / userBufferStatuses.size();
   }
 
-  /**
-   * Get the avg user produce speed, the unit is bytes/sec.
-   */
+  /** Get the avg user produce speed, the unit is bytes/sec. */
   private long getUserProduceSpeed(UserBufferInfo userBufferInfo) {
     if (userBufferInfo != null) {
       return userBufferInfo.getBufferStatusHub().avgBytesPerSec();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
@@ -135,8 +135,6 @@ public class CongestionController {
     }
 
     long pendingConsumed = getTotalPendingBytes();
-
-    // The potential consume speed in average
     long avgConsumeSpeed = getPotentialConsumeSpeed();
 
     if (pendingConsumed > highWatermark && overHighWatermark.compareAndSet(false, true)) {
@@ -213,16 +211,12 @@ public class CongestionController {
       return 0;
     }
 
-    BufferStatusHub.BufferStatusNode totalBufferStatus = consumedBufferStatusHub.sum();
-    // The potential consume speed in average
-    return totalBufferStatus.numBytes()
-        / ((long) sampleTimeWindowSeconds * userBufferStatuses.size());
+    return consumedBufferStatusHub.avgBytes() / userBufferStatuses.size();
   }
 
   private long getUserProduceSpeed(UserBufferInfo userBufferInfo) {
     if (userBufferInfo != null) {
-      BufferStatusHub.BufferStatusNode userBufferStatus = userBufferInfo.getBufferStatusHub().sum();
-      return userBufferStatus.numBytes() / sampleTimeWindowSeconds;
+      return userBufferInfo.getBufferStatusHub().avgBytes();
     }
 
     return 0L;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
@@ -206,17 +206,24 @@ public class CongestionController {
     MemoryManager.instance().trimAllListeners();
   }
 
+  /**
+   * Get avg consumed bytes in a configured time window, and divide with the
+   * number of active users to determine the potential consume speed.
+   */
   public long getPotentialConsumeSpeed() {
     if (userBufferStatuses.size() == 0) {
       return 0;
     }
 
-    return consumedBufferStatusHub.avgBytes() / userBufferStatuses.size();
+    return consumedBufferStatusHub.avgBytesPerSec() / userBufferStatuses.size();
   }
 
+  /**
+   * Get the avg user produce speed, the unit is bytes/sec.
+   */
   private long getUserProduceSpeed(UserBufferInfo userBufferInfo) {
     if (userBufferInfo != null) {
-      return userBufferInfo.getBufferStatusHub().avgBytes();
+      return userBufferInfo.getBufferStatusHub().avgBytesPerSec();
     }
 
     return 0L;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -144,6 +144,10 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
 
   protected abstract N newEmptyNode();
 
+  protected int getCurrentTimeWindowsInMills() {
+    return _deque.size() * intervalPerBucketInMills;
+  }
+
   @VisibleForTesting
   protected long currentTimeMillis() {
     return System.currentTimeMillis();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestCongestionController.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestCongestionController.java
@@ -42,7 +42,7 @@ public class TestCongestionController {
   public void initialize() {
     // Make sampleTimeWindow a bit larger in case the tests run time exceed this window.
     controller =
-        new CongestionController(source, 10, 1000, 500, userInactiveTimeMills) {
+        new CongestionController(source, 10, 10000, 5000, userInactiveTimeMills) {
           @Override
           public long getTotalPendingBytes() {
             return pendingBytes;
@@ -67,11 +67,11 @@ public class TestCongestionController {
 
     Assert.assertFalse(controller.isUserCongested(userIdentifier));
 
-    controller.produceBytes(userIdentifier, 1001);
-    pendingBytes = 1001;
+    controller.produceBytes(userIdentifier, 10001);
+    pendingBytes = 10001;
     Assert.assertTrue(controller.isUserCongested(userIdentifier));
 
-    controller.consumeBytes(1001);
+    controller.consumeBytes(10001);
     pendingBytes = 0;
     Assert.assertFalse(controller.isUserCongested(userIdentifier));
   }
@@ -87,18 +87,18 @@ public class TestCongestionController {
 
     // If pendingBytes exceed the high watermark, user1 produce speed > avg consume speed
     // While user2 produce speed < avg consume speed
-    controller.produceBytes(user1, 800);
-    controller.produceBytes(user2, 201);
-    controller.consumeBytes(500);
-    pendingBytes = 1001;
+    controller.produceBytes(user1, 8000);
+    controller.produceBytes(user2, 2001);
+    controller.consumeBytes(5000);
+    pendingBytes = 10001;
     Assert.assertTrue(controller.isUserCongested(user1));
     Assert.assertFalse(controller.isUserCongested(user2));
 
     // If both users higher than the avg consume speed, should congest them all.
-    controller.produceBytes(user1, 800);
-    controller.produceBytes(user2, 800);
-    controller.consumeBytes(500);
-    pendingBytes = 1600;
+    controller.produceBytes(user1, 8000);
+    controller.produceBytes(user2, 8000);
+    controller.consumeBytes(5000);
+    pendingBytes = 16000;
     Assert.assertTrue(controller.isUserCongested(user1));
     Assert.assertTrue(controller.isUserCongested(user2));
 

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestCongestionController.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestCongestionController.java
@@ -42,7 +42,7 @@ public class TestCongestionController {
   public void initialize() {
     // Make sampleTimeWindow a bit larger in case the tests run time exceed this window.
     controller =
-        new CongestionController(source, 10, 10000, 5000, userInactiveTimeMills) {
+        new CongestionController(source, 10, 1000, 500, userInactiveTimeMills) {
           @Override
           public long getTotalPendingBytes() {
             return pendingBytes;
@@ -67,11 +67,11 @@ public class TestCongestionController {
 
     Assert.assertFalse(controller.isUserCongested(userIdentifier));
 
-    controller.produceBytes(userIdentifier, 10001);
-    pendingBytes = 10001;
+    controller.produceBytes(userIdentifier, 1001);
+    pendingBytes = 1001;
     Assert.assertTrue(controller.isUserCongested(userIdentifier));
 
-    controller.consumeBytes(10001);
+    controller.consumeBytes(1001);
     pendingBytes = 0;
     Assert.assertFalse(controller.isUserCongested(userIdentifier));
   }
@@ -87,18 +87,18 @@ public class TestCongestionController {
 
     // If pendingBytes exceed the high watermark, user1 produce speed > avg consume speed
     // While user2 produce speed < avg consume speed
-    controller.produceBytes(user1, 8000);
-    controller.produceBytes(user2, 2001);
-    controller.consumeBytes(5000);
-    pendingBytes = 10001;
+    controller.produceBytes(user1, 800);
+    controller.produceBytes(user2, 201);
+    controller.consumeBytes(500);
+    pendingBytes = 1001;
     Assert.assertTrue(controller.isUserCongested(user1));
     Assert.assertFalse(controller.isUserCongested(user2));
 
     // If both users higher than the avg consume speed, should congest them all.
-    controller.produceBytes(user1, 8000);
-    controller.produceBytes(user2, 8000);
-    controller.consumeBytes(5000);
-    pendingBytes = 16000;
+    controller.produceBytes(user1, 800);
+    controller.produceBytes(user2, 800);
+    controller.consumeBytes(500);
+    pendingBytes = 1600;
     Assert.assertTrue(controller.isUserCongested(user1));
     Assert.assertTrue(controller.isUserCongested(user2));
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Change the avg calculation in Congestion control to use `currentTimeWindow` instead of `maxTimeTimeWindow`(sampleTimeWindowSeconds)


### Why are the changes needed?

If a user just connect to a worker, we'll directly calculate the avg bytes by all bytes produced / sampleTimeWindowSeconds, but this is not right, we should use the current time window instead of the max time window

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?
Existing tests.
