### PR TITLE
[CELEBORN-418][FLINK][FOLLOW UP]Need drop unused bytes

### DIFF
--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplierSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplierSuiteJ.java
@@ -57,11 +57,11 @@ public class TransportFrameDecoderWithBufferSupplierSuiteJ {
     ChannelHandlerContext context = Mockito.mock(ChannelHandlerContext.class);
 
     BacklogAnnouncement announcement = new BacklogAnnouncement(0, 0);
-    ReadData unUsedReadData = new ReadData(1, 8, 0, generateData(1024));
-    ReadData readData = new ReadData(2, 8, 0, generateData(1024));
+    ReadData unUsedReadData = new ReadData(1, generateData(1024));
+    ReadData readData = new ReadData(2, generateData(1024));
     BacklogAnnouncement announcement1 = new BacklogAnnouncement(0, 0);
-    ReadData unUsedReadData1 = new ReadData(1, 8, 0, generateData(1024));
-    ReadData readData1 = new ReadData(2, 8, 0, generateData(8));
+    ReadData unUsedReadData1 = new ReadData(1, generateData(1024));
+    ReadData readData1 = new ReadData(2, generateData(8));
 
     ByteBuf buffer = Unpooled.buffer(5000);
     encodeMessage(announcement, buffer);


### PR DESCRIPTION
…n task was already failed

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
it's very rare for supplier.get() cause exception, but we need handle that


### Why are the changes needed?
drop bytes when supplier.get encounter exception.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT & TPCDS random kill
