### PR TITLE
[CELEBORN-402] Enable autolink to Jira

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,6 +34,7 @@ github:
     discussions: true
     wiki: false
     projects: false
+  autolink_jira: CELEBORN
 notifications:
   commits: commits@celeborn.apache.org
   issues: issues@celeborn.apache.org


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable autolink to Jira.

Example: https://github.com/apache/flink-connector-kafka/commits/main