### PR TITLE
[CELEBORN-397][FLINK] Flink plugin support UnpooledByteBufAllocator.

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/FlinkTransportClientFactory.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/FlinkTransportClientFactory.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
+import io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.TransportContext;
@@ -40,6 +41,11 @@ public class FlinkTransportClientFactory extends TransportClientFactory {
       throws IOException, InterruptedException {
     return createClient(
         remoteHost, remotePort, -1, new TransportFrameDecoderWithBufferSupplier(bufferSuppliers));
+  }
+
+  @Override
+  protected void initializeMemoryAllocator() {
+    this.pooledAllocator = new UnpooledByteBufAllocator(true);
   }
 
   public void registerSupplier(long streamId, Supplier<ByteBuf> supplier) {

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.base.Preconditions;
 import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.*;
 import io.netty.channel.socket.SocketChannel;
 import org.slf4j.Logger;
@@ -76,7 +76,7 @@ public class TransportClientFactory implements Closeable {
 
   private final Class<? extends Channel> socketChannelClass;
   private EventLoopGroup workerGroup;
-  private PooledByteBufAllocator pooledAllocator;
+  protected ByteBufAllocator pooledAllocator;
 
   public TransportClientFactory(TransportContext context) {
     this.context = Preconditions.checkNotNull(context);
@@ -90,6 +90,10 @@ public class TransportClientFactory implements Closeable {
     logger.info("mode " + ioMode + " threads " + conf.clientThreads());
     this.workerGroup =
         NettyUtils.createEventLoop(ioMode, conf.clientThreads(), conf.getModuleName() + "-client");
+    initializeMemoryAllocator();
+  }
+
+  protected void initializeMemoryAllocator() {
     this.pooledAllocator =
         NettyUtils.createPooledByteBufAllocator(
             conf.preferDirectBufs(), false /* allowCache */, conf.clientThreads());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change flink shuffle plugin memory allocator to UnpooledBytebufAllocator because flink task manager  off-heap memory is quite limited.


### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT and cluster run.
