### PR TITLE
[CELEBORN-521] correct exception and unify unRetryableException

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
@@ -23,7 +23,6 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.network.protocol.BacklogAnnouncement;
 import org.apache.celeborn.common.network.protocol.ReadAddCredit;
 import org.apache.celeborn.common.network.protocol.RequestMessage;
@@ -90,7 +89,7 @@ public class RemoteBufferStreamReader extends CreditListener {
           RemoteBufferStreamReader.this::requestBuffer, initialCredit, messageConsumer);
     } catch (Exception e) {
       logger.warn("Failed to open stream and report to flink framework. ", e);
-      messageConsumer.accept(new TransportableError(0L, new CelebornIOException(e)));
+      messageConsumer.accept(new TransportableError(0L, e));
     }
     isOpened = true;
   }

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGate.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGate.java
@@ -62,7 +62,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
-import org.apache.celeborn.common.exception.CelebornIOException;
+import org.apache.celeborn.common.exception.PartitionUnRetryAbleException;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.plugin.flink.buffer.BufferPacker;
 import org.apache.celeborn.plugin.flink.buffer.TransferBufferPool;
@@ -484,8 +484,8 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
           return;
         }
         LOG.error("Input {} gate failed ", this, throwable);
-        Class<?> clazz = CelebornIOException.class;
-        if (throwable.getMessage().contains(clazz.getName())) {
+        Class<?> clazz = PartitionUnRetryAbleException.class;
+        if (throwable.getMessage() != null && throwable.getMessage().contains(clazz.getName())) {
           cause = new PartitionNotFoundException(rpID);
         } else {
           cause = throwable;

--- a/common/src/main/java/org/apache/celeborn/common/network/server/MapDataPartitionReader.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/MapDataPartitionReader.java
@@ -381,7 +381,8 @@ public class MapDataPartitionReader implements Comparable<MapDataPartitionReader
       // And do not close channel because multiple streams are using the very same channel.
       // wrapIOException to PartitionUnRetryAbleException, client may choose regenerate the data.
       this.associatedChannel.writeAndFlush(
-          new TransportableError(streamId, ExceptionUtils.wrapIOExceptionToUnRetryable(throwable)));
+          new TransportableError(
+              streamId, ExceptionUtils.wrapIOExceptionToUnRetryable(throwable, true)));
     }
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/server/MapDataPartitionReader.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/MapDataPartitionReader.java
@@ -19,6 +19,7 @@ package org.apache.celeborn.common.network.server;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -33,7 +34,7 @@ import io.netty.channel.ChannelFutureListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.celeborn.common.exception.CelebornIOException;
+import org.apache.celeborn.common.exception.FileCorruptedException;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.network.protocol.BacklogAnnouncement;
 import org.apache.celeborn.common.network.protocol.ReadData;
@@ -41,6 +42,7 @@ import org.apache.celeborn.common.network.protocol.TransportableError;
 import org.apache.celeborn.common.network.server.memory.BufferQueue;
 import org.apache.celeborn.common.network.server.memory.BufferRecycler;
 import org.apache.celeborn.common.network.server.memory.RecyclableBuffer;
+import org.apache.celeborn.common.util.ExceptionUtils;
 import org.apache.celeborn.common.util.Utils;
 
 public class MapDataPartitionReader implements Comparable<MapDataPartitionReader> {
@@ -257,7 +259,7 @@ public class MapDataPartitionReader implements Comparable<MapDataPartitionReader
     int bufferLength = header.getInt(12);
     if (bufferLength <= 0 || bufferLength > buffer.capacity()) {
       logger.error("Incorrect buffer header, buffer length: {}.", bufferLength);
-      throw new RuntimeException("File " + filename + " is corrupted");
+      throw new FileCorruptedException("File " + filename + " is corrupted");
     }
     buffer.writeBytes(header);
     readBufferIntoReadBuffer(channel, buffer, bufferLength);
@@ -294,7 +296,7 @@ public class MapDataPartitionReader implements Comparable<MapDataPartitionReader
       if (dataConsumingOffset < 0
           || dataConsumingOffset + currentPartitionRemainingBytes > dataFileChannel.size()
           || currentPartitionRemainingBytes < 0) {
-        throw new RuntimeException("File " + fileInfo.getFilePath() + " is corrupted");
+        throw new FileCorruptedException("File " + fileInfo.getFilePath() + " is corrupted");
       }
     }
   }
