### PR TITLE
[CELEBORN-525] Fix wrong parameter celeborn.push.buffer.size

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ spark.celeborn.master.endpoints clb-1:9097,clb-2:9098,clb-3:9099
 spark.shuffle.service.enabled false
 
 # options: hash, sort
-# Hash shuffle writer use (partition count) * (celeborn.push.buffer.size) * (spark.executor.cores) memory.
+# Hash shuffle writer use (partition count) * (celeborn.push.buffer.max.size) * (spark.executor.cores) memory.
 # Sort shuffle writer use less memory than hash shuffle writer, if your shuffle partition count is large, try to use sort hash writer.  
 spark.celeborn.shuffle.writer hash
 

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
@@ -172,7 +172,7 @@ public class RssShuffleWriterSuiteJ {
   @Test
   public void testMergeSmallBlock() throws Exception {
     final KryoSerializer serializer = new KryoSerializer(sparkConf);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "1024");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "1024");
     check(10000, conf, serializer, true);
     check(10000, conf, serializer, false);
   }
@@ -180,7 +180,7 @@ public class RssShuffleWriterSuiteJ {
   @Test
   public void testMergeSmallBlockWithFastWrite() throws Exception {
     final UnsafeRowSerializer serializer = new UnsafeRowSerializer(2, null);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "1024");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "1024");
     check(10000, conf, serializer, true);
     check(10000, conf, serializer, false);
   }
@@ -188,7 +188,7 @@ public class RssShuffleWriterSuiteJ {
   @Test
   public void testGiantRecord() throws Exception {
     final KryoSerializer serializer = new KryoSerializer(sparkConf);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "5");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "5");
     check(10000, conf, serializer, true);
     check(10000, conf, serializer, false);
   }
@@ -196,7 +196,7 @@ public class RssShuffleWriterSuiteJ {
   @Test
   public void testGiantRecordWithFastWrite() throws Exception {
     final UnsafeRowSerializer serializer = new UnsafeRowSerializer(2, null);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "5");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "5");
     check(10000, conf, serializer, true);
     check(10000, conf, serializer, false);
   }
@@ -204,7 +204,7 @@ public class RssShuffleWriterSuiteJ {
   @Test
   public void testGiantRecordAndMergeSmallBlock() throws Exception {
     final KryoSerializer serializer = new KryoSerializer(sparkConf);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "128");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "128");
     check(2 << 30, conf, serializer, true);
     check(2 << 30, conf, serializer, false);
   }
