### PR TITLE
[CELEBORN-510][FLINK] DataPartitionReader.addBuffer should not call s…

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/server/BufferStreamManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/BufferStreamManager.java
@@ -359,7 +359,7 @@ public class BufferStreamManager {
               new BufferRecycler(memoryManager, (buffer) -> this.recycle(buffer, buffers));
           DataPartitionReader reader = sortedReaders.poll();
           try {
-            if (!reader.readAndSend(buffers, bufferRecycler)) {
+            if (!reader.readData(buffers, bufferRecycler)) {
               readers.remove(reader);
             }
           } catch (Throwable e) {

--- a/common/src/main/java/org/apache/celeborn/common/network/server/BufferStreamManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/BufferStreamManager.java
@@ -382,10 +382,8 @@ public class BufferStreamManager {
     public void addReaderCredit(int numCredit, long streamId) {
       DataPartitionReader streamReader = this.getStreamReader(streamId);
       if (streamReader != null) {
-        boolean canSendWithCredit = streamReader.sendWithCredit(numCredit);
-        if (canSendWithCredit) {
-          readExecutor.submit(() -> streamReader.sendData());
-        }
+        streamReader.addCredit(numCredit);
+        readExecutor.submit(() -> streamReader.sendData());
       }
     }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/server/DataPartitionReader.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/DataPartitionReader.java
@@ -129,7 +129,7 @@ public class DataPartitionReader implements Comparable<DataPartitionReader> {
     credits.getAndAdd(credit);
   }
 
-  public synchronized boolean readAndSend(Queue<ByteBuf> bufferQueue, Recycler bufferRecycler)
+  public synchronized boolean readData(Queue<ByteBuf> bufferQueue, Recycler bufferRecycler)
       throws IOException {
     boolean hasRemaining = hasRemaining();
     boolean continueReading = hasRemaining;

--- a/common/src/main/java/org/apache/celeborn/common/network/server/DataPartitionReader.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/DataPartitionReader.java
@@ -125,13 +125,8 @@ public class DataPartitionReader implements Comparable<DataPartitionReader> {
     }
   }
 
-  public boolean sendWithCredit(int credit) {
-    int oldCredit = credits.getAndAdd(credit);
-    if (oldCredit == 0) {
-      return true;
-    }
-
-    return false;
+  public void addCredit(int credit) {
+    credits.getAndAdd(credit);
   }
 
   public synchronized boolean readAndSend(Queue<ByteBuf> bufferQueue, Recycler bufferRecycler)
@@ -176,7 +171,6 @@ public class DataPartitionReader implements Comparable<DataPartitionReader> {
       return;
     }
     final boolean recycleBuffer;
-    boolean notifyDataAvailable = false;
     final Throwable throwable;
     synchronized (lock) {
       recycleBuffer = isReleased || isClosed || isError;
@@ -184,7 +178,6 @@ public class DataPartitionReader implements Comparable<DataPartitionReader> {
       isClosed = !hasRemaining;
 
       if (!recycleBuffer) {
-        notifyDataAvailable = buffersRead.isEmpty();
         buffersRead.add(new WrappedDataBuffer(buffer, bufferRecycler));
       }
     }
@@ -192,9 +185,6 @@ public class DataPartitionReader implements Comparable<DataPartitionReader> {
     if (recycleBuffer) {
       bufferRecycler.release(buffer);
       throw new RuntimeException("Partition reader has been failed or finished.", throwable);
-    }
-    if (notifyDataAvailable) {
-      sendData();
     }
   }
 


### PR DESCRIPTION
…endData

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
DataPartitionReader.addBuffer should not call sendData, and always trigger sendData in addReaderCredit.
To make code more concise.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UT and IT.
