### PR TITLE
[CELEBORN-466][FLINK] ReadBufferDispatcher.recycle should log error w…

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferDispatcher.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/memory/ReadBufferDispatcher.java
@@ -48,10 +48,12 @@ public class ReadBufferDispatcher extends Thread {
 
   public void recycle(ByteBuf buf) {
     int bufferSize = buf.capacity();
-    if (buf.refCnt() == 0) {
-      logger.warn("recycle encounter: {}", buf.refCnt());
-    } else {
-      buf.release(buf.refCnt());
+    int refCnt = buf.refCnt();
+    if (refCnt != 1) {
+      logger.error("recycle buffer refCnt: {} not equal to 1!", buf.refCnt());
+    }
+    if (refCnt > 0) {
+      buf.release(refCnt);
     }
     memoryManager.changeReadBufferCounter(-1 * bufferSize);
   }


### PR DESCRIPTION
…hen refCnt != 1

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
ReadBufferDispatcher.recycle should log error when refCnt != 1


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
