### PR TITLE
[CELEBORN-535][FLINK] Reduce message decoder overhead.

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/TransportFrameDecoderWithBufferSupplier.java
@@ -54,9 +54,7 @@ public class TransportFrameDecoderWithBufferSupplier extends ChannelInboundHandl
 
   private void copyByteBuf(io.netty.buffer.ByteBuf source, ByteBuf target, int targetSize) {
     int bytes = Math.min(source.readableBytes(), targetSize - target.readableBytes());
-    for (int i = 0; i < bytes; i++) {
-      target.writeByte(source.readByte());
-    }
+    target.writeBytes(source.readSlice(bytes).nioBuffer());
   }
 
   private void decodeHeader(io.netty.buffer.ByteBuf buf, ChannelHandlerContext ctx) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
To reduce message decoding overhead.


### Why are the changes needed?
Before:
<img width="1544" alt="截屏2023-04-18 20 43 41" src="https://user-images.githubusercontent.com/4150993/232951475-7f8b698a-db77-4fb7-8bfd-282b83d8b9c0.png">

After:
<img width="1757" alt="截屏2023-04-18 20 44 31" src="https://user-images.githubusercontent.com/4150993/232951489-7f27a6c3-c074-42f4-97e2-cbe9dd27e75b.png">



### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT and cluster run.
