### PR TITLE
[CELEBORN-391][FLINK][FOLLOW UP] fix clean stream twice & refine log & add ut

### DIFF
--- a/common/src/test/java/org/apache/celeborn/common/network/TestUtils.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TestUtils.java
@@ -18,6 +18,7 @@
 package org.apache.celeborn.common.network;
 
 import java.net.InetAddress;
+import java.util.concurrent.Callable;
 
 public class TestUtils {
   public static String getLocalHost() {
@@ -25,6 +26,18 @@ public class TestUtils {
       return InetAddress.getLocalHost().getHostAddress();
     } catch (Exception e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  public static void timeOutOrMeetCondition(Callable<Boolean> callable) throws Exception {
+    int timeout = 10000; // 10s
+    while (true) {
+      if (callable.call() || timeout < 0) {
+        break;
+      }
+
+      timeout = timeout - 100;
+      Thread.sleep(100);
     }
   }
 }

--- a/common/src/test/java/org/apache/celeborn/common/network/server/BufferStreamManagerSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/server/BufferStreamManagerSuiteJ.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.server;
+
+import static org.apache.celeborn.common.network.TestUtils.timeOutOrMeetCondition;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import io.netty.channel.Channel;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.identity.UserIdentifier;
+import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.network.server.memory.MemoryManager;
+import org.apache.celeborn.common.util.JavaUtils;
+import org.apache.celeborn.common.util.Utils;
+
+public class BufferStreamManagerSuiteJ {
+  private static final Logger LOG = LoggerFactory.getLogger(BufferStreamManagerSuiteJ.class);
+  private static File tempDir =
+      Utils.createTempDir(System.getProperty("java.io.tmpdir"), "celeborn");
+
+  @BeforeClass
+  public static void beforeAll() {
+    MemoryManager.initialize(0.8, 0.9, 0.5, 0.6, 0.1, 0.1, 10, 10);
+  }
+
+  private File createTemporaryFileWithIndexFile() throws IOException {
+    String filename = UUID.randomUUID().toString();
+    File temporaryFile = new File(tempDir, filename);
+    File indexFile = new File(tempDir, filename + ".index");
+    temporaryFile.createNewFile();
+    indexFile.createNewFile();
+    return temporaryFile;
+  }
+
+  @Test
+  public void testStreamRegisterAndCleanup() throws Exception {
+    BufferStreamManager bufferStreamManager = new BufferStreamManager(10, 10, 1);
+    Channel channel = Mockito.mock(Channel.class);
+    FileInfo fileInfo =
+        new FileInfo(createTemporaryFileWithIndexFile(), new UserIdentifier("default", "default"));
+    fileInfo.setNumReducerPartitions(10);
+    Consumer<Long> streamIdConsumer = streamId -> Assert.assertTrue(streamId > 0);
+
+    long registerStream1 =
+        bufferStreamManager.registerStream(streamIdConsumer, channel, 0, 1, 1, fileInfo);
+    Assert.assertTrue(registerStream1 > 0);
+    Assert.assertEquals(1, bufferStreamManager.numStreamStates());
+
+    long registerStream2 =
+        bufferStreamManager.registerStream(streamIdConsumer, channel, 0, 1, 1, fileInfo);
+    Assert.assertNotEquals(registerStream1, registerStream2);
+    Assert.assertEquals(2, bufferStreamManager.numStreamStates());
+
+    bufferStreamManager.registerStream(streamIdConsumer, channel, 0, 1, 1, fileInfo);
+    bufferStreamManager.registerStream(streamIdConsumer, channel, 0, 1, 1, fileInfo);
+
+    BufferStreamManager.MapDataPartition mapDataPartition1 =
+        bufferStreamManager.getServingStreams().get(registerStream1);
+    BufferStreamManager.MapDataPartition mapDataPartition2 =
+        bufferStreamManager.getServingStreams().get(registerStream2);
+    Assert.assertEquals(mapDataPartition1, mapDataPartition2);
+
+    mapDataPartition1.getStreamReader(registerStream1).recycle();
+
+    timeOutOrMeetCondition(() -> bufferStreamManager.numRecycleStreams() == 0);
+    Assert.assertEquals(bufferStreamManager.numRecycleStreams(), 0);
+    Assert.assertEquals(3, bufferStreamManager.numStreamStates());
+
+    // registerStream2 can't be cleaned as registerStream2 is not finished
+    AtomicInteger numInFlightRequests =
+        mapDataPartition2.getStreamReader(registerStream2).getNumInFlightRequests();
+    numInFlightRequests.incrementAndGet();
+
+    bufferStreamManager.cleanResource(registerStream2);
+    Assert.assertEquals(bufferStreamManager.numRecycleStreams(), 1);
+    Assert.assertEquals(3, bufferStreamManager.numStreamStates());
+
+    // recycle all channel
+    numInFlightRequests.decrementAndGet();
+    bufferStreamManager.connectionTerminated(channel);
+    timeOutOrMeetCondition(() -> bufferStreamManager.numRecycleStreams() == 0);
+    Assert.assertEquals(bufferStreamManager.numStreamStates(), 0);
+  }
+
+  @AfterClass
+  public static void afterAll() {
+    if (tempDir != null) {
+      try {
+        JavaUtils.deleteRecursively(tempDir);
+        tempDir = null;
+      } catch (IOException e) {
+        LOG.error("Failed to delete temp dir.", e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1.fix the condition when recycle stream.
2.add channel remote address to the log.
3.add ut for BufferStreamManager.
4.Don't send data when buffersRead is already released.

### Why are the changes needed?
1.Currently will recycle stream with extra try as it need meet all stream finished.
2.Register stream with remote channel address would make debug easier.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT & TPCDS 1T 
