### PR TITLE
[CELEBORN-348] Support fetchTime in load-aware slots assignment strategy

### DIFF
--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -105,6 +105,7 @@ message PbDiskInfo {
   int64 avgFlushTime = 3;
   int64 usedSlots = 4;
   int32 status = 5;
+  int64 avgFetchTime = 6;
 }
 
 message PbWorkerInfo {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2036,7 +2036,7 @@ object CelebornConf extends Logging {
       .withAlternative("rss.flusher.avg.time.window")
       .categories("worker")
       .doc("The size of sliding windows used to calculate statistics about flushed time and count.")
-      .version("0.2.0")
+      .version("0.2.1")
       .intConf
       .createWithDefault(20)
 
@@ -2047,7 +2047,7 @@ object CelebornConf extends Logging {
       .categories("worker")
       .doc("The minimum flush count to enter a sliding window" +
         " to calculate statistics about flushed time and count.")
-      .version("0.2.0")
+      .version("0.2.1")
       .internal
       .intConf
       .createWithDefault(500)
@@ -2057,7 +2057,7 @@ object CelebornConf extends Logging {
       .categories("worker")
       .doc("The minimum fetch count to enter a sliding window" +
         " to calculate statistics about flushed time and count.")
-      .version("0.2.0")
+      .version("0.2.1")
       .internal
       .intConf
       .createWithDefault(100)

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -729,7 +729,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def hddFlusherThreads: Int = get(WORKER_FLUSHER_HDD_THREADS)
   def ssdFlusherThreads: Int = get(WORKER_FLUSHER_SSD_THREADS)
   def hdfsFlusherThreads: Int = get(WORKER_FLUSHER_HDFS_THREADS)
-  def diskTimeSlidingWindowSize: Int = get(WORKER_DISK_TIME_SLIDINGWINDOW_SIZE)
+  def diskTimeSlidingWindowSize: Int = get(WORKER_DISKTIME_SLIDINGWINDOW_SIZE)
   def diskTimeSlidingWindowMinFlushCount: Int =
     get(WORKER_DISKTIME_SLIDINGWINDOW_MINFLUSHCOUNT)
   def diskTimeSlidingWindowMinFetchCount: Int =
@@ -2030,7 +2030,7 @@ object CelebornConf extends Logging {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("5G")
 
-  val WORKER_DISK_TIME_SLIDINGWINDOW_SIZE: ConfigEntry[Int] =
+  val WORKER_DISKTIME_SLIDINGWINDOW_SIZE: ConfigEntry[Int] =
     buildConf("celeborn.worker.diskTime.slidingWindow.size")
       .withAlternative("celeborn.worker.flusher.avgFlushTime.slidingWindow.size")
       .withAlternative("rss.flusher.avg.time.window")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -730,8 +730,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def ssdFlusherThreads: Int = get(WORKER_FLUSHER_SSD_THREADS)
   def hdfsFlusherThreads: Int = get(WORKER_FLUSHER_HDFS_THREADS)
   def diskTimeSlidingWindowSize: Int = get(WORKER_DISK_TIME_SLIDINGWINDOW_SIZE)
-  def diskTimeSlidingWindowMinCount: Int =
-    get(WORKER_DISKTIME_SLIDINGWINDOW_MINCOUNT)
+  def diskTimeSlidingWindowMinFlushCount: Int =
+    get(WORKER_DISKTIME_SLIDINGWINDOW_MINFLUSHCOUNT)
+  def diskTimeSlidingWindowMinFetchCount: Int =
+    get(WORKER_DISKTIME_SLIDINGWINDOW_MINFETCHCOUNT)
   def diskReserveSize: Long = get(WORKER_DISK_RESERVE_SIZE)
   def diskMonitorEnabled: Boolean = get(WORKER_DISK_MONITOR_ENABLED)
   def diskMonitorCheckList: Seq[String] = get(WORKER_DISK_MONITOR_CHECKLIST)
@@ -2038,8 +2040,8 @@ object CelebornConf extends Logging {
       .intConf
       .createWithDefault(20)
 
-  val WORKER_DISKTIME_SLIDINGWINDOW_MINCOUNT: ConfigEntry[Int] =
-    buildConf("celeborn.worker.diskTime.slidingWindow.minCount")
+  val WORKER_DISKTIME_SLIDINGWINDOW_MINFLUSHCOUNT: ConfigEntry[Int] =
+    buildConf("celeborn.worker.diskTime.slidingWindow.minFlushCount")
       .withAlternative("celeborn.worker.flusher.avgFlushTime.slidingWindow.minCount")
       .withAlternative("rss.flusher.avg.time.minimum.count")
       .categories("worker")
@@ -2048,7 +2050,17 @@ object CelebornConf extends Logging {
       .version("0.2.0")
       .internal
       .intConf
-      .createWithDefault(1000)
+      .createWithDefault(500)
+
+  val WORKER_DISKTIME_SLIDINGWINDOW_MINFETCHCOUNT: ConfigEntry[Int] =
+    buildConf("celeborn.worker.diskTime.slidingWindow.minFetchCount")
+      .categories("worker")
+      .doc("The minimum fetch count to enter a sliding window" +
+        " to calculate statistics about flushed time and count.")
+      .version("0.2.0")
+      .internal
+      .intConf
+      .createWithDefault(100)
 
   val SLOTS_ASSIGN_LOADAWARE_DISKGROUP_NUM: ConfigEntry[Int] =
     buildConf("celeborn.slots.assign.loadAware.numDiskGroups")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -467,6 +467,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def slotsAssignLoadAwareDiskGroupNum: Int = get(SLOTS_ASSIGN_LOADAWARE_DISKGROUP_NUM)
   def slotsAssignLoadAwareDiskGroupGradient: Double =
     get(SLOTS_ASSIGN_LOADAWARE_DISKGROUP_GRADIENT)
+  def slotsAssignLoadAwareFlushTimeWeight: Double =
+    get(SLOTS_ASSIGN_LOADAWARE_FLUSHTIME_WEIGHT)
+  def slotsAssignLoadAwareFetchTimeWeight: Double =
+    get(SLOTS_ASSIGN_LOADAWARE_FETCHTIME_WEIGHT)
   def slotsAssignExtraSlots: Int = get(SLOTS_ASSIGN_EXTRA_SLOTS)
   def slotsAssignPolicy: SlotsAssignPolicy = SlotsAssignPolicy.valueOf(get(SLOTS_ASSIGN_POLICY))
   def initialEstimatedPartitionSize: Long = get(SHUFFLE_INITIAL_ESRIMATED_PARTITION_SIZE)
@@ -725,9 +729,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def hddFlusherThreads: Int = get(WORKER_FLUSHER_HDD_THREADS)
   def ssdFlusherThreads: Int = get(WORKER_FLUSHER_SSD_THREADS)
   def hdfsFlusherThreads: Int = get(WORKER_FLUSHER_HDFS_THREADS)
-  def avgFlushTimeSlidingWindowSize: Int = get(WORKER_FLUSHER_AVGFLUSHTIME_SLIDINGWINDOW_SIZE)
-  def avgFlushTimeSlidingWindowMinCount: Int =
-    get(WORKER_FLUSHER_AVGFLUSHTIME_SLIDINGWINDOW_MINCOUNT)
+  def diskTimeSlidingWindowSize: Int = get(WORKER_DISK_TIME_SLIDINGWINDOW_SIZE)
+  def diskTimeSlidingWindowMinCount: Int =
+    get(WORKER_DISKTIME_SLIDINGWINDOW_MINCOUNT)
   def diskReserveSize: Long = get(WORKER_DISK_RESERVE_SIZE)
   def diskMonitorEnabled: Boolean = get(WORKER_DISK_MONITOR_ENABLED)
   def diskMonitorCheckList: Seq[String] = get(WORKER_DISK_MONITOR_CHECKLIST)
@@ -2024,8 +2028,9 @@ object CelebornConf extends Logging {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("5G")
 
-  val WORKER_FLUSHER_AVGFLUSHTIME_SLIDINGWINDOW_SIZE: ConfigEntry[Int] =
-    buildConf("celeborn.worker.flusher.avgFlushTime.slidingWindow.size")
+  val WORKER_DISK_TIME_SLIDINGWINDOW_SIZE: ConfigEntry[Int] =
+    buildConf("celeborn.worker.diskTime.slidingWindow.size")
+      .withAlternative("celeborn.worker.flusher.avgFlushTime.slidingWindow.size")
       .withAlternative("rss.flusher.avg.time.window")
       .categories("worker")
       .doc("The size of sliding windows used to calculate statistics about flushed time and count.")
@@ -2033,8 +2038,9 @@ object CelebornConf extends Logging {
       .intConf
       .createWithDefault(20)
 
-  val WORKER_FLUSHER_AVGFLUSHTIME_SLIDINGWINDOW_MINCOUNT: ConfigEntry[Int] =
-    buildConf("celeborn.worker.flusher.avgFlushTime.slidingWindow.minCount")
+  val WORKER_DISKTIME_SLIDINGWINDOW_MINCOUNT: ConfigEntry[Int] =
+    buildConf("celeborn.worker.diskTime.slidingWindow.minCount")
+      .withAlternative("celeborn.worker.flusher.avgFlushTime.slidingWindow.minCount")
       .withAlternative("rss.flusher.avg.time.minimum.count")
       .categories("worker")
       .doc("The minimum flush count to enter a sliding window" +
@@ -2063,6 +2069,24 @@ object CelebornConf extends Logging {
       .version("0.2.0")
       .doubleConf
       .createWithDefault(0.1)
+
+  val SLOTS_ASSIGN_LOADAWARE_FLUSHTIME_WEIGHT: ConfigEntry[Double] =
+    buildConf("celeborn.slots.assign.loadAware.flushTimeWeight")
+      .categories("master")
+      .doc(
+        "Weight of average flush time when calculating ordering in load-aware assignment strategy")
+      .version("0.2.1")
+      .doubleConf
+      .createWithDefault(0)
+
+  val SLOTS_ASSIGN_LOADAWARE_FETCHTIME_WEIGHT: ConfigEntry[Double] =
+    buildConf("celeborn.slots.assign.loadAware.fetchTimeWeight")
+      .categories("master")
+      .doc(
+        "Weight of average fetch time when calculating ordering in load-aware assignment strategy")
+      .version("0.2.1")
+      .doubleConf
+      .createWithDefault(1)
 
   val SLOTS_ASSIGN_EXTRA_SLOTS: ConfigEntry[Int] =
     buildConf("celeborn.slots.assign.extraSlots")

--- a/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
@@ -80,14 +80,12 @@ class DiskInfo(
     this
   }
 
-  def setFlushTime(avgFlushTime: Long): this.type = this.synchronized {
-    this.avgFlushTime = avgFlushTime
-    this
+  def updateFlushTime(): Unit = {
+    avgFlushTime = flushTimeMetrics.getAverage()
   }
 
-  def setFetchTime(avgFetchTime: Long): this.type = this.synchronized {
-    this.avgFetchTime = avgFetchTime
-    this
+  def updateFetchTime(): Unit = {
+    avgFetchTime = fetchTimeMetrics.getAverage()
   }
 
   def availableSlots(): Long = this.synchronized {

--- a/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable.ListBuffer
 
 import org.slf4j.LoggerFactory
 
+import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.protocol.StorageInfo
 import org.apache.celeborn.common.util.Utils.runCommand
@@ -35,18 +36,33 @@ class DiskInfo(
     var actualUsableSpace: Long,
     // avgFlushTime is nano seconds
     var avgFlushTime: Long,
+    var avgFetchTime: Long,
     var activeSlots: Long,
     val dirs: List[File],
     val deviceInfo: DeviceInfo) extends Serializable with Logging {
 
-  def this(mountPoint: String, usableSpace: Long, avgFlushTime: Long, activeSlots: Long) = {
-    this(mountPoint, usableSpace, avgFlushTime, activeSlots, List.empty, null)
+  def this(
+      mountPoint: String,
+      usableSpace: Long,
+      avgFlushTime: Long,
+      avgFetchTime: Long,
+      activeSlots: Long) = {
+    this(mountPoint, usableSpace, avgFlushTime, avgFetchTime, activeSlots, List.empty, null)
   }
 
-  def this(mountPoint: String, dirs: List[File], deviceInfo: DeviceInfo) = {
-    this(mountPoint, 0, 0, 0, dirs, deviceInfo)
+  def this(
+      mountPoint: String,
+      dirs: List[File],
+      deviceInfo: DeviceInfo,
+      windowSize: Int,
+      minWindowCount: Int) = {
+    this(mountPoint, 0, 0, 0, 0, dirs, deviceInfo)
+    flushTimeMetrics = new TimeWindow(windowSize, minWindowCount)
+    fetchTimeMetrics = new TimeWindow(windowSize, minWindowCount)
   }
 
+  var flushTimeMetrics: TimeWindow = _
+  var fetchTimeMetrics: TimeWindow = _
   var status: DiskStatus = DiskStatus.HEALTHY
   var threadCount = 1
   var configuredUsableSpace = 0L
@@ -66,6 +82,11 @@ class DiskInfo(
 
   def setFlushTime(avgFlushTime: Long): this.type = this.synchronized {
     this.avgFlushTime = avgFlushTime
+    this
+  }
+
+  def setFetchTime(avgFetchTime: Long): this.type = this.synchronized {
+    this.avgFetchTime = avgFetchTime
     this
   }
 
@@ -112,6 +133,7 @@ class DiskInfo(
       s" mountPoint: $mountPoint," +
       s" usableSpace: $actualUsableSpace," +
       s" avgFlushTime: $avgFlushTime," +
+      s" avgFetchTime: $avgFetchTime," +
       s" activeSlots: $activeSlots)" +
       s" status: $status" +
       s" dirs ${dirs.mkString("\t")}"
@@ -145,12 +167,13 @@ object DeviceInfo {
 
   /**
    * @param workingDirs array of (workingDir, max usable space, flush thread count, storage type)
-   * @return it will return three maps
+   * @return it will return two maps
    *         (deviceName -> deviceInfo)
    *         (mount point -> diskInfo)
    */
-  def getDeviceAndDiskInfos(workingDirs: Seq[(File, Long, Int, StorageInfo.Type)])
-      : (util.Map[String, DeviceInfo], util.Map[String, DiskInfo]) = {
+  def getDeviceAndDiskInfos(
+      workingDirs: Seq[(File, Long, Int, StorageInfo.Type)],
+      conf: CelebornConf): (util.Map[String, DeviceInfo], util.Map[String, DiskInfo]) = {
     val deviceNameToDeviceInfo = new util.HashMap[String, DeviceInfo]()
     val mountPointToDeviceInfo = new util.HashMap[String, DeviceInfo]()
 
@@ -209,7 +232,12 @@ object DeviceInfo {
     }.foreach {
       case (mountPoint, dirs) =>
         val deviceInfo = mountPointToDeviceInfo.get(mountPoint)
-        val diskInfo = new DiskInfo(mountPoint, dirs.map(_._1).toList, deviceInfo)
+        val diskInfo = new DiskInfo(
+          mountPoint,
+          dirs.map(_._1).toList,
+          deviceInfo,
+          conf.diskTimeSlidingWindowSize,
+          conf.diskTimeSlidingWindowMinCount)
         val (_, maxUsableSpace, threadCount, storageType) = dirs(0)
         diskInfo.configuredUsableSpace = maxUsableSpace
         diskInfo.threadCount = threadCount

--- a/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
@@ -54,11 +54,12 @@ class DiskInfo(
       mountPoint: String,
       dirs: List[File],
       deviceInfo: DeviceInfo,
-      windowSize: Int,
-      minWindowCount: Int) = {
+      conf: CelebornConf) = {
     this(mountPoint, 0, 0, 0, 0, dirs, deviceInfo)
-    flushTimeMetrics = new TimeWindow(windowSize, minWindowCount)
-    fetchTimeMetrics = new TimeWindow(windowSize, minWindowCount)
+    flushTimeMetrics =
+      new TimeWindow(conf.diskTimeSlidingWindowSize, conf.diskTimeSlidingWindowMinFlushCount)
+    fetchTimeMetrics =
+      new TimeWindow(conf.diskTimeSlidingWindowSize, conf.diskTimeSlidingWindowMinFetchCount)
   }
 
   var flushTimeMetrics: TimeWindow = _
@@ -234,8 +235,7 @@ object DeviceInfo {
           mountPoint,
           dirs.map(_._1).toList,
           deviceInfo,
-          conf.diskTimeSlidingWindowSize,
-          conf.diskTimeSlidingWindowMinCount)
+          conf)
         val (_, maxUsableSpace, threadCount, storageType) = dirs(0)
         diskInfo.configuredUsableSpace = maxUsableSpace
         diskInfo.threadCount = threadCount

--- a/common/src/main/scala/org/apache/celeborn/common/meta/TimeWindow.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/TimeWindow.scala
@@ -20,10 +20,14 @@ package org.apache.celeborn.common.meta
 import java.util.concurrent.atomic.LongAdder
 
 class TimeWindow(windowSize: Int, minWindowCount: Int) {
-  protected val totalCount = new LongAdder
-  protected val totalTime = new LongAdder
-  protected val timeWindow = new Array[(Long, Long)](windowSize)
-  protected var index = 0
+  val totalCount = new LongAdder
+  val totalTime = new LongAdder
+  val timeWindow = new Array[(Long, Long)](windowSize)
+  var index = 0
+
+  for (i <- 0 until windowSize) {
+    timeWindow(i) = (0L, 0L)
+  }
 
   def update(delta: Long): Unit = {
     totalTime.add(delta)

--- a/common/src/main/scala/org/apache/celeborn/common/meta/TimeWindow.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/TimeWindow.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.celeborn.common.meta
 
 import java.util.concurrent.atomic.LongAdder

--- a/common/src/main/scala/org/apache/celeborn/common/meta/TimeWindow.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/TimeWindow.scala
@@ -35,23 +35,23 @@ class TimeWindow(windowSize: Int, minWindowCount: Int) {
   }
 
   def getAverage(): Long = {
-    val currentFlushTime = totalTime.sumThenReset()
-    val currentFlushCount = totalCount.sumThenReset()
+    val currentTime = totalTime.sumThenReset()
+    val currentCount = totalCount.sumThenReset()
 
-    var totalFlushTime = 0L
-    var totalFlushCount = 0L
-    if (currentFlushCount >= minWindowCount) {
-      timeWindow(index) = (currentFlushTime, currentFlushCount)
+    if (currentCount >= minWindowCount) {
+      timeWindow(index) = (currentTime, currentCount)
       index = (index + 1) % windowSize
     }
 
+    var time = 0L
+    var count = 0L
     timeWindow.foreach { case (flushTime, flushCount) =>
-      totalFlushTime = totalFlushTime + flushTime
-      totalFlushCount = totalFlushCount + flushCount
+      time = time + flushTime
+      count = count + flushCount
     }
 
-    if (totalFlushCount != 0) {
-      totalFlushTime / totalFlushCount
+    if (count != 0) {
+      time / count
     } else {
       0L
     }

--- a/common/src/main/scala/org/apache/celeborn/common/meta/TimeWindow.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/TimeWindow.scala
@@ -1,0 +1,38 @@
+package org.apache.celeborn.common.meta
+
+import java.util.concurrent.atomic.LongAdder
+
+class TimeWindow(windowSize: Int, minWindowCount: Int) {
+  protected val totalCount = new LongAdder
+  protected val totalTime = new LongAdder
+  protected val timeWindow = new Array[(Long, Long)](windowSize)
+  protected var index = 0
+
+  def update(delta: Long): Unit = {
+    totalTime.add(delta)
+    totalCount.increment()
+  }
+
+  def getAverage(): Long = {
+    val currentFlushTime = totalTime.sumThenReset()
+    val currentFlushCount = totalCount.sumThenReset()
+
+    var totalFlushTime = 0L
+    var totalFlushCount = 0L
+    if (currentFlushCount >= minWindowCount) {
+      timeWindow(index) = (currentFlushTime, currentFlushCount)
+      index = (index + 1) % windowSize
+    }
+
+    timeWindow.foreach { case (flushTime, flushCount) =>
+      totalFlushTime = totalFlushTime + flushTime
+      totalFlushCount = totalFlushCount + flushCount
+    }
+
+    if (totalFlushCount != 0) {
+      totalFlushTime / totalFlushCount
+    } else {
+      0L
+    }
+  }
+}

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -200,6 +200,7 @@ class WorkerInfo(
         curDisk.actualUsableSpace_$eq(newDisk.actualUsableSpace)
         curDisk.activeSlots_$eq(Math.max(curDisk.activeSlots, newDisk.activeSlots))
         curDisk.avgFlushTime_$eq(newDisk.avgFlushTime)
+        curDisk.avgFetchTime_$eq(newDisk.avgFetchTime)
         curDisk.maxSlots_$eq(curDisk.actualUsableSpace / estimatedPartitionSize)
         curDisk.setStatus(newDisk.status)
       } else {

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -68,6 +68,7 @@ object PbSerDeUtils {
       pbDiskInfo.getMountPoint,
       pbDiskInfo.getUsableSpace,
       pbDiskInfo.getAvgFlushTime,
+      pbDiskInfo.getAvgFetchTime,
       pbDiskInfo.getUsedSlots)
       .setStatus(Utils.toDiskStatus(pbDiskInfo.getStatus))
 
@@ -76,6 +77,7 @@ object PbSerDeUtils {
       .setMountPoint(diskInfo.mountPoint)
       .setUsableSpace(diskInfo.actualUsableSpace)
       .setAvgFlushTime(diskInfo.avgFlushTime)
+      .setAvgFetchTime(diskInfo.avgFetchTime)
       .setUsedSlots(diskInfo.activeSlots)
       .setStatus(diskInfo.status.getValue)
       .build

--- a/common/src/test/java/org/apache/celeborn/common/network/server/ChunkStreamManagerSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/server/ChunkStreamManagerSuiteJ.java
@@ -39,10 +39,10 @@ public class ChunkStreamManagerSuiteJ {
     FileManagedBuffers buffers3 = Mockito.mock(FileManagedBuffers.class);
     FileManagedBuffers buffers4 = Mockito.mock(FileManagedBuffers.class);
 
-    manager.registerStream("shuffleKey1", buffers);
-    manager.registerStream("shuffleKey1", buffers2);
-    manager.registerStream("shuffleKey2", buffers3);
-    long stream3 = manager.registerStream("shuffleKey3", buffers4);
+    manager.registerStream("shuffleKey1", buffers, null);
+    manager.registerStream("shuffleKey1", buffers2, null);
+    manager.registerStream("shuffleKey2", buffers3, null);
+    long stream3 = manager.registerStream("shuffleKey3", buffers4, null);
     Assert.assertEquals(4, manager.numStreamStates());
     Assert.assertEquals(manager.numStreamStates(), manager.numShuffleSteams());
 

--- a/common/src/test/scala/org/apache/celeborn/common/meta/TimeWindowSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/TimeWindowSuite.scala
@@ -17,22 +17,24 @@
 
 package org.apache.celeborn.common.meta
 
+import java.util
+import java.util.{Map => jMap}
+import java.util.concurrent.{ConcurrentHashMap, Future, ThreadLocalRandom}
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+import org.junit.Assert.{assertEquals, assertNotEquals, assertNotNull}
+
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.quota.ResourceConsumption
-import org.apache.celeborn.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
 import org.apache.celeborn.common.rpc._
+import org.apache.celeborn.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
 import org.apache.celeborn.common.util.ThreadUtils
-import org.junit.Assert.{assertEquals, assertNotEquals, assertNotNull}
-
-import java.util
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.{ConcurrentHashMap, Future, ThreadLocalRandom}
-import java.util.{Map => jMap}
-import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.duration._
-import scala.reflect.ClassTag
 
 class TimeWindowSuite extends CelebornFunSuite {
 

--- a/common/src/test/scala/org/apache/celeborn/common/meta/TimeWindowSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/TimeWindowSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.meta
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.quota.ResourceConsumption
+import org.apache.celeborn.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
+import org.apache.celeborn.common.rpc._
+import org.apache.celeborn.common.util.ThreadUtils
+import org.junit.Assert.{assertEquals, assertNotEquals, assertNotNull}
+
+import java.util
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ConcurrentHashMap, Future, ThreadLocalRandom}
+import java.util.{Map => jMap}
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+class TimeWindowSuite extends CelebornFunSuite {
+
+  test("test TimeWindow") {
+    val tw = new TimeWindow(2, 2)
+    tw.update(10)
+    tw.getAverage()
+    assert(tw.index == 0)
+    tw.update(10)
+    tw.update(10)
+    tw.getAverage()
+    assert(tw.index == 1)
+    assert(tw.timeWindow(0) == (20, 2))
+    tw.update(5)
+    tw.update(5)
+    tw.update(5)
+    val avg = tw.getAverage()
+    assert(tw.timeWindow(1) == (15, 3))
+    assert(tw.index == 0)
+    assert(avg == 7)
+  }
+}

--- a/common/src/test/scala/org/apache/celeborn/common/meta/TimeWindowSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/TimeWindowSuite.scala
@@ -17,24 +17,7 @@
 
 package org.apache.celeborn.common.meta
 
-import java.util
-import java.util.{Map => jMap}
-import java.util.concurrent.{ConcurrentHashMap, Future, ThreadLocalRandom}
-import java.util.concurrent.atomic.AtomicInteger
-
-import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.duration._
-import scala.reflect.ClassTag
-
-import org.junit.Assert.{assertEquals, assertNotEquals, assertNotNull}
-
 import org.apache.celeborn.CelebornFunSuite
-import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.identity.UserIdentifier
-import org.apache.celeborn.common.quota.ResourceConsumption
-import org.apache.celeborn.common.rpc._
-import org.apache.celeborn.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
-import org.apache.celeborn.common.util.ThreadUtils
 
 class TimeWindowSuite extends CelebornFunSuite {
 

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -226,7 +226,7 @@ class WorkerInfoSuite extends CelebornFunSuite {
     val disks = new util.HashMap[String, DiskInfo]()
     disks.put("disk1", new DiskInfo("disk1", Int.MaxValue, 1, 1, 10))
     disks.put("disk2", new DiskInfo("disk2", Int.MaxValue, 2, 2, 20))
-    disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 3, 2, 30))
+    disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 3, 3, 30))
     val userResourceConsumption = new ConcurrentHashMap[UserIdentifier, ResourceConsumption]()
     userResourceConsumption.put(
       UserIdentifier("tenant1", "name1"),
@@ -297,9 +297,9 @@ class WorkerInfoSuite extends CelebornFunSuite {
          |SlotsUsed: 60
          |LastHeartbeat: 0
          |Disks: $placeholder
-         |  DiskInfo0: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk3, usableSpace: 2147483647, avgFlushTime: 3, activeSlots: 30) status: HEALTHY dirs $placeholder
-         |  DiskInfo1: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk1, usableSpace: 2147483647, avgFlushTime: 1, activeSlots: 10) status: HEALTHY dirs $placeholder
-         |  DiskInfo2: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk2, usableSpace: 2147483647, avgFlushTime: 2, activeSlots: 20) status: HEALTHY dirs $placeholder
+         |  DiskInfo0: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk3, usableSpace: 2147483647, avgFlushTime: 3, avgFetchTime: 3, activeSlots: 30) status: HEALTHY dirs $placeholder
+         |  DiskInfo1: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk1, usableSpace: 2147483647, avgFlushTime: 1, avgFetchTime: 1, activeSlots: 10) status: HEALTHY dirs $placeholder
+         |  DiskInfo2: DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: disk2, usableSpace: 2147483647, avgFlushTime: 2, avgFetchTime: 2, activeSlots: 20) status: HEALTHY dirs $placeholder
          |UserResourceConsumption: $placeholder
          |  UserIdentifier: `tenant1`.`name1`, ResourceConsumption: ResourceConsumption(diskBytesWritten: 20.0 MB, diskFileCount: 1, hdfsBytesWritten: 50.0 MB, hdfsFileCount: 1)
          |WorkerRef: NettyRpcEndpointRef(rss://mockRpc@localhost:12345)

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -64,9 +64,9 @@ class WorkerInfoSuite extends CelebornFunSuite {
   test("multi-thread modify same WorkerInfo.") {
     val numSlots = 10000
     val disks = new util.HashMap[String, DiskInfo]()
-    disks.put("disk1", new DiskInfo("disk1", Int.MaxValue, 1, 0))
-    disks.put("disk2", new DiskInfo("disk2", Int.MaxValue, 1, 0))
-    disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 1, 0))
+    disks.put("disk1", new DiskInfo("disk1", Int.MaxValue, 1, 1, 0))
+    disks.put("disk2", new DiskInfo("disk2", Int.MaxValue, 1, 1, 0))
+    disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 1, 1, 0))
     val userResourceConsumption = new ConcurrentHashMap[UserIdentifier, ResourceConsumption]()
     userResourceConsumption.put(UserIdentifier("tenant1", "name1"), ResourceConsumption(1, 1, 1, 1))
     val worker =
@@ -224,9 +224,9 @@ class WorkerInfoSuite extends CelebornFunSuite {
       null)
 
     val disks = new util.HashMap[String, DiskInfo]()
-    disks.put("disk1", new DiskInfo("disk1", Int.MaxValue, 1, 10))
-    disks.put("disk2", new DiskInfo("disk2", Int.MaxValue, 2, 20))
-    disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 3, 30))
+    disks.put("disk1", new DiskInfo("disk1", Int.MaxValue, 1, 1, 10))
+    disks.put("disk2", new DiskInfo("disk2", Int.MaxValue, 2, 2, 20))
+    disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 3, 2, 30))
     val userResourceConsumption = new ConcurrentHashMap[UserIdentifier, ResourceConsumption]()
     userResourceConsumption.put(
       UserIdentifier("tenant1", "name1"),

--- a/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
@@ -43,8 +43,8 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
   val files = List(file1, file2)
 
   val device = new DeviceInfo("device-a")
-  val diskInfo1 = new DiskInfo("/mnt/disk/0", 1000, 1000, 1000, files, device)
-  val diskInfo2 = new DiskInfo("/mnt/disk/1", 2000, 2000, 2000, files, device)
+  val diskInfo1 = new DiskInfo("/mnt/disk/0", 1000, 1000, 1000, 1000, files, device)
+  val diskInfo2 = new DiskInfo("/mnt/disk/1", 2000, 2000, 2000, 2000, files, device)
   val diskInfos = new util.HashMap[String, DiskInfo]()
   diskInfos.put("disk1", diskInfo1)
   diskInfos.put("disk2", diskInfo2)
@@ -108,6 +108,7 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
     assert(restoredDiskInfo.mountPoint.equals(diskInfo1.mountPoint))
     assert(restoredDiskInfo.actualUsableSpace.equals(diskInfo1.actualUsableSpace))
     assert(restoredDiskInfo.avgFlushTime.equals(diskInfo1.avgFlushTime))
+    assert(restoredDiskInfo.avgFetchTime.equals(diskInfo1.avgFetchTime))
     assert(restoredDiskInfo.activeSlots.equals(diskInfo1.activeSlots))
     assert(restoredDiskInfo.dirs.equals(List.empty))
     assert(restoredDiskInfo.deviceInfo == null)

--- a/docs/configuration/master.md
+++ b/docs/configuration/master.md
@@ -44,6 +44,8 @@ license: |
 | celeborn.shuffle.initialEstimatedPartitionSize | 64mb | Initial partition size for estimation, it will change according to runtime stats. | 0.2.0 | 
 | celeborn.slots.assign.extraSlots | 2 | Extra slots number when master assign slots. | 0.2.0 | 
 | celeborn.slots.assign.loadAware.diskGroupGradient | 0.1 | This value means how many more workload will be placed into a faster disk group than a slower group. | 0.2.0 | 
+| celeborn.slots.assign.loadAware.fetchTimeWeight | 1.0 | Weight of average fetch time when calculating ordering in load-aware assignment strategy | 0.2.1 | 
+| celeborn.slots.assign.loadAware.flushTimeWeight | 0.0 | Weight of average flush time when calculating ordering in load-aware assignment strategy | 0.2.1 | 
 | celeborn.slots.assign.loadAware.numDiskGroups | 5 | This configuration is a guidance for load-aware slot allocation algorithm. This value is control how many disk groups will be created. | 0.2.0 | 
 | celeborn.slots.assign.policy | ROUNDROBIN | Policy for master to assign slots, Celeborn supports two types of policy: roundrobin and loadaware. | 0.2.0 | 
 | celeborn.worker.heartbeat.timeout | 120s | Worker heartbeat timeout. | 0.2.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -49,7 +49,7 @@ license: |
 | celeborn.worker.disk.checkFileClean.maxRetries | 3 | The number of retries for a worker to check if the working directory is cleaned up before registering with the master. | 0.2.0 | 
 | celeborn.worker.disk.checkFileClean.timeout | 1000ms | The wait time per retry for a worker to check if the working directory is cleaned up before registering with the master. | 0.2.0 | 
 | celeborn.worker.disk.reserve.size | 5G | Celeborn worker reserved space for each disk. | 0.2.0 | 
-| celeborn.worker.diskTime.slidingWindow.size | 20 | The size of sliding windows used to calculate statistics about flushed time and count. | 0.2.0 | 
+| celeborn.worker.diskTime.slidingWindow.size | 20 | The size of sliding windows used to calculate statistics about flushed time and count. | 0.2.1 | 
 | celeborn.worker.fetch.io.threads | &lt;undefined&gt; | Netty IO thread number of worker to handle client fetch data. The default threads number is the number of flush thread. | 0.2.0 | 
 | celeborn.worker.fetch.port | 0 | Server port for Worker to receive fetch data request from ShuffleClient. | 0.2.0 | 
 | celeborn.worker.flusher.buffer.size | 256k | Size of buffer used by a single flusher. | 0.2.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -49,9 +49,9 @@ license: |
 | celeborn.worker.disk.checkFileClean.maxRetries | 3 | The number of retries for a worker to check if the working directory is cleaned up before registering with the master. | 0.2.0 | 
 | celeborn.worker.disk.checkFileClean.timeout | 1000ms | The wait time per retry for a worker to check if the working directory is cleaned up before registering with the master. | 0.2.0 | 
 | celeborn.worker.disk.reserve.size | 5G | Celeborn worker reserved space for each disk. | 0.2.0 | 
+| celeborn.worker.diskTime.slidingWindow.size | 20 | The size of sliding windows used to calculate statistics about flushed time and count. | 0.2.0 | 
 | celeborn.worker.fetch.io.threads | &lt;undefined&gt; | Netty IO thread number of worker to handle client fetch data. The default threads number is the number of flush thread. | 0.2.0 | 
 | celeborn.worker.fetch.port | 0 | Server port for Worker to receive fetch data request from ShuffleClient. | 0.2.0 | 
-| celeborn.worker.flusher.avgFlushTime.slidingWindow.size | 20 | The size of sliding windows used to calculate statistics about flushed time and count. | 0.2.0 | 
 | celeborn.worker.flusher.buffer.size | 256k | Size of buffer used by a single flusher. | 0.2.0 | 
 | celeborn.worker.flusher.hdd.threads | 1 | Flusher's thread count per disk used for write data to HDD disks. | 0.2.0 | 
 | celeborn.worker.flusher.hdfs.threads | 4 | Flusher's thread count used for write data to HDFS. | 0.2.0 | 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/MetaUtil.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/MetaUtil.java
@@ -57,7 +57,11 @@ public class MetaUtil {
         (k, v) -> {
           DiskInfo diskInfo =
               new DiskInfo(
-                  v.getMountPoint(), v.getUsableSpace(), v.getAvgFlushTime(), v.getUsedSlots());
+                  v.getMountPoint(),
+                  v.getUsableSpace(),
+                  v.getAvgFlushTime(),
+                  v.getAvgFetchTime(),
+                  v.getUsedSlots());
           diskInfo.setStatus(Utils.toDiskStatus(v.getStatus()));
           map.put(k, diskInfo);
         });
@@ -75,6 +79,7 @@ public class MetaUtil {
                     .setMountPoint(v.mountPoint())
                     .setUsableSpace(v.actualUsableSpace())
                     .setAvgFlushTime(v.avgFlushTime())
+                    .setAvgFetchTime(v.avgFetchTime())
                     .setUsedSlots(v.activeSlots())
                     .setStatus(v.status().getValue())
                     .build()));

--- a/master/src/main/proto/Resource.proto
+++ b/master/src/main/proto/Resource.proto
@@ -57,6 +57,7 @@ message DiskInfo {
   required int64 avgFlushTime = 3;
   required int64 usedSlots = 4;
   required int32 status = 5;
+  required int64 avgFetchTime = 6;
 }
 
 message RequestSlotsRequest {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -107,9 +107,10 @@ private[celeborn] class Master(
 
   private def diskReserveSize = conf.diskReserveSize
 
-  private def slotsAssignLoadAwareDiskGroupNum = conf.slotsAssignLoadAwareDiskGroupNum
-
-  private def slotsAssignLoadAwareDiskGroupGradient = conf.slotsAssignLoadAwareDiskGroupGradient
+  private val slotsAssignLoadAwareDiskGroupNum = conf.slotsAssignLoadAwareDiskGroupNum
+  private val slotsAssignLoadAwareDiskGroupGradient = conf.slotsAssignLoadAwareDiskGroupGradient
+  private val loadAwareFlushTimeWeight = conf.slotsAssignLoadAwareFlushTimeWeight
+  private val loadAwareFetchTimeWeight = conf.slotsAssignLoadAwareFetchTimeWeight
 
   private val estimatedPartitionSizeUpdaterInitialDelay =
     conf.estimatedPartitionSizeUpdaterInitialDelay
@@ -516,8 +517,8 @@ private[celeborn] class Master(
               diskReserveSize,
               slotsAssignLoadAwareDiskGroupNum,
               slotsAssignLoadAwareDiskGroupGradient,
-              conf.slotsAssignLoadAwareFlushTimeWeight,
-              conf.slotsAssignLoadAwareFetchTimeWeight)
+              loadAwareFlushTimeWeight,
+              loadAwareFetchTimeWeight)
           }
         }
       }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -515,7 +515,9 @@ private[celeborn] class Master(
               requestSlots.shouldReplicate,
               diskReserveSize,
               slotsAssignLoadAwareDiskGroupNum,
-              slotsAssignLoadAwareDiskGroupGradient)
+              slotsAssignLoadAwareDiskGroupGradient,
+              conf.slotsAssignLoadAwareFlushTimeWeight,
+              conf.slotsAssignLoadAwareFetchTimeWeight)
           }
         }
       }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -45,13 +45,25 @@ public class SlotsAllocatorSuiteJ {
     Map<String, DiskInfo> disks1 = new HashMap<>();
     DiskInfo diskInfo1 =
         new DiskInfo(
-            "/mnt/disk1", random.nextInt() + 100 * 1024 * 1024 * 1024L, random.nextInt(1000), 0);
+            "/mnt/disk1",
+            random.nextInt() + 100 * 1024 * 1024 * 1024L,
+            random.nextInt(1000),
+            random.nextInt(1000),
+            0);
     DiskInfo diskInfo2 =
         new DiskInfo(
-            "/mnt/disk2", random.nextInt() + 95 * 1024 * 1024 * 1024L, random.nextInt(1000), 0);
+            "/mnt/disk2",
+            random.nextInt() + 95 * 1024 * 1024 * 1024L,
+            random.nextInt(1000),
+            random.nextInt(1000),
+            0);
     DiskInfo diskInfo3 =
         new DiskInfo(
-            "/mnt/disk3", random.nextInt() + 90 * 1024 * 1024 * 1024L, random.nextInt(1000), 0);
+            "/mnt/disk3",
+            random.nextInt() + 90 * 1024 * 1024 * 1024L,
+            random.nextInt(1000),
+            random.nextInt(1000),
+            0);
     diskInfo1.maxSlots_$eq(diskInfo1.actualUsableSpace() / assumedPartitionSize);
     diskInfo2.maxSlots_$eq(diskInfo2.actualUsableSpace() / assumedPartitionSize);
     diskInfo3.maxSlots_$eq(diskInfo3.actualUsableSpace() / assumedPartitionSize);
@@ -62,13 +74,25 @@ public class SlotsAllocatorSuiteJ {
     Map<String, DiskInfo> disks2 = new HashMap<>();
     DiskInfo diskInfo4 =
         new DiskInfo(
-            "/mnt/disk1", random.nextInt() + 100 * 1024 * 1024 * 1024L, random.nextInt(1000), 0);
+            "/mnt/disk1",
+            random.nextInt() + 100 * 1024 * 1024 * 1024L,
+            random.nextInt(1000),
+            random.nextInt(1000),
+            0);
     DiskInfo diskInfo5 =
         new DiskInfo(
-            "/mnt/disk2", random.nextInt() + 95 * 1024 * 1024 * 1024L, random.nextInt(1000), 0);
+            "/mnt/disk2",
+            random.nextInt() + 95 * 1024 * 1024 * 1024L,
+            random.nextInt(1000),
+            random.nextInt(1000),
+            0);
     DiskInfo diskInfo6 =
         new DiskInfo(
-            "/mnt/disk3", random.nextInt() + 90 * 1024 * 1024 * 1024L, random.nextInt(1000), 0);
+            "/mnt/disk3",
+            random.nextInt() + 90 * 1024 * 1024 * 1024L,
+            random.nextInt(1000),
+            random.nextInt(1000),
+            0);
     diskInfo4.maxSlots_$eq(diskInfo4.actualUsableSpace() / assumedPartitionSize);
     diskInfo5.maxSlots_$eq(diskInfo5.actualUsableSpace() / assumedPartitionSize);
     diskInfo6.maxSlots_$eq(diskInfo6.actualUsableSpace() / assumedPartitionSize);
@@ -79,13 +103,25 @@ public class SlotsAllocatorSuiteJ {
     Map<String, DiskInfo> disks3 = new HashMap<>();
     DiskInfo diskInfo7 =
         new DiskInfo(
-            "/mnt/disk1", random.nextInt() + 100 * 1024 * 1024 * 1024L, random.nextInt(1000), 0);
+            "/mnt/disk1",
+            random.nextInt() + 100 * 1024 * 1024 * 1024L,
+            random.nextInt(1000),
+            random.nextInt(1000),
+            0);
     DiskInfo diskInfo8 =
         new DiskInfo(
-            "/mnt/disk2", random.nextInt() + 95 * 1024 * 1024 * 1024L, random.nextInt(1000), 0);
+            "/mnt/disk2",
+            random.nextInt() + 95 * 1024 * 1024 * 1024L,
+            random.nextInt(1000),
+            random.nextInt(1000),
+            0);
     DiskInfo diskInfo9 =
         new DiskInfo(
-            "/mnt/disk3", random.nextInt() + 90 * 1024 * 1024 * 1024L, random.nextInt(1000), 0);
+            "/mnt/disk3",
+            random.nextInt() + 90 * 1024 * 1024 * 1024L,
+            random.nextInt(1000),
+            random.nextInt(1000),
+            0);
     diskInfo7.maxSlots_$eq(diskInfo7.actualUsableSpace() / assumedPartitionSize);
     diskInfo8.maxSlots_$eq(diskInfo8.actualUsableSpace() / assumedPartitionSize);
     diskInfo9.maxSlots_$eq(diskInfo9.actualUsableSpace() / assumedPartitionSize);
@@ -194,7 +230,9 @@ public class SlotsAllocatorSuiteJ {
             shouldReplicate,
             10 * 1024 * 1024 * 1024L,
             conf.slotsAssignLoadAwareDiskGroupNum(),
-            conf.slotsAssignLoadAwareDiskGroupGradient());
+            conf.slotsAssignLoadAwareDiskGroupGradient(),
+            conf.slotsAssignLoadAwareFlushTimeWeight(),
+            conf.slotsAssignLoadAwareFetchTimeWeight());
     if (expectSuccess) {
       if (shouldReplicate) {
         slots.forEach(

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -83,22 +83,22 @@ public class DefaultMetaSystemSuiteJ {
     statusSystem = new SingleMasterMetaManager(mockRpcEnv, conf);
 
     disks1.clear();
-    disks1.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks1.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks1.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks1.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 0));
+    disks1.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks1.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks1.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks1.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
 
     disks2.clear();
-    disks2.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks2.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks2.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks2.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 0));
+    disks2.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks2.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks2.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks2.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
 
     disks3.clear();
-    disks3.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks3.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks3.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks3.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 0));
+    disks3.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks3.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks3.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks3.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
   }
 
   @After

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -207,9 +207,9 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
     File tmpFile = File.createTempFile("tef", "test" + System.currentTimeMillis());
 
     Map<String, DiskInfo> disks1 = new HashMap<>();
-    disks1.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024, 100, 0));
-    disks1.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024, 100, 0));
-    disks1.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024, 100, 0));
+    disks1.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024, 100, 100, 0));
+    disks1.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024, 100, 100, 0));
+    disks1.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024, 100, 100, 0));
     Map<UserIdentifier, ResourceConsumption> userResourceConsumption1 = new ConcurrentHashMap<>();
     userResourceConsumption1.put(
         new UserIdentifier("tenant1", "name1"), new ResourceConsumption(1000, 1, 1000, 1));
