### PR TITLE
[CELEBORN-345] TransportResponseHandler create too much thread

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -73,11 +73,12 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
     this.outstandingPushes = new ConcurrentHashMap<>();
     this.timeOfLastRequestNs = new AtomicLong(0);
     pushTimeoutCheckerInterval = conf.pushDataTimeoutCheckIntervalMs();
-    scheduleFuture = pushTimeoutChecker.scheduleAtFixedRate(
-        () -> failExpiredPushRequest(),
-        pushTimeoutCheckerInterval,
-        pushTimeoutCheckerInterval,
-        TimeUnit.MILLISECONDS);
+    scheduleFuture =
+        pushTimeoutChecker.scheduleAtFixedRate(
+            () -> failExpiredPushRequest(),
+            pushTimeoutCheckerInterval,
+            pushTimeoutCheckerInterval,
+            TimeUnit.MILLISECONDS);
   }
 
   public void failExpiredPushRequest() {

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -62,7 +62,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
 
   private final long pushTimeoutCheckerInterval;
   private static final ScheduledExecutorService pushTimeoutChecker =
-      ThreadUtils.newDaemonThreadPoolScheduledExecutor("push-timeout-checker-", 16);
+      ThreadUtils.newDaemonThreadPoolScheduledExecutor("push-timeout-checker", 16);
   private ScheduledFuture scheduleFuture;
 
   public TransportResponseHandler(TransportConf conf, Channel channel) {

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -72,7 +72,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
     this.outstandingPushes = new ConcurrentHashMap<>();
     this.timeOfLastRequestNs = new AtomicLong(0);
     pushTimeoutCheckerInterval = conf.pushDataTimeoutCheckIntervalMs();
-    synchronized (pushTimeoutChecker) {
+    synchronized (TransportResponseHandler.class) {
       if (pushTimeoutChecker == null) {
         pushTimeoutChecker =
             ThreadUtils.newDaemonThreadPoolScheduledExecutor(

--- a/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
@@ -145,6 +145,10 @@ public class TransportConf {
     return celebornConf;
   }
 
+  public int pushDataTimeoutCheckerThreads() {
+    return celebornConf.pushDataTimeoutCheckerThreads();
+  }
+
   public long pushDataTimeoutCheckIntervalMs() {
     return celebornConf.pushTimeoutCheckInterval();
   }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -695,6 +695,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def rpcCacheConcurrencyLevel: Int = get(RPC_CACHE_CONCURRENCY_LEVEL)
   def rpcCacheExpireTime: Long = get(RPC_CACHE_EXPIRE_TIME)
   def pushDataTimeoutMs: Long = get(PUSH_DATA_TIMEOUT)
+  def pushDataTimeoutCheckerThreads: Int = get(PUSH_TIMEOUT_CHECK_THREADS)
   def pushTimeoutCheckInterval: Long = get(PUSH_TIMEOUT_CHECK_INTERVAL)
   def registerShuffleRpcAskTimeout: RpcTimeout =
     new RpcTimeout(
@@ -1328,6 +1329,14 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("30s")
+
+  val PUSH_TIMEOUT_CHECK_THREADS: ConfigEntry[Long] =
+    buildConf("celeborn.push.timeoutCheck.threads")
+      .categories("common")
+      .doc("Threads num for checking push data timeout.")
+      .version("0.3.0")
+      .intConf
+      .createWithDefault(16)
 
   val FETCH_TIMEOUT: ConfigEntry[Long] =
     buildConf("celeborn.fetch.timeout")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1330,7 +1330,7 @@ object CelebornConf extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("30s")
 
-  val PUSH_TIMEOUT_CHECK_THREADS: ConfigEntry[Long] =
+  val PUSH_TIMEOUT_CHECK_THREADS: ConfigEntry[Int] =
     buildConf("celeborn.push.timeoutCheck.threads")
       .categories("common")
       .doc("Threads num for checking push data timeout.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current `TransportResponseHandler` will create one thread for each channel, it's too much. In this pr, we make it use one public thread pool.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

