### PR TITLE
[CELEBORN-389][FLINK] Fix remove transportClient from readClientHandler caused NPE

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
@@ -47,7 +47,6 @@ public class ReadClientHandler extends BaseMessageHandler {
     streamHandlers.remove(streamId);
     TransportClient client = streamClients.remove(streamId);
     // If read handler is removed, we should notify worker to release resource.
-    // client might be null because stream clients might be cleared by close method
     if (client != null && client.isActive()) {
       client.getChannel().writeAndFlush(new BufferStreamEnd(streamId));
     }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
@@ -44,10 +44,10 @@ public class ReadClientHandler extends BaseMessageHandler {
   }
 
   public void removeHandler(long streamId) {
-    streamHandlers.remove(streamId);
     TransportClient client = streamClients.remove(streamId);
     // If read handler is removed, we should notify worker to release resource.
-    if (client.isActive()) {
+    // client might be null because stream clients might be cleared by close method
+    if (client != null && client.isActive()) {
       client.getChannel().writeAndFlush(new BufferStreamEnd(streamId));
     }
   }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
@@ -44,6 +44,7 @@ public class ReadClientHandler extends BaseMessageHandler {
   }
 
   public void removeHandler(long streamId) {
+    streamHandlers.remove(streamId);
     TransportClient client = streamClients.remove(streamId);
     // If read handler is removed, we should notify worker to release resource.
     // client might be null because stream clients might be cleared by close method

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -104,7 +104,6 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
         new TransportContext(
             dataTransportConf, readClientHandler, conf.clientCloseIdleConnections());
     this.flinkTransportClientFactory = new FlinkTransportClientFactory(context);
-    this.setupMetaServiceRef(driverHost, port);
   }
 
   public RssBufferStream readBufferedPartition(


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Check transport client is null or not when sending BufferStreamEnd Rpc to worker.
2. Remove redundant code.


### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT and cluster run.
