### PR TITLE
[CELEBORN-460][BUG][HELM]Helm Upgrade Release Fail due to change image version

### DIFF
--- a/charts/celeborn/Chart.yaml
+++ b/charts/celeborn/Chart.yaml
@@ -39,4 +39,4 @@ version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 0.2.1

--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -23,7 +23,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- include "celeborn.labels" . | nindent 4 }}
 data:

--- a/charts/celeborn/templates/master-service.yaml
+++ b/charts/celeborn/templates/master-service.yaml
@@ -23,7 +23,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- include "celeborn.labels" . | nindent 4 }}
 spec:
@@ -36,6 +36,6 @@ spec:
   clusterIP: None
   selector:
     app.kubernetes.io/name: {{ .Chart.Name }}
-    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/role: master
     {{- include "celeborn.selectorLabels" . | nindent 4 }}

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -23,7 +23,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/role: master
     {{- include "celeborn.labels" . | nindent 4 }}
@@ -32,7 +32,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+      app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       app.kubernetes.io/role: master
       {{- include "celeborn.selectorLabels" . | nindent 6 }}
   serviceName: celeborn-master-svc
@@ -46,7 +46,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
         app.kubernetes.io/role: master
         {{- include "celeborn.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -48,6 +48,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
         app.kubernetes.io/role: master
+        app.kubernetes.io/tag: {{ .Values.image.tag }}
         {{- include "celeborn.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.affinity.master }}

--- a/charts/celeborn/templates/prometheus-podmonitor.yaml
+++ b/charts/celeborn/templates/prometheus-podmonitor.yaml
@@ -25,7 +25,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- include "celeborn.labels" . | nindent 4 }}
 spec:
@@ -50,7 +50,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- include "celeborn.labels" . | nindent 4 }}
 spec:

--- a/charts/celeborn/templates/worker-service.yaml
+++ b/charts/celeborn/templates/worker-service.yaml
@@ -23,7 +23,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- include "celeborn.labels" . | nindent 4 }}
 spec:
@@ -31,6 +31,6 @@ spec:
   clusterIP: None
   selector:
     app.kubernetes.io/name: {{ .Chart.Name }}
-    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/role: worker
     {{- include "celeborn.selectorLabels" . | nindent 4 }}

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -23,7 +23,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/role: worker
     {{- include "celeborn.labels" . | nindent 4 }}
@@ -32,7 +32,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+      app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       app.kubernetes.io/role: worker
       {{- include "celeborn.selectorLabels" . | nindent 6 }}
   serviceName: celeborn-worker
@@ -46,7 +46,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
         app.kubernetes.io/role: worker
         {{- include "celeborn.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -48,6 +48,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
         app.kubernetes.io/role: worker
+        app.kubernetes.io/tag: {{ .Values.image.tag }}
         {{- include "celeborn.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.affinity.worker }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
After https://github.com/apache/incubator-celeborn/pull/1156 PR, Celeborn Master\Worker Statefulset will contains  `app.kubernetes.io/version` label with image tag as value.

Due to [Kubenretes StatefulSet Update only allow 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds'](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#rolling-updates)

We may face Error when `helm upgrade` with image version changed.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

Kubernetes Cluster Test
