### PR TITLE
[CELEBORN-497][CI] Enable JDK11 for CI.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         java:
           - 8
+          - 11
     steps:
     - uses: actions/checkout@v2
     - name: Setup JDK ${{ matrix.java }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable JDK11 for CI.


### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT.
