### PR TITLE
[CELEBORN-541][FOLLOWUP] handleGetReducerFileGroup occupy too much RPC thread cause other RPC can't been handled

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -54,7 +54,8 @@ class ReducePartitionCommitHandler(
   extends CommitHandler(appId, conf, committedPartitionInfo)
   with Logging {
 
-  private val getReducerFileGroupRequest = JavaUtils.newConcurrentHashMap[Int, util.Set[RpcCallContext]]()
+  private val getReducerFileGroupRequest =
+    JavaUtils.newConcurrentHashMap[Int, util.Set[RpcCallContext]]()
   private val dataLostShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val stageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()
   private val inProcessStageEndShuffleSet = ConcurrentHashMap.newKeySet[Int]()

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -97,9 +97,8 @@ class ReducePartitionCommitHandler(
   override def setStageEnd(shuffleId: Int): Unit = {
     getReducerFileGroupRequest synchronized {
       stageEndShuffleSet.add(shuffleId)
-    }
-    getReducerFileGroupRequest.remove(shuffleId)
-      .asScala.foreach(replyGetReducerFileGroup(_, shuffleId))
+      getReducerFileGroupRequest.remove(shuffleId)
+    }.asScala.foreach(replyGetReducerFileGroup(_, shuffleId))
   }
 
   override def removeExpiredShuffle(shuffleId: Int): Unit = {

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -98,8 +98,9 @@ class ReducePartitionCommitHandler(
     // Set empty HashSet during register shuffle, no NPE issue here.
     getReducerFileGroupRequest synchronized {
       stageEndShuffleSet.add(shuffleId)
-      getReducerFileGroupRequest.remove(shuffleId)
-    }.asScala.foreach(replyGetReducerFileGroup(_, shuffleId))
+    }
+    getReducerFileGroupRequest.remove(shuffleId)
+      .asScala.foreach(replyGetReducerFileGroup(_, shuffleId))
   }
 
   override def removeExpiredShuffle(shuffleId: Int): Unit = {

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -95,10 +95,11 @@ class ReducePartitionCommitHandler(
   }
 
   override def setStageEnd(shuffleId: Int): Unit = {
-    val requests = getReducerFileGroupRequest synchronized {
+    getReducerFileGroupRequest synchronized {
       stageEndShuffleSet.add(shuffleId)
-      getReducerFileGroupRequest.remove(shuffleId)
     }
+
+    val requests = getReducerFileGroupRequest.remove(shuffleId)
     // Set empty HashSet during register shuffle, but handleStageEnd may call
     // un-registered shuffle, here still need a null check
     if (requests != null && !requests.isEmpty) {

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -95,11 +95,12 @@ class ReducePartitionCommitHandler(
   }
 
   override def setStageEnd(shuffleId: Int): Unit = {
-    // Set empty HashSet during register shuffle, no NPE issue here.
     val requests = getReducerFileGroupRequest synchronized {
       stageEndShuffleSet.add(shuffleId)
       getReducerFileGroupRequest.remove(shuffleId)
     }
+    // Set empty HashSet during register shuffle, but handleStageEnd may call
+    // un-registered shuffle, here still need a null check
     if (requests != null && !requests.isEmpty) {
       requests.asScala.foreach(replyGetReducerFileGroup(_, shuffleId))
     }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -97,9 +97,9 @@ class ReducePartitionCommitHandler(
   override def setStageEnd(shuffleId: Int): Unit = {
     getReducerFileGroupRequest synchronized {
       stageEndShuffleSet.add(shuffleId)
-      getReducerFileGroupRequest.remove(shuffleId)
-        .asScala.foreach(replyGetReducerFileGroup(_, shuffleId))
     }
+    getReducerFileGroupRequest.remove(shuffleId)
+      .asScala.foreach(replyGetReducerFileGroup(_, shuffleId))
   }
 
   override def removeExpiredShuffle(shuffleId: Int): Unit = {

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -100,8 +100,9 @@ class ReducePartitionCommitHandler(
     }
 
     val requests = getReducerFileGroupRequest.remove(shuffleId)
-    // Set empty HashSet during register shuffle, but handleStageEnd may call
-    // un-registered shuffle, here still need a null check
+    // Set empty HashSet during register shuffle.
+    // In case of stage with no shuffle data, register shuffle will not be called,
+    // so here we still need to check null.
     if (requests != null && !requests.isEmpty) {
       requests.asScala.foreach(replyGetReducerFileGroup(_, shuffleId))
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Follow comment and fix NPE issue


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

