### PR TITLE
[CELEBORN-377][BUILD] `build/mvn` should always respect `maven.version` defined in `pom.xml`

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -76,7 +76,7 @@ install_mvn() {
   fi
   # See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
   function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
-  if [ $(version $MVN_DETECTED_VERSION) -lt $(version $MVN_VERSION) ]; then
+  if [ $(version $MVN_DETECTED_VERSION) -ne $(version $MVN_VERSION) ]; then
     local APACHE_MIRROR=${APACHE_MIRROR:-'https://archive.apache.org/dist/'}
 
     install_app \


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Make `build/mvn` always respect `maven.version` defined in `pom.xml`.

### Why are the changes needed?

The new version of maven may contains unexpected change which affects our build and test process. e.g. the Maven 3.9.0 has about ~10% performance downgrade [MNG-7677](https://issues.apache.org/jira/browse/MNG-7677) which slows the CI.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass CI.