### PR TITLE
[CELEBORN-368][FLINK] Pass exceptions in buffer stream.

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/MessageDecoderExt.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/MessageDecoderExt.java
@@ -81,6 +81,13 @@ public class MessageDecoderExt {
         backlog = in.readInt();
         return new BacklogAnnouncement(streamId, backlog);
 
+      case TRANSPORTABLE_ERROR:
+        streamId = in.readLong();
+        int len = in.readInt();
+        byte[] errorBytes = new byte[len];
+        in.readBytes(errorBytes);
+        return new TransportableError(streamId, errorBytes);
+
       default:
         throw new IllegalArgumentException("Unexpected message type: " + type);
     }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
@@ -53,9 +53,10 @@ public class ReadClientHandler extends BaseMessageHandler {
   }
 
   private void processMessageInternal(long streamId, RequestMessage msg) {
-    if (streamHandlers.containsKey(streamId)) {
+    Consumer<RequestMessage> handler = streamHandlers.get(streamId);
+    if (handler != null) {
       logger.debug("received streamId: {}, msg :{}", streamId, msg);
-      streamHandlers.get(streamId).accept(msg);
+      handler.accept(msg);
     } else {
       logger.warn("Unexpected streamId received: {}", streamId);
     }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
@@ -25,7 +25,9 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.protocol.BacklogAnnouncement;
+import org.apache.celeborn.common.network.protocol.BufferStreamEnd;
 import org.apache.celeborn.common.network.protocol.RequestMessage;
+import org.apache.celeborn.common.network.protocol.TransportableError;
 import org.apache.celeborn.common.network.server.BaseMessageHandler;
 import org.apache.celeborn.plugin.flink.protocol.ReadData;
 
@@ -43,7 +45,20 @@ public class ReadClientHandler extends BaseMessageHandler {
 
   public void removeHandler(long streamId) {
     streamHandlers.remove(streamId);
-    streamClients.remove(streamId);
+    TransportClient client = streamClients.remove(streamId);
+    // If read handler is removed, we should notify worker to release resource.
+    if (client.isActive()) {
+      client.getChannel().writeAndFlush(new BufferStreamEnd(streamId));
+    }
+  }
+
+  private void processMessageInternal(long streamId, RequestMessage msg) {
+    if (streamHandlers.containsKey(streamId)) {
+      logger.debug("received streamId: {}, msg :{}", streamId, msg);
+      streamHandlers.get(streamId).accept(msg);
+    } else {
+      logger.warn("Unexpected streamId received: {}", streamId);
+    }
   }
 
   @Override
@@ -53,27 +68,17 @@ public class ReadClientHandler extends BaseMessageHandler {
       case READ_DATA:
         ReadData readData = (ReadData) msg;
         streamId = readData.getStreamId();
-        if (streamHandlers.containsKey(streamId)) {
-          logger.debug(
-              "received streamId: {}, readData size:{}",
-              streamId,
-              readData.getFlinkBuffer().readableBytes());
-          streamHandlers.get(streamId).accept(msg);
-        } else {
-          logger.warn("Unexpected streamId received: {}", streamId);
-        }
+        processMessageInternal(streamId, readData);
         break;
       case BACKLOG_ANNOUNCEMENT:
         BacklogAnnouncement backlogAnnouncement = (BacklogAnnouncement) msg;
         streamId = backlogAnnouncement.getStreamId();
-        Consumer<RequestMessage> consumer = streamHandlers.get(streamId);
-        if (consumer != null) {
-          logger.debug(
-              "received streamId: {}, backlog: {}", streamId, backlogAnnouncement.getBacklog());
-          consumer.accept(msg);
-        } else {
-          logger.warn("Unexpected streamId received: {}", streamId);
-        }
+        processMessageInternal(streamId, backlogAnnouncement);
+        break;
+      case TRANSPORTABLE_ERROR:
+        TransportableError transportableError = ((TransportableError) msg);
+        streamId = transportableError.getStreamId();
+        processMessageInternal(streamId, transportableError);
         break;
       case ONE_WAY_MESSAGE:
         // ignore it.

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
@@ -17,6 +17,8 @@
 
 package org.apache.celeborn.plugin.flink.network;
 
+import static org.apache.celeborn.plugin.flink.utils.Utils.checkState;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
@@ -121,6 +123,8 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
       io.netty.buffer.ByteBuf buf, ChannelHandlerContext ctx) {
     ReadData readData = (ReadData) curMsg;
     if (externalBuf == null) {
+      Supplier<ByteBuf> supplier = bufferSuppliers.get(readData.getStreamId());
+      checkState(supplier == null, "Stream " + readData.getStreamId() + " buffer supplier is null");
       externalBuf = bufferSuppliers.get(readData.getStreamId()).get();
     }
     copyByteBuf(buf, externalBuf, bodySize);

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/BufferStreamEnd.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/BufferStreamEnd.java
@@ -1,0 +1,35 @@
+package org.apache.celeborn.common.network.protocol;
+
+import io.netty.buffer.ByteBuf;
+
+public class BufferStreamEnd extends RequestMessage {
+  private long streamId;
+
+  public BufferStreamEnd(long streamId) {
+    this.streamId = streamId;
+  }
+
+  @Override
+  public int encodedLength() {
+    return 8;
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {
+    buf.writeLong(streamId);
+  }
+
+  @Override
+  public Type type() {
+    return Type.BUFFER_STREAM_END;
+  }
+
+  public static Message decode(ByteBuf buffer) {
+    long streamId = buffer.readLong();
+    return new BufferStreamEnd(streamId);
+  }
+
+  public long getStreamId() {
+    return streamId;
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/BufferStreamEnd.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/BufferStreamEnd.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.celeborn.common.network.protocol;
 
 import io.netty.buffer.ByteBuf;

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -92,7 +92,9 @@ public abstract class Message implements Encodable {
     READ_ADD_CREDIT(16),
     READ_DATA(17),
     OPEN_STREAM_WITH_CREDIT(18),
-    BACKLOG_ANNOUNCEMENT(19);
+    BACKLOG_ANNOUNCEMENT(19),
+    TRANSPORTABLE_ERROR(20),
+    BUFFER_STREAM_END(21);
     private final byte id;
 
     Type(int id) {
@@ -158,6 +160,10 @@ public abstract class Message implements Encodable {
           return OPEN_STREAM_WITH_CREDIT;
         case 19:
           return BACKLOG_ANNOUNCEMENT;
+        case 20:
+          return TRANSPORTABLE_ERROR;
+        case 21:
+          return BUFFER_STREAM_END;
         case -1:
           throw new IllegalArgumentException("User type messages cannot be decoded.");
         default:
@@ -222,6 +228,11 @@ public abstract class Message implements Encodable {
 
       case BACKLOG_ANNOUNCEMENT:
         return BacklogAnnouncement.decode(in);
+
+      case TRANSPORTABLE_ERROR:
+        return TransportableError.decode(in);
+      case BUFFER_STREAM_END:
+        return BufferStreamEnd.decode(in);
 
       default:
         throw new IllegalArgumentException("Unexpected message type: " + msgType);

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportableError.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportableError.java
@@ -20,8 +20,7 @@ package org.apache.celeborn.common.network.protocol;
 import java.nio.charset.StandardCharsets;
 
 import io.netty.buffer.ByteBuf;
-
-import org.apache.celeborn.common.util.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class TransportableError extends RequestMessage {
   private long streamId;
@@ -29,8 +28,7 @@ public class TransportableError extends RequestMessage {
 
   public TransportableError(long streamId, Throwable throwable) {
     this.streamId = streamId;
-    this.errorMessage =
-        ExceptionUtils.summaryErrorMessageStack(throwable).getBytes(StandardCharsets.UTF_8);
+    this.errorMessage = ExceptionUtils.getStackTrace(throwable).getBytes(StandardCharsets.UTF_8);
   }
 
   public TransportableError(long streamId, byte[] errorMessage) {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportableError.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportableError.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.protocol;
+
+import java.nio.charset.StandardCharsets;
+
+import io.netty.buffer.ByteBuf;
+
+import org.apache.celeborn.common.util.ExceptionUtils;
+
+public class TransportableError extends RequestMessage {
+  private long streamId;
+  private byte[] errorMessage;
+
+  public TransportableError(long streamId, Throwable throwable) {
+    this.streamId = streamId;
+    this.errorMessage =
+        ExceptionUtils.summaryErrorMessageStack(throwable).getBytes(StandardCharsets.UTF_8);
+  }
+
+  public TransportableError(long streamId, byte[] errorMessage) {
+    this.streamId = streamId;
+    this.errorMessage = errorMessage;
+  }
+
+  @Override
+  public int encodedLength() {
+    return 8 + 4 + errorMessage.length;
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {
+    buf.writeLong(streamId);
+    buf.writeInt(errorMessage.length);
+    buf.writeBytes(errorMessage);
+  }
+
+  @Override
+  public Type type() {
+    return Type.TRANSPORTABLE_ERROR;
+  }
+
+  public static TransportableError decode(ByteBuf buf) {
+    long streamId = buf.readLong();
+    int msgLen = buf.readInt();
+    byte[] errorMsg = new byte[msgLen];
+    buf.readBytes(errorMsg);
+    return new TransportableError(streamId, errorMsg);
+  }
+
+  public long getStreamId() {
+    return streamId;
+  }
+
+  public String getErrorMessage() {
+    return new String(errorMessage, StandardCharsets.UTF_8);
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/server/BufferStreamManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/BufferStreamManager.java
@@ -335,14 +335,12 @@ public class BufferStreamManager {
             logger.error("reader exception, reader: {}, message: {}", reader, e.getMessage(), e);
             readers.remove(reader);
             reader.recycleOnError(e);
-            recycleStream(reader.getStreamId());
           }
         }
       } catch (Throwable e) {
         logger.error("Fatal: failed to read partition data. {}", e.getMessage(), e);
         for (DataPartitionReader reader : readers) {
           reader.recycleOnError(e);
-          recycleStream(reader.getStreamId());
         }
 
         readers.clear();

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -32,15 +32,4 @@ public class ExceptionUtils {
       throw new CelebornIOException(exception.getMessage(), exception);
     }
   }
-
-  public static String summaryErrorMessageStack(Throwable t) {
-    StringBuilder sb = new StringBuilder();
-    do {
-      if (sb.length() != 0) {
-        sb.append(" -> ");
-      }
-      sb.append("[").append(t.getClass().getName()).append(": ").append(t.getMessage()).append("]");
-    } while ((t = t.getCause()) != null);
-    return sb.toString();
-  }
 }

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -32,4 +32,15 @@ public class ExceptionUtils {
       throw new CelebornIOException(exception.getMessage(), exception);
     }
   }
+
+  public static String summaryErrorMessageStack(Throwable t) {
+    StringBuilder sb = new StringBuilder();
+    do {
+      if (sb.length() != 0) {
+        sb.append(" -> ");
+      }
+      sb.append("[").append(t.getClass().getName()).append(": ").append(t.getMessage()).append("]");
+    } while ((t = t.getCause()) != null);
+    return sb.toString();
+  }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -74,6 +74,9 @@ class FetchHandler(val conf: TransportConf) extends BaseMessageHandler with Logg
 
   override def receive(client: TransportClient, msg: RequestMessage): Unit = {
     msg match {
+      case r: BufferStreamEnd =>
+        rpcSource.updateMessageMetrics(r, 0)
+        handleEndStreamFromClient(client, r)
       case r: ReadAddCredit =>
         rpcSource.updateMessageMetrics(r, 0)
         handleReadAddCredit(client, r)
@@ -181,6 +184,10 @@ class FetchHandler(val conf: TransportConf) extends BaseMessageHandler with Logg
           request.requestId,
           Throwables.getStackTraceAsString(ioe)))
     }
+  }
+
+  def handleEndStreamFromClient(client: TransportClient, req: BufferStreamEnd): Unit = {
+    bufferStreamManager.notifyStreamEndByClient(req.getStreamId)
   }
 
   def handleReadAddCredit(client: TransportClient, req: ReadAddCredit): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Pass the worker's exception to the client in the buffer stream reader.
2. Remove stream resources from worker if a client has an exception.


### Why are the changes needed?
1. To improve debug process.
2. To release resources timely.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT.
