### PR TITLE
[CELEBORN-455] Use 4 bytes instead of 16 to read mapId in FileWriter.…

### DIFF
--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SkewJoinSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SkewJoinSuite.scala
@@ -58,6 +58,7 @@ class SkewJoinSuite extends AnyFunSuite
         .set("spark.sql.autoBroadcastJoinThreshold", "-1")
         .set("spark.sql.parquet.compression.codec", "gzip")
         .set("spark.celeborn.shuffle.compression.codec", codec.name)
+        .set("spark.celeborn.shuffle.rangeReadFilter.enabled", "true")
 
       enableRss(sparkConf)
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -200,7 +200,7 @@ public abstract class FileWriter implements DeviceObserver {
         mapIdBitMap.add(mapId);
       }
       if (flushBuffer.readableBytes() != 0
-          && flushBuffer.readableBytes() + numBytes >= this.flusherBufferSize) {
+          && flushBuffer.readableBytes() + numBytes >= flusherBufferSize) {
         flush(false);
         takeBuffer();
       }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -175,7 +175,7 @@ public abstract class FileWriter implements DeviceObserver {
 
     int mapId = 0;
     if (rangeReadFilter) {
-      byte[] header = new byte[16];
+      byte[] header = new byte[4];
       data.markReaderIndex();
       data.readBytes(header);
       data.resetReaderIndex();


### PR DESCRIPTION
…write

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
The header in PushData is (mapId, attemptId, batchId, size), so we only need read 4 bytes to get mapId


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
IT.
