### PR TITLE
[CELEBORN-415] Fix syntax error in prometheus-podmonitor.yaml

### DIFF
--- a/charts/celeborn/templates/prometheus-podmonitor.yaml
+++ b/charts/celeborn/templates/prometheus-podmonitor.yaml
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{ - include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.labels" . | nindent 4 }}
 spec:
   podMetricsEndpoints:
     - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{ - include "celeborn.labels" . | nindent 4 }}
+    {{- include "celeborn.labels" . | nindent 4 }}
 spec:
   podMetricsEndpoints:
     - interval: {{ .Values.podMonitor.podMetricsEndpoint.interval }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->


### What changes were proposed in this pull request?
Fix two syntax error in prometheus-podmonitor.yaml to enable helm deployment.

### Why are the changes needed?
Extra space causes syntax error when deploying,
![image](https://user-images.githubusercontent.com/86960423/224676801-69201dac-42e0-4167-81e7-d2b74784fa34.png)

![image](https://user-images.githubusercontent.com/86960423/224676826-3d29ed21-9d28-4301-a671-463c4e6d1310.png)


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

