### PR TITLE
[CELEBORN-544] Remove unnecessary PbUnregisterShuffleResponse between LifecycleManager and Master

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1083,15 +1083,12 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
   private def requestUnregisterShuffle(
       rssHARetryClient: RssHARetryClient,
-      message: PbUnregisterShuffle): PbUnregisterShuffleResponse = {
+      message: PbUnregisterShuffle): Unit = {
     try {
-      rssHARetryClient.askSync[PbUnregisterShuffleResponse](
-        message,
-        classOf[PbUnregisterShuffleResponse])
+      rssHARetryClient.send(message)
     } catch {
       case e: Exception =>
         logError(s"AskSync UnregisterShuffle for ${message.getShuffleId} failed.", e)
-        UnregisterShuffleResponse(StatusCode.REQUEST_FAILED)
     }
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/haclient/RssHARetryClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/haclient/RssHARetryClient.java
@@ -114,6 +114,22 @@ public class RssHARetryClient {
     LOG.debug("Send one-way message {}.", message);
   }
 
+  public void send(GeneratedMessageV3 message) throws Throwable {
+    // Send a one-way message. Because we need to know whether the leader between Masters has
+    // switched, we must adopt a synchronous method, but for a one-way message, we don't care
+    // whether it can be sent successfully, so we adopt an asynchronous method. Therefore, we
+    // choose to use one Thread pool to use synchronization.
+    oneWayMessageSender.submit(
+        () -> {
+          try {
+            sendMessageInner(message, OneWayMessageResponse$.class);
+          } catch (Throwable e) {
+            LOG.warn("Exception occurs while send one-way message.", e);
+          }
+        });
+    LOG.debug("Send one-way message {}.", message);
+  }
+
   public <T> T askSync(Message message, Class<T> clz) throws Throwable {
     return sendMessageInner(message, clz);
   }

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -35,7 +35,7 @@ enum MessageType {
   GET_REDUCER_FILE_GROUP = 14;
   GET_REDUCER_FILE_GROUP_RESPONSE = 15;
   UNREGISTER_SHUFFLE = 16;
-  UNREGISTER_SHUFFLE_RESPONSE = 17;
+//  UNREGISTER_SHUFFLE_RESPONSE = 17;
   APPLICATION_LOST = 18;
   APPLICATION_LOST_RESPONSE = 19;
   HEARTBEAT_FROM_APPLICATION = 20;
@@ -263,10 +263,6 @@ message PbUnregisterShuffle {
   string appId = 1;
   int32 shuffleId = 2;
   string requestId = 3;
-}
-
-message PbUnregisterShuffleResponse {
-  int32 status = 1;
 }
 
 message PbApplicationLost {

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -300,13 +300,6 @@ object ControlMessages extends Logging {
         .build()
   }
 
-  object UnregisterShuffleResponse {
-    def apply(status: StatusCode): PbUnregisterShuffleResponse =
-      PbUnregisterShuffleResponse.newBuilder()
-        .setStatus(status.getValue)
-        .build()
-  }
-
   case class ApplicationLost(
       appId: String,
       override var requestId: String = ZERO_UUID) extends MasterRequestMessage
@@ -594,9 +587,6 @@ object ControlMessages extends Logging {
 
     case pb: PbUnregisterShuffle =>
       new TransportMessage(MessageType.UNREGISTER_SHUFFLE, pb.toByteArray)
-
-    case pb: PbUnregisterShuffleResponse =>
-      new TransportMessage(MessageType.UNREGISTER_SHUFFLE_RESPONSE, pb.toByteArray)
 
     case ApplicationLost(appId, requestId) =>
       val payload = PbApplicationLost.newBuilder()
@@ -947,9 +937,6 @@ object ControlMessages extends Logging {
 
       case UNREGISTER_SHUFFLE =>
         PbUnregisterShuffle.parseFrom(message.getPayload)
-
-      case UNREGISTER_SHUFFLE_RESPONSE =>
-        PbUnregisterShuffleResponse.parseFrom(message.getPayload)
 
       case APPLICATION_LOST =>
         val pbApplicationLost = PbApplicationLost.parseFrom(message.getPayload)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -593,7 +593,6 @@ private[celeborn] class Master(
     val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
     statusSystem.handleUnRegisterShuffle(shuffleKey, requestId)
     logInfo(s"Unregister shuffle $shuffleKey")
-    context.reply(UnregisterShuffleResponse(StatusCode.SUCCESS))
   }
 
   def handleGetBlacklist(context: RpcCallContext, msg: GetBlacklist): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
UnregisterShuffleResponse is not used. remove it.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

