### PR TITLE
[CELEBORN-479][FOLLOWUP]   Add push task should check if loc is null

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -99,6 +99,8 @@ public class DataPushQueue {
             client.getPartitionLocation(appId, shuffleId, numMappers, numPartitions);
         if (partitionLocationMap != null) {
           PartitionLocation loc = partitionLocationMap.get(partitionId);
+          // According to CELEBORN-560, call rerun task and speculative task after LifecycleManager
+          // handle StageEnd will return empty PartitionLocation map, here loc can be null
           if (loc != null) {
             Integer oldCapacity = workerCapacity.get(loc.hostAndPushPort());
             if (oldCapacity == null) {

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -99,15 +99,19 @@ public class DataPushQueue {
             client.getPartitionLocation(appId, shuffleId, numMappers, numPartitions);
         if (partitionLocationMap != null) {
           PartitionLocation loc = partitionLocationMap.get(partitionId);
-          Integer oldCapacity = workerCapacity.get(loc.hostAndPushPort());
-          if (oldCapacity == null) {
-            oldCapacity = maxInFlight - pushState.inflightPushes(loc.hostAndPushPort());
-            workerCapacity.put(loc.hostAndPushPort(), oldCapacity);
-          }
-          if (oldCapacity > 0) {
-            iterator.remove();
+          if (loc != null) {
+            Integer oldCapacity = workerCapacity.get(loc.hostAndPushPort());
+            if (oldCapacity == null) {
+              oldCapacity = maxInFlight - pushState.inflightPushes(loc.hostAndPushPort());
+              workerCapacity.put(loc.hostAndPushPort(), oldCapacity);
+            }
+            if (oldCapacity > 0) {
+              iterator.remove();
+              tasks.add(task);
+              workerCapacity.put(loc.hostAndPushPort(), oldCapacity - 1);
+            }
+          } else {
             tasks.add(task);
-            workerCapacity.put(loc.hostAndPushPort(), oldCapacity - 1);
           }
         } else {
           tasks.add(task);


### PR DESCRIPTION
### What changes were proposed in this pull request?


According to CELEBORN-560, call rerun task and speculative task after LifecycleManager
handle StageEnd will return an empty PartitionLocation map, here loc can be null


```
23/04/03 11:14:24 INFO CodeGenerator: Code generated in 1017.663846 ms
23/04/03 11:14:24 INFO SortBasedShuffleWriter: Pushdata in close, memory used 100663296
23/04/03 11:14:24 INFO Executor: Executor is trying to kill task 24.0 in stage 2.0 (TID 248), reason: another attempt succeeded
23/04/03 11:14:24 INFO DataPusher: Thread interrupted while joining pushThread
23/04/03 11:14:25 ERROR SparkUncaughtExceptionHandler: Uncaught exception in thread Thread[DataPusher-248,5,main]
java.lang.NullPointerException
    at com.aliyun.emr.rss.client.write.DataPushQueue.takePushTasks(DataPushQueue.java:100)
    at com.aliyun.emr.rss.client.write.DataPusher$1.run(DataPusher.java:125) 
```


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

