### PR TITLE
[CELEBORN-385] Add rolling file in log4j configuration template

### DIFF
--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -22,24 +22,20 @@
   -->
 <Configuration status="INFO">
     <Appenders>
-        <Console name="stdout" target="SYSTEM_OUT">
-            <!--
-              ~ In the pattern layout configuration below, we specify an explicit `%ex` conversion
-              ~ pattern for logging Throwables. If this was omitted, then (by default) Log4J would
-              ~ implicitly add an `%xEx` conversion pattern which logs stacktraces with additional
-              ~ class packaging information. That extra information can sometimes add a substantial
-              ~ performance overhead, so we disable it in our default logging config.
-              -->
+        <RollingRandomAccessFile name="rollingBySize" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log" filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d" ignoreExceptions="false" append="true">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
-        </Console>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="7"/>
+        </RollingRandomAccessFile>
     </Appenders>
-
     <Loggers>
         <Root level="INFO">
-            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="rollingBySize"/>
         </Root>
         <Logger name="org.apache.hadoop.hdfs" level="WARN" additivity="false">
-            <Appender-ref ref="stdout" level="WARN" />
+            <Appender-ref ref="rollingBySize" level="WARN"/>
         </Logger>
     </Loggers>
 </Configuration>

--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -40,6 +40,7 @@
             <DefaultRolloverStrategy max="7"/>
         </RollingRandomAccessFile>
     </Appenders>
+
     <Loggers>
         <Root level="INFO">
             <!--

--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -32,7 +32,7 @@
               -->
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
         </Console>
-        <RollingRandomAccessFile name="rollingBySize" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log" filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d" ignoreExceptions="false" append="true">
+        <RollingRandomAccessFile name="file" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log" filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d" ignoreExceptions="false" append="true">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="200 MB"/>
@@ -47,11 +47,11 @@
               ~ Here are appender templates, keep the appender as your need.
               -->
             <AppenderRef ref="stdout"/>
-            <AppenderRef ref="rollingBySize"/>
+            <AppenderRef ref="file"/>
         </Root>
         <Logger name="org.apache.hadoop.hdfs" level="WARN" additivity="false">
             <Appender-ref ref="stdout" level="WARN" />
-            <Appender-ref ref="rollingBySize" level="WARN"/>
+            <Appender-ref ref="file" level="WARN"/>
         </Logger>
     </Loggers>
 </Configuration>

--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -22,6 +22,16 @@
   -->
 <Configuration status="INFO">
     <Appenders>
+        <Console name="stdout" target="SYSTEM_OUT">
+            <!--
+              ~ In the pattern layout configuration below, we specify an explicit `%ex` conversion
+              ~ pattern for logging Throwables. If this was omitted, then (by default) Log4J would
+              ~ implicitly add an `%xEx` conversion pattern which logs stacktraces with additional
+              ~ class packaging information. That extra information can sometimes add a substantial
+              ~ performance overhead, so we disable it in our default logging config.
+              -->
+            <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
+        </Console>
         <RollingRandomAccessFile name="rollingBySize" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log" filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d" ignoreExceptions="false" append="true">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Policies>
@@ -32,9 +42,14 @@
     </Appenders>
     <Loggers>
         <Root level="INFO">
+            <!--
+              ~ Here are appender templates, keep the appender as your need.
+              -->
+            <AppenderRef ref="stdout"/>
             <AppenderRef ref="rollingBySize"/>
         </Root>
         <Logger name="org.apache.hadoop.hdfs" level="WARN" additivity="false">
+            <Appender-ref ref="stdout" level="WARN" />
             <Appender-ref ref="rollingBySize" level="WARN"/>
         </Logger>
     </Loggers>

--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -32,7 +32,7 @@
               -->
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
         </Console>
-        <RollingRandomAccessFile name="file" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log" filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d" ignoreExceptions="false" append="true">
+        <RollingRandomAccessFile name="file" fileName="${env:CELEBORN_LOG_DIR}/celeborn.log" filePattern="${env:CELEBORN_LOG_DIR}/celeborn.log.%d">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="200 MB"/>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a rolling log4j configuration template.


### Why are the changes needed?
Celeborn logs can be very large so we need to limit log's disk usage.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT and manual cluster run.
