### PR TITLE
[CELEBORN-403][FLINK] Add metrics about buffer dispatcher requests queue length.

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/server/memory/MemoryManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/memory/MemoryManager.java
@@ -370,6 +370,10 @@ public class MemoryManager {
     return pausePushDataAndReplicateCounter.sum();
   }
 
+  public int dispatchRequestsLength() {
+    return readBufferDispatcher.requestsLength();
+  }
+
   enum MemoryManagerStat {
     resumeAll,
     pausePushDataAndReplicate,

--- a/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferDispatcher.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferDispatcher.java
@@ -99,4 +99,8 @@ public class ReadBufferDispatcher extends Thread {
       }
     }
   }
+
+  public int requestsLength() {
+    return requests.size();
+  }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -99,6 +99,7 @@ object WorkerSource {
   val PausePushDataCount = "PausePushData"
   val PausePushDataAndReplicateCount = "PausePushDataAndReplicate"
   val BufferStreamReadBuffer = "BufferStreamReadBuffer"
+  val readBufferDispatcherRequestsLength = "ReadBufferDispatcherRequestsLength"
 
   // local device
   val DeviceOSFreeCapacity = "DeviceOSFreeCapacity(B)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
To show metrics about buffer dispatcher requests queue length.


### Why are the changes needed?
To show the busyness of workers in allocating read memory.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
PR and cluster run.
