### PR TITLE
[CELEBORN-551] Remove unnecessary ShuffleClient.get()

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -102,7 +102,10 @@ public class RssShuffleManager implements ShuffleManager {
           lifecycleManager = new LifecycleManager(appId, celebornConf);
           rssShuffleClient =
               ShuffleClient.get(
-                  lifecycleManager.self(), celebornConf, lifecycleManager.getUserIdentifier());
+                  lifecycleManager.getRssMetaServiceHost(),
+                  lifecycleManager.getRssMetaServicePort(),
+                  celebornConf,
+                  lifecycleManager.getUserIdentifier());
         }
       }
     }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -100,7 +100,10 @@ public class RssShuffleManager implements ShuffleManager {
           lifecycleManager = new LifecycleManager(appId, celebornConf);
           rssShuffleClient =
               ShuffleClient.get(
-                  lifecycleManager.self(), celebornConf, lifecycleManager.getUserIdentifier());
+                  lifecycleManager.getRssMetaServiceHost(),
+                  lifecycleManager.getRssMetaServicePort(),
+                  celebornConf,
+                  lifecycleManager.getUserIdentifier());
         }
       }
     }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -52,30 +52,6 @@ public abstract class ShuffleClient {
   protected ShuffleClient() {}
 
   public static ShuffleClient get(
-      RpcEndpointRef driverRef, CelebornConf conf, UserIdentifier userIdentifier) {
-    if (null == _instance || !initialized) {
-      synchronized (ShuffleClient.class) {
-        if (null == _instance) {
-          // During the execution of Spark tasks, each task may be interrupted due to speculative
-          // tasks. If the Task is interrupted while obtaining the ShuffleClient and the
-          // ShuffleClient is building a singleton, it may cause the MetaServiceEndpoint to not be
-          // assigned. An Executor will only construct a ShuffleClient singleton once. At this time,
-          // when communicating with MetaService, it will cause a NullPointerException.
-          _instance = new ShuffleClientImpl(conf, userIdentifier);
-          _instance.setupMetaServiceRef(driverRef);
-          initialized = true;
-        } else if (!initialized) {
-          _instance.shutdown();
-          _instance = new ShuffleClientImpl(conf, userIdentifier);
-          _instance.setupMetaServiceRef(driverRef);
-          initialized = true;
-        }
-      }
-    }
-    return _instance;
-  }
-
-  public static ShuffleClient get(
       String driverHost, int port, CelebornConf conf, UserIdentifier userIdentifier) {
     if (null == _instance || !initialized) {
       synchronized (ShuffleClient.class) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Two `ShuffleClient.get()` implement is same logic, remove unnecessary one.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