@@ -323,7 +325,7 @@ public class MapDataPartitionReader implements Comparable<MapDataPartitionReader
 
       // if this check fails, the partition file must be corrupted
       if (currentPartitionRemainingBytes < 0) {
-        throw new RuntimeException("File is corrupted");
+        throw new FileCorruptedException("File is corrupted");
       } else if (currentPartitionRemainingBytes == 0) {
         logger.debug(
             "readBuffer end, {},  {}, {}, {}",
@@ -370,11 +372,16 @@ public class MapDataPartitionReader implements Comparable<MapDataPartitionReader
 
   private void notifyError(Throwable throwable) {
     logger.error("read error stream id {} message:{}", streamId, throwable.getMessage(), throwable);
+    if (throwable instanceof ClosedChannelException) {
+      return;
+    }
+
     if (this.associatedChannel.isActive()) {
       // If a stream is failed, send exceptions with the best effort, do not expect response.
       // And do not close channel because multiple streams are using the very same channel.
+      // wrapIOException to PartitionUnRetryAbleException, client may choose regenerate the data.
       this.associatedChannel.writeAndFlush(
-          new TransportableError(streamId, new CelebornIOException(throwable)));
+          new TransportableError(streamId, ExceptionUtils.wrapIOExceptionToUnRetryable(throwable)));
     }
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -17,11 +17,13 @@
 
 package org.apache.celeborn.common.util;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import org.apache.celeborn.common.exception.CelebornIOException;
+import org.apache.celeborn.common.exception.FileCorruptedException;
 import org.apache.celeborn.common.exception.PartitionUnRetryAbleException;
 
 public class ExceptionUtils {
@@ -36,8 +38,11 @@ public class ExceptionUtils {
     }
   }
 
-  public static Throwable wrapIOExceptionToUnRetryable(Throwable throwable) {
-    if (throwable instanceof IOException) {
+  public static Throwable wrapIOExceptionToUnRetryable(
+      Throwable throwable, boolean convertAllIOException2UnRetryable) {
+    if (throwable instanceof FileNotFoundException || throwable instanceof FileCorruptedException) {
+      return new PartitionUnRetryAbleException(throwable.getMessage(), throwable);
+    } else if (throwable instanceof IOException && convertAllIOException2UnRetryable) {
       return new PartitionUnRetryAbleException(throwable.getMessage(), throwable);
     } else {
       return throwable;

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -22,6 +22,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import org.apache.celeborn.common.exception.CelebornIOException;
+import org.apache.celeborn.common.exception.PartitionUnRetryAbleException;
 
 public class ExceptionUtils {
 
@@ -32,6 +33,14 @@ public class ExceptionUtils {
       throw new CelebornIOException(exception);
     } else {
       throw new CelebornIOException(exception.getMessage(), exception);
+    }
+  }
+
+  public static Throwable wrapIOExceptionToUnRetryable(Throwable throwable) {
+    if (throwable instanceof IOException) {
+      return new PartitionUnRetryAbleException(throwable.getMessage(), throwable);
+    } else {
+      return throwable;
     }
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/exception/FileCorruptedException.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/exception/FileCorruptedException.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.exception
+
+import java.io.IOException
+
+class FileCorruptedException(message: String, cause: Throwable)
+  extends IOException(message, cause) {
+
+  def this(message: String) = this(message, null)
+
+}

--- a/common/src/main/scala/org/apache/celeborn/common/exception/PartitionUnRetryAbleException.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/exception/PartitionUnRetryAbleException.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.exception
+
+import java.io.IOException
+
+class PartitionUnRetryAbleException(message: String, cause: Throwable)
+  extends IOException(message, cause) {
+
+  def this(message: String) = this(message, null)
+
+}

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -26,7 +26,6 @@ import java.util.function.Consumer
 import com.google.common.base.Throwables
 import io.netty.util.concurrent.{Future, GenericFutureListener}
 
-import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{FileInfo, FileManagedBuffers}
 import org.apache.celeborn.common.network.buffer.NioManagedBuffer
@@ -199,7 +198,7 @@ class FetchHandler(val conf: TransportConf) extends BaseMessageHandler with Logg
     // PartitionUnRetryableException for reader can give up this partition and choose to regenerate the partition data
     client.getChannel.writeAndFlush(new RpcFailure(
       requestId,
-      Throwables.getStackTraceAsString(ExceptionUtils.wrapIOExceptionToUnRetryable(ioe))))
+      Throwables.getStackTraceAsString(ExceptionUtils.wrapIOExceptionToUnRetryable(ioe, false))))
   }
 
   def handleEndStreamFromClient(req: BufferStreamEnd): Unit = {


### PR DESCRIPTION
…rtitionUnRetryableException

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Correct exception and unify unRetryableException

### Why are the changes needed?
Currently Some Exception Type is not correct for client to identify what should do next. Such as throw RuntimeException when file corrupted in MapDataPartitionReader / OpenStream when FileNotFoundException. We can unify to PartitionUnRetryableException for reader can give up this partition and choose to regenerate the partition data, And this would benefit Flink to regenerate upstream data.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tpcds & Random worker kill.
