### PR TITLE
[CELEBORN-514][FLINK] RssBufferStream need guarantee close the stream.

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.protocol.BacklogAnnouncement;
-import org.apache.celeborn.common.network.protocol.BufferStreamEnd;
 import org.apache.celeborn.common.network.protocol.RequestMessage;
 import org.apache.celeborn.common.network.protocol.TransportableError;
 import org.apache.celeborn.common.network.server.BaseMessageHandler;
@@ -47,11 +46,7 @@ public class ReadClientHandler extends BaseMessageHandler {
 
   public void removeHandler(long streamId) {
     streamHandlers.remove(streamId);
-    TransportClient client = streamClients.remove(streamId);
-    // If read handler is removed, we should notify worker to release resource.
-    if (client != null && client.isActive()) {
-      client.getChannel().writeAndFlush(new BufferStreamEnd(streamId));
-    }
+    streamClients.remove(streamId);
   }
 
   private void processMessageInternal(long streamId, RequestMessage msg) {

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -124,6 +124,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
       return RssBufferStream.empty();
     } else {
       return RssBufferStream.create(
+          this,
           conf,
           flinkTransportClientFactory,
           shuffleKey,

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
@@ -86,7 +86,7 @@ public class RemoteBufferStreamReader extends CreditListener {
           client.readBufferedPartition(
               applicationId, shuffleId, partitionId, subPartitionIndexStart, subPartitionIndexEnd);
       bufferStream.open(
-          RemoteBufferStreamReader.this::requestBuffer, initialCredit, client, messageConsumer);
+          RemoteBufferStreamReader.this::requestBuffer, initialCredit, messageConsumer);
     } catch (Exception e) {
       logger.warn("Failed to open stream and report to flink framework. ", e);
       messageConsumer.accept(new TransportableError(0L, e));
@@ -98,7 +98,6 @@ public class RemoteBufferStreamReader extends CreditListener {
     // need set closed first before remove Handler
     closed = true;
     if (this.bufferStream != null) {
-      client.getReadClientHandler().removeHandler(this.bufferStream.getStreamId());
       bufferStream.close();
     } else {
       logger.warn(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Guarantee close the stream when rssbufferStream is already closed by Flink framework.


### Why are the changes needed?
StreamId may not received when rssbufferStream is already closed by Flink framework, then the stream may not closed.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual with Tpcds 