@@ -219,9 +219,9 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
         new UserIdentifier("tenant1", "name3"), new ResourceConsumption(3000, 3, 3000, 3));
 
     Map<String, DiskInfo> disks2 = new HashMap<>();
-    disks2.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024, 100, 0));
-    disks2.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024, 100, 0));
-    disks2.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024, 100, 0));
+    disks2.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024, 100, 100, 0));
+    disks2.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024, 100, 100, 0));
+    disks2.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024, 100, 100, 0));
     Map<UserIdentifier, ResourceConsumption> userResourceConsumption2 = new ConcurrentHashMap<>();
     userResourceConsumption2.put(
         new UserIdentifier("tenant2", "name1"), new ResourceConsumption(1000, 1, 1000, 1));
@@ -231,9 +231,9 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
         new UserIdentifier("tenant2", "name3"), new ResourceConsumption(3000, 3, 3000, 3));
 
     Map<String, DiskInfo> disks3 = new HashMap<>();
-    disks3.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024, 100, 0));
-    disks3.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024, 100, 0));
-    disks3.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024, 100, 0));
+    disks3.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024, 100, 100, 0));
+    disks3.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024, 100, 100, 0));
+    disks3.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024, 100, 100, 0));
     Map<UserIdentifier, ResourceConsumption> userResourceConsumption3 = new ConcurrentHashMap<>();
     userResourceConsumption3.put(
         new UserIdentifier("tenant3", "name1"), new ResourceConsumption(1000, 1, 1000, 1));

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -765,22 +765,22 @@ public class RatisMasterStatusSystemSuiteJ {
     STATUSSYSTEM3.workerLostEvents.clear();
 
     disks1.clear();
-    disks1.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks1.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks1.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks1.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 0));
+    disks1.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks1.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks1.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks1.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
 
     disks2.clear();
