### PR TITLE
[CELEBORN-453] [FLINK] In the removeExpiredShuffle method, the taskShuffleId should be removed instead of the shuffleId

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleTaskInfo.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleTaskInfo.java
@@ -73,7 +73,7 @@ public class ShuffleTaskInfo {
     if (shuffleIdToTaskShuffleId.containsKey(shuffleId)) {
       String taskShuffleId = shuffleIdToTaskShuffleId.remove(shuffleId);
       taskShuffleIdToShuffleId.remove(taskShuffleId);
-      taskShuffleAttemptIdIndex.remove(shuffleId);
+      taskShuffleAttemptIdIndex.remove(taskShuffleId);
       taskShuffleAttemptIdToAttemptId.remove(taskShuffleId);
     }
   }

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/ShuffleTaskInfoSuitJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/ShuffleTaskInfoSuitJ.java
@@ -47,10 +47,13 @@ public class ShuffleTaskInfoSuitJ {
     shuffleTaskInfo.removeExpiredShuffle(encodeShuffleId);
     int encodeShuffleIdNew = shuffleTaskInfo.getShuffleId("shuffleId");
     Assert.assertEquals(encodeShuffleIdNew, 2);
+
+    int encodeAttemptId211 = shuffleTaskInfo.getAttemptId("shuffleId", 1, "attempt1");
+    Assert.assertEquals(encodeAttemptId211, 0);
   }
 
   @Test
-  public void testRemoveNonExistShuffl() {
+  public void testRemoveNonExistShuffle() {
     ShuffleTaskInfo shuffleTaskInfo = new ShuffleTaskInfo();
     // remove none exist shuffle
     shuffleTaskInfo.removeExpiredShuffle(0);


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

In the removeExpiredShuffle method, the taskShuffleId should be removed instead of the shuffleId

### Why are the changes needed?

In the removeExpiredShuffle method, the taskShuffleId should be removed instead of the shuffleId

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?
UT
