### PR TITLE
[CELEBORN-537][FOLLOWUP] Fix blacklist potentially lost failure workers

### DIFF
--- a/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
@@ -63,6 +63,11 @@ class WorkerStatusTrackerSuite extends CelebornFunSuite {
     Assert.assertTrue(statusTracker.blacklist.containsKey(mock("host3")))
     Assert.assertTrue(statusTracker.blacklist.containsKey(mock("host4")))
 
+    // test re heartbeat with shutdown workers
+    val response3 = buildResponse(Array.empty, Array.empty, Array("host4"))
+    statusTracker.handleHeartbeatResponse(response3)
+    Assert.assertTrue(statusTracker.blacklist.containsKey(mock("host4")))
+
     // test remove
     val workers = new util.HashSet[WorkerInfo]
     workers.add(mock("host4"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Record shuttingWorkers & improve remove


### Why are the changes needed?
1. if workers returned by heartbeat contains being removed workers, It would better don't remove from blacklist.
2. blacklist need record every worker in heartbeat workers list. (Currently may lost record shuttingWorkers)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
