### PR TITLE
[CELEBORN-428][FLINK] Remove unnecessary lock in PartitionSortedBuffer

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
@@ -201,18 +201,18 @@ public class PartitionSortedBuffer implements SortBuffer {
 
   private boolean allocateBuffersForRecord(int numRecordBytes) throws IOException {
     int numBytesRequired = INDEX_ENTRY_SIZE + numRecordBytes;
-    int availableBytes = writeSegmentIndex == buffers.size() ? 0 : bufferSize - writeSegmentOffset;
+    int currentBufferAvailableBytes = writeSegmentIndex == buffers.size() ? 0 : bufferSize - writeSegmentOffset;
 
     // return directly if current available bytes is adequate
-    if (availableBytes >= numBytesRequired) {
+    if (currentBufferAvailableBytes >= numBytesRequired) {
       return true;
     }
 
     // skip the remaining free space if the available bytes is not enough for an index entry
-    if (availableBytes < INDEX_ENTRY_SIZE) {
-      updateWriteSegmentIndexAndOffset(availableBytes);
-      availableBytes = 0;
+    if (currentBufferAvailableBytes < INDEX_ENTRY_SIZE) {
+      updateWriteSegmentIndexAndOffset(currentBufferAvailableBytes);
     }
+    int totalAvailableBytes = (buffers.size() - writeSegmentIndex) * bufferSize - writeSegmentOffset;
 
     // allocate exactly enough buffers for the appended record
     do {
@@ -222,9 +222,9 @@ public class PartitionSortedBuffer implements SortBuffer {
         return false;
       }
 
-      availableBytes += bufferSize;
+      totalAvailableBytes += bufferSize;
       addBuffer(segment);
-    } while (availableBytes < numBytesRequired);
+    } while (totalAvailableBytes < numBytesRequired);
 
     return true;
   }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
@@ -59,7 +59,6 @@ public class PartitionSortedBuffer implements SortBuffer {
    */
   private static final int INDEX_ENTRY_SIZE = 4 + 4 + 8;
 
-  private final Object lock;
   /** A buffer pool to request memory segments from. */
   private final BufferPool bufferPool;
 

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
@@ -199,8 +199,7 @@ public class PartitionSortedBuffer implements SortBuffer {
 
   private boolean allocateBuffersForRecord(int numRecordBytes) throws IOException {
     int numBytesRequired = INDEX_ENTRY_SIZE + numRecordBytes;
-    int currentBufferAvailableBytes =
-        writeSegmentIndex == buffers.size() ? 0 : bufferSize - writeSegmentOffset;
+    int currentBufferAvailableBytes = writeSegmentIndex == buffers.size() ? 0 : bufferSize - writeSegmentOffset;
 
     // return directly if current available bytes is adequate
     if (currentBufferAvailableBytes >= numBytesRequired) {
@@ -211,8 +210,7 @@ public class PartitionSortedBuffer implements SortBuffer {
     if (currentBufferAvailableBytes < INDEX_ENTRY_SIZE) {
       updateWriteSegmentIndexAndOffset(currentBufferAvailableBytes);
     }
-    int totalAvailableBytes =
-        (buffers.size() - writeSegmentIndex) * bufferSize - writeSegmentOffset;
+    int totalAvailableBytes = (buffers.size() - writeSegmentIndex) * bufferSize - writeSegmentOffset;
 
     // allocate exactly enough buffers for the appended record
     do {

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
@@ -201,7 +201,8 @@ public class PartitionSortedBuffer implements SortBuffer {
 
   private boolean allocateBuffersForRecord(int numRecordBytes) throws IOException {
     int numBytesRequired = INDEX_ENTRY_SIZE + numRecordBytes;
-    int currentBufferAvailableBytes = writeSegmentIndex == buffers.size() ? 0 : bufferSize - writeSegmentOffset;
+    int currentBufferAvailableBytes =
+        writeSegmentIndex == buffers.size() ? 0 : bufferSize - writeSegmentOffset;
 
     // return directly if current available bytes is adequate
     if (currentBufferAvailableBytes >= numBytesRequired) {
@@ -212,7 +213,8 @@ public class PartitionSortedBuffer implements SortBuffer {
     if (currentBufferAvailableBytes < INDEX_ENTRY_SIZE) {
       updateWriteSegmentIndexAndOffset(currentBufferAvailableBytes);
     }
-    int totalAvailableBytes = (buffers.size() - writeSegmentIndex) * bufferSize - writeSegmentOffset;
+    int totalAvailableBytes =
+        (buffers.size() - writeSegmentIndex) * bufferSize - writeSegmentOffset;
 
     // allocate exactly enough buffers for the appended record
     do {

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
@@ -199,18 +199,18 @@ public class PartitionSortedBuffer implements SortBuffer {
 
   private boolean allocateBuffersForRecord(int numRecordBytes) throws IOException {
     int numBytesRequired = INDEX_ENTRY_SIZE + numRecordBytes;
-    int currentBufferAvailableBytes = writeSegmentIndex == buffers.size() ? 0 : bufferSize - writeSegmentOffset;
+    int availableBytes = writeSegmentIndex == buffers.size() ? 0 : bufferSize - writeSegmentOffset;
 
     // return directly if current available bytes is adequate
-    if (currentBufferAvailableBytes >= numBytesRequired) {
+    if (availableBytes >= numBytesRequired) {
       return true;
     }
 
     // skip the remaining free space if the available bytes is not enough for an index entry
-    if (currentBufferAvailableBytes < INDEX_ENTRY_SIZE) {
-      updateWriteSegmentIndexAndOffset(currentBufferAvailableBytes);
+    if (availableBytes < INDEX_ENTRY_SIZE) {
+      updateWriteSegmentIndexAndOffset(availableBytes);
+      availableBytes = 0;
     }
-    int totalAvailableBytes = (buffers.size() - writeSegmentIndex) * bufferSize - writeSegmentOffset;
 
     // allocate exactly enough buffers for the appended record
     do {
@@ -220,9 +220,9 @@ public class PartitionSortedBuffer implements SortBuffer {
         return false;
       }
 
-      totalAvailableBytes += bufferSize;
+      availableBytes += bufferSize;
       addBuffer(segment);
-    } while (totalAvailableBytes < numBytesRequired);
+    } while (availableBytes < numBytesRequired);
 
     return true;
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Remove unnecessary lock in PartitionSortedBuffer, see https://github.com/apache/flink/pull/18364

### Why are the changes needed?
ditto

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
UT
