### PR TITLE
[CELEBORN-470][FLINK] support stopTrackingAndReleasePartitions 

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleDescriptor.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleDescriptor.java
@@ -19,12 +19,14 @@ package org.apache.celeborn.plugin.flink;
 
 import java.util.Optional;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 
 public class RemoteShuffleDescriptor implements ShuffleDescriptor {
   private final String celebornAppId;
+  private final JobID jobId;
   // jobId-datasetId
   private final String shuffleId;
   private final ResultPartitionID resultPartitionID;
@@ -32,10 +34,12 @@ public class RemoteShuffleDescriptor implements ShuffleDescriptor {
 
   public RemoteShuffleDescriptor(
       String celebornAppId,
+      JobID jobId,
       String shuffleId,
       ResultPartitionID resultPartitionID,
       RemoteShuffleResource shuffleResource) {
     this.celebornAppId = celebornAppId;
+    this.jobId = jobId;
     this.shuffleId = shuffleId;
     this.resultPartitionID = resultPartitionID;
     this.shuffleResource = shuffleResource;
@@ -48,6 +52,10 @@ public class RemoteShuffleDescriptor implements ShuffleDescriptor {
 
   public String getCelebornAppId() {
     return celebornAppId;
+  }
+
+  public JobID getJobId() {
+    return jobId;
   }
 
   public RemoteShuffleResource getShuffleResource() {
@@ -63,6 +71,7 @@ public class RemoteShuffleDescriptor implements ShuffleDescriptor {
   public String toString() {
     final StringBuilder sb = new StringBuilder("RemoteShuffleDescriptor{");
     sb.append("celebornAppId='").append(celebornAppId).append('\'');
+    sb.append(", jobID=").append(jobId);
     sb.append(", shuffleId='").append(shuffleId).append('\'');
     sb.append(", resultPartitionID=").append(resultPartitionID);
     sb.append(", shuffleResource=").append(shuffleResource);

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResourceTracker.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResourceTracker.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.client.LifecycleManager;
+import org.apache.celeborn.client.listener.WorkerStatusListener;
+import org.apache.celeborn.client.listener.WorkersStatus;
+import org.apache.celeborn.common.meta.ShufflePartitionLocationInfo;
+import org.apache.celeborn.common.meta.WorkerInfo;
+
+public class ShuffleResourceTracker implements WorkerStatusListener {
+  private static final Logger LOG = LoggerFactory.getLogger(ShuffleResourceTracker.class);
+  private final ExecutorService executorService;
+  private final LifecycleManager lifecycleManager;
+  // JobID -> ShuffleResourceListener
+  private final Map<JobID, JobShuffleResourceListener> shuffleResourceListeners =
+      new ConcurrentHashMap<>();
+  private static final int MAX_RETRY_TIMES = 3;
+
+  public ShuffleResourceTracker(
+      ExecutorService executorService, LifecycleManager lifecycleManager) {
+    this.executorService = executorService;
+    this.lifecycleManager = lifecycleManager;
+    lifecycleManager.registerWorkerStatusListener(this);
+  }
+
+  public void registerJob(JobShuffleContext jobShuffleContext) {
+    shuffleResourceListeners.put(
+        jobShuffleContext.getJobId(),
+        new JobShuffleResourceListener(jobShuffleContext, executorService));
+  }
+
+  public void addPartitionResource(
+      JobID jobId, int shuffleId, int partitionId, ResultPartitionID partitionID) {
+    JobShuffleResourceListener shuffleResourceListener = shuffleResourceListeners.get(jobId);
+    shuffleResourceListener.addPartitionResource(shuffleId, partitionId, partitionID);
+  }
+
+  public void removePartitionResource(JobID jobID, int shuffleId, int partitionId) {
+    JobShuffleResourceListener shuffleResourceListener = shuffleResourceListeners.get(jobID);
+    if (shuffleResourceListener != null) {
+      shuffleResourceListener.removePartitionResource(shuffleId, partitionId);
+    }
+  }
+
+  public JobShuffleResourceListener getJobResourceListener(JobID jobID) {
+    return shuffleResourceListeners.get(jobID);
+  }
+
+  public void unRegisterJob(JobID jobID) {
+    shuffleResourceListeners.remove(jobID);
+  }
+
+  @Override
+  public void notifyChangedWorkersStatus(WorkersStatus workersStatus) {
+    try {
+      List<WorkerInfo> unknownWorkers = workersStatus.unknownWorkers;
+      if (unknownWorkers != null && !unknownWorkers.isEmpty()) {
+        // untrack by job
+        for (Map.Entry<JobID, JobShuffleResourceListener> entry :
+            shuffleResourceListeners.entrySet()) {
+          Set<ResultPartitionID> partitionIds = new HashSet<>();
+          JobShuffleResourceListener shuffleResourceListener = entry.getValue();
+          for (Map.Entry<Integer, Map<Integer, ResultPartitionID>> mapEntry :
+              shuffleResourceListener.getResultPartitionMap().entrySet()) {
+            int shuffleId = mapEntry.getKey();
+            if (!mapEntry.getValue().isEmpty()) {
+              for (WorkerInfo unknownWorker : unknownWorkers) {
+                Map<WorkerInfo, ShufflePartitionLocationInfo> shuffleAllocateInfo =
+                    lifecycleManager.workerSnapshots(shuffleId);
+                // shuffleResourceListener may release when the shuffle is ended
+                if (shuffleAllocateInfo != null) {
+                  ShufflePartitionLocationInfo shufflePartitionLocationInfo =
+                      shuffleAllocateInfo.remove(unknownWorker);
+                  if (shufflePartitionLocationInfo != null) {
+                    // TODO if we support partition replica for map partition we need refactor this
+                    //  Currently we only untrack master partitions for map partition
+                    shufflePartitionLocationInfo
+                        .getMasterPartitionIds()
+                        .forEach(
+                            id -> {
+                              ResultPartitionID resultPartitionId =
+                                  shuffleResourceListener.removePartitionResource(shuffleId, id);
+                              if (resultPartitionId != null) {
+                                partitionIds.add(resultPartitionId);
+                              }
+                            });
+                  }
+                }
+              }
+            }
+          }
+
+          shuffleResourceListener.notifyStopTrackingPartitions(partitionIds, MAX_RETRY_TIMES);
+        }
+      }
+    } catch (Throwable e) {
+      // listener never throw exception
+      LOG.error("Failed to handle unknown workers, message: {}.", e.getMessage(), e);
+    }
+  }
+
+  public static class JobShuffleResourceListener {
+
+    private final JobShuffleContext context;
+    private final ExecutorService executorService;
+    // celeborn shuffleId -> partitionId -> Flink ResultPartitionID
+    private Map<Integer, Map<Integer, ResultPartitionID>> resultPartitionMap =
+        new ConcurrentHashMap<>();
+
+    public JobShuffleResourceListener(
+        JobShuffleContext jobShuffleContext, ExecutorService executorService) {
+      this.context = jobShuffleContext;
+      this.executorService = executorService;
+    }
+
+    public void addPartitionResource(
+        int shuffleId, int partitionId, ResultPartitionID partitionID) {
+      Map<Integer, ResultPartitionID> shufflePartitionMap =
+          resultPartitionMap.computeIfAbsent(shuffleId, (s) -> new ConcurrentHashMap<>());
+      shufflePartitionMap.put(partitionId, partitionID);
+    }
+
+    private void notifyStopTrackingPartitions(
+        Set<ResultPartitionID> partitionIDS, int remainingRetries) {
+      if (partitionIDS == null || partitionIDS.isEmpty()) {
+        return;
+      }
+
+      LOG.info(
+          "jobId: {}, stop tracking partitions {}.",
+          context.getJobId(),
+          Arrays.toString(partitionIDS.toArray()));
+
+      int count = remainingRetries - 1;
+      try {
+        CompletableFuture<?> future = context.stopTrackingAndReleasePartitions(partitionIDS);
+        future.whenCompleteAsync(
+            (ignored, throwable) -> {
+              if (throwable == null) {
+                return;
+              }
+
+              if (count == 0) {
+                LOG.error(
+                    "jobId: {}, Failed to stop tracking partitions {}.",
+                    context.getJobId(),
+                    Arrays.toString(partitionIDS.toArray()));
+                return;
+              }
+              notifyStopTrackingPartitions(partitionIDS, count);
+            },
+            executorService);
+      } catch (Throwable throwable) {
+        if (count == 0) {
+          LOG.error(
+              "jobId: {}, Failed to stop tracking partitions {}.",
+              context.getJobId(),
+              Arrays.toString(partitionIDS.toArray()),
+              throwable);
+          return;
+        }
+        notifyStopTrackingPartitions(partitionIDS, count);
+      }
+    }
+
+    public Map<Integer, Map<Integer, ResultPartitionID>> getResultPartitionMap() {
+      return resultPartitionMap;
+    }
+
+    public ResultPartitionID removePartitionResource(int shuffleId, int partitionId) {
+      Map<Integer, ResultPartitionID> partitionIDMap = resultPartitionMap.get(shuffleId);
+      if (partitionIDMap != null) {
+        return partitionIDMap.remove(partitionId);
+      }
+
+      return null;
+    }
+  }
+}

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -563,6 +563,7 @@ public class RemoteShuffleResultPartitionSuiteJ {
     Mockito.when(shuffleTask.getShuffleId()).thenReturn(1);
     return new RemoteShuffleDescriptor(
         new JobID(bytes).toString(),
+        new JobID(bytes),
         new JobID(bytes).toString(),
         new ResultPartitionID(),
         new RemoteShuffleResource("1", 2, new ShuffleResourceDescriptor(shuffleTask)));

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerTest.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.plugin.flink;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import com.google.common.collect.Sets;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.shuffle.JobShuffleContext;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.apache.celeborn.client.LifecycleManager;
+import org.apache.celeborn.client.listener.WorkersStatus;
+import org.apache.celeborn.common.meta.ShufflePartitionLocationInfo;
+import org.apache.celeborn.common.meta.WorkerInfo;
+import org.apache.celeborn.common.protocol.PartitionLocation;
+
+public class ShuffleResourceTrackerTest {
+
+  @Test
+  public void testNotifyUnknownWorkers() {
+    LifecycleManager lifecycleManager = Mockito.mock(LifecycleManager.class);
+    ScheduledThreadPoolExecutor executor = Mockito.mock(ScheduledThreadPoolExecutor.class);
+
+    ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map = new ConcurrentHashMap<>();
+    WorkerInfo workerInfo = new WorkerInfo("mock", -1, -1, -1, -1);
+    ShufflePartitionLocationInfo shufflePartitionLocationInfo = new ShufflePartitionLocationInfo();
+
+    List<PartitionLocation> masterLocations = new ArrayList<>();
+    masterLocations.add(mock(1));
+    masterLocations.add(mock(2));
+
+    List<PartitionLocation> slaveLocations = new ArrayList<>();
+    slaveLocations.add(mock(3));
+    slaveLocations.add(mock(4));
+
+    shufflePartitionLocationInfo.addMasterPartitions(masterLocations);
+    shufflePartitionLocationInfo.addSlavePartitions(slaveLocations);
+
+    map.put(workerInfo, shufflePartitionLocationInfo);
+    Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt()))
+        .thenReturn(map, new HashMap<>(map), new HashMap<>(map));
+
+    ShuffleResourceTracker shuffleResourceTracker =
+        new ShuffleResourceTracker(executor, lifecycleManager);
+
+    JobID jobID1 = new JobID();
+    shuffleResourceTracker.registerJob(createJobShuffleContext(jobID1));
+    shuffleResourceTracker.addPartitionResource(jobID1, 1, 1, new ResultPartitionID());
+    shuffleResourceTracker.addPartitionResource(jobID1, 1, 2, new ResultPartitionID());
+    shuffleResourceTracker.addPartitionResource(jobID1, 1, 3, new ResultPartitionID());
+    shuffleResourceTracker.addPartitionResource(jobID1, 2, 3, new ResultPartitionID());
+
+    JobID jobID2 = new JobID();
+    shuffleResourceTracker.registerJob(createJobShuffleContext(jobID2));
+    shuffleResourceTracker.addPartitionResource(jobID2, 3, 1, new ResultPartitionID());
+
+    List<WorkerInfo> workerInfoList = new ArrayList<>();
+    workerInfoList.add(workerInfo);
+    shuffleResourceTracker.notifyChangedWorkersStatus(new WorkersStatus(workerInfoList, null));
+
+    Assert.assertEquals(
+        Sets.newHashSet(3),
+        shuffleResourceTracker
+            .getJobResourceListener(jobID1)
+            .getResultPartitionMap()
+            .get(2)
+            .keySet());
+    Assert.assertEquals(
+        Sets.newHashSet(3),
+        shuffleResourceTracker
+            .getJobResourceListener(jobID1)
+            .getResultPartitionMap()
+            .get(2)
+            .keySet());
+    Assert.assertTrue(
+        shuffleResourceTracker
+            .getJobResourceListener(jobID2)
+            .getResultPartitionMap()
+            .get(3)
+            .isEmpty());
+  }
+
+  public JobShuffleContext createJobShuffleContext(JobID jobId) {
+    return new JobShuffleContext() {
+      @Override
+      public org.apache.flink.api.common.JobID getJobId() {
+        return jobId;
+      }
+
+      @Override
+      public CompletableFuture<?> stopTrackingAndReleasePartitions(
+          Collection<ResultPartitionID> collection) {
+        return CompletableFuture.completedFuture(null);
+      }
+    };
+  }
+
+  private PartitionLocation mock(int partitionId) {
+    return new PartitionLocation(
+        partitionId, -1, "mock", -1, -1, -1, -1, PartitionLocation.Mode.MASTER);
+  }
+}

--- a/client/src/main/java/org/apache/celeborn/client/listener/WorkerStatusListener.java
+++ b/client/src/main/java/org/apache/celeborn/client/listener/WorkerStatusListener.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client.listener;
+
+/** The Listener about the status change of the shuffle workers. */
+public interface WorkerStatusListener {
+
+  /**
+   * Notifies that shuffle: has unKnowWorkers(probably worker was terminated unexpected) has
+   * shutdownWorkers
+   *
+   * @param workerStatus
+   */
+  void notifyChangedWorkersStatus(WorkersStatus workerStatus);
+}

--- a/client/src/main/java/org/apache/celeborn/client/listener/WorkersStatus.java
+++ b/client/src/main/java/org/apache/celeborn/client/listener/WorkersStatus.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client.listener;
+
+import java.util.List;
+
+import org.apache.celeborn.common.meta.WorkerInfo;
+
+public class WorkersStatus {
+  public final List<WorkerInfo> unknownWorkers;
+
+  public final List<WorkerInfo> shutdownWorkers;
+
+  public WorkersStatus(List<WorkerInfo> unknownWorkers, List<WorkerInfo> shutdownWorkers) {
+    this.unknownWorkers = unknownWorkers;
+    this.shutdownWorkers = shutdownWorkers;
+  }
+}

--- a/client/src/main/scala/org/apache/celeborn/client/ApplicationHeartbeater.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ApplicationHeartbeater.scala
@@ -55,7 +55,7 @@ class ApplicationHeartbeater(
                 appId,
                 tmpTotalWritten,
                 tmpFileCount,
-                workerStatusTracker.blacklist.asScala.keys.toList.asJava,
+                workerStatusTracker.getNeedCheckedWorkers().toList.asJava,
                 ZERO_UUID)
             val response = requestHeartbeat(appHeartbeat)
             if (response.statusCode == StatusCode.SUCCESS) {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -28,6 +28,7 @@ import scala.util.Random
 import com.google.common.annotations.VisibleForTesting
 
 import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, ShuffleFailedWorkers}
+import org.apache.celeborn.client.listener.WorkerStatusListener
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.haclient.RssHARetryClient
 import org.apache.celeborn.common.identity.{IdentityProvider, UserIdentifier}
@@ -117,7 +118,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
   private val rssHARetryClient = new RssHARetryClient(rpcEnv, conf)
   val commitManager = new CommitManager(appId, conf, this)
-  val workerStatusTracker = new WorkerStatusTracker(conf, this, commitManager)
+  val workerStatusTracker = new WorkerStatusTracker(conf, this)
   private val heartbeater =
     new ApplicationHeartbeater(
       appId,
@@ -1103,11 +1104,22 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
   // Once a partition is released, it will be never needed anymore
   def releasePartition(shuffleId: Int, partitionId: Int): Unit = {
-    releasePartitionManager.releasePartition(shuffleId, partitionId)
+    commitManager.releasePartitionResource(shuffleId, partitionId)
     val partitionLocation = latestPartitionLocation.get(shuffleId)
     if (partitionLocation != null) {
       partitionLocation.remove(partitionId)
     }
+
+    releasePartitionManager.releasePartition(shuffleId, partitionId)
+  }
+
+  def getAllocatedWorkers(): Set[WorkerInfo] = {
+    shuffleAllocatedWorkers.asScala.values.flatMap(_.keys().asScala).toSet
+  }
+
+  // delegate workerStatusTracker to register listener
+  def registerWorkerStatusListener(workerStatusListener: WorkerStatusListener): Unit = {
+    workerStatusTracker.registerWorkerStatusListener(workerStatusListener)
   }
 
   // Initialize at the end of LifecycleManager construction.

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -283,7 +283,7 @@ message PbHeartbeatFromApplication {
   int64 totalWritten = 2;
   int64 fileCount = 3 ;
   string requestId = 4;
-  repeated PbWorkerInfo localBlackList = 5;
+  repeated PbWorkerInfo needCheckedWorkerList = 5;
 }
 
 message PbHeartbeatFromApplicationResponse {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -535,6 +535,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def appHeartbeatTimeoutMs: Long = get(APPLICATION_HEARTBEAT_TIMEOUT)
   def appHeartbeatIntervalMs: Long = get(APPLICATION_HEARTBEAT_INTERVAL)
   def shuffleExpiredCheckIntervalMs: Long = get(SHUFFLE_EXPIRED_CHECK_INTERVAL)
+  def workerCheckedUseAllocatedWorkers: Boolean = get(WORKER_CHECKED_USE_ALLOCATED_WORKERS)
   def workerExcludedExpireTimeout: Long = get(WORKER_EXCLUDED_EXPIRE_TIMEOUT)
   def blacklistSlaveEnabled: Boolean = get(BLACKLIST_SLAVE_ENABLED)
   def shuffleRangeReadFilterEnabled: Boolean = get(SHUFFLE_RANGE_READ_FILTER_ENABLED)
@@ -1417,6 +1418,17 @@ object CelebornConf extends Logging {
       .doc("Interval for client to check expired shuffles.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("60s")
+
+  val WORKER_CHECKED_USE_ALLOCATED_WORKERS: ConfigEntry[Boolean] =
+    buildConf("celeborn.worker.checked.useAllocatedWorkers")
+      .internal
+      .categories("client")
+      .version("0.3.0")
+      .doc("When true, Celeborn will use local allocated workers as candidate being checked workers(check the workers" +
+        "whether unKnown in master), this may be more useful for map partition to regenerate the lost data), " +
+        "otherwise use local black list as candidate being checked workers.")
+      .booleanConf
+      .createWithDefault(false)
 
   val WORKER_EXCLUDED_EXPIRE_TIMEOUT: ConfigEntry[Long] =
     buildConf("celeborn.worker.excluded.expireTimeout")

--- a/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
@@ -26,6 +26,7 @@ import org.apache.celeborn.common.protocol.PartitionLocation
 
 class ShufflePartitionLocationInfo {
   type PartitionInfo = ConcurrentHashMap[Int, util.Set[PartitionLocation]]
+
   private val masterPartitionLocations = new PartitionInfo
   private val slavePartitionLocations = new PartitionInfo
   implicit val partitionOrdering: Ordering[PartitionLocation] = Ordering.by(_.getEpoch)
@@ -44,6 +45,11 @@ class ShufflePartitionLocationInfo {
 
   def getSlavePartitions(partitionIdOpt: Option[Int] = None): util.Set[PartitionLocation] = {
     getPartitions(slavePartitionLocations, partitionIdOpt)
+  }
+
+  def getMasterPartitionIds(): util.Set[Integer] = {
+    val value = masterPartitionLocations.keySet().asScala
+    value.asJava.asInstanceOf[util.Set[Integer]]
   }
 
   def containsPartition(partitionId: Int): Boolean = {

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -365,7 +365,7 @@ object PbSerDeUtils {
       blacklist: java.util.Set[WorkerInfo],
       workerLostEvent: java.util.Set[WorkerInfo],
       appHeartbeatTime: java.util.Map[String, java.lang.Long],
-      workers: java.util.ArrayList[WorkerInfo],
+      workers: java.util.List[WorkerInfo],
       partitionTotalWritten: java.lang.Long,
       partitionTotalFileCount: java.lang.Long,
       appDiskUsageMetricSnapshots: Array[AppDiskUsageSnapShot],

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -634,7 +634,7 @@ private[celeborn] class Master(
       appId: String,
       totalWritten: Long,
       fileCount: Long,
-      localBlacklist: util.List[WorkerInfo],
+      needCheckedWorkerList: util.List[WorkerInfo],
       requestId: String): Unit = {
     statusSystem.handleAppHeartbeat(
       appId,
@@ -642,11 +642,12 @@ private[celeborn] class Master(
       fileCount,
       System.currentTimeMillis(),
       requestId)
-    localBlacklist.removeAll(workersSnapShot)
+    // unknown workers will retain in needCheckedWorkerList
+    needCheckedWorkerList.removeAll(workersSnapShot)
     context.reply(HeartbeatFromApplicationResponse(
       StatusCode.SUCCESS,
       new util.ArrayList(statusSystem.blacklist),
-      localBlacklist,
+      needCheckedWorkerList,
       shutdownWorkerSnapshot))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1、support stopTrackingAndReleasePartitions when celeborn workers were not available.

### Why are the changes needed?
When encounter celeborn worker shutdown, data would be lost, Flink tasks will be retry but still try to read the lost data, but the job would not success. So we need to let the Flink framework known which data of the partitions can't be reading anymore, then Flink will schedule these partitions to regenerate


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
TPCDS with random worker kill
