### PR TITLE
[CELEBORN-419][FLINK] Fix memory leak when receive RPCs with body.

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
@@ -94,7 +94,7 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
     if (bodyBuf == null) {
       if (buf.readableBytes() >= bodySize) {
         io.netty.buffer.ByteBuf body = buf.retain().readSlice(bodySize);
-        curMsg.setBody(body.nioBuffer());
+        curMsg.setBody(body);
         ctx.fireChannelRead(curMsg);
         clear();
         return buf;
@@ -112,7 +112,7 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
     }
     bodyBuf.addComponent(next).writerIndex(bodyBuf.writerIndex() + next.readableBytes());
     if (bodyBuf.readableBytes() == bodySize) {
-      curMsg.setBody(bodyBuf.nioBuffer());
+      curMsg.setBody(bodyBuf);
       ctx.fireChannelRead(curMsg);
       clear();
     }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -50,10 +50,6 @@ public abstract class Message implements Encodable {
     this.body = new NettyManagedBuffer(buf);
   }
 
-  public void setBody(ByteBuffer buf) {
-    this.body = new NettyManagedBuffer(buf);
-  }
-
   /** Whether the body should be copied out in frame decoder. */
   public boolean needCopyOut() {
     return false;


### PR DESCRIPTION
### What changes were proposed in this pull request?
TransportFrameDecoderWithBufferSupplier should not pass converted Bytebuffer which converted from netty bytebuf. The bytebuf is needed and there is no need to wrap it again.
The wrapping operation breaks the retain and release pair which caused the memory leak.


### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT and cluster run.
