### PR TITLE
[CELEBORN-533] Bootstrap scripts should use exec to avoid fork subprocess

### DIFF
--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
           - "/bin/sh"
           - '-c'
           {{- $namespace := .Release.Namespace }}
-          - "until {{ range until (.Values.masterReplicas |int) }}nslookup celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && /opt/celeborn/sbin/start-master.sh"
+          - "until {{ range until (.Values.masterReplicas |int) }}nslookup celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-master.sh"
         resources:
           {{- toYaml .Values.resources.master | nindent 12 }}
         ports:

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
           - "/bin/sh"
           - '-c'
           {{- $namespace := .Release.Namespace }}
-          - "until {{ range until (.Values.masterReplicas |int) }}nslookup celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && /opt/celeborn/sbin/start-worker.sh"
+          - "until {{ range until (.Values.masterReplicas |int) }}nslookup celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-worker.sh"
         resources:
           {{- toYaml .Values.resources.worker | nindent 12 }}
         ports:

--- a/sbin/celeborn-daemon.sh
+++ b/sbin/celeborn-daemon.sh
@@ -101,7 +101,7 @@ fi
 
 execute_command() {
   if [ -z ${CELEBORN_NO_DAEMONIZE+set} ]; then
-      nohup -- "$@" >> $log 2>&1 < /dev/null &
+      exec nohup -- "$@" >> $log 2>&1 < /dev/null &
       newpid="$!"
 
       echo "$newpid" > "$pid"
@@ -123,7 +123,7 @@ execute_command() {
         echo "full log in $log"
       fi
   else
-      "$@"
+      exec "$@"
   fi
 }
 

--- a/sbin/start-master.sh
+++ b/sbin/start-master.sh
@@ -30,4 +30,4 @@ fi
 
 export CELEBORN_JAVA_OPTS="-Xmx$CELEBORN_MASTER_MEMORY $CELEBORN_MASTER_JAVA_OPTS"
 
-"${CELEBORN_HOME}/sbin/celeborn-daemon.sh" start org.apache.celeborn.service.deploy.master.Master 1 "$@"
+exec "${CELEBORN_HOME}/sbin/celeborn-daemon.sh" start org.apache.celeborn.service.deploy.master.Master 1 "$@"

--- a/sbin/start-worker.sh
+++ b/sbin/start-worker.sh
@@ -42,4 +42,4 @@ if [ "$WORKER_INSTANCE" = "" ]; then
   WORKER_INSTANCE=1
 fi
 
-"${CELEBORN_HOME}/sbin/celeborn-daemon.sh" start org.apache.celeborn.service.deploy.worker.Worker "$WORKER_INSTANCE" "$@"
+exec "${CELEBORN_HOME}/sbin/celeborn-daemon.sh" start org.apache.celeborn.service.deploy.worker.Worker "$WORKER_INSTANCE" "$@"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Use `exec` in bootstrap scripts to avoid fork subprocess

### Why are the changes needed?

In K8s pod,  run  `ps -ef |grep celeborn`, the result as follows. when killing -15 pod, the sigterm pass to pid 1 by k8s and tini will pass sigterm to pid 22,  but pid 60(the real worker process) can't get the sigterm. so worker's ShutdowHookManager can't be called and master also can't know the worker have shutdown.

```
root          1      0  0 12:11 ?        00:00:00 /usr/bin/tini -- /bin/sh -c until nslookup celeborn-master-0.celeborn-master-svc.flink-celeborn.svc.cluster.local && nslookup celeborn-master-1.celeborn-master-svc.flink-celeborn.svc.cluster.local && nslookup celeborn-master-2.celeborn-master-svc.flink-celeborn.svc.cluster.local && true; do echo waiting for master; sleep 2; done && /opt/celeborn/sbin/start-worker.sh
root         22      1  0 12:11 ?        00:00:00 /bin/sh -c until nslookup celeborn-master-0.celeborn-master-svc.flink-celeborn.svc.cluster.local && nslookup celeborn-master-1.celeborn-master-svc.flink-celeborn.svc.cluster.local && nslookup celeborn-master-2.celeborn-master-svc.flink-celeborn.svc.cluster.local && true; do echo waiting for master; sleep 2; done && /opt/celeborn/sbin/start-worker.sh
root         35     22  0 12:11 ?        00:00:00 bash /opt/celeborn/sbin/start-worker.sh
root         60     35  0 12:11 ?        00:00:00 bash /opt/celeborn/sbin/celeborn-daemon.sh start org.apache.celeborn.service.deploy.worker.Worker 1
root         66     60  0 12:11 ?        00:00:26 java -Xmx2g -XX:MaxDirectMemorySize=12g -XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced -cp /opt/celeborn/conf::/opt/celeborn/worker-jars/* org.apache.celeborn.service.deploy.worker.Worker
```

### Does this PR introduce _any_ user-facing change?

Bug fix.

### How was this patch tested?

After applying this pr,  run `ps -ef |grep celeborn`, we can see there only 2 records. so the sigterm will be transfer to worker.
```
root          1      0  0 17:33 ?        00:00:00 /usr/bin/tini -- /bin/sh -c until nslookup celeborn-master-0.celeborn-master-svc.flink-celeborn.svc.cluster.local && nslookup celeborn-master-1.celeborn-master-svc.flink-celeborn.svc.cluster.local && nslookup celeborn-master-2.celeborn-master-svc.flink-celeborn.svc.cluster.local && true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-worker.sh
root         22      1 11 17:33 ?        00:00:03 java -Xmx2g -XX:MaxDirectMemorySize=12g -XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-worker.out -Dio.netty.leakDetectionLevel=advanced -cp /opt/celeborn/conf::/opt/celeborn/worker-jars/* org.apache.celeborn.service.deploy.worker.Worker
```