### PR TITLE
[CELEBORN-356] [FLINK] Support release single partition resource

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -212,6 +212,10 @@ class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: Lif
         lifecycleManager.recordWorkerFailure(r))
   }
 
+  def releasePartitionResource(shuffleId: Int, partitionId: Int): Unit = {
+    getCommitHandler(shuffleId).releasePartitionResource(shuffleId, partitionId)
+  }
+
   def removeExpiredShuffle(shuffleId: Int): Unit = {
     committedPartitionInfo.remove(shuffleId)
     getCommitHandler(shuffleId).removeExpiredShuffle(shuffleId)

--- a/client/src/main/scala/org/apache/celeborn/client/ReleasePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ReleasePartitionManager.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import java.util
+import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, ScheduledFuture, TimeUnit}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.DurationInt
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.meta.{ShufflePartitionLocationInfo, WorkerInfo}
+import org.apache.celeborn.common.protocol.message.ControlMessages.WorkerResource
+import org.apache.celeborn.common.util.ThreadUtils
+
+class ReleasePartitionManager(
+    appId: String,
+    val conf: CelebornConf,
+    lifecycleManager: LifecycleManager)
+  extends Logging {
+
+  // shuffleId -> (partitionId set of release)
+  private val shuffleReleasePartitionRequests = new ConcurrentHashMap[Int, util.Set[Int]]
+  private val batchHandleReleasePartitionEnabled = conf.batchHandleReleasePartitionEnabled
+  private val batchHandleReleasePartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(
+    "rss-lifecycle-manager-release-partition-executor",
+    conf.batchHandleReleasePartitionNumThreads)
+  private val batchHandleReleasePartitionRequestInterval =
+    conf.batchHandleReleasePartitionRequestInterval
+  private val batchHandleReleasePartitionSchedulerThread: Option[ScheduledExecutorService] =
+    if (batchHandleReleasePartitionEnabled) {
+      Some(ThreadUtils.newDaemonSingleThreadScheduledExecutor(
+        "rss-lifecycle-manager-release-partition-scheduler"))
+    } else {
+      None
+    }
+  private var batchHandleReleasePartition: Option[ScheduledFuture[_]] = _
+
+  def start(): Unit = {
+    batchHandleReleasePartition = batchHandleReleasePartitionSchedulerThread.map {
+      // noinspection ConvertExpressionToSAM
+      _.scheduleAtFixedRate(
+        new Runnable {
+          override def run(): Unit = {
+            try {
+              shuffleReleasePartitionRequests.asScala.foreach {
+                case (shuffleId, unReleasedPartitionIdRequestSet) =>
+                  batchHandleReleasePartitionExecutors.submit {
+                    new Runnable {
+                      override def run(): Unit = {
+                        val unReleasePartitionIds = new util.HashSet[Int]
+                        unReleasedPartitionIdRequestSet.synchronized {
+                          unReleasePartitionIds.addAll(unReleasedPartitionIdRequestSet)
+                          unReleasedPartitionIdRequestSet.clear()
+                        }
+
+                        lifecycleManager.workerSnapshots(shuffleId).asScala.foreach {
+                          case (workerInfo, partitionLocationInfo) =>
+                            val destroyResource = new WorkerResource
+                            unReleasePartitionIds.asScala.foreach {
+                              partitionId =>
+                                addDestroyResource(
+                                  destroyResource,
+                                  workerInfo,
+                                  partitionLocationInfo,
+                                  partitionId)
+                            }
+
+                            if (!destroyResource.isEmpty) {
+                              lifecycleManager.destroySlotsWithRetry(
+                                appId,
+                                shuffleId,
+                                destroyResource)
+                              logTrace(s"Destroyed partition resource for shuffle $shuffleId $destroyResource")
+                            }
+                        }
+                      }
+                    }
+                  }
+              }
+            } catch {
+              case e: InterruptedException =>
+                logError("Partition split scheduler thread is shutting down, detail: ", e)
+                throw e
+            }
+          }
+        },
+        0,
+        batchHandleReleasePartitionRequestInterval,
+        TimeUnit.MILLISECONDS)
+    }
+  }
+
+  def stop(): Unit = {
+    batchHandleReleasePartition.foreach(_.cancel(true))
+    batchHandleReleasePartitionSchedulerThread.foreach(ThreadUtils.shutdown(_, 800.millis))
+  }
+
+  def releasePartition(shuffleId: Int, partitionId: Int): Unit = {
+    if (batchHandleReleasePartitionEnabled) {
+      shuffleReleasePartitionRequests.putIfAbsent(shuffleId, new util.HashSet[Int])
+      val unReleasedPartitionIdRequestSet = shuffleReleasePartitionRequests.get(shuffleId)
+      unReleasedPartitionIdRequestSet.synchronized {
+        unReleasedPartitionIdRequestSet.add(partitionId)
+      }
+    } else {
+      val destroyResource = new WorkerResource
+      lifecycleManager.workerSnapshots(shuffleId).asScala.foreach {
+        case (workerInfo, partitionLocationInfo) =>
+          addDestroyResource(destroyResource, workerInfo, partitionLocationInfo, partitionId)
+      }
+
+      if (!destroyResource.isEmpty) {
+        lifecycleManager.destroySlotsWithRetry(appId, shuffleId, destroyResource)
+        logTrace(
+          s"Destroyed partition resource for partition $shuffleId-$partitionId, $destroyResource")
+      }
+    }
+  }
+
+  private def addDestroyResource(
+      workerResource: WorkerResource,
+      workerInfo: WorkerInfo,
+      partitionLocationInfo: ShufflePartitionLocationInfo,
+      partitionId: Int): Unit = {
+    if (partitionLocationInfo.containsPartition(partitionId)) {
+      val masterLocations = partitionLocationInfo.removeMasterPartitions(partitionId)
+      if (masterLocations != null && !masterLocations.isEmpty) {
+        workerResource.computeIfAbsent(
+          workerInfo,
+          lifecycleManager.newLocationFunc)._1.addAll(masterLocations)
+      }
+
+      val slaveLocations = partitionLocationInfo.removeSlavePartitions(partitionId)
+      if (slaveLocations != null && !slaveLocations.isEmpty) {
+        workerResource.computeIfAbsent(
+          workerInfo,
+          lifecycleManager.newLocationFunc)._2.addAll(slaveLocations)
+      }
+    }
+  }
+}

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -218,10 +218,10 @@ abstract class CommitHandler(
         (
           masterParts.asScala
             .filterNot(shuffleCommittedInfo.handledPartitionLocations.contains)
-            .map(_.getUniqueId).asJava,
+            .map(_.getUniqueId).toList.asJava,
           slaveParts.asScala
             .filterNot(shuffleCommittedInfo.handledPartitionLocations.contains)
-            .map(_.getUniqueId).asJava)
+            .map(_.getUniqueId).toList.asJava)
       }
 
       commitFiles(
@@ -462,4 +462,11 @@ abstract class CommitHandler(
   }
 
   def commitMetrics(): (Long, Long) = (totalWritten.sumThenReset(), fileCount.sumThenReset())
+
+  def releasePartitionResource(shuffleId: Int, partitionId: Int): Unit = {
+    val fileGroups = reducerFileGroupsMap.get(shuffleId)
+    if (fileGroups != null) {
+      fileGroups.remove(partitionId)
+    }
+  }
 }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
