### PR TITLE
[CELEBORN-527][DOC] Fix incorrect monitor the arrangement of documents

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -106,13 +106,13 @@ These metrics are exposed by Celeborn master.
     [Dropwizard/Codahale Metric Sets for JVM instrumentation](https://metrics.dropwizard.io/4.2.0/manual/jvm.html)
     and in particular the metric sets BufferPoolMetricSet, GarbageCollectorMetricSet and MemoryUsageGaugeSet.
 
-    - namespace=ResourceConsumption
-      - **notes:**
-        - This merics data is generated for each user and they are identified using a metric tag. 
-      - diskFileCount
-      - diskBytesWritten
-      - hdfsFileCount
-      - hdfsBytesWritten
+  - namespace=ResourceConsumption
+    - **notes:**
+      - This merics data is generated for each user and they are identified using a metric tag. 
+    - diskFileCount
+    - diskBytesWritten
+    - hdfsFileCount
+    - hdfsBytesWritten
 
 ### Component instance = Worker
 These metrics are exposed by Celeborn worker.


### PR DESCRIPTION
### What changes were proposed in this pull request?
<img width="1155" alt="截屏2023-04-17 上午10 50 25" src="https://user-images.githubusercontent.com/46485123/232366832-f77ebb61-762d-4b79-86b0-5d5e866a3c6a.png">



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

