### PR TITLE
[CELEBORN-382] Call checkDiskFullAndSplit in the handlePushData method to avoid repeated definitions

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -225,7 +225,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       return
     }
 
-    if(checkDiskFullAndSplit(fileWriter, isMaster, softSplit, callbackWithTimer)) return
+    if (checkDiskFullAndSplit(fileWriter, isMaster, softSplit, callbackWithTimer)) return
 
     fileWriter.incrementPendingWrites()
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -224,16 +224,9 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       callbackWithTimer.onFailure(new CelebornIOException(cause))
       return
     }
-    val diskFull = checkDiskFull(fileWriter)
-    if ((diskFull && fileWriter.getFileInfo.getFileLength > partitionSplitMinimumSize) ||
-      (isMaster && fileWriter.getFileInfo.getFileLength > fileWriter.getSplitThreshold())) {
-      if (fileWriter.getSplitMode == PartitionSplitMode.SOFT) {
-        softSplit.set(true)
-      } else {
-        callbackWithTimer.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
-        return
-      }
-    }
+
+    if(checkDiskFullAndSplit(fileWriter, isMaster, softSplit, callbackWithTimer)) return
+
     fileWriter.incrementPendingWrites()
 
     // for master, send data to slave

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -224,14 +224,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       callbackWithTimer.onFailure(new CelebornIOException(cause))
       return
     }
-    val diskFull =
-      if (fileWriter.flusher.isInstanceOf[LocalFlusher]) {
-        workerInfo.diskInfos
-          .get(fileWriter.flusher.asInstanceOf[LocalFlusher].mountPoint)
-          .actualUsableSpace < diskReserveSize
-      } else {
-        false
-      }
+    val diskFull = checkDiskFull(fileWriter)
     if ((diskFull && fileWriter.getFileInfo.getFileLength > partitionSplitMinimumSize) ||
       (isMaster && fileWriter.getFileInfo.getFileLength > fileWriter.getSplitThreshold())) {
       if (fileWriter.getSplitMode == PartitionSplitMode.SOFT) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Call checkDiskFullAndSplit in the handlePushData method to avoid repeated definitions

### Why are the changes needed?

Simplify the code

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

passing CI