### PR TITLE
[CELEBORN-491] Improve exception logging in RssInputStream

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
@@ -233,12 +233,14 @@ public abstract class RssInputStream extends InputStream {
             logger.warn(
                 "CreatePartitionReader failed {}/{} times, change to peer",
                 fetchChunkRetryCnt,
-                fetchChunkMaxRetry);
+                fetchChunkMaxRetry,
+                e);
           } else {
             logger.warn(
                 "CreatePartitionReader failed {}/{} times, retry the same location",
                 fetchChunkRetryCnt,
-                fetchChunkMaxRetry);
+                fetchChunkMaxRetry,
+                e);
             Uninterruptibles.sleepUninterruptibly(retryWaitMs, TimeUnit.MILLISECONDS);
           }
         }
@@ -254,18 +256,19 @@ public abstract class RssInputStream extends InputStream {
           fetchChunkRetryCnt++;
           currentReader.close();
           if (fetchChunkRetryCnt == fetchChunkMaxRetry) {
-            logger.warn("Fetch chunk fail exceeds max retry {}", fetchChunkRetryCnt);
+            logger.warn("Fetch chunk fail exceeds max retry {}", fetchChunkRetryCnt, e);
             throw new CelebornIOException(
-                "Fetch chunk failed for " + fetchChunkRetryCnt + " times");
+                "Fetch chunk failed for " + fetchChunkRetryCnt + " times", e);
           } else {
             if (currentReader.getLocation().getPeer() != null) {
               logger.warn(
                   "Fetch chunk failed {}/{} times, change to peer",
                   fetchChunkRetryCnt,
-                  fetchChunkMaxRetry);
+                  fetchChunkMaxRetry,
+                  e);
               currentReader = createReaderWithRetry(currentReader.getLocation().getPeer());
             } else {
-              logger.warn("Fetch chunk failed {}/{} times", fetchChunkRetryCnt, fetchChunkMaxRetry);
+              logger.warn("Fetch chunk failed {}/{} times", fetchChunkRetryCnt, fetchChunkMaxRetry, e);
               Uninterruptibles.sleepUninterruptibly(retryWaitMs, TimeUnit.MILLISECONDS);
               currentReader = createReaderWithRetry(currentReader.getLocation());
             }

--- a/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
@@ -268,7 +268,8 @@ public abstract class RssInputStream extends InputStream {
                   e);
               currentReader = createReaderWithRetry(currentReader.getLocation().getPeer());
             } else {
-              logger.warn("Fetch chunk failed {}/{} times", fetchChunkRetryCnt, fetchChunkMaxRetry, e);
+              logger.warn(
+                  "Fetch chunk failed {}/{} times", fetchChunkRetryCnt, fetchChunkMaxRetry, e);
               Uninterruptibles.sleepUninterruptibly(retryWaitMs, TimeUnit.MILLISECONDS);
               currentReader = createReaderWithRetry(currentReader.getLocation());
             }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Improving logging of exceptions in `RssInputStream`. 



### Why are the changes needed?
Currently, the error logs are not surfaced in the logs, making it difficult to realize why something is failing. This will log the exception in both the log message and also the exception itself. 

For example, it just looks like this:
```
/02/24 06:22:11 WARN task 2462.0 in stage 2.0 (TID 10872) RssInputStream: CreatePartitionReader failed 2/3 times, retry the same location 
```
This does not help with debugging issues that come up. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Trivial change - Tested on our own cluster internally to ensure that the exception is being shown.