@@ -212,7 +212,7 @@ public class RssShuffleWriterSuiteJ {
   @Test
   public void testGiantRecordAndMergeSmallBlockWithFastWrite() throws Exception {
     final UnsafeRowSerializer serializer = new UnsafeRowSerializer(2, null);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "128");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "128");
     check(2 << 30, conf, serializer, true);
     check(2 << 30, conf, serializer, false);
   }

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
@@ -158,42 +158,42 @@ public class RssShuffleWriterSuiteJ {
   @Test
   public void testMergeSmallBlock() throws Exception {
     final KryoSerializer serializer = new KryoSerializer(sparkConf);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "1024");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "1024");
     check(10000, conf, serializer);
   }
 
   @Test
   public void testMergeSmallBlockWithFastWrite() throws Exception {
     final UnsafeRowSerializer serializer = new UnsafeRowSerializer(2, null);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "1024");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "1024");
     check(10000, conf, serializer);
   }
 
   @Test
   public void testGiantRecord() throws Exception {
     final KryoSerializer serializer = new KryoSerializer(sparkConf);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "5");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "5");
     check(10000, conf, serializer);
   }
 
   @Test
   public void testGiantRecordWithFastWrite() throws Exception {
     final UnsafeRowSerializer serializer = new UnsafeRowSerializer(2, null);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "5");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "5");
     check(10000, conf, serializer);
   }
 
   @Test
   public void testGiantRecordAndMergeSmallBlock() throws Exception {
     final KryoSerializer serializer = new KryoSerializer(sparkConf);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "128");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "128");
     check(2 << 30, conf, serializer);
   }
 
   @Test
   public void testGiantRecordAndMergeSmallBlockWithFastWrite() throws Exception {
     final UnsafeRowSerializer serializer = new UnsafeRowSerializer(2, null);
-    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.size", "128");
+    final CelebornConf conf = new CelebornConf().set("celeborn.push.buffer.max.size", "128");
     check(2 << 30, conf, serializer);
   }
 

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
@@ -84,7 +84,7 @@ public abstract class ShuffleClientBaseSuiteJ {
     CelebornConf conf = new CelebornConf();
     conf.set("celeborn.shuffle.compression.codec", codec.name());
     conf.set("celeborn.push.retry.threads", "1");
-    conf.set("celeborn.push.buffer.size", "1K");
+    conf.set("celeborn.push.buffer.max.size", "1K");
     shuffleClient = new ShuffleClientImpl(conf, new UserIdentifier("mock", "mock"));
     masterLocation.setPeer(slaveLocation);
 

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -176,7 +176,7 @@ public class ShuffleClientSuiteJ {
     CelebornConf conf = new CelebornConf();
     conf.set("celeborn.shuffle.compression.codec", codec.name());
     conf.set("celeborn.push.retry.threads", "1");
-    conf.set("celeborn.push.buffer.size", "1K");
+    conf.set("celeborn.push.buffer.max.size", "1K");
     shuffleClient = new ShuffleClientImpl(conf, new UserIdentifier("mock", "mock"));
 
     masterLocation.setPeer(slaveLocation);

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -132,7 +132,7 @@ Assume we have a cluster described as below:
 As we need to reserve 20% off-heap memory for netty,
 so we could assume 16 GB off-heap memory can be used for flush buffers.
 
-If `spark.celeborn.push.buffer.size` is 64 KB, we can have in-flight requests up to 1310720.
+If `spark.celeborn.push.buffer.max.size` is 64 KB, we can have in-flight requests up to 1310720.
 If you have 8192 mapper tasks, you could set `spark.celeborn.push.maxReqsInFlight=160` to gain performance improvements.
 
 If `celeborn.worker.flush.buffer.size` is 256 KB, we can have total slots up to 327680 slots.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -116,7 +116,7 @@ spark.celeborn.master.endpoints clb-1:9097,clb-2:9098,clb-3:9099
 spark.shuffle.service.enabled false
 
 # options: hash, sort
-# Hash shuffle writer use (partition count) * (celeborn.push.buffer.size) * (spark.executor.cores) memory.
+# Hash shuffle writer use (partition count) * (celeborn.push.buffer.max.size) * (spark.executor.cores) memory.
 # Sort shuffle writer use less memory than hash shuffle writer, if your shuffle partition count is large, try to use sort hash writer.  
 spark.celeborn.shuffle.writer hash
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
@@ -28,7 +28,7 @@ class ShuffleClientSuite extends WithShuffleClientSuite with MiniClusterFeature 
 
   celebornConf.set("celeborn.master.endpoints", s"localhost:$masterPort")
     .set("celeborn.push.replicate.enabled", "true")
-    .set("celeborn.push.buffer.size", "256K")
+    .set("celeborn.push.buffer.max.size", "256K")
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -70,7 +70,7 @@ trait MiniClusterFeature extends Logging {
     val conf = new CelebornConf()
     conf.set("celeborn.worker.storage.dirs", createTmpDir())
     conf.set("celeborn.worker.monitor.disk.enabled", "false")
-    conf.set("celeborn.push.buffer.size", "256K")
+    conf.set("celeborn.push.buffer.max.size", "256K")
     conf.set(
       "celeborn.worker.metrics.prometheus.port",
       s"${workerPrometheusPort.incrementAndGet()}")

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
@@ -58,7 +58,7 @@ trait ReadWriteTestBase extends AnyFunSuite
       .set("celeborn.master.endpoints", s"localhost:$masterPort")
       .set("celeborn.shuffle.compression.codec", codec.name)
       .set("celeborn.push.replicate.enabled", "true")
-      .set("celeborn.push.buffer.size", "256K")
+      .set("celeborn.push.buffer.max.size", "256K")
       .set("celeborn.data.io.numConnectionsPerPeer", "1")
     val lifecycleManager = new LifecycleManager(APP, clientConf)
     val shuffleClient = new ShuffleClientImpl(clientConf, UserIdentifier("mock", "mock"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replac `celeborn.push.buffer.size` with the correct parameter `celeborn.push.buffer.max.size`.


### Why are the changes needed?
The documentation is incorrect.


### Does this PR introduce _any_ user-facing change?
Users who read the documentation.


### How was this patch tested?
exist UT
