### PR TITLE
[CELEBORN-484][FOLLOWUP] Return shutting worker is empty also need to retain LifecycleManager's shutting workers

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1237,15 +1237,13 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
   }
 
   private def resolveShutdownWorkers(newShutdownWorkers: JList[WorkerInfo]): Unit = {
-    if (!newShutdownWorkers.isEmpty) {
-      // shutdownWorkers only retain workers appeared in response.
-      shuttingWorkers.retainAll(newShutdownWorkers)
-      newShutdownWorkers.asScala.filterNot(shuttingWorkers.asScala.contains)
-        .foreach { workerInfo =>
-          commitManager.handleShutdownWorker(workerInfo)
-        }
-      shuttingWorkers.addAll(newShutdownWorkers)
-    }
+    // shutdownWorkers only retain workers appeared in response.
+    shuttingWorkers.retainAll(newShutdownWorkers)
+    newShutdownWorkers.asScala.filterNot(shuttingWorkers.asScala.contains)
+      .foreach { workerInfo =>
+        commitManager.handleShutdownWorker(workerInfo)
+      }
+    shuttingWorkers.addAll(newShutdownWorkers)
   }
 
   private def shuffleResourceExists(shuffleId: Int): Boolean = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Return shutting worker is empty also need to retain LifecycleManager's shutting workers


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

