### PR TITLE
[CELEBORN-412] In the cleanupOldFiles method of the StateMachine class, when onlyCleanupMD5Files is true, md5flie should be deleted instead of file

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
@@ -144,7 +144,7 @@ public class StateMachine extends BaseStateMachine {
               File file = fileInfo.getFile().getPath().toFile();
               File md5File = new File(file.getAbsolutePath() + MD5FileUtil.MD5_SUFFIX);
               if (onlyCleanupMD5Files) {
-                LOG.info("Deleting old md5 file at {}.", file.getAbsolutePath());
+                LOG.info("Deleting old md5 file at {}.", md5File.getAbsolutePath());
                 FileUtils.deleteFileQuietly(md5File);
               } else {
                 LOG.info(

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
@@ -142,11 +142,11 @@ public class StateMachine extends BaseStateMachine {
                 continue;
               }
               File file = fileInfo.getFile().getPath().toFile();
+              File md5File = new File(file.getAbsolutePath() + MD5FileUtil.MD5_SUFFIX);
               if (onlyCleanupMD5Files) {
                 LOG.info("Deleting old md5 file at {}.", file.getAbsolutePath());
-                FileUtils.deleteFileQuietly(file);
+                FileUtils.deleteFileQuietly(md5File);
               } else {
-                File md5File = new File(file.getAbsolutePath() + MD5FileUtil.MD5_SUFFIX);
                 LOG.info(
                     "Deleting old snapshot at {}, md5 file at {}.",
                     file.getAbsolutePath(),


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
In the cleanupOldFiles method of the StateMachine class, when onlyCleanupMD5Files is true, md5flie should be deleted instead of file


### Why are the changes needed?

In the cleanupOldFiles method of the StateMachine class, when onlyCleanupMD5Files is true, md5flie should be deleted instead of file

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?
passing CI
