### PR TITLE
[CELEBORN-405] Add metrics about lost workers

### DIFF
--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -464,4 +464,5 @@ message PbSnapshotMetaInfo {
   int64 partitionTotalFileCount = 9;
   repeated PbAppDiskUsageSnapshot appDiskUsageMetricSnapshots = 10;
   optional PbAppDiskUsageSnapshot currentAppDiskUsageMetricsSnapshot = 11;
+  map<string, int64> lostWorkers = 12;
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -369,7 +369,8 @@ object PbSerDeUtils {
       partitionTotalWritten: java.lang.Long,
       partitionTotalFileCount: java.lang.Long,
       appDiskUsageMetricSnapshots: Array[AppDiskUsageSnapShot],
-      currentAppDiskUsageMetricsSnapshot: AppDiskUsageSnapShot): PbSnapshotMetaInfo = {
+      currentAppDiskUsageMetricsSnapshot: AppDiskUsageSnapShot,
+      lostWorkers: ConcurrentHashMap[WorkerInfo, java.lang.Long]): PbSnapshotMetaInfo = {
     val builder = PbSnapshotMetaInfo.newBuilder()
       .setEstimatedPartitionSize(estimatedPartitionSize)
       .addAllRegisteredShuffle(registeredShuffle)
@@ -384,6 +385,9 @@ object PbSerDeUtils {
       // protobuf repeated value can't support null value in list.
       .addAllAppDiskUsageMetricSnapshots(appDiskUsageMetricSnapshots.filter(_ != null)
         .map(toPbAppDiskUsageSnapshot).toList.asJava)
+      .putAllLostWorkers(lostWorkers.asScala.map {
+        case (worker: WorkerInfo, time: java.lang.Long) => (worker.toUniqueId(), time)
+      }.asJava)
     if (currentAppDiskUsageMetricsSnapshot != null) {
       builder.setCurrentAppDiskUsageMetricsSnapshot(
         toPbAppDiskUsageSnapshot(currentAppDiskUsageMetricsSnapshot))

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -313,7 +313,8 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       snapshotMetaInfo
           .getLostWorkersMap()
           .entrySet()
-          .forEach(entry -> lostWorkers.put(WorkerInfo.fromUniqueId(entry.getKey()), entry.getValue()));
+          .forEach(
+              entry -> lostWorkers.put(WorkerInfo.fromUniqueId(entry.getKey()), entry.getValue()));
 
       partitionTotalWritten.reset();
       partitionTotalWritten.add(snapshotMetaInfo.getPartitionTotalWritten());

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -52,6 +52,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
   public final Set<String> registeredShuffle = ConcurrentHashMap.newKeySet();
   public final Set<String> hostnameSet = ConcurrentHashMap.newKeySet();
   public final ArrayList<WorkerInfo> workers = new ArrayList<>();
+  public final ConcurrentHashMap<WorkerInfo, Long> lostWorkers = new ConcurrentHashMap<>();
   public final ConcurrentHashMap<String, Long> appHeartbeatTime = new ConcurrentHashMap<>();
   // blacklist
   public final Set<WorkerInfo> blacklist = ConcurrentHashMap.newKeySet();
@@ -145,6 +146,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     // remove worker from workers
     synchronized (workers) {
       workers.remove(worker);
+      lostWorkers.put(worker, System.currentTimeMillis());
     }
     // delete from blacklist
     blacklist.remove(worker);
@@ -157,6 +159,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     // remove worker from workers
     synchronized (workers) {
       workers.remove(worker);
+      lostWorkers.put(worker, System.currentTimeMillis());
     }
     // delete from blacklist
     blacklist.remove(worker);
@@ -240,6 +243,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     synchronized (workers) {
       if (!workers.contains(workerInfo)) {
         workers.add(workerInfo);
+        lostWorkers.remove(workerInfo);
       }
     }
   }
@@ -263,7 +267,8 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
                 partitionTotalWritten.sum(),
                 partitionTotalFileCount.sum(),
                 appDiskUsageMetric.snapShots(),
-                appDiskUsageMetric.currentSnapShot().get())
+                appDiskUsageMetric.currentSnapShot().get(),
+                lostWorkers)
             .toByteArray();
     Files.write(file.toPath(), snapshotBytes);
   }
@@ -304,6 +309,11 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
           snapshotMetaInfo.getWorkersList().stream()
               .map(PbSerDeUtils::fromPbWorkerInfo)
               .collect(Collectors.toSet()));
+
+      snapshotMetaInfo
+          .getLostWorkersMap()
+          .entrySet()
+          .forEach(entry -> lostWorkers.put(WorkerInfo.fromUniqueId(entry.getKey()), entry.getValue()));
 
       partitionTotalWritten.reset();
       partitionTotalWritten.add(snapshotMetaInfo.getPartitionTotalWritten());

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -144,6 +144,7 @@ private[celeborn] class Master(
   masterSource.addGauge(MasterSource.BlacklistedWorkerCount, _ => statusSystem.blacklist.size())
   // worker count
   masterSource.addGauge(MasterSource.WorkerCount, _ => statusSystem.workers.size())
+  masterSource.addGauge(MasterSource.LostWorkerCount, _ => statusSystem.lostWorkers.size())
   masterSource.addGauge(MasterSource.PartitionSize, _ => statusSystem.estimatedPartitionSize)
   // is master active under HA mode
   masterSource.addGauge(MasterSource.IsActiveMaster, _ => isMasterActive)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
@@ -37,6 +37,8 @@ object MasterSource {
 
   val WorkerCount = "WorkerCount"
 
+  val LostWorkerCount = "LostWorkers"
+
   val BlacklistedWorkerCount = "BlacklistedWorkerCount"
 
   val RegisteredShuffleCount = "RegisteredShuffleCount"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, if the worker is just lost, the blacklist will remove it too, we need to add metrics to indicate the lost workers and later add it to the HTTP request.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