-    disks2.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks2.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks2.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks2.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 0));
+    disks2.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks2.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks2.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks2.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
 
     disks3.clear();
-    disks3.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks3.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks3.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 0));
-    disks3.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 0));
+    disks3.put("disk1", new DiskInfo("disk1", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks3.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks3.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    disks3.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
   }
 
   @Test

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -127,7 +127,7 @@ class FetchHandler(val conf: TransportConf) extends BaseMessageHandler with Logg
               new NioManagedBuffer(streamHandle.toByteBuffer)))
           } else {
             val buffers = new FileManagedBuffers(fileInfo, conf)
-            val fetchTimeMetrics = storageManager.getDiskInfo(fileInfo.getFile).fetchTimeMetrics
+            val fetchTimeMetrics = storageManager.getFetchTimeMetric(fileInfo.getFile)
             val streamId = chunkStreamManager.registerStream(
               shuffleKey,
               buffers,

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -68,8 +68,8 @@ abstract private[worker] class Flusher(
                   val flushBeginTime = System.nanoTime()
                   lastBeginFlushTime.set(index, flushBeginTime)
                   task.flush()
-                  val delta = System.nanoTime() - flushBeginTime
                   if (flushTimeMetric != null) {
+                    val delta = System.nanoTime() - flushBeginTime
                     flushTimeMetric.update(delta)
                   }
                 } catch {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -39,7 +39,7 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus, FileInfo}
+import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus, FileInfo, TimeWindow}
 import org.apache.celeborn.common.metrics.source.AbstractSource
 import org.apache.celeborn.common.network.server.memory.MemoryManager.MemoryPressureListener
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType}
@@ -395,8 +395,13 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     }
   }
 
