### PR TITLE
[CELEBORN-474][FOLLOWUP] Using inner static ConcurrentHashMap class and only apply for JDK8

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -48,9 +48,9 @@ class ChangePartitionManager(
   private val pushReplicateEnabled = conf.pushReplicateEnabled
   // shuffleId -> (partitionId -> set of ChangePartition)
   private val changePartitionRequests =
-    new ConcurrentHashMap[Int, ConcurrentHashMap[Integer, JSet[ChangePartitionRequest]]]()
+    JavaUtils.newConcurrentHashMap[Int, ConcurrentHashMap[Integer, JSet[ChangePartitionRequest]]]()
   // shuffleId -> set of partition id
-  private val inBatchPartitions = new ConcurrentHashMap[Int, JSet[Integer]]()
+  private val inBatchPartitions = JavaUtils.newConcurrentHashMap[Int, JSet[Integer]]()
 
   private val batchHandleChangePartitionEnabled = conf.batchHandleChangePartitionEnabled
   private val batchHandleChangePartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -37,6 +37,7 @@ import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc.RpcCallContext
 // Can Remove this if celeborn don't support scala211 in future
 import org.apache.celeborn.common.util.FunctionConverter._
+import org.apache.celeborn.common.util.JavaUtils
 import org.apache.celeborn.common.util.ThreadUtils
 
 case class ShuffleCommittedInfo(
@@ -86,7 +87,7 @@ class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: Lif
       None
     }
   private var batchHandleCommitPartition: Option[ScheduledFuture[_]] = _
-  private val commitHandlers = new ConcurrentHashMap[PartitionType, CommitHandler]()
+  private val commitHandlers = JavaUtils.newConcurrentHashMap[PartitionType, CommitHandler]()
 
   def start(): Unit = {
     batchHandleCommitPartition = batchHandleCommitPartitionSchedulerThread.map {
@@ -172,18 +173,18 @@ class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: Lif
     committedPartitionInfo.put(
       shuffleId,
       ShuffleCommittedInfo(
-        new ConcurrentHashMap[Int, util.List[String]](),
-        new ConcurrentHashMap[Int, util.List[String]](),
-        new ConcurrentHashMap[String, WorkerInfo](),
-        new ConcurrentHashMap[String, WorkerInfo](),
-        new ConcurrentHashMap[String, StorageInfo](),
-        new ConcurrentHashMap[String, StorageInfo](),
-        new ConcurrentHashMap[String, RoaringBitmap](),
+        JavaUtils.newConcurrentHashMap[Int, util.List[String]](),
+        JavaUtils.newConcurrentHashMap[Int, util.List[String]](),
+        JavaUtils.newConcurrentHashMap[String, WorkerInfo](),
+        JavaUtils.newConcurrentHashMap[String, WorkerInfo](),
+        JavaUtils.newConcurrentHashMap[String, StorageInfo](),
+        JavaUtils.newConcurrentHashMap[String, StorageInfo](),
+        JavaUtils.newConcurrentHashMap[String, RoaringBitmap](),
         new LongAdder,
         new util.HashSet[PartitionLocation](),
         new util.HashSet[PartitionLocation](),
         new AtomicInteger(),
-        new ConcurrentHashMap[Int, AtomicInteger]()))
+        JavaUtils.newConcurrentHashMap[Int, AtomicInteger]()))
 
     getCommitHandler(shuffleId).registerShuffle(shuffleId, numMappers);
   }

--- a/client/src/main/scala/org/apache/celeborn/client/ReleasePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ReleasePartitionManager.scala
@@ -27,7 +27,7 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{ShufflePartitionLocationInfo, WorkerInfo}
 import org.apache.celeborn.common.protocol.message.ControlMessages.WorkerResource
-import org.apache.celeborn.common.util.ThreadUtils
+import org.apache.celeborn.common.util.{JavaUtils, ThreadUtils}
 
 class ReleasePartitionManager(
     appId: String,
@@ -36,7 +36,7 @@ class ReleasePartitionManager(
   extends Logging {
 
   // shuffleId -> (partitionId set of release)
-  private val shuffleReleasePartitionRequests = new ConcurrentHashMap[Int, util.Set[Int]]
+  private val shuffleReleasePartitionRequests = JavaUtils.newConcurrentHashMap[Int, util.Set[Int]]
   private val batchHandleReleasePartitionEnabled = conf.batchHandleReleasePartitionEnabled
   private val batchHandleReleasePartitionExecutors = ThreadUtils.newDaemonCachedThreadPool(
     "rss-lifecycle-manager-release-partition-executor",

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -184,8 +184,8 @@ abstract class CommitHandler(
       allocatedWorkers: util.Map[WorkerInfo, ShufflePartitionLocationInfo],
       partitionIdOpt: Option[Int] = None): CommitResult = {
     val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
-    val masterPartMap = new ConcurrentHashMap[String, PartitionLocation]
-    val slavePartMap = new ConcurrentHashMap[String, PartitionLocation]
+    val masterPartMap = JavaUtils.newConcurrentHashMap[String, PartitionLocation]
+    val slavePartMap = JavaUtils.newConcurrentHashMap[String, PartitionLocation]
     val commitFilesFailedWorkers = new ShuffleFailedWorkers()
 
     if (CollectionUtils.isEmpty(allocatedWorkers)) {

--- a/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
@@ -55,10 +55,10 @@ class MapPartitionCommitHandler(
   extends CommitHandler(appId, conf, committedPartitionInfo)
   with Logging {
 
-  private val shuffleSucceedPartitionIds = new ConcurrentHashMap[Int, util.Set[Integer]]()
+  private val shuffleSucceedPartitionIds = JavaUtils.newConcurrentHashMap[Int, util.Set[Integer]]()
 
   // shuffleId -> in processing partitionId set
-  private val inProcessMapPartitionEndIds = new ConcurrentHashMap[Int, util.Set[Integer]]()
+  private val inProcessMapPartitionEndIds = JavaUtils.newConcurrentHashMap[Int, util.Set[Integer]]()
 
   override def getPartitionType(): PartitionType = {
     PartitionType.MAP

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -57,7 +57,7 @@ class ReducePartitionCommitHandler(
   private val dataLostShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
-  private val shuffleMapperAttempts = new ConcurrentHashMap[Int, Array[Int]]()
+  private val shuffleMapperAttempts = JavaUtils.newConcurrentHashMap[Int, Array[Int]]()
   private val stageEndTimeout = conf.pushStageEndTimeout
 
   private val rpcCacheSize = conf.rpcCacheSize

--- a/common/src/main/java/org/apache/celeborn/common/util/JavaUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/JavaUtils.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -430,11 +431,28 @@ public class JavaUtils {
     }
   }
 
+  public static <K, V> ConcurrentHashMap<K, V> newConcurrentHashMap(
+      Map<? extends K, ? extends V> m) {
+    if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
+      return new ConcurrentHashMap(m);
+    } else {
+      return new ConcurrentHashMapForJDK8(m);
+    }
+  }
+
   /**
    * For JDK8, there is bug for ConcurrentHashMap#computeIfAbsent, checking the key existence to
    * speed up. See details in CELEBORN-474.
    */
   private static class ConcurrentHashMapForJDK8<K, V> extends ConcurrentHashMap<K, V> {
+    public ConcurrentHashMapForJDK8() {
+      super();
+    }
+
+    public ConcurrentHashMapForJDK8(Map<? extends K, ? extends V> m) {
+      super(m);
+    }
+
     @Override
     public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
       V result;

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -36,7 +36,7 @@ import org.apache.celeborn.common.protocol.StorageInfo.Type
 import org.apache.celeborn.common.protocol.StorageInfo.Type.{HDD, SSD}
 import org.apache.celeborn.common.quota.DefaultQuotaManager
 import org.apache.celeborn.common.rpc.RpcTimeout
-import org.apache.celeborn.common.util.Utils
+import org.apache.celeborn.common.util.{JavaUtils, Utils}
 
 class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Serializable {
 
@@ -45,7 +45,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   /** Create a CelebornConf that loads defaults from system properties and the classpath */
   def this() = this(true)
 
-  private val settings = new ConcurrentHashMap[String, String]()
+  private val settings = JavaUtils.newConcurrentHashMap[String, String]()
 
   @transient private lazy val reader: ConfigReader = {
     val _reader = new ConfigReader(new CelebornConfigProvider(settings))

--- a/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigEntry.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigEntry.scala
@@ -19,6 +19,8 @@ package org.apache.celeborn.common.internal.config
 
 import java.util.concurrent.ConcurrentHashMap
 
+import org.apache.celeborn.common.util.JavaUtils
+
 // ====================================================================================
 //                      The guideline for naming configurations
 // ====================================================================================
@@ -281,7 +283,7 @@ object ConfigEntry {
 
   val UNDEFINED = "<undefined>"
 
-  private val knownConfigs = new ConcurrentHashMap[String, ConfigEntry[_]]()
+  private val knownConfigs = JavaUtils.newConcurrentHashMap[String, ConfigEntry[_]]()
 
   def registerEntry(entry: ConfigEntry[_]): Unit = {
     val existing = knownConfigs.putIfAbsent(entry.key, entry)

--- a/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.protocol.StorageInfo
+import org.apache.celeborn.common.util.JavaUtils
 import org.apache.celeborn.common.util.Utils.runCommand
 
 class DiskInfo(
@@ -223,8 +224,8 @@ object DeviceInfo {
       mountPointToDeviceInfo.putIfAbsent(mountPoint, deviceInfo)
     }
 
-    val retDeviceInfos = new ConcurrentHashMap[String, DeviceInfo]()
-    val retDiskInfos = new ConcurrentHashMap[String, DiskInfo]()
+    val retDeviceInfos = JavaUtils.newConcurrentHashMap[String, DeviceInfo]()
+    val retDiskInfos = JavaUtils.newConcurrentHashMap[String, DiskInfo]()
 
     workingDirs.groupBy { f =>
       getMountPoint(f._1.getAbsolutePath, mountPointToDeviceInfo.keySet())

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -28,6 +28,7 @@ import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.quota.ResourceConsumption
 import org.apache.celeborn.common.rpc.RpcEndpointRef
 import org.apache.celeborn.common.rpc.netty.NettyRpcEndpointRef
+import org.apache.celeborn.common.util.JavaUtils
 
 class WorkerInfo(
     val host: String,
@@ -49,7 +50,7 @@ class WorkerInfo(
       fetchPort,
       replicatePort,
       new util.HashMap[String, DiskInfo](),
-      new ConcurrentHashMap[UserIdentifier, ResourceConsumption](),
+      JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption](),
       null)
   }
 
@@ -67,7 +68,7 @@ class WorkerInfo(
       fetchPort,
       replicatePort,
       new util.HashMap[String, DiskInfo](),
-      new ConcurrentHashMap[UserIdentifier, ResourceConsumption](),
+      JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption](),
       endpoint)
   }
 
@@ -217,7 +218,9 @@ class WorkerInfo(
         diskInfos.remove(nonExistsMountPoint)
       }
     }
-    new ConcurrentHashMap[String, DiskInfo](diskInfos)
+    val diskInfoMap = JavaUtils.newConcurrentHashMap[String, DiskInfo]()
+    diskInfoMap.putAll(diskInfos)
+    diskInfoMap
   }
 
   def updateThenGetUserResourceConsumption(consumption: util.Map[

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -218,9 +218,7 @@ class WorkerInfo(
         diskInfos.remove(nonExistsMountPoint)
       }
     }
-    val diskInfoMap = JavaUtils.newConcurrentHashMap[String, DiskInfo]()
-    diskInfoMap.putAll(diskInfos)
-    diskInfoMap
+    JavaUtils.newConcurrentHashMap[String, DiskInfo](diskInfos)
   }
 
   def updateThenGetUserResourceConsumption(consumption: util.Map[

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.protocol.PartitionLocation
+import org.apache.celeborn.common.util.JavaUtils
 
 class WorkerPartitionLocationInfo extends Logging {
 
@@ -146,7 +147,9 @@ class WorkerPartitionLocationInfo extends Logging {
       locations: util.List[PartitionLocation],
       partitionInfo: PartitionInfo): Unit = {
     if (locations != null && locations.size() > 0) {
-      partitionInfo.putIfAbsent(shuffleKey, new ConcurrentHashMap[Long, PartitionLocation]())
+      partitionInfo.putIfAbsent(
+        shuffleKey,
+        JavaUtils.newConcurrentHashMap[Long, PartitionLocation]())
       val partitionMap = partitionInfo.get(shuffleKey)
       locations.asScala.foreach { loc =>
         partitionMap.putIfAbsent(encode(loc.getId, loc.getEpoch), loc)

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -28,7 +28,7 @@ import com.codahale.metrics._
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.metrics.{MetricLabels, ResettableSlidingWindowReservoir, RssHistogram, RssTimer}
-import org.apache.celeborn.common.util.{ThreadUtils, Utils}
+import org.apache.celeborn.common.util.{JavaUtils, ThreadUtils, Utils}
 
 case class NamedCounter(name: String, counter: Counter, labels: Map[String, String])
   extends MetricLabels
@@ -90,7 +90,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
   }
 
   protected val namedTimers =
-    new ConcurrentHashMap[String, (NamedTimer, ConcurrentHashMap[String, Long])]()
+    JavaUtils.newConcurrentHashMap[String, (NamedTimer, ConcurrentHashMap[String, Long])]()
 
   def addTimer(name: String): Unit = addTimer(name, Map.empty[String, String])
 
@@ -100,12 +100,14 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
         metricRegistry.timer(metricNameWithLabels(name, labels + roleLabel), timerSupplier)
       namedTimers.putIfAbsent(
         metricNameWithLabels(name, labels + roleLabel),
-        (NamedTimer(name, timer, labels + roleLabel), new ConcurrentHashMap[String, Long]()))
+        (
+          NamedTimer(name, timer, labels + roleLabel),
+          JavaUtils.newConcurrentHashMap[String, Long]()))
     }
   }
 
   protected val namedCounters: ConcurrentHashMap[String, NamedCounter] =
-    new ConcurrentHashMap[String, NamedCounter]()
+    JavaUtils.newConcurrentHashMap[String, NamedCounter]()
 
   def addCounter(name: String): Unit = addCounter(name, Map.empty[String, String])
 

--- a/common/src/main/scala/org/apache/celeborn/common/quota/QuotaManager.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/quota/QuotaManager.scala
@@ -21,11 +21,12 @@ import java.util.concurrent.ConcurrentHashMap
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.util.JavaUtils
 
 abstract class QuotaManager(conf: CelebornConf) extends Logging {
 
   val userQuotas: ConcurrentHashMap[UserIdentifier, Quota] =
-    new ConcurrentHashMap[UserIdentifier, Quota]()
+    JavaUtils.newConcurrentHashMap[UserIdentifier, Quota]()
 
   /**
    * Initialize user quota settings.

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Dispatcher.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/Dispatcher.scala
@@ -28,7 +28,7 @@ import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.network.client.RpcResponseCallback
 import org.apache.celeborn.common.rpc._
-import org.apache.celeborn.common.util.ThreadUtils
+import org.apache.celeborn.common.util.{JavaUtils, ThreadUtils}
 
 /**
  * A message dispatcher, responsible for routing RPC messages to the appropriate endpoint(s).
@@ -46,9 +46,9 @@ private[celeborn] class Dispatcher(nettyEnv: NettyRpcEnv, numUsableCores: Int) e
   }
 
   private val endpoints: ConcurrentMap[String, EndpointData] =
-    new ConcurrentHashMap[String, EndpointData]
+    JavaUtils.newConcurrentHashMap[String, EndpointData]
   private val endpointRefs: ConcurrentMap[RpcEndpoint, RpcEndpointRef] =
-    new ConcurrentHashMap[RpcEndpoint, RpcEndpointRef]
+    JavaUtils.newConcurrentHashMap[RpcEndpoint, RpcEndpointRef]
 
   // Track the receivers whose inboxes may contain messages.
   private val receivers = new LinkedBlockingQueue[EndpointData]

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
@@ -42,7 +42,7 @@ import org.apache.celeborn.common.network.server._
 import org.apache.celeborn.common.protocol.{RpcNameConstants, TransportModuleConstants}
 import org.apache.celeborn.common.rpc._
 import org.apache.celeborn.common.serializer.{JavaSerializer, JavaSerializerInstance, SerializationStream}
-import org.apache.celeborn.common.util.{ByteBufferInputStream, ByteBufferOutputStream, ThreadUtils, Utils}
+import org.apache.celeborn.common.util.{ByteBufferInputStream, ByteBufferOutputStream, JavaUtils, ThreadUtils, Utils}
 
 class NettyRpcEnv(
     val conf: CelebornConf,
@@ -83,7 +83,7 @@ class NettyRpcEnv(
    * A map for [[RpcAddress]] and [[Outbox]]. When we are connecting to a remote [[RpcAddress]],
    * we just put messages to its [[Outbox]] to implement a non-blocking `send` method.
    */
-  private val outboxes = new ConcurrentHashMap[RpcAddress, Outbox]()
+  private val outboxes = JavaUtils.newConcurrentHashMap[RpcAddress, Outbox]()
 
   /**
    * Remove the address's Outbox and stop it.
@@ -537,7 +537,7 @@ private[celeborn] class NettyRpcHandler(
     nettyEnv: NettyRpcEnv) extends BaseMessageHandler with Logging {
 
   // A variable to track the remote RpcEnv addresses of all clients
-  private val remoteAddresses = new ConcurrentHashMap[RpcAddress, RpcAddress]()
+  private val remoteAddresses = JavaUtils.newConcurrentHashMap[RpcAddress, RpcAddress]()
 
   override def receive(
       client: TransportClient,

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -109,7 +109,7 @@ object PbSerDeUtils {
       data: Array[Byte],
       cache: ConcurrentHashMap[String, UserIdentifier]): ConcurrentHashMap[String, FileInfo] = {
     val pbFileInfoMap = PbFileInfoMap.parseFrom(data)
-    val fileInfoMap = new ConcurrentHashMap[String, FileInfo]
+    val fileInfoMap = JavaUtils.newConcurrentHashMap[String, FileInfo]
     pbFileInfoMap.getValuesMap.entrySet().asScala.foreach { entry =>
       val fileName = entry.getKey
       val pbFileInfo = entry.getValue
@@ -128,7 +128,7 @@ object PbSerDeUtils {
   }
 
   def toPbFileInfoMap(fileInfoMap: ConcurrentHashMap[String, FileInfo]): Array[Byte] = {
-    val pbFileInfoMap = new ConcurrentHashMap[String, PbFileInfo]()
+    val pbFileInfoMap = JavaUtils.newConcurrentHashMap[String, PbFileInfo]()
     fileInfoMap.entrySet().asScala.foreach { entry =>
       pbFileInfoMap.put(entry.getKey, toPbFileInfo(entry.getValue))
     }
@@ -177,7 +177,7 @@ object PbSerDeUtils {
   }
 
   def fromPbWorkerInfo(pbWorkerInfo: PbWorkerInfo): WorkerInfo = {
-    val disks = new ConcurrentHashMap[String, DiskInfo]
+    val disks = JavaUtils.newConcurrentHashMap[String, DiskInfo]
     if (pbWorkerInfo.getDisksCount > 0) {
       pbWorkerInfo.getDisksList.asScala.foreach(pbDiskInfo =>
         disks.put(pbDiskInfo.getMountPoint, fromPbDiskInfo(pbDiskInfo)))

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -449,7 +449,7 @@ object Utils extends Logging {
 
   // Typically, this will be of order of number of nodes in cluster
   // If not, we should change it to LRUCache or something.
-  private val hostPortParseResults = new ConcurrentHashMap[String, (String, Int)]()
+  private val hostPortParseResults = JavaUtils.newConcurrentHashMap[String, (String, Int)]()
 
   def parseHostPort(hostPort: String): (String, Int) = {
     // Check cache first.

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -34,7 +34,7 @@ import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.quota.ResourceConsumption
 import org.apache.celeborn.common.rpc.{RpcAddress, RpcEndpointAddress, RpcEndpointRef, RpcEnv, RpcTimeout}
 import org.apache.celeborn.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
-import org.apache.celeborn.common.util.ThreadUtils
+import org.apache.celeborn.common.util.{JavaUtils, ThreadUtils}
 
 class WorkerInfoSuite extends CelebornFunSuite {
 
@@ -67,7 +67,8 @@ class WorkerInfoSuite extends CelebornFunSuite {
     disks.put("disk1", new DiskInfo("disk1", Int.MaxValue, 1, 1, 0))
     disks.put("disk2", new DiskInfo("disk2", Int.MaxValue, 1, 1, 0))
     disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 1, 1, 0))
-    val userResourceConsumption = new ConcurrentHashMap[UserIdentifier, ResourceConsumption]()
+    val userResourceConsumption =
+      JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption]()
     userResourceConsumption.put(UserIdentifier("tenant1", "name1"), ResourceConsumption(1, 1, 1, 1))
     val worker =
       new WorkerInfo("localhost", 10000, 10001, 10002, 10003, disks, userResourceConsumption, null)
@@ -227,7 +228,8 @@ class WorkerInfoSuite extends CelebornFunSuite {
     disks.put("disk1", new DiskInfo("disk1", Int.MaxValue, 1, 1, 10))
     disks.put("disk2", new DiskInfo("disk2", Int.MaxValue, 2, 2, 20))
     disks.put("disk3", new DiskInfo("disk3", Int.MaxValue, 3, 3, 30))
-    val userResourceConsumption = new ConcurrentHashMap[UserIdentifier, ResourceConsumption]()
+    val userResourceConsumption =
+      JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption]()
     userResourceConsumption.put(
       UserIdentifier("tenant1", "name1"),
       ResourceConsumption(20971520, 1, 52428800, 1))

--- a/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
@@ -19,7 +19,6 @@ package org.apache.celeborn.common.util
 
 import java.io.File
 import java.util
-import java.util.concurrent.ConcurrentHashMap
 
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.identity.UserIdentifier
@@ -57,10 +56,10 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
 
   val fileInfo1 = new FileInfo("/tmp/1", chunkOffsets1, userIdentifier1)
   val fileInfo2 = new FileInfo("/tmp/2", chunkOffsets2, userIdentifier2)
-  val fileInfoMap = new ConcurrentHashMap[String, FileInfo]()
+  val fileInfoMap = JavaUtils.newConcurrentHashMap[String, FileInfo]()
   fileInfoMap.put("file1", fileInfo1)
   fileInfoMap.put("file2", fileInfo2)
-  val cache = new ConcurrentHashMap[String, UserIdentifier]()
+  val cache = JavaUtils.newConcurrentHashMap[String, UserIdentifier]()
 
   val resourceConsumption1 = ResourceConsumption(1000, 2000, 3000, 4000)
   val resourceConsumption2 = ResourceConsumption(2000, 4000, 6000, 8000)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -37,7 +37,7 @@ import org.apache.celeborn.common.protocol.message.{ControlMessages, StatusCode}
 import org.apache.celeborn.common.protocol.message.ControlMessages._
 import org.apache.celeborn.common.quota.{QuotaManager, ResourceConsumption}
 import org.apache.celeborn.common.rpc._
-import org.apache.celeborn.common.util.{PbSerDeUtils, ThreadUtils, Utils}
+import org.apache.celeborn.common.util.{JavaUtils, PbSerDeUtils, ThreadUtils, Utils}
 import org.apache.celeborn.server.common.{HttpService, Service}
 import org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager
 import org.apache.celeborn.service.deploy.master.clustermeta.ha.{HAHelper, HAMasterMetaManager, MetaHandler}
@@ -99,13 +99,13 @@ private[celeborn] class Master(
   private val quotaManager = QuotaManager.instantiate(conf)
   private val metricsResourceConsumptionInterval = conf.metricsResourceConsumptionInterval
   private val userResourceConsumptions =
-    new ConcurrentHashMap[UserIdentifier, (ResourceConsumption, Long)]()
+    JavaUtils.newConcurrentHashMap[UserIdentifier, (ResourceConsumption, Long)]()
 
   // States
   private def workersSnapShot: util.List[WorkerInfo] =
     statusSystem.workers.synchronized(new util.ArrayList[WorkerInfo](statusSystem.workers))
   private def lostWorkersSnapshot: ConcurrentHashMap[WorkerInfo, java.lang.Long] =
-    statusSystem.workers.synchronized(new ConcurrentHashMap(statusSystem.lostWorkers))
+    statusSystem.workers.synchronized(JavaUtils.newConcurrentHashMap(statusSystem.lostWorkers))
 
   private def diskReserveSize = conf.diskReserveSize
 
@@ -417,7 +417,7 @@ private[celeborn] class Master(
       fetchPort,
       replicatePort,
       new util.HashMap[String, DiskInfo](),
-      new ConcurrentHashMap[UserIdentifier, ResourceConsumption](),
+      JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption](),
       null)
     val worker: WorkerInfo = workersSnapShot
       .asScala
@@ -807,7 +807,7 @@ private[celeborn] class Master(
       -1,
       -1,
       new util.HashMap[String, DiskInfo](),
-      new ConcurrentHashMap[UserIdentifier, ResourceConsumption](),
+      JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption](),
       null))
     GetWorkerInfosResponse(StatusCode.REQUEST_FAILED, result.asScala: _*)
   }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 
@@ -264,7 +263,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
 
     // Wait for update snapshot
     Thread.sleep(60000);
-    Map<String, Long> appDiskUsage = new ConcurrentHashMap<String, Long>();
+    Map<String, Long> appDiskUsage = JavaUtils.newConcurrentHashMap();
     appDiskUsage.put("app-1", 100L);
     appDiskUsage.put("app-2", 200L);
     masterStatusSystem.appDiskUsageMetric.update(appDiskUsage);

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -37,7 +37,7 @@ import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMod
 import org.apache.celeborn.common.protocol.message.ControlMessages._
 import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc._
-import org.apache.celeborn.common.util.Utils
+import org.apache.celeborn.common.util.{JavaUtils, Utils}
 import org.apache.celeborn.service.deploy.worker.storage.StorageManager
 
 private[deploy] class Controller(
@@ -351,7 +351,7 @@ private[deploy] class Controller(
 
     val shuffleCommitTimeout = conf.workerShuffleCommitTimeout
 
-    shuffleCommitInfos.putIfAbsent(shuffleKey, new ConcurrentHashMap[Long, CommitInfo]())
+    shuffleCommitInfos.putIfAbsent(shuffleKey, JavaUtils.newConcurrentHashMap[Long, CommitInfo]())
     val epochCommitMap = shuffleCommitInfos.get(shuffleKey)
     epochCommitMap.putIfAbsent(epoch, new CommitInfo(null, CommitInfo.COMMIT_NOTSTARTED))
     val commitInfo = epochCommitMap.get(epoch)
@@ -409,9 +409,9 @@ private[deploy] class Controller(
     val committedSlaveIds = ConcurrentHashMap.newKeySet[String]()
     val failedMasterIds = ConcurrentHashMap.newKeySet[String]()
     val failedSlaveIds = ConcurrentHashMap.newKeySet[String]()
-    val committedMasterStorageInfos = new ConcurrentHashMap[String, StorageInfo]()
-    val committedSlaveStorageInfos = new ConcurrentHashMap[String, StorageInfo]()
-    val committedMapIdBitMap = new ConcurrentHashMap[String, RoaringBitmap]()
+    val committedMasterStorageInfos = JavaUtils.newConcurrentHashMap[String, StorageInfo]()
+    val committedSlaveStorageInfos = JavaUtils.newConcurrentHashMap[String, StorageInfo]()
+    val committedMapIdBitMap = JavaUtils.newConcurrentHashMap[String, RoaringBitmap]()
     val partitionSizeList = new LinkedBlockingQueue[Long]()
 
     val masterFuture =

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/ObservedDevice.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/ObservedDevice.scala
@@ -30,12 +30,13 @@ import org.slf4j.LoggerFactory
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus}
 import org.apache.celeborn.common.metrics.source.AbstractSource
+import org.apache.celeborn.common.util.JavaUtils
 
 class ObservedDevice(val deviceInfo: DeviceInfo, conf: CelebornConf, workerSource: AbstractSource) {
 
   val logger = LoggerFactory.getLogger(classOf[ObservedDevice])
 
-  val diskInfos = new ConcurrentHashMap[String, DiskInfo]()
+  val diskInfos = JavaUtils.newConcurrentHashMap[String, DiskInfo]()
   deviceInfo.diskInfos.foreach { case diskInfo =>
     diskInfos.put(diskInfo.mountPoint, diskInfo)
   }
@@ -45,7 +46,7 @@ class ObservedDevice(val deviceInfo: DeviceInfo, conf: CelebornConf, workerSourc
   val statFile = new File(s"$sysBlockDir/${deviceInfo.name}/stat")
   val inFlightFile = new File(s"$sysBlockDir/${deviceInfo.name}/inflight")
 
-  val nonCriticalErrors = new ConcurrentHashMap[DiskStatus, util.Set[Long]]()
+  val nonCriticalErrors = JavaUtils.newConcurrentHashMap[DiskStatus, util.Set[Long]]()
   val notifyErrorThreshold = conf.diskMonitorNotifyErrorThreshold
   val notifyErrorExpireTimeout = conf.diskMonitorNotifyErrorExpireTimeout
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
@@ -20,7 +20,6 @@ package org.apache.celeborn.service.deploy.worker.storage
 import java.io.File
 import java.util
 import java.util.{HashSet => JHashSet}
-import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
 
@@ -31,6 +30,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType}
+import org.apache.celeborn.common.util.JavaUtils
 import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 
 class WorkerSuite extends AnyFunSuite {
@@ -77,7 +77,7 @@ class WorkerSuite extends AnyFunSuite {
     val worker = new Worker(conf, workerArgs)
     val dir = new File("/tmp")
     val allWriters = new util.HashSet[FileWriter]()
-    val map = new ConcurrentHashMap[String, FileWriter]()
+    val map = JavaUtils.newConcurrentHashMap[String, FileWriter]()
     worker.storageManager.workingDirWriters.put(dir, map)
     worker.storageManager.workingDirWriters.asScala.foreach { case (_, writers) =>
       writers.synchronized {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Using inner static ConcurrentHashMap class and bypass for JDK9 above.

### Why are the changes needed?
Address comments: https://github.com/apache/incubator-celeborn/pull/1383#discussion_r1148521718 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

Existing UT.