### PR TITLE
[CELEBORN-522] Add worker consume speed metric

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/CongestionController.java
@@ -76,6 +76,9 @@ public class CongestionController {
 
     this.workerSource.addGauge(
         WorkerSource.PotentialConsumeSpeed(), this::getPotentialConsumeSpeed);
+
+    this.workerSource.addGauge(
+        WorkerSource.WorkerConsumeSpeed(), consumedBufferStatusHub::avgBytesPerSec);
   }
 
   public static synchronized CongestionController initialize(

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -111,4 +111,5 @@ object WorkerSource {
   // Congestion control
   val PotentialConsumeSpeed = "PotentialConsumeSpeed"
   val UserProduceSpeed = "UserProduceSpeed"
+  val WorkerConsumeSpeed = "WorkerConsumeSpeed"
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add a new metric `WorkerConsumeSpeed` to monitor the whole flush speed from worker side.

### Why are the changes needed?
Help us to track if the worker has bottleneck to flush data to storages.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
Existing UT
