### PR TITLE
[CELEBORN-545] Remove unnecessary ReleaseSlotsResponse between LifecycleManager and Master

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1071,13 +1071,12 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
   private def requestReleaseSlots(
       rssHARetryClient: RssHARetryClient,
-      message: ReleaseSlots): ReleaseSlotsResponse = {
+      message: ReleaseSlots): Unit = {
     try {
-      rssHARetryClient.askSync[ReleaseSlotsResponse](message, classOf[ReleaseSlotsResponse])
+      rssHARetryClient.send(message)
     } catch {
       case e: Exception =>
         logError(s"AskSync ReleaseSlots for ${message.shuffleId} failed.", e)
-        ReleaseSlotsResponse(StatusCode.REQUEST_FAILED)
     }
   }
 

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -26,7 +26,7 @@ enum MessageType {
   REGISTER_SHUFFLE_RESPONSE = 5;
   REQUEST_SLOTS = 6;
   RELEASE_SLOTS = 7;
-  RELEASE_SLOTS_RESPONSE = 8;
+//  RELEASE_SLOTS_RESPONSE = 8;
   REQUEST_SLOTS_RESPONSE = 9;
   REVIVE = 10;
   CHANGE_LOCATION_RESPONSE = 11;
@@ -194,10 +194,6 @@ message PbReleaseSlots {
   repeated string workerIds = 3;
   repeated PbSlotInfo slots = 4;
   string requestId = 6;
-}
-
-message PbReleaseSlotsResponse {
-  int32 status = 1;
 }
 
 message PbRequestSlotsResponse {

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -178,9 +178,6 @@ object ControlMessages extends Logging {
       override var requestId: String = ZERO_UUID)
     extends MasterRequestMessage
 
-  case class ReleaseSlotsResponse(status: StatusCode)
-    extends MasterMessage
-
   case class RequestSlotsResponse(
       status: StatusCode,
       workerResource: WorkerResource)
@@ -512,11 +509,6 @@ object ControlMessages extends Logging {
         .addAllSlots(pbSlots.asJava)
         .build().toByteArray
       new TransportMessage(MessageType.RELEASE_SLOTS, payload)
-
-    case ReleaseSlotsResponse(status) =>
-      val payload = PbReleaseSlotsResponse.newBuilder()
-        .setStatus(status.getValue).build().toByteArray
-      new TransportMessage(MessageType.RELEASE_SLOTS_RESPONSE, payload)
 
     case RequestSlotsResponse(status, workerResource) =>
       val builder = PbRequestSlotsResponse.newBuilder()
@@ -888,10 +880,6 @@ object ControlMessages extends Logging {
           new util.ArrayList[String](pbReleaseSlots.getWorkerIdsList),
           new util.ArrayList[util.Map[String, Integer]](slotsList),
           pbReleaseSlots.getRequestId)
-
-      case RELEASE_SLOTS_RESPONSE =>
-        val pbReleaseSlotsResponse = PbReleaseSlotsResponse.parseFrom(message.getPayload)
-        ReleaseSlotsResponse(Utils.toStatusCode(pbReleaseSlotsResponse.getStatus))
 
       case REQUEST_SLOTS_RESPONSE =>
         val pbRequestSlotsResponse = PbRequestSlotsResponse.parseFrom(message.getPayload)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -582,7 +582,6 @@ private[celeborn] class Master(
     val shuffleKey = Utils.makeShuffleKey(applicationId, shuffleId)
     statusSystem.handleReleaseSlots(shuffleKey, workerIds, slots, requestId)
     logInfo(s"Release all slots of $shuffleKey")
-    context.reply(ReleaseSlotsResponse(StatusCode.SUCCESS))
   }
 
   def handleUnregisterShuffle(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove unnecessary ReleaseSlotsResponse between LifecycleManager and Master


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

