### PR TITLE
[CELEBORN-479][PERF] Refactor DataPushQueue.takePushTask to avoid busy wait

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -80,7 +80,7 @@ public class DataPushQueue {
   }
 
   /*
-   * Now, `takePushTask` is only used by one thread,
+   * Now, `takePushTasks` is only used by one thread,
    * so it is not thread-safe.
    * */
   public ArrayList<PushTask> takePushTasks() throws IOException {

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -100,7 +100,7 @@ public class DataPushQueue {
           PartitionLocation loc = partitionLocationMap.get(partitionId);
           Integer oldCapacity = workerCapacity.get(loc.hostAndPushPort());
           if (oldCapacity == null) {
-            oldCapacity = pushState.pushCapacity(loc.hostAndPushPort(), maxInFlight);
+            oldCapacity = maxInFlight - pushState.inflightPushes(loc.hostAndPushPort());
             workerCapacity.put(loc.hostAndPushPort(), oldCapacity);
           }
           if (oldCapacity > 0) {

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -87,7 +87,8 @@ public class DataPushQueue {
     ArrayList<PushTask> tasks = new ArrayList<>();
     HashMap<String, Integer> workerCapacity = new HashMap<>();
     while (dataPusher.stillRunning()) {
-      // clear() here is necessary since pushCapacity might change after sleeping takeTaskWaitTimeMs
+      // clear() here is necessary since inflight pushes might change after sleeping
+      // takeTaskWaitTimeMs
       // in last loop
       workerCapacity.clear();
       Iterator<PushTask> iterator = workingQueue.iterator();

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -18,6 +18,7 @@
 package org.apache.celeborn.client.write;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -121,12 +122,12 @@ public class DataPusher {
           public void run() {
             while (stillRunning()) {
               try {
-                PushTask task = dataPushQueue.takePushTask();
-                if (Objects.isNull(task)) {
-                  continue;
+                ArrayList<PushTask> tasks = dataPushQueue.takePushTasks();
+                for (int i = 0; i < tasks.size(); i++) {
+                  PushTask task = tasks.get(i);
+                  pushData(task);
+                  reclaimTask(task);
                 }
-                pushData(task);
-                reclaimTask(task);
               } catch (CelebornIOException e) {
                 exceptionRef.set(e);
               } catch (InterruptedException | IOException e) {

--- a/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuitJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuitJ.java
@@ -129,13 +129,16 @@ public class DataPushQueueSuitJ {
             () -> {
               while (running.get()) {
                 try {
-                  PushTask task = dataPushQueue.takePushTask();
-                  byte[] buffer = task.getBuffer();
-                  int partitionId = task.getPartitionId();
-                  tarWorkerData.get(partitionId % numWorker).add(bytesToInt(buffer));
-                  pushState.removeBatch(
-                      partitionBatchIdMap.get(partitionId),
-                      reducePartitionMap.get(partitionId).hostAndPushPort());
+                  ArrayList<PushTask> tasks = dataPushQueue.takePushTasks();
+                  for (int i = 0; i < tasks.size(); i++) {
+                    PushTask task = tasks.get(i);
+                    byte[] buffer = task.getBuffer();
+                    int partitionId = task.getPartitionId();
+                    tarWorkerData.get(partitionId % numWorker).add(bytesToInt(buffer));
+                    pushState.removeBatch(
+                        partitionBatchIdMap.get(partitionId),
+                        reducePartitionMap.get(partitionId).hostAndPushPort());
+                  }
                 } catch (IOException e) {
                   throw new RuntimeException(e);
                 }

--- a/common/src/main/java/org/apache/celeborn/common/write/InFlightRequestTracker.java
+++ b/common/src/main/java/org/apache/celeborn/common/write/InFlightRequestTracker.java
@@ -160,15 +160,6 @@ public class InFlightRequestTracker {
     return times <= 0;
   }
 
-  public int pushCapacity(String hostAndPushPort, int maxInFlight) throws IOException {
-    if (pushState.exception.get() != null) {
-      throw pushState.exception.get();
-    }
-
-    Set<Integer> batchIdSet = getBatchIdSetByAddressPair(hostAndPushPort);
-    return maxInFlight - batchIdSet.size();
-  }
-
   protected int nextBatchId() {
     return batchId.incrementAndGet();
   }

--- a/common/src/main/java/org/apache/celeborn/common/write/InFlightRequestTracker.java
+++ b/common/src/main/java/org/apache/celeborn/common/write/InFlightRequestTracker.java
@@ -160,13 +160,13 @@ public class InFlightRequestTracker {
     return times <= 0;
   }
 
-  public boolean reachLimit(String hostAndPushPort, int maxInFlight) throws IOException {
+  public int pushCapacity(String hostAndPushPort, int maxInFlight) throws IOException {
     if (pushState.exception.get() != null) {
       throw pushState.exception.get();
     }
 
     Set<Integer> batchIdSet = getBatchIdSetByAddressPair(hostAndPushPort);
-    return batchIdSet.size() > maxInFlight;
+    return maxInFlight - batchIdSet.size();
   }
 
   protected int nextBatchId() {

--- a/common/src/main/java/org/apache/celeborn/common/write/PushState.java
+++ b/common/src/main/java/org/apache/celeborn/common/write/PushState.java
@@ -90,7 +90,7 @@ public class PushState {
     return inFlightRequestTracker.limitZeroInFlight();
   }
 
-  public int pushCapacity(String hostAndPushPort, int maxInFlight) throws IOException {
-    return inFlightRequestTracker.pushCapacity(hostAndPushPort, maxInFlight);
+  public int inflightPushes(String hostAndPushPort) {
+    return inFlightRequestTracker.getBatchIdSetByAddressPair(hostAndPushPort).size();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/write/PushState.java
+++ b/common/src/main/java/org/apache/celeborn/common/write/PushState.java
@@ -90,7 +90,7 @@ public class PushState {
     return inFlightRequestTracker.limitZeroInFlight();
   }
 
-  public boolean reachLimit(String hostAndPushPort, int maxInFlight) throws IOException {
-    return inFlightRequestTracker.reachLimit(hostAndPushPort, maxInFlight);
+  public int pushCapacity(String hostAndPushPort, int maxInFlight) throws IOException {
+    return inFlightRequestTracker.pushCapacity(hostAndPushPort, maxInFlight);
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -683,6 +683,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     }
   def pushLimitInFlightSleepDeltaMs: Long = get(PUSH_LIMIT_IN_FLIGHT_SLEEP_INTERVAL)
   def pushSplitPartitionThreads: Int = get(PUSH_SPLIT_PARTITION_THREADS)
+  def pushTakeTaskWaitTimeMs: Long = get(PUSH_TAKE_TASK_WAIT_TIME)
   def partitionSplitMode: PartitionSplitMode = PartitionSplitMode.valueOf(get(PARTITION_SPLIT_MODE))
   def partitionSplitThreshold: Long = get(PARTITION_SPLIT_THRESHOLD)
   def batchHandleChangePartitionEnabled: Boolean = get(BATCH_HANDLE_CHANGE_PARTITION_ENABLED)
@@ -2343,6 +2344,14 @@ object CelebornConf extends Logging {
       .version("0.2.0")
       .intConf
       .createWithDefault(8)
+
+  val PUSH_TAKE_TASK_WAIT_TIME: ConfigEntry[Long] =
+    buildConf("celeborn.push.takeTaskWaitTime")
+      .categories("client")
+      .doc("Wait time if no task available to push to worker.")
+      .version("0.3.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("100ms")
 
   val PARTITION_SPLIT_THRESHOLD: ConfigEntry[Long] =
     buildConf("celeborn.shuffle.partitionSplit.threshold")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2351,7 +2351,7 @@ object CelebornConf extends Logging {
       .doc("Wait time if no task available to push to worker.")
       .version("0.3.0")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("100ms")
+      .createWithDefaultString("50ms")
 
   val PARTITION_SPLIT_THRESHOLD: ConfigEntry[Long] =
     buildConf("celeborn.shuffle.partitionSplit.threshold")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -45,6 +45,7 @@ license: |
 | celeborn.push.sortMemory.threshold | 64m | When SortBasedPusher use memory over the threshold, will trigger push data. | 0.2.0 | 
 | celeborn.push.splitPartition.threads | 8 | Thread number to process shuffle split request in shuffle client. | 0.2.0 | 
 | celeborn.push.stageEnd.timeout | &lt;undefined&gt; | Timeout for waiting StageEnd. Default value should be `celeborn.rpc.askTimeout * (celeborn.rpc.requestCommitFiles.maxRetries + 1)`. | 0.2.0 | 
+| celeborn.push.takeTaskWaitTime | 50ms | Wait time if no task available to push to worker. | 0.3.0 | 
 | celeborn.rpc.cache.concurrencyLevel | 32 | The number of write locks to update rpc cache. | 0.2.0 | 
 | celeborn.rpc.cache.expireTime | 15s | The time before a cache item is removed. | 0.2.0 | 
 | celeborn.rpc.cache.size | 256 | The max cache items count for rpc cache. | 0.2.0 | 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Currently DataPushQueue.takePushTasks will busy looping workingQueue, which causes CPU waste:
![image](https://user-images.githubusercontent.com/948245/227866691-56d78691-7b3d-4c39-9679-1ead3a9d6aa7.png)
This PR returns all available tasks in takePushTasks instead of one, and sleep a while if non task is available.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UT.
