### PR TITLE
[CELEBORN-511][IMPROVE] Move onTrim tag to StorageManager to avoid frequent trim action

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/server/memory/MemoryManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/memory/MemoryManager.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -67,7 +66,6 @@ public class MemoryManager {
   private final LongAdder pausePushDataAndReplicateCounter = new LongAdder();
   private MemoryManagerStat memoryManagerStat = MemoryManagerStat.resumeAll;
   private boolean underPressure;
-  private final AtomicBoolean trimInProcess = new AtomicBoolean(false);
 
   // For buffer stream
   private final AtomicLong readBufferCounter = new AtomicLong(0);
@@ -204,18 +202,11 @@ public class MemoryManager {
               }
             } else {
               if (memoryManagerStat != MemoryManagerStat.resumeAll) {
-                if (!trimInProcess.get()) {
-                  trimInProcess.set(true);
-                  actionService.submit(
-                      () -> {
-                        try {
-                          logger.debug("Trigger trim action");
-                          memoryPressureListeners.forEach(MemoryPressureListener::onTrim);
-                        } finally {
-                          trimInProcess.set(false);
-                        }
-                      });
-                }
+                actionService.submit(
+                    () -> {
+                      logger.debug("Trigger trim action");
+                      memoryPressureListeners.forEach(MemoryPressureListener::onTrim);
+                    });
               }
             }
           } catch (Exception e) {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -680,6 +680,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   override def onTrim(): Unit = {
     if (!trimInProcess.get()) {
       trimInProcess.set(true)
+      logInfo(s"Trigger ${this.getClass.getCanonicalName} trim action")
       actionService.submit(new Runnable {
         override def run(): Unit = {
           try {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -678,8 +678,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   override def onResume(moduleName: String): Unit = {}
 
   override def onTrim(): Unit = {
-    if (!trimInProcess.get()) {
-      trimInProcess.set(true)
+    if (trimInProcess.compareAndSet(false, true)) {
       logInfo(s"Trigger ${this.getClass.getCanonicalName} trim action")
       actionService.submit(new Runnable {
         override def run(): Unit = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -117,9 +117,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     (flushers, totalThread)
   }
 
-  private val actionService = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder()
-    .setNameFormat("StorageManager-action-thread").build)
-
   deviceMonitor.startCheck()
 
   val hdfsDir = conf.hdfsDir
@@ -677,11 +674,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   override def onResume(moduleName: String): Unit = {}
 
   override def onTrim(): Unit = {
-    actionService.submit(new Runnable {
-      override def run(): Unit = {
-        flushFileWriters()
-      }
-    })
+    flushFileWriters()
   }
 
   def updateDiskInfos(): Unit = this.synchronized {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, if we call trim. in StorageManager, it still just add it to actionService, then return, the flag will directly set to false, then add a new trim action, here we should directly execute the onTrim in StorageManager.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

