### PR TITLE
[CELEBORN-495] Leader should step down when its metadata directory has IO exception

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -41,6 +41,7 @@ import org.apache.ratis.protocol.*;
 import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
+import org.apache.ratis.rpc.CallId;
 import org.apache.ratis.rpc.RpcType;
 import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.RaftServer;
@@ -499,5 +500,26 @@ public class HARaftServer {
 
   public String getRpcEndpoint() {
     return this.rpcEndpoint;
+  }
+
+  void stepDown() {
+    try {
+      TransferLeadershipRequest request =
+          new TransferLeadershipRequest(
+              clientId,
+              server.getId(),
+              raftGroup.getGroupId(),
+              CallId.getAndIncrement(),
+              null,
+              60_000);
+      RaftClientReply reply = server.transferLeadership(request);
+      if (reply.isSuccess()) {
+        LOG.info("Successfully step down leader {}.", server.getId());
+      } else {
+        LOG.warn("Step down leader failed!");
+      }
+    } catch (Exception e) {
+      LOG.warn("Step down leader failed!", e);
+    }
   }
 }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
@@ -372,6 +372,14 @@ public class StateMachine extends BaseStateMachine {
     return lastTermIndex.getIndex();
   }
 
+  @Override
+  public void notifyLogFailed(Throwable cause, RaftProtos.LogEntryProto failedEntry) {
+    LOG.warn("Log failed {}", cause.getMessage());
+    if (masterRatisServer != null && masterRatisServer.isLeader()) {
+      masterRatisServer.stepDown();
+    }
+  }
+
   /** Notifies the state machine that the raft peer is no longer leader. */
   @Override
   public void notifyNotLeader(Collection<TransactionContext> pendingEntries) throws IOException {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -862,9 +862,7 @@ public class RatisMasterStatusSystemSuiteJ {
             .getMasterStateMachine()
             .notifyLogFailed(new Exception("test leader step down"), null);
         Assert.assertFalse(haRaftServer.isLeader());
-        while(pickLeaderStatusSystem() != null) {
-          break;
-        }
+        break;
       }
     }
   }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -855,4 +855,18 @@ public class RatisMasterStatusSystemSuiteJ {
     statusSystem.handleUpdatePartitionSize();
     Thread.sleep(3000L);
   }
+
+  @Test
+  public void testNotifyLogFailed() {
+    List<HARaftServer> list = Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3);
+    for (HARaftServer haRaftServer : list) {
+      if (haRaftServer.isLeader()) {
+        haRaftServer
+            .getMasterStateMachine()
+            .notifyLogFailed(new Exception("test leader step down"), null);
+        Assert.assertFalse(haRaftServer.isLeader());
+        break;
+      }
+    }
+  }
 }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -25,10 +25,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.Mockito;
 
 import org.apache.celeborn.common.CelebornConf;
@@ -856,7 +853,7 @@ public class RatisMasterStatusSystemSuiteJ {
     Thread.sleep(3000L);
   }
 
-  @Test
+  @After
   public void testNotifyLogFailed() {
     List<HARaftServer> list = Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3);
     for (HARaftServer haRaftServer : list) {
@@ -865,7 +862,9 @@ public class RatisMasterStatusSystemSuiteJ {
             .getMasterStateMachine()
             .notifyLogFailed(new Exception("test leader step down"), null);
         Assert.assertFalse(haRaftServer.isLeader());
-        break;
+        while(pickLeaderStatusSystem() != null) {
+          break;
+        }
       }
     }
   }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -854,7 +854,7 @@ public class RatisMasterStatusSystemSuiteJ {
   }
 
   @AfterClass
