### PR TITLE
[CELEBORN-503][FLINK] fix attempt task may use wrong partitionId.

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -398,7 +398,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
                     applicationId,
                     shuffleId,
                     context.context,
-                    partitionId,
+                    context.partitionId,
                     partitionLocations)
                 } else {
                   // when register not success, need reply origin response,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Use context partitionId to apply new slots.


### Why are the changes needed?
Flink task may retry register with new attemptId while lifecycle manager still offer slots for the attempt 0 tasks. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Random kill workers 
