### PR TITLE
[CELEBORN-393] responseBuilder.setCmdType should be called only once in MetaHandler's handleReadRequest method

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
@@ -68,7 +68,6 @@ public class MetaHandler {
   public ResourceResponse handleReadRequest(ResourceProtos.ResourceRequest request) {
     ResourceProtos.Type cmdType = request.getCmdType();
     ResourceResponse.Builder responseBuilder = getMasterMetaResponseBuilder(request);
-    responseBuilder.setCmdType(cmdType);
     try {
       switch (cmdType) {
         default:


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
responseBuilder.setCmdType should be called only once in MetaHandler's handleReadRequest method


### Why are the changes needed?
responseBuilder.setCmdType should be called only once in MetaHandler's handleReadRequest method


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
passing CI
