### PR TITLE
[CELEBORN-488] [FLINK] Calculate required shuffle memory before allocating slots if resources are specified

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.util.Utils;
+import org.apache.celeborn.plugin.flink.config.PluginConf;
 
 public class FlinkUtils {
 
@@ -51,5 +53,9 @@ public class FlinkUtils {
 
   public static String toAttemptId(ExecutionAttemptID attemptID) {
     return attemptID.toString();
+  }
+
+  public static long byteStringValueAsBytes(Configuration flinkConf, PluginConf pluginConf) {
+    return Utils.byteStringAsBytes(PluginConf.getValue(flinkConf, pluginConf));
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
implements computeShuffleMemorySizeForTask for remote shuffle service


### Why are the changes needed?
see [FLINK-15031](https://github.com/apache/flink/pull/16173)



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
