### PR TITLE
[CELEBORN-401] Modify prometheus-podmonitor.yaml to collect metrics correctly

### DIFF
--- a/charts/celeborn/templates/prometheus-podmonitor.yaml
+++ b/charts/celeborn/templates/prometheus-podmonitor.yaml
@@ -40,7 +40,7 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: celeborn-master
+      app.kubernetes.io/role: master
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -65,6 +65,6 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: celeborn-worker
+      app.kubernetes.io/role: worker
 {{ end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Change the matchLabels of podMonitor from` app.kubernetes.io/name` to `app.kubernetes.io/role`


### Why are the changes needed?
when deploy celeborn on k8s, master pods will be labeled as
![image](https://user-images.githubusercontent.com/86960423/224467301-02bdd640-2bae-4c1b-9e98-61db15441d6e.png)
This does not match` app.kubernetes.io/name: celeborn-master` in `prometheus-podmonitor.yaml`, in fact, this label is a combination of `name `and `role`, after changing it to `app.kubernetes.io/role` to match The metrics of the pod can be captured normally.
### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

