### PR TITLE
[CELEBORN-517][IMPROVEMENT] Optimize stopTimer/startTimer cpu cost

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/MetricLabels.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/MetricLabels.scala
@@ -20,7 +20,7 @@ package org.apache.celeborn.common.metrics
 private[metrics] trait MetricLabels {
   val labels: Map[String, String]
 
-  def labelString: String = MetricLabels.labelString(labels)
+  final val labelString: String = MetricLabels.labelString(labels)
 }
 
 object MetricLabels {


### PR DESCRIPTION
### What changes were proposed in this pull request?
`startTimer` and  `stopTimer` cost too much CPU, especially cost on `metricNameWithLabels`. This pr improve the logic
<img width="1358" alt="截屏2023-04-12 下午6 16 57" src="https://user-images.githubusercontent.com/46485123/231428684-d2b19bcf-52e1-44ac-9ece-7718272ba5bf.png">



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

