### PR TITLE
[CELEBORN-422][FLINK] Remove unused fields in ReadData.

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/MessageDecoderExt.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/MessageDecoderExt.java
@@ -72,13 +72,11 @@ public class MessageDecoderExt {
 
       case READ_DATA:
         streamId = in.readLong();
-        int backlog = in.readInt();
-        long offset = in.readLong();
-        return new ReadData(streamId, backlog, offset);
+        return new ReadData(streamId);
 
       case BACKLOG_ANNOUNCEMENT:
         streamId = in.readLong();
-        backlog = in.readInt();
+        int backlog = in.readInt();
         return new BacklogAnnouncement(streamId, backlog);
 
       case TRANSPORTABLE_ERROR:

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/protocol/ReadData.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/protocol/ReadData.java
@@ -25,8 +25,6 @@ import org.apache.celeborn.common.network.protocol.RequestMessage;
 
 public final class ReadData extends RequestMessage {
   private final long streamId;
-  private final int backlog;
-  private final long offset;
   private ByteBuf flinkBuffer;
 
   @Override
@@ -34,35 +32,23 @@ public final class ReadData extends RequestMessage {
     return true;
   }
 
-  public ReadData(long streamId, int backlog, long offset) {
+  public ReadData(long streamId) {
     this.streamId = streamId;
-    this.backlog = backlog;
-    this.offset = offset;
   }
 
   @Override
   public int encodedLength() {
-    return 8 + 4 + 8;
+    return 8;
   }
 
   // This method will not be called because ReadData won't be created at flink client.
   @Override
   public void encode(io.netty.buffer.ByteBuf buf) {
     buf.writeLong(streamId);
-    buf.writeInt(backlog);
-    buf.writeLong(offset);
   }
 
   public long getStreamId() {
     return streamId;
-  }
-
-  public int getBacklog() {
-    return backlog;
-  }
-
-  public long getOffset() {
-    return offset;
   }
 
   @Override
@@ -75,26 +61,17 @@ public final class ReadData extends RequestMessage {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ReadData readData = (ReadData) o;
-    return streamId == readData.streamId
-        && backlog == readData.backlog
-        && offset == readData.offset;
+    return streamId == readData.streamId && Objects.equals(flinkBuffer, readData.flinkBuffer);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(streamId, backlog, offset);
+    return Objects.hash(streamId, flinkBuffer);
   }
 
   @Override
   public String toString() {
-    return "ReadData{"
-        + "streamId="
-        + streamId
-        + ", backlog="
-        + backlog
-        + ", offset="
-        + offset
-        + '}';
+    return "ReadData{" + "streamId=" + streamId + ", flinkBuffer=" + flinkBuffer + '}';
   }
 
   public ByteBuf getFlinkBuffer() {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -28,7 +28,7 @@ import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
 
 /** An on-the-wire transmittable message. */
 public abstract class Message implements Encodable {
-  protected ManagedBuffer body;
+  private ManagedBuffer body;
 
   protected Message() {
     this(null);

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -28,7 +28,7 @@ import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
 
 /** An on-the-wire transmittable message. */
 public abstract class Message implements Encodable {
-  private ManagedBuffer body;
+  protected ManagedBuffer body;
 
   protected Message() {
     this(null);

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ReadData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ReadData.java
@@ -57,12 +57,12 @@ public class ReadData extends RequestMessage {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ReadData readData = (ReadData) o;
-    return streamId == readData.streamId && Objects.equals(body, readData.body);
+    return streamId == readData.streamId && super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(streamId);
+    return Objects.hash(streamId, super.hashCode());
   }
 
   @Override

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ReadData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ReadData.java
@@ -27,38 +27,24 @@ import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
 // It doesn't need decode in worker.
 public class ReadData extends RequestMessage {
   private long streamId;
-  private int backlog;
-  private long offset;
 
-  public ReadData(long streamId, int backlog, long offset, ByteBuf buf) {
+  public ReadData(long streamId, ByteBuf buf) {
     super(new NettyManagedBuffer(buf));
     this.streamId = streamId;
-    this.backlog = backlog;
-    this.offset = offset;
   }
 
   @Override
   public int encodedLength() {
-    return 8 + 4 + 8;
+    return 8;
   }
 
   @Override
   public void encode(ByteBuf buf) {
     buf.writeLong(streamId);
-    buf.writeInt(backlog);
-    buf.writeLong(offset);
   }
 
   public long getStreamId() {
     return streamId;
-  }
-
-  public int getBacklog() {
-    return backlog;
-  }
-
-  public long getOffset() {
-    return offset;
   }
 
   @Override
@@ -71,25 +57,16 @@ public class ReadData extends RequestMessage {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ReadData readData = (ReadData) o;
-    return streamId == readData.streamId
-        && backlog == readData.backlog
-        && offset == readData.offset;
+    return streamId == readData.streamId && body == readData.body;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(streamId, backlog, offset);
+    return Objects.hash(streamId, body);
   }
 
   @Override
   public String toString() {
-    return "ReadData{"
-        + "streamId="
-        + streamId
-        + ", backlog="
-        + backlog
-        + ", offset="
-        + offset
-        + '}';
+    return "ReadData{" + "streamId=" + streamId + '}';
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ReadData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ReadData.java
@@ -57,12 +57,12 @@ public class ReadData extends RequestMessage {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ReadData readData = (ReadData) o;
-    return streamId == readData.streamId && body == readData.body;
+    return streamId == readData.streamId && Objects.equals(body, readData.body);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(streamId, body);
+    return Objects.hash(streamId);
   }
 
   @Override

--- a/common/src/main/java/org/apache/celeborn/common/network/server/DataPartitionReader.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/DataPartitionReader.java
@@ -211,8 +211,9 @@ public class DataPartitionReader implements Comparable<DataPartitionReader> {
       }
 
       ByteBuf byteBuf = wrappedBuffer.byteBuf;
+      int backlog = buffersRead.size();
       int readableBytes = byteBuf.readableBytes();
-      logger.debug("send data start: {}, {}", streamId, readableBytes);
+      logger.debug("send data start: {}, {}, {}", streamId, readableBytes, backlog);
       ReadData readData = new ReadData(streamId, byteBuf);
       associatedChannel
           .writeAndFlush(readData)

--- a/common/src/main/java/org/apache/celeborn/common/network/server/DataPartitionReader.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/DataPartitionReader.java
@@ -206,10 +206,9 @@ public class DataPartitionReader implements Comparable<DataPartitionReader> {
       }
 
       ByteBuf byteBuf = wrappedBuffer.byteBuf;
-      int backlog = buffersRead.size();
       int readableBytes = byteBuf.readableBytes();
-      logger.debug("send data start: {}, {}, {}", streamId, readableBytes, backlog);
-      ReadData readData = new ReadData(streamId, backlog, 0, byteBuf);
+      logger.debug("send data start: {}, {}", streamId, readableBytes);
+      ReadData readData = new ReadData(streamId, byteBuf);
       associatedChannel
           .writeAndFlush(readData)
           .addListener(
@@ -223,7 +222,7 @@ public class DataPartitionReader implements Comparable<DataPartitionReader> {
                         wrappedBuffer.recycle();
                       }
                     } finally {
-                      logger.debug("send data start: {}, {}, {}", streamId, readableBytes, backlog);
+                      logger.debug("send data start: {}, {}", streamId, readableBytes);
                       numInFlightRequests.decrementAndGet();
                     }
                   });


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Remove offset from ReadData.
2. Remove backlog from ReadData


### Why are the changes needed?
To reduce rpc size and improve performance.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT.
