### PR TITLE
[CELEBORN-541][FOLLOWUP] handleGetReducerFileGroup occupy too much RPC thread cause other RPC can't been handled

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -54,7 +54,8 @@ class ReducePartitionCommitHandler(
   extends CommitHandler(appId, conf, committedPartitionInfo)
   with Logging {
 
-  private val getReducerFileGroupRequest = JavaUtils.newConcurrentHashMap[Int, util.Set[RpcCallContext]]()
+  private val getReducerFileGroupRequest =
+    JavaUtils.newConcurrentHashMap[Int, util.Set[RpcCallContext]]()
   private val dataLostShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -97,9 +97,9 @@ class ReducePartitionCommitHandler(
   override def setStageEnd(shuffleId: Int): Unit = {
     getReducerFileGroupRequest synchronized {
       stageEndShuffleSet.add(shuffleId)
-      getReducerFileGroupRequest.remove(shuffleId)
-        .asScala.foreach(replyGetReducerFileGroup(_, shuffleId))
     }
+    getReducerFileGroupRequest.remove(shuffleId)
+      .asScala.foreach(replyGetReducerFileGroup(_, shuffleId))
   }
 
   override def removeExpiredShuffle(shuffleId: Int): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Follow missed comment  https://github.com/apache/incubator-celeborn/pull/1444/files#r1173430611


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

