### PR TITLE
[CELEBORN-372][0.2] Remove the standard Apache License header from the top of third-party source files

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -34,3 +34,4 @@ assets/**
 build/apache-maven-*/**
 build/scala-*/**
 **/benchmarks/**
+LimitedInputStream.java

--- a/common/src/main/java/org/apache/celeborn/common/network/util/LimitedInputStream.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/LimitedInputStream.java
@@ -1,21 +1,4 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
  * Based on LimitedInputStream.java from Google Guava
  *
  * Copyright (C) 2007 The Guava Authors


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR aims to remove the standard Apache License header from the top of third-party source files.


### Why are the changes needed?
This was discussed via general@incubator mailing list when releasing Celeborn

- https://lists.apache.org/thread/q8hchs4n2twhjl0qf3rn0ln0hyrvrnnp

and discussed in dev@spark

- https://lists.apache.org/thread/wfy9sykncw2znhzlvyd18bkyjr7l9x43

Here is the ASF legal policy.

- https://www.apache.org/legal/src-headers.html#3party

> Do not add the standard Apache License header to the top of third-party source files.


### Does this PR introduce _any_ user-facing change?
No. This is a source code distribution.



### How was this patch tested?
Manual review.
