### PR TITLE
[CELEBORN-518] fix bug that worer uses celeborn.master.metrics.promet…

### DIFF
--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -85,7 +85,7 @@ spec:
         resources:
           {{- toYaml .Values.resources.worker | nindent 12 }}
         ports:
-          - containerPort: {{ get .Values.celeborn "celeborn.master.metrics.prometheus.port" | default 9096 }}
+          - containerPort: {{ get .Values.celeborn "celeborn.worker.metrics.prometheus.port" | default 9096 }}
             name: metrics
             protocol: TCP
         volumeMounts:


### PR DESCRIPTION
…heus.port in worker-statefulse

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
now worker pod use celeborn.master.metrics.prometheus.port, but it should use celeborn.worker.metrics.prometheus.port


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?
@zwangsheng 
