### PR TITLE
[CELEBORN-537] Improve blacklist compute & minor fix for Flink

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResourceTracker.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/ShuffleResourceTracker.java
@@ -101,12 +101,12 @@ public class ShuffleResourceTracker implements WorkerStatusListener {
                 // shuffleResourceListener may release when the shuffle is ended
                 if (shuffleAllocateInfo != null) {
                   ShufflePartitionLocationInfo shufflePartitionLocationInfo =
-                      shuffleAllocateInfo.remove(unknownWorker);
+                      shuffleAllocateInfo.get(unknownWorker);
                   if (shufflePartitionLocationInfo != null) {
                     // TODO if we support partition replica for map partition we need refactor this
                     //  Currently we only untrack master partitions for map partition
                     shufflePartitionLocationInfo
-                        .getMasterPartitionIds()
+                        .removeAndGetAllMasterPartitionIds()
                         .forEach(
                             id -> {
                               ResultPartitionID resultPartitionId =

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerTest.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/ShuffleResourceTrackerTest.java
@@ -55,8 +55,7 @@ public class ShuffleResourceTrackerTest {
     ConcurrentHashMap<WorkerInfo, ShufflePartitionLocationInfo> map3 = new ConcurrentHashMap<>();
     map3.put(workerInfo, mockShufflePartitionLocationInfo());
 
-    Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt()))
-        .thenReturn(map, map2, map3);
+    Mockito.when(lifecycleManager.workerSnapshots(Mockito.anyInt())).thenReturn(map, map2, map3);
 
     ShuffleResourceTracker shuffleResourceTracker =
         new ShuffleResourceTracker(executor, lifecycleManager);

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -442,8 +442,8 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
     candidatesWorkers.removeAll(connectFailedWorkers.asScala.keys.toList.asJava)
     workerStatusTracker.recordWorkerFailure(connectFailedWorkers)
-    // if newly allocated from master and setupEndpoint success, we can remove worker from blacklist to
-    // improve the accuracy of the blacklist
+    // If newly allocated from master and can setup endpoint success, LifecycleManager should remove worker from
+    // the blacklist to improve the accuracy of the blacklist
     workerStatusTracker.removeFromBlacklist(candidatesWorkers)
 
     // Third, for each slot, LifecycleManager should ask Worker to reserve the slot

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -152,25 +152,24 @@ class WorkerStatusTracker(
       }
 
       if (!res.blacklist.isEmpty) {
-        blacklist.putAll(res.blacklist.asScala.filterNot(e => blacklist.containsKey(e)).map(
+        blacklist.putAll(res.blacklist.asScala.filterNot(blacklist.containsKey).map(
           _ -> (StatusCode.WORKER_IN_BLACKLIST -> current)).toMap.asJava)
       }
 
       if (!res.unknownWorkers.isEmpty || !newShutdownWorkers.isEmpty) {
-        blacklist.putAll(res.unknownWorkers.asScala.filterNot(e => blacklist.containsKey(e)).map(
+        blacklist.putAll(res.unknownWorkers.asScala.filterNot(blacklist.containsKey).map(
           _ -> (StatusCode.UNKNOWN_WORKER -> current)).toMap.asJava)
-        blacklist.putAll(res.shuttingWorkers.asScala.filterNot(e => blacklist.containsKey(e)).map(
+        blacklist.putAll(res.shuttingWorkers.asScala.filterNot(blacklist.containsKey).map(
           _ -> (StatusCode.WORKER_SHUTDOWN -> current)).toMap.asJava)
 
         val workerStatus = new WorkersStatus(res.unknownWorkers, newShutdownWorkers)
-        workerStatusListeners.asScala.foreach {
-          listener =>
-            try {
-              listener.notifyChangedWorkersStatus(workerStatus)
-            } catch {
-              case t: Throwable =>
-                logError("Error while notify listener", t)
-            }
+        workerStatusListeners.asScala.foreach { listener =>
+          try {
+            listener.notifyChangedWorkersStatus(workerStatus)
+          } catch {
+            case t: Throwable =>
+              logError("Error while notify listener", t)
+          }
         }
       }
 

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -152,15 +152,15 @@ class WorkerStatusTracker(
       }
 
       if (!res.blacklist.isEmpty) {
-        blacklist.putAll(res.blacklist.asScala.filterNot(blacklist.containsKey).map(
-          _ -> (StatusCode.WORKER_IN_BLACKLIST -> current)).toMap.asJava)
+        blacklist.putAll(res.blacklist.asScala.filterNot(blacklist.containsKey)
+          .map(_ -> (StatusCode.WORKER_IN_BLACKLIST -> current)).toMap.asJava)
       }
 
       if (!res.unknownWorkers.isEmpty || !newShutdownWorkers.isEmpty) {
-        blacklist.putAll(res.unknownWorkers.asScala.filterNot(blacklist.containsKey).map(
-          _ -> (StatusCode.UNKNOWN_WORKER -> current)).toMap.asJava)
-        blacklist.putAll(res.shuttingWorkers.asScala.filterNot(blacklist.containsKey).map(
-          _ -> (StatusCode.WORKER_SHUTDOWN -> current)).toMap.asJava)
+        blacklist.putAll(res.unknownWorkers.asScala.filterNot(blacklist.containsKey)
+          .map(_ -> (StatusCode.UNKNOWN_WORKER -> current)).toMap.asJava)
+        blacklist.putAll(res.shuttingWorkers.asScala.filterNot(blacklist.containsKey)
+          .map(_ -> (StatusCode.WORKER_SHUTDOWN -> current)).toMap.asJava)
 
         val workerStatus = new WorkersStatus(res.unknownWorkers, newShutdownWorkers)
         workerStatusListeners.asScala.foreach { listener =>

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -123,8 +123,8 @@ class WorkerStatusTracker(
     }
   }
 
-  def removeFromBlacklist(workerInfo: WorkerInfo): Unit = {
-    blacklist.remove(workerInfo)
+  def removeFromBlacklist(workers: JHashSet[WorkerInfo]): Unit = {
+    blacklist.keySet.removeAll(workers)
   }
 
   def handleHeartbeatResponse(res: HeartbeatFromApplicationResponse): Unit = {

--- a/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client
+
+import java.util
+
+import org.junit.Assert
+
+import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.CelebornConf.WORKER_EXCLUDED_EXPIRE_TIMEOUT
+import org.apache.celeborn.common.meta.WorkerInfo
+import org.apache.celeborn.common.protocol.message.ControlMessages.HeartbeatFromApplicationResponse
+import org.apache.celeborn.common.protocol.message.StatusCode
+
+class WorkerStatusTrackerSuite extends CelebornFunSuite {
+
+  test("handleHeartbeatResponse") {
+    val celebornConf = new CelebornConf()
+    celebornConf.set(WORKER_EXCLUDED_EXPIRE_TIMEOUT, 2000L);
+    val statusTracker = new WorkerStatusTracker(celebornConf, null)
+
+    val registerTime = System.currentTimeMillis()
+    statusTracker.blacklist.put(mock("host1"), (StatusCode.UNKNOWN_WORKER, registerTime));
+    statusTracker.blacklist.put(mock("host2"), (StatusCode.WORKER_SHUTDOWN, registerTime));
+
+    // test reserve (only statusCode list in handleHeartbeatResponse)
+    val empty = buildResponse(Array.empty, Array.empty, Array.empty)
+    statusTracker.handleHeartbeatResponse(empty)
+
+    // only reserve host1
+    Assert.assertEquals(
+      statusTracker.blacklist.get(mock("host1")),
+      (StatusCode.UNKNOWN_WORKER, registerTime))
+    Assert.assertFalse(statusTracker.blacklist.containsKey(mock("host2")))
+
+    // add shutdown/blacklist
+    val response1 = buildResponse(Array("host0"), Array("host1", "host3"), Array("host4"))
+    statusTracker.handleHeartbeatResponse(response1)
+
+    // test keep Unknown register time
+    Assert.assertEquals(
+      statusTracker.blacklist.get(mock("host1")),
+      (StatusCode.UNKNOWN_WORKER, registerTime))
+
+    // test new added workers
+    Assert.assertTrue(statusTracker.blacklist.containsKey(mock("host0")))
+    Assert.assertTrue(statusTracker.blacklist.containsKey(mock("host3")))
+    Assert.assertTrue(statusTracker.blacklist.containsKey(mock("host4")))
+
+    // test remove
+    statusTracker.removeFromBlacklist(mock("host4"))
+    Assert.assertFalse(statusTracker.blacklist.containsKey(mock("host4")))
+
+    // test register time elapsed
+    Thread.sleep(3000)
+    val response2 = buildResponse(Array.empty, Array("host5", "host6"), Array.empty)
+    statusTracker.handleHeartbeatResponse(response2)
+    Assert.assertEquals(statusTracker.blacklist.size(), 2)
+    Assert.assertFalse(statusTracker.blacklist.containsKey(mock("host1")))
+  }
+
+  private def buildResponse(
+      blackWorkerHosts: Array[String],
+      unknownWorkerHosts: Array[String],
+      shuttingWorkerHosts: Array[String]): HeartbeatFromApplicationResponse = {
+    val blacklist = mockWorkers(blackWorkerHosts)
+    val unknownWorkers = mockWorkers(unknownWorkerHosts)
+    val shuttingWorkers = mockWorkers(shuttingWorkerHosts)
+    HeartbeatFromApplicationResponse(StatusCode.SUCCESS, blacklist, unknownWorkers, shuttingWorkers)
+  }
+
+  private def mockWorkers(workerHosts: Array[String]): util.ArrayList[WorkerInfo] = {
+    val workers = new util.ArrayList[WorkerInfo]
+    workerHosts.foreach(h => workers.add(mock(h)))
+    workers
+  }
+
+  private def mock(host: String): WorkerInfo = {
+    new WorkerInfo(host, -1, -1, -1, -1);
+  }
+}

--- a/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
@@ -64,7 +64,9 @@ class WorkerStatusTrackerSuite extends CelebornFunSuite {
     Assert.assertTrue(statusTracker.blacklist.containsKey(mock("host4")))
 
     // test remove
-    statusTracker.removeFromBlacklist(mock("host4"))
+    val workers = new util.HashSet[WorkerInfo]
+    workers.add(mock("host4"))
+    statusTracker.removeFromBlacklist(workers)
     Assert.assertFalse(statusTracker.blacklist.containsKey(mock("host4")))
 
     // test register time elapsed

--- a/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
@@ -19,6 +19,7 @@ package org.apache.celeborn.common.meta
 
 import java.util
 import java.util.concurrent.ConcurrentHashMap
+import java.util.stream.Collectors
 
 import scala.collection.JavaConverters._
 
@@ -47,11 +48,6 @@ class ShufflePartitionLocationInfo {
     getPartitions(slavePartitionLocations, partitionIdOpt)
   }
 
-  def getMasterPartitionIds(): util.Set[Integer] = {
-    val value = masterPartitionLocations.keySet().asScala
-    value.asJava.asInstanceOf[util.Set[Integer]]
-  }
-
   def containsPartition(partitionId: Int): Boolean = {
     masterPartitionLocations.containsKey(partitionId) ||
     slavePartitionLocations.containsKey(partitionId)
@@ -63,6 +59,12 @@ class ShufflePartitionLocationInfo {
 
   def removeSlavePartitions(partitionId: Int): util.Set[PartitionLocation] = {
     removePartitions(slavePartitionLocations, partitionId)
+  }
+
+  def removeAndGetAllMasterPartitionIds(): util.Set[Integer] = {
+    masterPartitionLocations.entrySet().asScala
+      .filter(e => masterPartitionLocations.remove(e.getKey, e.getValue))
+      .map(e => e.getKey).toSet.asJava.asInstanceOf[util.Set[Integer]]
   }
 
   private def removePartitions(

--- a/common/src/test/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfoSuite.scala
@@ -61,7 +61,6 @@ class ShufflePartitionLocationInfoSuite extends CelebornFunSuite {
 
     // test get min epoch
     val locations = shufflePartitionLocationInfo.getAllMasterLocationsWithMinEpoch()
-    println(locations)
     assertTrue(locations.contains(partitionLocation00) && locations.contains(partitionLocation11))
 
     // test remove
@@ -72,6 +71,12 @@ class ShufflePartitionLocationInfoSuite extends CelebornFunSuite {
     assertEquals(shufflePartitionLocationInfo.removeSlavePartitions(0).size(), 1)
     assertEquals(shufflePartitionLocationInfo.getSlavePartitions().size(), 1)
     assertEquals(shufflePartitionLocationInfo.getSlavePartitions(Some(1)).size(), 1)
+
+    // test remove all
+    assertEquals(
+      shufflePartitionLocationInfo.removeAndGetAllMasterPartitionIds(),
+      new util.HashSet[Integer] { add(1) })
+    assertEquals(shufflePartitionLocationInfo.getMasterPartitions().size(), 0)
   }
 
   private def mockPartition(partitionId: Int, epoch: Int): PartitionLocation = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. use local shutdown workers as cache, refreshed by master when heartbeat
2. make unknown workers can expired, refreshed by master when heartbeat
3. refresh blacklist when new shuffle registered
4. donot remove worker when notify unknown workers for Flink.
5. Flink don't support revive, we just return exception for this.

### Why are the changes needed?
when test graceful shutdown for Flink, there encounter some problems like blacklist list seems not reasonable, early remove worker from shuffleAllocationWorkers. 

1. work shutdown message would be reported to master/remove from master timely, so shutdown worker info in local can be regarded as cache. it can be refreshed by app heartbeat
2. if worker became unknown workers, this worker can never become alive, IMO it would be better added to checked list and if when blacklist workers expired timeout, we can refresh unknown worker list from master.
3. unknown workers/other workers can be refreshed when new shuffle registered(no need to wait expired timeout)
4. blacklist will be empty for a short time（blacklist.clear）
5. donot remove workers from shuffle allocated worker for Flink

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
UT & Random worker kill
