### PR TITLE
[CELEBORN-489][FLINK]fix retry create client for open stream

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -105,7 +105,8 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
     TransportContext context =
         new TransportContext(
             dataTransportConf, readClientHandler, conf.clientCloseIdleConnections());
-    this.flinkTransportClientFactory = new FlinkTransportClientFactory(context);
+    this.flinkTransportClientFactory =
+        new FlinkTransportClientFactory(context, conf.fetchMaxRetries());
   }
 
   public RssBufferStream readBufferedPartition(

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -116,17 +116,6 @@ public class TransportClientFactory implements Closeable {
     return createClient(remoteHost, remotePort, partitionId, new TransportFrameDecoder());
   }
 
-  public TransportClient createClientWithRetry(
-      String remoteHost, int remotePort, int partitionId, ChannelInboundHandlerAdapter decoder)
-      throws IOException, InterruptedException {
-    try {
-      return createClient(remoteHost, remotePort, partitionId, decoder);
-    } catch (IOException | InterruptedException e) {
-      logger.warn("Retrying create client to {}:{}", remoteHost, remotePort, e);
-      return createClient(remoteHost, remotePort, partitionId, decoder);
-    }
-  }
-
   public TransportClient createClient(
       String remoteHost, int remotePort, int partitionId, ChannelInboundHandlerAdapter decoder)
       throws IOException, InterruptedException {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
use new TransportFrameDecoderWithBufferSupplier for creating client


### Why are the changes needed?
Can not use the same TransportFrameDecoderWithBufferSupplier to retry create client

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual kill worker test
