### PR TITLE
[CELEBORN-442]Support hdfs compatible file system

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -957,9 +957,10 @@ object Utils extends Logging {
   val SORTED_SUFFIX = ".sorted"
   val INDEX_SUFFIX = ".index"
   val SUFFIX_HDFS_WRITE_SUCCESS = ".success"
+  val COMPATIBLE_HDFS_REGEX = "^[a-zA-z0-9]+://((\\w)+/?)+$"
 
   def isHdfsPath(path: String): Boolean = {
-    path.startsWith("hdfs://")
+    path.matches(COMPATIBLE_HDFS_REGEX)
   }
 
   def getSortedFilePath(path: String): String = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
More and more companies use hdfs compatible distributed file system, such as juicefs, jindofs, ozone. We do not always use the 'hdfs' scheme in the production environment(juicefs uses jfs://xxx/yyy), so when using Celeborn as an RSS service, we have to hardcode to change Celeborn's current implementation logic of isHdfsPath(String path).
It's wonderful that we can use Celeborn normally just after adding the necessary jar package dependencies and core-site.xml configuration.


### Why are the changes needed?
As above.


### Does this PR introduce _any_ user-facing change?
Allows wider configuration for distributed filesystem backend


### How was this patch tested?

