### PR TITLE
[CELEBORN-479][FOLLOWUP] Return empty tasks instead of null to avoid NPE

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -123,7 +123,7 @@ public class DataPushQueue {
         ExceptionUtils.wrapAndThrowIOException(ie);
       }
     }
-    return null;
+    return tasks;
   }
 
   public boolean addPushTask(PushTask pushTask) throws InterruptedException {

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -123,9 +123,6 @@ public class DataPusher {
             while (stillRunning()) {
               try {
                 ArrayList<PushTask> tasks = dataPushQueue.takePushTasks();
-                if (Objects.isNull(tasks)) {
-                  continue;
-                }
                 for (int i = 0; i < tasks.size(); i++) {
                   PushTask task = tasks.get(i);
                   pushData(task);

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -123,6 +123,9 @@ public class DataPusher {
             while (stillRunning()) {
               try {
                 ArrayList<PushTask> tasks = dataPushQueue.takePushTasks();
+                if (Objects.isNull(tasks)) {
+                  continue;
+                }
                 for (int i = 0; i < tasks.size(); i++) {
                   PushTask task = tasks.get(i);
                   pushData(task);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Should add null check for return tasks


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

