### PR TITLE
[CELEBORN-541][PERF] handleGetReducerFileGroup occupy too much RPC thread cause other RPC can't been handled

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -54,7 +54,8 @@ class ReducePartitionCommitHandler(
   extends CommitHandler(appId, conf, committedPartitionInfo)
   with Logging {
 
-  private val getReducerFileGroupRequest = JavaUtils.newConcurrentHashMap[Int, util.Set[RpcCallContext]]()
+  private val getReducerFileGroupRequest =
+    JavaUtils.newConcurrentHashMap[Int, util.Set[RpcCallContext]]()
   private val dataLostShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
handleGetReducerFileGroup occupy too much RPC thread cause other RPC can't been handled

```
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
23/04/21 08:37:52 INFO LifecycleManager: [handleGetReducerFileGroup] Waiting for handleStageEnd complete...
```
```
23/04/21 08:37:14 ERROR Executor: Exception in task 67.2 in stage 5.0 (TID 27521)
com.aliyun.emr.rss.common.rpc.RpcTimeoutException: Futures timed out after [30 seconds]. This timeout is controlled by rss.rpc.lookupTimeout
	at com.aliyun.emr.rss.common.rpc.RpcTimeout.com$aliyun$emr$rss$common$rpc$RpcTimeout$$createRpcTimeoutException(RpcTimeout.scala:46)
	at com.aliyun.emr.rss.common.rpc.RpcTimeout$$anonfun$addMessageIfTimeout$1.applyOrElse(RpcTimeout.scala:61)
	at com.aliyun.emr.rss.common.rpc.RpcTimeout$$anonfun$addMessageIfTimeout$1.applyOrElse(RpcTimeout.scala:57)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:38)
	at com.aliyun.emr.rss.common.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:75)
	at com.aliyun.emr.rss.common.rpc.RpcEnv.setupEndpointRefByURI(RpcEnv.scala:95)
	at com.aliyun.emr.rss.common.rpc.RpcEnv.setupEndpointRef(RpcEnv.scala:103)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.setupMetaServiceRef(ShuffleClientImpl.java:1089)
	at com.aliyun.emr.rss.client.ShuffleClient.get(ShuffleClient.java:86)
	at org.apache.spark.shuffle.rss.RssShuffleReader.<init>(RssShuffleReader.scala:43)
	at org.apache.spark.shuffle.rss.RssShuffleManager.getReader(RssShuffleManager.scala:203)
	at org.apache.spark.sql.execution.ShuffledRowRDD.compute(ShuffledRowRDD.scala:190)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.rdd.ZippedPartitionsRDD2.compute(ZippedPartitionsRDD.scala:89)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:497)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1509)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:500)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.util.concurrent.TimeoutException: Futures timed out after [30 seconds]
	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:259)
	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:263)
	at com.aliyun.emr.rss.common.util.ThreadUtils$.awaitResult(ThreadUtils.scala:220)
	at com.aliyun.emr.rss.common.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:74)
	... 32 more 
```


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

