### PR TITLE
[CELEBORN-473] Enable file system cache for viewfs in ShuffleClient as well

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -106,9 +106,10 @@ public abstract class ShuffleClient {
           Configuration hdfsConfiguration = new Configuration();
           // enable fs cache to avoid too many fs instances
           hdfsConfiguration.set("fs.hdfs.impl.disable.cache", "false");
+          hdfsConfiguration.set("fs.viewfs.impl.disable.cache", "false");
           logger.info(
               "Celeborn client will ignore cluster"
-                  + " settings about fs.hdfs.impl.disable.cache and set it to false");
+                  + " settings about fs.hdfs/viewfs.impl.disable.cache and set it to false");
           try {
             hdfsFs = FileSystem.get(hdfsConfiguration);
           } catch (IOException e) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

This pr enable cache both for hdfs and viewfs filesystems.

### Why are the changes needed?
For HDFS, hdfs and viewfs are two popular schemas.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UT.
