### PR TITLE
[CELEBORN-367][FOLLOWUP] [FLINK] fix conflicts in RemoteShuffleResultPartitionS…

### DIFF
--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -457,7 +457,6 @@ public class RemoteShuffleResultPartitionSuiteJ {
     @Override
     FlinkShuffleClientImpl createWriteClient() {
       FlinkShuffleClientImpl client = mock(FlinkShuffleClientImpl.class);
-
       doNothing().when(client).cleanup(anyString(), anyInt(), anyInt(), anyInt());
       return client;
     }

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -17,7 +17,6 @@
 
 package org.apache.celeborn.plugin.flink;
 
-import org.apache.celeborn.plugin.flink.readclient.FlinkShuffleClientImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyBoolean;
@@ -64,11 +63,10 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import org.apache.celeborn.client.LifecycleManager;
-import org.apache.celeborn.client.ShuffleClient;
-import org.apache.celeborn.client.ShuffleClientImpl;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.plugin.flink.buffer.BufferPacker;
 import org.apache.celeborn.plugin.flink.buffer.SortBuffer;
+import org.apache.celeborn.plugin.flink.readclient.FlinkShuffleClientImpl;
 import org.apache.celeborn.plugin.flink.utils.BufferUtils;
 
 public class RemoteShuffleResultPartitionSuiteJ {

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.plugin.flink;
 
+import org.apache.celeborn.plugin.flink.readclient.FlinkShuffleClientImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyBoolean;
@@ -456,8 +457,8 @@ public class RemoteShuffleResultPartitionSuiteJ {
     }
 
     @Override
-    ShuffleClient createWriteClient() {
-      ShuffleClient client = mock(ShuffleClientImpl.class);
+    FlinkShuffleClientImpl createWriteClient() {
+      FlinkShuffleClientImpl client = mock(FlinkShuffleClientImpl.class);
 
       doNothing().when(client).cleanup(anyString(), anyInt(), anyInt(), anyInt());
       return client;


### PR DESCRIPTION
…uiteJ

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
CELEBORN-367 has replaced shuffleclient to flinkShuffleclientimpl, so this pr must fix this conflicts.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

