### PR TITLE
[CELEBORN-348][FOLLOWUP] Refine comparator to support nanoseconds whi…

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -261,13 +261,11 @@ public class SlotsAllocator {
       double flushTimeWeight,
       double fetchTimeWeight) {
     List<List<DiskInfo>> diskGroups = new ArrayList<>();
-    usableDisks.sort(
-        (o1, o2) ->
-            Math.toIntExact(
-                (long)
-                    ((o1.avgFlushTime() * flushTimeWeight + o1.avgFetchTime() * fetchTimeWeight)
-                        - (o2.avgFlushTime() * flushTimeWeight
-                            + o2.avgFetchTime() * fetchTimeWeight))));
+    usableDisks.sort((o1, o2) -> {
+      double delta = (o1.avgFlushTime() * flushTimeWeight + o1.avgFetchTime() * fetchTimeWeight)
+        - (o2.avgFlushTime() * flushTimeWeight + o2.avgFetchTime() * fetchTimeWeight);
+      return delta < 0 ? -1 : (delta > 0 ? 1 : 0);
+    });
     int diskCount = usableDisks.size();
     int startIndex = 0;
     int groupSizeSize = (int) Math.ceil(usableDisks.size() / (double) diskGroupCount);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -261,11 +261,13 @@ public class SlotsAllocator {
       double flushTimeWeight,
       double fetchTimeWeight) {
     List<List<DiskInfo>> diskGroups = new ArrayList<>();
-    usableDisks.sort((o1, o2) -> {
-      double delta = (o1.avgFlushTime() * flushTimeWeight + o1.avgFetchTime() * fetchTimeWeight)
-        - (o2.avgFlushTime() * flushTimeWeight + o2.avgFetchTime() * fetchTimeWeight);
-      return delta < 0 ? -1 : (delta > 0 ? 1 : 0);
-    });
+    usableDisks.sort(
+        (o1, o2) -> {
+          double delta =
+              (o1.avgFlushTime() * flushTimeWeight + o1.avgFetchTime() * fetchTimeWeight)
+                  - (o2.avgFlushTime() * flushTimeWeight + o2.avgFetchTime() * fetchTimeWeight);
+          return delta < 0 ? -1 : (delta > 0 ? 1 : 0);
+        });
     int diskCount = usableDisks.size();
     int startIndex = 0;
     int groupSizeSize = (int) Math.ceil(usableDisks.size() / (double) diskGroupCount);


### PR DESCRIPTION
…ch may exceeds Integer

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Nanoseconds may exceeds Integer's capacity, so we need to refine the Comparator passed to sort in SlotAllocator.
Former exception:
![image](https://user-images.githubusercontent.com/948245/222661392-71237482-c6ab-408f-9971-145d47a4eb9b.png)
![image](https://user-images.githubusercontent.com/948245/222661467-83a9d026-e42d-4951-b684-a8450969ad41.png)



### Why are the changes needed?
As above.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT and regression.
