### PR TITLE
[CELEBORN-418][FLINK]Need drop unused bytes from netty when task was already failed

### DIFF
--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplierSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplierSuiteJ.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink.network;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.apache.celeborn.common.network.protocol.BacklogAnnouncement;
+import org.apache.celeborn.common.network.protocol.Message;
+import org.apache.celeborn.common.network.protocol.ReadData;
+
+public class TransportFrameDecoderWithBufferSupplierSuiteJ {
+
+  @Test
+  public void testDropUnusedBytes() throws IOException {
+    ConcurrentHashMap<Long, Supplier<org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf>>
+        supplier = new ConcurrentHashMap<>();
+    List<org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf> buffers = new ArrayList<>();
+
+    supplier.put(
+        2L,
+        () -> {
+          org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf buffer =
+              org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.buffer(32000);
+          buffers.add(buffer);
+          return buffer;
+        });
+
+    TransportFrameDecoderWithBufferSupplier decoder =
+        new TransportFrameDecoderWithBufferSupplier(supplier);
+    ChannelHandlerContext context = Mockito.mock(ChannelHandlerContext.class);
+
+    BacklogAnnouncement announcement = new BacklogAnnouncement(0, 0);
+    ReadData unUsedReadData = new ReadData(1, 8, 0, generateData(1024));
+    ReadData readData = new ReadData(2, 8, 0, generateData(1024));
+    BacklogAnnouncement announcement1 = new BacklogAnnouncement(0, 0);
+    ReadData unUsedReadData1 = new ReadData(1, 8, 0, generateData(1024));
+    ReadData readData1 = new ReadData(2, 8, 0, generateData(8));
+
+    ByteBuf buffer = Unpooled.buffer(5000);
+    encodeMessage(announcement, buffer);
+    encodeMessage(unUsedReadData, buffer);
+    encodeMessage(readData, buffer);
+    encodeMessage(announcement1, buffer);
+    encodeMessage(unUsedReadData1, buffer);
+    encodeMessage(readData1, buffer);
+
+    // simulate
+    buffer.retain();
+    decoder.channelRead(context, buffer);
+    Assert.assertEquals(buffers.get(0).nioBuffer(), readData.body().nioByteBuffer());
+    Assert.assertEquals(buffers.get(1).nioBuffer(), readData1.body().nioByteBuffer());
+
+    // simulate 1 - split the unUsedReadData buffer
+    buffer.retain();
+    buffer.resetReaderIndex();
+    decoder.channelRead(context, buffer.retainedSlice(0, 555));
+    ByteBuf byteBuf = buffer.retainedSlice(0, buffer.readableBytes());
+    byteBuf.readerIndex(555);
+    decoder.channelRead(context, byteBuf);
+
+    Assert.assertEquals(buffers.get(2).nioBuffer(), readData.body().nioByteBuffer());
+    Assert.assertEquals(buffers.get(3).nioBuffer(), readData1.body().nioByteBuffer());
+
+    // simulate 2 - split the readData buffer
+    buffer.retain();
+    buffer.resetReaderIndex();
+    decoder.channelRead(context, buffer.retainedSlice(0, 1500));
+    byteBuf = buffer.retainedSlice(0, buffer.readableBytes());
+    byteBuf.readerIndex(1500);
+    decoder.channelRead(context, byteBuf);
+
+    Assert.assertEquals(buffers.get(4).nioBuffer(), readData.body().nioByteBuffer());
+    Assert.assertEquals(buffers.get(5).nioBuffer(), readData1.body().nioByteBuffer());
+    Assert.assertEquals(buffers.size(), 6);
+  }
+
+  public ByteBuf encodeMessage(Message in, ByteBuf byteBuf) throws IOException {
+    byteBuf.writeInt(in.encodedLength());
+    in.type().encode(byteBuf);
+    if (in.body() != null) {
+      byteBuf.writeInt((int) in.body().size());
+      in.encode(byteBuf);
+      byteBuf.writeBytes(in.body().nioByteBuffer());
+    } else {
+      byteBuf.writeInt(0);
+      in.encode(byteBuf);
+    }
+
+    return byteBuf;
+  }
+
+  public ByteBuf generateData(int size) {
+    ByteBuf data = Unpooled.buffer(size);
+    for (int i = 0; i < size; i++) {
+      data.writeByte(new Random().nextInt(7));
+    }
+
+    return data;
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
drop data buffers which belongs to the failed task from Netty bytebuf.


### Why are the changes needed?
The task which shared the same channel with the previous failed task, would read the wrong buffer. Then the task may stuck.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT & TPCDS 1T with random worker kill.
