### PR TITLE
[CELEBORN-512][IMPROVEMENT] Sort timestamp and show in date format

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -729,8 +729,8 @@ private[celeborn] class Master(
   override def getLostWorkers: String = {
     val sb = new StringBuilder
     sb.append("======================= Lost Workers in Master ========================\n")
-    lostWorkersSnapshot.asScala.foreach { case (worker, time) =>
-      sb.append(s"${worker.toUniqueId().padTo(50, " ").mkString}$time\n")
+    lostWorkersSnapshot.asScala.toSeq.sortBy(_._2).foreach { case (worker, time) =>
+      sb.append(s"${worker.toUniqueId().padTo(50, " ").mkString}${simpleDateFormat.format(time)}\n")
     }
     sb.toString()
   }
@@ -772,8 +772,8 @@ private[celeborn] class Master(
   override def getApplicationList: String = {
     val sb = new StringBuilder
     sb.append("================= LifecycleManager Hostname List ======================\n")
-    statusSystem.appHeartbeatTime.asScala.foreach { case (appId, time) =>
-      sb.append(s"${appId.padTo(40, " ").mkString}$time\n")
+    statusSystem.appHeartbeatTime.asScala.toSeq.sortBy(_._2).foreach { case (appId, time) =>
+      sb.append(s"${appId.padTo(40, " ").mkString}${simpleDateFormat.format(time)}\n")
     }
     sb.toString()
   }

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -17,12 +17,17 @@
 
 package org.apache.celeborn.server.common
 
+import java.text.SimpleDateFormat
+import java.util.Locale
+
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.server.common.http.{HttpRequestHandler, HttpServer, HttpServerInitializer}
 
 abstract class HttpService extends Service with Logging {
 
   private var httpServer: HttpServer = _
+
+  protected val simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.ROOT)
 
   def getConf: String = {
     val sb = new StringBuilder

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -505,7 +505,7 @@ private[celeborn] class Worker(
     val sb = new StringBuilder
     sb.append("==================== Unavailable Peers of Worker =====================\n")
     unavailablePeers.asScala.foreach { case (peer, time) =>
-      sb.append(s"${peer.toUniqueId().padTo(50, " ").mkString}$time\n")
+      sb.append(s"${peer.toUniqueId().padTo(50, " ").mkString}${simpleDateFormat.format(time)}\n")
     }
     sb.toString()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Test

```
  test("CELEBORN-512: Sort timestamp and show in date format") {
    Map("11111" -> (System.currentTimeMillis()+10000L),
      "222222" -> (System.currentTimeMillis() + 1000L),
      "333333333" -> (System.currentTimeMillis() + 200000L)).toSeq
      .sortBy(_._2).foreach { case (worker, time) =>
      println(s"${worker.padTo(50, " ").mkString}${new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(time)}\n")
    }
  }
```

Result 
```
222222                                            2023-04-11T18:58:37.224+0800

11111                                             2023-04-11T18:58:46.224+0800

333333333                                         2023-04-11T19:01:56.224+0800
```

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