@@ -197,11 +197,6 @@ class MapPartitionCommitHandler(
       recordWorkerFailure(commitFailedWorkers)
     }
 
-    // release resources and clear related info
-    partitionAllocatedWorkers.asScala.foreach { case (_, partitionLocationInfo) =>
-      partitionLocationInfo.removePartitions(partitionId)
-    }
-
     inProcessingPartitionIds.remove(partitionId)
     if (dataCommitSuccess) {
       val resultPartitions =
@@ -225,5 +220,14 @@ class MapPartitionCommitHandler(
       reducerFileGroupsMap.getOrDefault(shuffleId, new ConcurrentHashMap()),
       getMapperAttempts(shuffleId),
       succeedPartitionIds))
+  }
+
+  override def releasePartitionResource(shuffleId: Int, partitionId: Int): Unit = {
+    val succeedPartitionIds = shuffleSucceedPartitionIds.get(shuffleId)
+    if (succeedPartitionIds != null) {
+      succeedPartitionIds.remove(partitionId)
+    }
+
+    super.releasePartitionResource(shuffleId, partitionId)
   }
 }

--- a/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
@@ -18,14 +18,15 @@
 package org.apache.celeborn.client
 
 import scala.collection.JavaConverters._
-
 import org.junit.Assert
-
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.network.TestUtils
 import org.apache.celeborn.common.util.PackedPartitionId