-  def getDiskInfo(file: File): DiskInfo = {
-    diskInfos.get(DeviceInfo.getMountPoint(file.getAbsolutePath, diskInfos))
+  def getFetchTimeMetric(file: File): TimeWindow = {
+    if (diskInfos != null) {
+      val diskInfo = diskInfos.get(DeviceInfo.getMountPoint(file.getAbsolutePath, diskInfos))
+      if (diskInfo != null) {
+        diskInfo.fetchTimeMetrics
+      } else null
+    } else null
   }
 
   def shuffleKeySet(): util.HashSet[String] = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -680,11 +680,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       val workingDirUsableSpace =
         Math.min(diskInfo.configuredUsableSpace - totalUsage, fileSystemReportedUsableSpace)
       logDebug(s"updateDiskInfos  workingDirUsableSpace:$workingDirUsableSpace filemeta:$fileSystemReportedUsableSpace conf:${diskInfo.configuredUsableSpace} totalUsage:$totalUsage")
-      val flushTimeAverage = diskInfo.flushTimeMetrics.getAverage()
-      val fetchTimeAverage = diskInfo.fetchTimeMetrics.getAverage()
       diskInfo.setUsableSpace(workingDirUsableSpace)
-      diskInfo.setFlushTime(flushTimeAverage)
-      diskInfo.setFetchTime(fetchTimeAverage)
+      diskInfo.updateFlushTime()
+      diskInfo.updateFetchTime()
     }
     logInfo(s"Updated diskInfos: ${disksSnapshot()}")
   }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -126,6 +126,11 @@ public class FileWriterSuiteJ {
     FetchHandler handler =
         new FetchHandler(transConf) {
           @Override
+          public StorageManager storageManager() {
+            return new StorageManager(CONF, source);
+          }
+
+          @Override
           public FileInfo getRawFileInfo(String shuffleKey, String fileName) {
             return info;
           }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -118,7 +118,7 @@ public class FileWriterSuiteJ {
     dirs.$plus$eq(tempDir);
     localFlusher =
         new LocalFlusher(
-            source, DeviceMonitor$.MODULE$.EmptyMonitor(), 1, "disk1", 20, 1, StorageInfo.Type.HDD);
+            source, DeviceMonitor$.MODULE$.EmptyMonitor(), 1, "disk1", StorageInfo.Type.HDD, null);
     MemoryManager.initialize(0.8, 0.9, 0.5, 0.6, 0.1, 0.1, 10, 10);
   }
 
@@ -326,7 +326,7 @@ public class FileWriterSuiteJ {
     dirs.$plus$eq(file);
     localFlusher =
         new LocalFlusher(
-            source, DeviceMonitor$.MODULE$.EmptyMonitor(), 1, "disk2", 20, 1, StorageInfo.Type.HDD);
+            source, DeviceMonitor$.MODULE$.EmptyMonitor(), 1, "disk2", StorageInfo.Type.HDD, null);
   }
 
   @Test

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -336,7 +336,7 @@ public class FileWriterSuiteJ {
 
   @Test
   public void testWriteAndChunkRead() throws Exception {
-    final int threadsNum = 8;
+    final int threadsNum = 16;
     File file = getTemporaryFile();
     FileInfo fileInfo = new FileInfo(file, userIdentifier);
     FileWriter fileWriter =

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriterSuiteJ.java
@@ -81,7 +81,7 @@ public class MapPartitionFileWriterSuiteJ {
     dirs.$plus$eq(tempDir);
     localFlusher =
         new LocalFlusher(
-            source, DeviceMonitor$.MODULE$.EmptyMonitor(), 1, "disk1", 20, 1, StorageInfo.Type.HDD);
+            source, DeviceMonitor$.MODULE$.EmptyMonitor(), 1, "disk1", StorageInfo.Type.HDD, null);
     MemoryManager.initialize(0.8, 0.9, 0.5, 0.6, 0.1, 0.1, 10, 10);
   }
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
@@ -137,14 +137,18 @@ class DeviceMonitorSuite extends AnyFunSuite {
   withObjectMocked[org.apache.celeborn.common.util.Utils.type] {
     when(Utils.runCommand(dfCmd)) thenReturn dfOut
     when(Utils.runCommand(lsCmd)) thenReturn lsOut
-    val (tdeviceInfos, tdiskInfos) = DeviceInfo.getDeviceAndDiskInfos(dirs.asScala.toArray.map(f =>
-      (f, Long.MaxValue, 1, StorageInfo.Type.HDD)))
+    val (tdeviceInfos, tdiskInfos) = DeviceInfo.getDeviceAndDiskInfos(
+      dirs.asScala.toArray.map(f =>
+        (f, Long.MaxValue, 1, StorageInfo.Type.HDD)),
+      conf)
     deviceInfos = tdeviceInfos
     diskInfos = tdiskInfos
     when(Utils.runCommand(dfCmd)) thenReturn dfOut2
     val (tdeviceInfos2, tdiskInfos2) =
-      DeviceInfo.getDeviceAndDiskInfos(dirs2.asScala.toArray.map(f =>
-        (f, Int.MaxValue.toLong, 8, StorageInfo.Type.SSD)))
+      DeviceInfo.getDeviceAndDiskInfos(
+        dirs2.asScala.toArray.map(f =>
+          (f, Int.MaxValue.toLong, 8, StorageInfo.Type.SSD)),
+        conf)
     deviceInfos2 = tdeviceInfos2
     diskInfos2 = tdiskInfos2
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Currently load-aware slots assignment strategy only considers flush time, but flush time might not correctly
reflects disk performance because we do not flush to disk. It's more reasonable to also consider fetch time,
which more precisely reflects disk perf.

This PR considers both flush and fetch time, and uses ```celeborn.slots.assign.loadAware.flushTimeWeight```
and ```celeborn.slots.assign.loadAware.fetchTimeWeight``` for flush/fetch time weight respectively.


### Why are the changes needed?
As above.


### Does this PR introduce _any_ user-facing change?
Yes, adds two more configs: ```celeborn.slots.assign.loadAware.flushTimeWeight```
and ```celeborn.slots.assign.loadAware.fetchTimeWeight```.


### How was this patch tested?
UT and regression.
