### PR TITLE
[CELEBORN-336] Revive Failed should use keep the corresponding StatusCode

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -195,7 +195,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     if (!revive(
         applicationId, shuffleId, mapId, attemptId, partitionId, loc.getEpoch(), loc, cause)) {
       wrappedCallback.onFailure(
-          new CelebornIOException(cause + " then " + StatusCode.REVIVE_FAILED));
+          new CelebornIOException(cause + " then revive but " + StatusCode.REVIVE_FAILED));
     } else if (mapperEnded(shuffleId, mapId, attemptId)) {
       logger.debug(
           "Revive for push data success, but the mapper already ended for shuffle {} map {} attempt {} partition {} batch {} location {}.",
@@ -280,7 +280,8 @@ public class ShuffleClientImpl extends ShuffleClient {
           pushState.exception.compareAndSet(
               null,
               new CelebornIOException(
-                  errorMsg, new CelebornIOException(cause + " then " + StatusCode.REVIVE_FAILED)));
+                  errorMsg,
+                  new CelebornIOException(cause + " then revive but " + StatusCode.REVIVE_FAILED)));
           return;
         }
       } else if (mapperEnded(shuffleId, mapId, attemptId)) {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -194,7 +194,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     int partitionId = loc.getId();
     if (!revive(
         applicationId, shuffleId, mapId, attemptId, partitionId, loc.getEpoch(), loc, cause)) {
-      wrappedCallback.onFailure(new CelebornIOException(StatusCode.REVIVE_FAILED));
+      wrappedCallback.onFailure(new CelebornIOException(cause + " then " + StatusCode.REVIVE_FAILED));
     } else if (mapperEnded(shuffleId, mapId, attemptId)) {
       logger.debug(
           "Revive for push data success, but the mapper already ended for shuffle {} map {} attempt {} partition {} batch {} location {}.",
@@ -276,7 +276,9 @@ public class ShuffleClientImpl extends ShuffleClient {
               String.format(
                   "Revive failed while pushing merged for shuffle %d map %d attempt %d partition %d batch %d location %s.",
                   shuffleId, mapId, attemptId, partitionId, oldGroupedBatchId, batch.loc);
-          pushState.exception.compareAndSet(null, new CelebornIOException(errorMsg));
+          pushState.exception.compareAndSet(
+              null,
+              new CelebornIOException(errorMsg, new CelebornIOException(cause + " then " + StatusCode.REVIVE_FAILED)));
           return;
         }
       } else if (mapperEnded(shuffleId, mapId, attemptId)) {

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -194,7 +194,8 @@ public class ShuffleClientImpl extends ShuffleClient {
     int partitionId = loc.getId();
     if (!revive(
         applicationId, shuffleId, mapId, attemptId, partitionId, loc.getEpoch(), loc, cause)) {
-      wrappedCallback.onFailure(new CelebornIOException(cause + " then " + StatusCode.REVIVE_FAILED));
+      wrappedCallback.onFailure(
+          new CelebornIOException(cause + " then " + StatusCode.REVIVE_FAILED));
     } else if (mapperEnded(shuffleId, mapId, attemptId)) {
       logger.debug(
           "Revive for push data success, but the mapper already ended for shuffle {} map {} attempt {} partition {} batch {} location {}.",
@@ -278,7 +279,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                   shuffleId, mapId, attemptId, partitionId, oldGroupedBatchId, batch.loc);
           pushState.exception.compareAndSet(
               null,
-              new CelebornIOException(errorMsg, new CelebornIOException(cause + " then " + StatusCode.REVIVE_FAILED)));
+              new CelebornIOException(
+                  errorMsg, new CelebornIOException(cause + " then " + StatusCode.REVIVE_FAILED)));
           return;
         }
       } else if (mapperEnded(shuffleId, mapId, attemptId)) {


### PR DESCRIPTION

### What changes were proposed in this pull request?

For revive failed:
1. If we just pass StatusCode.REVIVE_FAILED, then the next retry may miss the real cause of last retry. Then LifecycleManager may miss some blacklist information.
2. If we just pass revive's cause, WrappedCallback miss the revive failed when print error message
3. So here we combine two status code here, make it more clear and won't miss information.



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