+
+import java.lang
+import java.util.concurrent.Callable
 
 trait WithShuffleClientSuite extends CelebornFunSuite {
 
@@ -100,8 +101,11 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
       shuffleId,
       PackedPartitionId.packedPartitionId(mapId, attemptId + 1))
 
-    TestUtils.timeOutOrMeetCondition(() =>
-      partitionLocationInfos.map(r => r.getMasterPartitions().size()).sum == numMappers)
+    TestUtils.timeOutOrMeetCondition(new Callable[java.lang.Boolean] {
+      override def call(): lang.Boolean = {
+        partitionLocationInfos.map(r => r.getMasterPartitions().size()).sum == numMappers
+      }
+    })
   }
 
   test("test release single partition") {

--- a/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
@@ -17,16 +17,18 @@
 
 package org.apache.celeborn.client
 
+import java.lang
+import java.util.concurrent.Callable
+
 import scala.collection.JavaConverters._
+
 import org.junit.Assert
+
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.network.TestUtils
 import org.apache.celeborn.common.util.PackedPartitionId
-
-import java.lang
-import java.util.concurrent.Callable
 
 trait WithShuffleClientSuite extends CelebornFunSuite {
 

--- a/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/PartitionLocation.java
@@ -49,6 +49,10 @@ public class PartitionLocation implements Serializable {
     }
   }
 
+  public static String getFileName(String uniqueId, Mode mode) {
+    return uniqueId + "-" + mode.mode();
+  }
+
   private int id;
   private int epoch;
   private String host;
@@ -227,6 +231,7 @@ public class PartitionLocation implements Serializable {
     return id + "-" + epoch;
   }
 
+  /** @see PartitionLocation#getFileName */
   public String getFileName() {
     return id + "-" + epoch + "-" + mode.mode;
   }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -691,6 +691,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def batchHandleCommitPartitionEnabled: Boolean = get(BATCH_HANDLE_COMMIT_PARTITION_ENABLED)
   def batchHandleCommitPartitionNumThreads: Int = get(BATCH_HANDLE_COMMIT_PARTITION_THREADS)
   def batchHandleCommitPartitionRequestInterval: Long = get(BATCH_HANDLED_COMMIT_PARTITION_INTERVAL)
+  def batchHandleReleasePartitionEnabled: Boolean = get(BATCH_HANDLE_RELEASE_PARTITION_ENABLED)
+  def batchHandleReleasePartitionNumThreads: Int = get(BATCH_HANDLE_RELEASE_PARTITION_THREADS)
+  def batchHandleReleasePartitionRequestInterval: Long =
+    get(BATCH_HANDLED_RELEASE_PARTITION_INTERVAL)
   def rpcCacheSize: Int = get(RPC_CACHE_SIZE)
   def rpcCacheConcurrencyLevel: Int = get(RPC_CACHE_CONCURRENCY_LEVEL)
   def rpcCacheExpireTime: Long = get(RPC_CACHE_EXPIRE_TIME)
@@ -2411,6 +2415,32 @@ object CelebornConf extends Logging {
       .categories("client")
       .doc("Interval for LifecycleManager to schedule handling commit partition requests in batch.")
       .version("0.2.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("5s")
+
+  val BATCH_HANDLE_RELEASE_PARTITION_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.shuffle.batchHandleReleasePartition.enabled")
+      .categories("client")
+      .doc("When true, LifecycleManager will handle release partition request in batch. " +
+        "Otherwise, LifecycleManager will process release partition request immediately")
+      .version("0.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val BATCH_HANDLE_RELEASE_PARTITION_THREADS: ConfigEntry[Int] =
+    buildConf("celeborn.shuffle.batchHandleReleasePartition.threads")
+      .categories("client")
+      .doc("Threads number for LifecycleManager to handle release partition request in batch.")
+      .version("0.3.0")
+      .intConf
+      .createWithDefault(8)
+
+  val BATCH_HANDLED_RELEASE_PARTITION_INTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.shuffle.batchHandleReleasePartition.interval")
+      .categories("client")
+      .doc(
+        "Interval for LifecycleManager to schedule handling release partition requests in batch.")
+      .version("0.3.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("5s")
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
@@ -25,10 +25,10 @@ import scala.collection.JavaConverters._
 import org.apache.celeborn.common.protocol.PartitionLocation
 
 class ShufflePartitionLocationInfo {
-
-  type PartitionInfo = ConcurrentHashMap[Int, util.List[PartitionLocation]]
+  type PartitionInfo = ConcurrentHashMap[Int, util.Set[PartitionLocation]]
   private val masterPartitionLocations = new PartitionInfo
   private val slavePartitionLocations = new PartitionInfo
+  implicit val partitionOrdering: Ordering[PartitionLocation] = Ordering.by(_.getEpoch)
 
   def addMasterPartitions(masterLocations: util.List[PartitionLocation]) = {
     addPartitions(masterPartitionLocations, masterLocations)
@@ -38,11 +38,11 @@ class ShufflePartitionLocationInfo {
     addPartitions(slavePartitionLocations, slaveLocations)
   }
 
-  def getMasterPartitions(partitionIdOpt: Option[Int] = None): util.List[PartitionLocation] = {
+  def getMasterPartitions(partitionIdOpt: Option[Int] = None): util.Set[PartitionLocation] = {
     getPartitions(masterPartitionLocations, partitionIdOpt)
   }
 
-  def getSlavePartitions(partitionIdOpt: Option[Int] = None): util.List[PartitionLocation] = {
+  def getSlavePartitions(partitionIdOpt: Option[Int] = None): util.Set[PartitionLocation] = {
     getPartitions(slavePartitionLocations, partitionIdOpt)
   }
 
@@ -51,23 +51,29 @@ class ShufflePartitionLocationInfo {
     slavePartitionLocations.containsKey(partitionId)
   }
 
-  def removePartitions(partitionId: Int): Unit = {
-    masterPartitionLocations.remove(partitionId)
-    slavePartitionLocations.remove(partitionId)
+  def removeMasterPartitions(partitionId: Int): util.Set[PartitionLocation] = {
+    removePartitions(masterPartitionLocations, partitionId)
   }
 
-  def getAllMasterLocationsWithMinEpoch(): util.List[PartitionLocation] = {
-    def order(a: Int, b: Int): Boolean = a < b
+  def removeSlavePartitions(partitionId: Int): util.Set[PartitionLocation] = {
+    removePartitions(slavePartitionLocations, partitionId)
+  }
 
-    masterPartitionLocations.values().asScala.map { list =>
-      var loc = list.get(0)
-      1 until list.size() foreach (ind => {
-        if (order(list.get(ind).getEpoch, loc.getEpoch)) {
-          loc = list.get(ind)
-        }
-      })
-      loc
-    }.toList.asJava
+  private def removePartitions(
+      partitionInfo: PartitionInfo,
+      partitionId: Int): util.Set[PartitionLocation] = {
+    val partitionLocations = partitionInfo.remove(partitionId)
+    if (partitionLocations != null) {
+      partitionLocations
+    } else {
+      new util.HashSet[PartitionLocation]()
+    }
+  }
+
+  def getAllMasterLocationsWithMinEpoch(): util.Set[PartitionLocation] = {
+    masterPartitionLocations.values().asScala.map { partitionLocations =>
+      partitionLocations.asScala.min
+    }.toSet.asJava
   }
 
   private def addPartitions(
@@ -75,20 +81,22 @@ class ShufflePartitionLocationInfo {
       locations: util.List[PartitionLocation]): Unit = synchronized {
     if (locations != null && locations.size() > 0) {
       locations.asScala.foreach { loc =>
-        partitionInfo.putIfAbsent(loc.getId, new util.ArrayList)
-        val locations = partitionInfo.get(loc.getId)
-        locations.add(loc)
+        partitionInfo.putIfAbsent(loc.getId, ConcurrentHashMap.newKeySet())
+        val partitionLocations = partitionInfo.get(loc.getId)
+        if (partitionLocations != null) {
+          partitionLocations.add(loc)
+        }
       }
     }
   }
 
   private def getPartitions(
       partitionInfo: PartitionInfo,
-      partitionIdOpt: Option[Int]): util.List[PartitionLocation] = {
+      partitionIdOpt: Option[Int]): util.Set[PartitionLocation] = {
     partitionIdOpt match {
       case Some(partitionId) =>
-        partitionInfo.getOrDefault(partitionId, new util.ArrayList)
-      case _ => partitionInfo.values().asScala.flatMap(_.asScala).toList.asJava
+        partitionInfo.getOrDefault(partitionId, new util.HashSet)
+      case _ => partitionInfo.values().asScala.flatMap(_.asScala).toSet.asJava
     }
   }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfoSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.meta
+
+import java.util
+
+import org.junit.Assert.{assertEquals, assertTrue}
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.protocol.PartitionLocation
+
+class ShufflePartitionLocationInfoSuite extends CelebornFunSuite {
+
+  test("test operate shuffle partition locations.") {
+    val partitionLocation00 = mockPartition(0, 0)
+    val partitionLocation01 = mockPartition(0, 1)
+    val partitionLocation02 = mockPartition(0, 2)
+    val partitionLocation12 = mockPartition(1, 2)
+    val partitionLocation11 = mockPartition(1, 1)
+
+    val masterLocations = new util.ArrayList[PartitionLocation]()
+    masterLocations.add(partitionLocation00)
+    masterLocations.add(partitionLocation01)
+    masterLocations.add(partitionLocation02)
+    masterLocations.add(partitionLocation11)
+    masterLocations.add(partitionLocation12)
+
+    val slaveLocations = new util.ArrayList[PartitionLocation]()
+    val partitionLocationSlave00 = mockPartition(0, 0)
+    val partitionLocationSlave10 = mockPartition(1, 0)
+    slaveLocations.add(partitionLocationSlave00)
+    slaveLocations.add(partitionLocationSlave10)
+
+    val shufflePartitionLocationInfo = new ShufflePartitionLocationInfo
+    shufflePartitionLocationInfo.addMasterPartitions(masterLocations)
+    shufflePartitionLocationInfo.addSlavePartitions(slaveLocations)
+
+    // test add
+    assertEquals(shufflePartitionLocationInfo.getMasterPartitions().size(), 5)
+    assertEquals(shufflePartitionLocationInfo.getMasterPartitions(Some(0)).size(), 3)
+    assertEquals(shufflePartitionLocationInfo.getMasterPartitions(Some(1)).size(), 2)
+
+    assertEquals(shufflePartitionLocationInfo.getSlavePartitions().size(), 2)
+    assertEquals(shufflePartitionLocationInfo.getSlavePartitions(Some(0)).size(), 1)
+    assertEquals(shufflePartitionLocationInfo.getSlavePartitions(Some(1)).size(), 1)
+
+    // test get min epoch
+    val locations = shufflePartitionLocationInfo.getAllMasterLocationsWithMinEpoch()
+    println(locations)
+    assertTrue(locations.contains(partitionLocation00) && locations.contains(partitionLocation11))
+
+    // test remove
+    assertEquals(shufflePartitionLocationInfo.removeMasterPartitions(0).size(), 3)
+    assertEquals(shufflePartitionLocationInfo.getMasterPartitions().size(), 2)
+    assertEquals(shufflePartitionLocationInfo.getMasterPartitions(Some(1)).size(), 2)
+
+    assertEquals(shufflePartitionLocationInfo.removeSlavePartitions(0).size(), 1)
+    assertEquals(shufflePartitionLocationInfo.getSlavePartitions().size(), 1)
+    assertEquals(shufflePartitionLocationInfo.getSlavePartitions(Some(1)).size(), 1)
+  }
+
+  private def mockPartition(partitionId: Int, epoch: Int): PartitionLocation = {
+    new PartitionLocation(
+      partitionId,
+      epoch,
+      "mock",
+      -1,
+      -1,
+      -1,
+      -1,
+      PartitionLocation.Mode.MASTER)
+  }
+
+}

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -59,6 +59,9 @@ license: |
 | celeborn.shuffle.batchHandleCommitPartition.enabled | false | When true, LifecycleManager will handle commit partition request in batch. Otherwise, LifecycleManager won't commit partition before stage end | 0.2.0 | 
 | celeborn.shuffle.batchHandleCommitPartition.interval | 5s | Interval for LifecycleManager to schedule handling commit partition requests in batch. | 0.2.0 | 
 | celeborn.shuffle.batchHandleCommitPartition.threads | 8 | Threads number for LifecycleManager to handle commit partition request in batch. | 0.2.0 | 
+| celeborn.shuffle.batchHandleReleasePartition.enabled | false | When true, LifecycleManager will handle release partition request in batch. Otherwise, LifecycleManager will process release partition request immediately | 0.3.0 | 
+| celeborn.shuffle.batchHandleReleasePartition.interval | 5s | Interval for LifecycleManager to schedule handling release partition requests in batch. | 0.3.0 | 
+| celeborn.shuffle.batchHandleReleasePartition.threads | 8 | Threads number for LifecycleManager to handle release partition request in batch. | 0.3.0 | 
 | celeborn.shuffle.chuck.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. | 0.2.0 | 
 | celeborn.shuffle.compression.codec | LZ4 | The codec used to compress shuffle data. By default, Celeborn provides two codecs: `lz4` and `zstd`. | 0.2.0 | 
 | celeborn.shuffle.compression.zstd.level | 1 | Compression level for Zstd compression codec, its value should be an integer between -5 and 22. Increasing the compression level will result in better compression at the expense of more CPU and memory. | 0.2.0 | 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1.use destroy rpc to support release single partition resource for flink
2.support batch mode to reduce the number of total rpcs

Here would try to release resources for later using,  anything which not released successfully will be released when the shuffle /job is expired.

### Why are the changes needed?
The unit of Flink resource management(or Map Partition mode) is partition，and if a partition is no longer needed, it can be immediately released, this will reduce the resources used by the Flink job, and the released partition resources can be reused later even in the same job. 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT & manual TPCDS 1T


### Result of this pr
![image](https://user-images.githubusercontent.com/28799061/223390920-5e52088b-bfb0-4f8b-ae91-cf28c3135834.png)