-  public void testNotifyLogFailed() {
+  public static void testNotifyLogFailed() {
     List<HARaftServer> list = Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3);
     for (HARaftServer haRaftServer : list) {
       if (haRaftServer.isLeader()) {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -853,7 +853,7 @@ public class RatisMasterStatusSystemSuiteJ {
     Thread.sleep(3000L);
   }
 
-  @After
+  @AfterClass
   public void testNotifyLogFailed() {
     List<HARaftServer> list = Arrays.asList(RATISSERVER1, RATISSERVER2, RATISSERVER3);
     for (HARaftServer haRaftServer : list) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add a notifyLogFailed method implementation in class StateMachine and a stepDown method in class HARaftServer and relative UT.


### Why are the changes needed?
https://issues.apache.org/jira/projects/CELEBORN/issues/CELEBORN-495?filter=allopenissues


If the metadata directory of leader has some exceptions(Input/Output error in my case) , resulting in IOException of log entries, the leader may not be able to process the requests anymore, but it will not step down, as a result, the service will be unavailable. 

LifecycleManager's log:
```
ERROR RssHARetryClient: Send rpc with failure, has tried 0, max try 15!
com.aliyun.emr.rss.common.rpc.RpcTimeoutException: Futures timed out after [30 seconds]. This timeout is controlled by rss.haclient.rpc.askTimeout
  at com.aliyun.emr.rss.common.rpc.RpcTimeout.com$aliyun$emr$rss$common$rpc$RpcTimeout$$createRpcTimeoutException(RpcTimeout.scala:46)
  at com.aliyun.emr.rss.common.rpc.RpcTimeout$$anonfun$addMessageIfTimeout$1.applyOrElse(RpcTimeout.scala:61)
  at com.aliyun.emr.rss.common.rpc.RpcTimeout$$anonfun$addMessageIfTimeout$1.applyOrElse(RpcTimeout.scala:57)
  at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:36)
  at com.aliyun.emr.rss.common.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:75)
  at com.aliyun.emr.rss.common.haclient.RssHARetryClient.sendMessageInner(RssHARetryClient.java:148)
  at com.aliyun.emr.rss.common.haclient.RssHARetryClient.lambda$send$0(RssHARetryClient.java:111)
  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
  at java.util.concurrent.FutureTask.run(FutureTask.java:266)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  at java.lang.Thread.run(Thread.java:750)
Caused by: java.util.concurrent.TimeoutException: Futures timed out after [30 seconds]
  at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:223)
  at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:227)
  at com.aliyun.emr.rss.common.util.ThreadUtils$.awaitResult(ThreadUtils.scala:220)
  at com.aliyun.emr.rss.common.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:74)
  ... 7 more
```

Master's logs:
```
[ERROR] - org.apache.ratis.server.leader.LogAppenderDaemon.run(LogAppenderDaemon.java:86) - node1@group-5869630CF75A->node2-LogAppenderDefault-LogAppenderDaemon failed
org.apache.ratis.server.raftlog.RaftLogIOException: Log already failed at index 255 for task WriteLog:255: (t:1, i:255), STATEMACHINELOGENTRY, StateMachineLogEntryProto:42@client-DC0FB96009FC
        at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogWorker.run(SegmentedRaftLogWorker.java:313) ~[master-0.1.0-shaded.jar:?]
        at java.lang.Thread.run(Thread.java:750) [?:1.8.0_342]
Caused by: java.io.IOException: Input/output error
        at sun.nio.ch.FileDispatcherImpl.seek0(Native Method) ~[?:1.8.0_342]
        at sun.nio.ch.FileDispatcherImpl.seek(FileDispatcherImpl.java:76) ~[?:1.8.0_342]
        at sun.nio.ch.FileChannelImpl.position(FileChannelImpl.java:264) ~[?:1.8.0_342]
        at org.apache.ratis.server.raftlog.segmented.BufferedWriteChannel.preallocateIfNecessary(BufferedWriteChannel.java:72) ~[master-0.1.0-shaded.jar:?]
        at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogOutputStream.preallocateIfNecessary(SegmentedRaftLogOutputStream.java:139) ~[master-0.1.0-shaded.jar:?]
        at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogOutputStream.write(SegmentedRaftLogOutputStream.java:90) ~[master-0.1.0-shaded.jar:?]
        at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogWorker$WriteLog.execute(SegmentedRaftLogWorker.java:510) ~[master-0.1.0-shaded.jar:?]
        at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogWorker.run(SegmentedRaftLogWorker.java:301) ~[master-0.1.0-shaded.jar:?]
        ... 1 more
```

BTW, my version is 0.1.0, but I have tried upgrading ratis to 2.4.1 and the same phenomenon occurs.
This problem can be solved after a new normal leader is re-elected.

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?
UT
