### PR TITLE
[CELEBORN-449] Repair the hdfs path regex

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -957,7 +957,7 @@ object Utils extends Logging {
   val SORTED_SUFFIX = ".sorted"
   val INDEX_SUFFIX = ".index"
   val SUFFIX_HDFS_WRITE_SUCCESS = ".success"
-  val COMPATIBLE_HDFS_REGEX = "^[a-zA-z0-9]+://((\\w)+/?)+$"
+  val COMPATIBLE_HDFS_REGEX = "^[a-zA-z0-9]+://.*"
 
   def isHdfsPath(path: String): Boolean = {
     path.matches(COMPATIBLE_HDFS_REGEX)

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -957,7 +957,7 @@ object Utils extends Logging {
   val SORTED_SUFFIX = ".sorted"
   val INDEX_SUFFIX = ".index"
   val SUFFIX_HDFS_WRITE_SUCCESS = ".success"
-  val COMPATIBLE_HDFS_REGEX = "^[a-zA-z0-9]+://.*"
+  val COMPATIBLE_HDFS_REGEX = "^[a-zA-Z0-9]+://.*"
 
   def isHdfsPath(path: String): Boolean = {
     path.matches(COMPATIBLE_HDFS_REGEX)

--- a/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
@@ -105,6 +105,34 @@ class UtilsSuite extends CelebornFunSuite {
     assert(mapperEnd == mapperEndTrans)
   }
 
+  test("validate hdfs compatible fs path") {
+    val hdfsPath = "hdfs://xxx:9000/xxxx/xx-xx/x-x-x"
+    val simpleHdfsPath = "hdfs:///xxxx/xx-xx/x-x-x"
+    val sortedHdfsPath = "hdfs://xxx:9000/xxxx/xx-xx/x-x-x.sorted"
+    val indexHdfsPath = "hdfs://xxx:9000/xxxx/xx-xx/x-x-x.index"
+    assert(true == Utils.isHdfsPath(hdfsPath))
+    assert(true == Utils.isHdfsPath(sortedHdfsPath))
+    assert(true == Utils.isHdfsPath(indexHdfsPath))
+    assert(true == Utils.isHdfsPath(simpleHdfsPath))
+
+    val juicePath = "jfs://xxxx/xx-xx/x-x-x"
+    val sortedJuicePath = "jfs://xxxx/xx-xx/x-x-x.sorted"
+    val indexJuicePath = "jfs://xxxx/xx-xx/x-x-x.index"
+    assert(true == Utils.isHdfsPath(juicePath))
+    assert(true == Utils.isHdfsPath(sortedJuicePath))
+    assert(true == Utils.isHdfsPath(indexJuicePath))
+
+    val ossPath = "oss://xxxx/xx-xx/x-x-x"
+    val sortedOssPath = "oss://xxxx/xx-xx/x-x-x.sorted"
+    val indexOssPath = "oss://xxxx/xx-xx/x-x-x.index"
+    assert(true == Utils.isHdfsPath(ossPath))
+    assert(true == Utils.isHdfsPath(sortedOssPath))
+    assert(true == Utils.isHdfsPath(indexOssPath))
+
+    val localPath = "/xxx/xxx/xx-xx/x-x-x"
+    assert(false == Utils.isHdfsPath(localPath))
+  }
+
   test("GetReducerFileGroupResponse class convert with pb") {
     val fileGroup = new util.HashMap[Integer, util.Set[PartitionLocation]]
     fileGroup.put(0, partitionLocation(0))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
change the hdfs path regex


### Why are the changes needed?
Path protocols are all started with xxx://, and is unnecessary to restrict the content after that. Actually, it makes an error when write shuffle files which like "xxx://abc/shuffle/hadoop/rss-worker/shuffle_data/spark-0de72e2ce2e24f6db69c2228dd12a514/0/0-0-0"


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?
has been tested in testing environment within the company
