### PR TITLE
[CELEBORN-534] Respect the user's configured master host settings

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
@@ -20,7 +20,7 @@ package org.apache.celeborn.service.deploy.master.clustermeta.ha
 import java.io.IOException
 import java.net.{InetAddress, InetSocketAddress}
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 import org.apache.ratis.util.NetUtils
 
@@ -90,14 +90,16 @@ object MasterNode extends Logging {
   }
 
   private def createSocketAddr(host: String, port: Int): InetSocketAddress = {
-    val socketAddr: InetSocketAddress =
-      Try(NetUtils.createSocketAddr(host, port)) match {
-        case Success(addr) => addr
-        case Failure(e) =>
+    val socketAddr: InetSocketAddress = {
+      try {
+        NetUtils.createSocketAddr(host, port)
+      } catch {
+        case e: Throwable =>
           throw new IOException(
             s"Couldn't create socket address for $host:$port",
             e)
       }
+    }
     if (socketAddr.isUnresolved)
       logError(s"Address of $host:$port couldn't be resolved. " +
         s"Proceeding with unresolved host to create Ratis ring.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

I am looking to deploy Apache Celeborn on Kubernetes in host network mode, with the aim of facilitating communication between Spark and Celeborn through IP addresses. Currently, the master node retrieves the container hostname by default, rather than taking into consideration the address settings configured by the user.


here is my `celeborn-defaults.conf`

```
celeborn.master.endpoints=192.168.1.2,192.168.1.3,192.168.1.4
celeborn.ha.master.node.0.host=192.168.1.2
celeborn.ha.master.node.1.host=192.168.1.3
celeborn.ha.master.node.2.host=192.168.1.4
celeborn.ha.master.node.0.ratis.host=192.168.1.2
celeborn.ha.master.node.1.ratis.host=192.168.1.3
celeborn.ha.master.node.2.ratis.host=192.168.1.4
```

hostnames:

```
k8s2  192.168.1.2
k8s3  192.168.1.3
k8s6  192.168.1.4
```

spark conf

```scala
val conf = new SparkConf().setIfMissing("spark.master", "local")
  .setIfMissing("spark.shuffle.manager", "org.apache.spark.shuffle.celeborn.RssShuffleManager")
  .set("spark.celeborn.master.endpoints", "192.168.1.4:9097")
```


logs before this PR:


```
Caused by: java.io.IOException: Failed to connect to k8s6:9097
	at org.apache.celeborn.common.network.client.TransportClientFactory.internalCreateClient(TransportClientFactory.java:234)
	at org.apache.celeborn.common.network.client.TransportClientFactory.createClient(TransportClientFactory.java:178)
	at org.apache.celeborn.common.network.client.TransportClientFactory.createClient(TransportClientFactory.java:116)
	at org.apache.celeborn.common.network.client.TransportClientFactory.createClient(TransportClientFactory.java:185)
	at org.apache.celeborn.common.rpc.netty.NettyRpcEnv.createClient(NettyRpcEnv.scala:197)
	at org.apache.celeborn.common.rpc.netty.Outbox$$anon$1.call(Outbox.scala:194)
	at org.apache.celeborn.common.rpc.netty.Outbox$$anon$1.call(Outbox.scala:190)
	... 4 more
```

> Please note that while the client machine is able to connect with k8s6 only via its IP address, and unable to establish a connection using the hostname.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

