### PR TITLE
[CELEBORN-507] don't set up worker endpoint when update meta and remove compare meta with workers

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -255,6 +255,7 @@ class WorkerInfo(
        |ReplicatePort: $replicatePort
        |SlotsUsed: $slots
        |LastHeartbeat: $lastHeartbeat
+       |HeartBeatElapsedSeconds: ${(System.currentTimeMillis() - lastHeartbeat) / 1000}
        |Disks: $diskInfosString
        |UserResourceConsumption: $userResourceConsumptionString
        |WorkerRef: $endpoint

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -312,9 +312,9 @@ class WorkerInfoSuite extends CelebornFunSuite {
     println(worker3)
     println(worker4)
 
-    assertEquals(exp1, worker1.toString)
-    assertEquals(exp2, worker2.toString)
-    assertEquals(exp3, worker3.toString)
-    assertEquals(exp4, worker4.toString)
+    assertEquals(exp1, worker1.toString.replaceAll("HeartBeatElapsedSeconds:.*\n", ""))
+    assertEquals(exp2, worker2.toString.replaceAll("HeartBeatElapsedSeconds:.*\n", ""))
+    assertEquals(exp3, worker3.toString.replaceAll("HeartBeatElapsedSeconds:.*\n", ""))
+    assertEquals(exp4, worker4.toString.replaceAll("HeartBeatElapsedSeconds:.*\n", ""))
   }
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -702,25 +702,10 @@ private[celeborn] class Master(
   override def getWorkerInfo: String = {
     val sb = new StringBuilder
     sb.append("====================== Workers Info in Master ===========================")
+
     workersSnapShot.asScala.foreach { w =>
-      sb.append(s"${w.toUniqueId().padTo(50, " ").mkString}in Master\n")
+      sb.append(s"${w.toUniqueId().padTo(50, " ").mkString}\n")
       sb.append(w).append("\n")
-
-      sb.append("\n")
-      val workerInfo = requestGetWorkerInfos(w.endpoint)
-        .workerInfos.asJava
-        .get(0)
-
-      sb.append(s"${w.toUniqueId().padTo(50, " ").mkString}in Worker\n")
-      sb.append(workerInfo).append("\n")
-      sb.append("\n")
-
-      if (w.hasSameInfoWith(workerInfo)) {
-        sb.append(s"${w.toUniqueId().padTo(50, " ").mkString}status consist!\n")
-      } else {
-        sb.append(s"${w.toUniqueId().padTo(50, " ").mkString}status not consist!\n")
-      }
-      sb.append("=====================================================================\n")
     }
 
     sb.toString()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. Remove setup worker endpoint
2. Remove Compare workerInfos


### Why are the changes needed?
1. Should not set up endpoint while updateWorkerHeartbeatMeta while this will potentially block celeborn master startup progress. 
2. Remove Compare workerInfos, as Heartbeat will keep them consist.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT