### PR TITLE
[CELEBORN-439] Fix java version check in start-worker

### DIFF
--- a/sbin/restart-worker.sh
+++ b/sbin/restart-worker.sh
@@ -33,7 +33,7 @@ if [ "$CELEBORN_WORKER_OFFHEAP_MEMORY" = "" ]; then
 fi
 
 export CELEBORN_JAVA_OPTS="-Xmx$CELEBORN_WORKER_MEMORY -XX:MaxDirectMemorySize=$CELEBORN_WORKER_OFFHEAP_MEMORY $CELEBORN_WORKER_JAVA_OPTS"
-JAVA_VERSION=$(java -version 2>&1 | grep " version " | head -1 | awk '{print $3}' | tr -d '"')
+JAVA_VERSION=$(${JAVA} -version 2>&1 | grep " version " | head -1 | awk '{print $3}' | tr -d '"')
 if [[ ! "$JAVA_VERSION" == 1.8.* ]]; then
   export CELEBORN_JAVA_OPTS="${CELEBORN_JAVA_OPTS} --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --illegal-access=warn -Dio.netty.tryReflectionSetAccessible=true"
 fi

--- a/sbin/start-worker.sh
+++ b/sbin/start-worker.sh
@@ -33,7 +33,7 @@ if [ "$CELEBORN_WORKER_OFFHEAP_MEMORY" = "" ]; then
 fi
 
 export CELEBORN_JAVA_OPTS="-Xmx$CELEBORN_WORKER_MEMORY -XX:MaxDirectMemorySize=$CELEBORN_WORKER_OFFHEAP_MEMORY $CELEBORN_WORKER_JAVA_OPTS"
-JAVA_VERSION=$(java -version 2>&1 | grep " version " | head -1 | awk '{print $3}' | tr -d '"')
+JAVA_VERSION=$(${JAVA} -version 2>&1 | grep " version " | head -1 | awk '{print $3}' | tr -d '"')
 if [[ ! "$JAVA_VERSION" == 1.8.* ]]; then
   export CELEBORN_JAVA_OPTS="${CELEBORN_JAVA_OPTS} --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --illegal-access=warn -Dio.netty.tryReflectionSetAccessible=true"
 fi


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
`JAVA_VERSION` in start-work.sh get a blank return when no `java` command in system. Use ${JAVA} instead.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
local

