### PR TITLE
[CELEBORN-552] Add HeartBeat between the client and worker to keep alive

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/MessageDecoderExt.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/MessageDecoderExt.java
@@ -86,6 +86,9 @@ public class MessageDecoderExt {
         in.readBytes(errorBytes);
         return new TransportableError(streamId, errorBytes);
 
+      case HEARTBEAT:
+        return new Heartbeat();
+
       default:
         throw new IllegalArgumentException("Unexpected message type: " + type);
     }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 
 import scala.reflect.ClassTag$;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
@@ -559,5 +560,10 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
 
   public void setDataClientFactory(TransportClientFactory dataClientFactory) {
     this.dataClientFactory = dataClientFactory;
+  }
+
+  @VisibleForTesting
+  public TransportClientFactory getDataClientFactory() {
+    return flinkTransportClientFactory;
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1558,4 +1558,9 @@ public class ShuffleClientImpl extends ShuffleClient {
         || (message.equals("Connection reset by peer"))
         || (message.startsWith("Failed to send RPC "));
   }
+
+  @VisibleForTesting
+  public TransportClientFactory getDataClientFactory() {
+    return dataClientFactory;
+  }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Heartbeat.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Heartbeat.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.protocol;
+
+import io.netty.buffer.ByteBuf;
+
+public class Heartbeat extends RequestMessage {
+
+  @Override
+  public int encodedLength() {
+    return 0;
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {}
+
+  public static Message decode(ByteBuf buffer) {
+    return new Heartbeat();
+  }
+
+  @Override
+  public Type type() {
+    return Type.HEARTBEAT;
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -90,7 +90,8 @@ public abstract class Message implements Encodable {
     OPEN_STREAM_WITH_CREDIT(18),
     BACKLOG_ANNOUNCEMENT(19),
     TRANSPORTABLE_ERROR(20),
-    BUFFER_STREAM_END(21);
+    BUFFER_STREAM_END(21),
+    HEARTBEAT(22);
     private final byte id;
 
     Type(int id) {
@@ -160,6 +161,8 @@ public abstract class Message implements Encodable {
           return TRANSPORTABLE_ERROR;
         case 21:
           return BUFFER_STREAM_END;
+        case 22:
+          return HEARTBEAT;
         case -1:
           throw new IllegalArgumentException("User type messages cannot be decoded.");
         default:
@@ -229,6 +232,9 @@ public abstract class Message implements Encodable {
         return TransportableError.decode(in);
       case BUFFER_STREAM_END:
         return BufferStreamEnd.decode(in);
+
+      case HEARTBEAT:
+        return new Heartbeat();
 
       default:
         throw new IllegalArgumentException("Unexpected message type: " + msgType);

--- a/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
@@ -152,4 +152,8 @@ public class TransportConf {
   public long pushDataTimeoutCheckIntervalMs() {
     return celebornConf.pushTimeoutCheckInterval();
   }
+
+  public long clientHearbeatInterval() {
+    return celebornConf.clientHeartbeatInterval();
+  }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -517,6 +517,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(PARTITION_SORTER_PER_PARTITION_RESERVED_MEMORY)
   def partitionSorterThreads: Int =
     get(PARTITION_SORTER_THREADS).getOrElse(Runtime.getRuntime.availableProcessors)
+  def workerPushHeartbeatEnabled: Boolean = get(WORKER_PUSH_HEARTBEAT_ENABLED)
+  def workerFetchHeartbeatEnabled: Boolean = get(WORKER_FETCH_HEARTBEAT_ENABLED)
 
   // //////////////////////////////////////////////////////
   //                      Client                         //
@@ -543,7 +545,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def shufflePartitionType: PartitionType = PartitionType.valueOf(get(SHUFFLE_PARTITION_TYPE))
   def requestCommitFilesMaxRetries: Int = get(COMMIT_FILE_REQUEST_MAX_RETRY)
   def shuffleClientPushBlacklistEnabled: Boolean = get(SHUFFLE_CLIENT_PUSH_BLACKLIST_ENABLED)
-
+  def clientHeartbeatInterval: Long = get(CLIENT_HEARTBEAT_INTERVAL)
   // //////////////////////////////////////////////////////
   //               Shuffle Compression                   //
   // //////////////////////////////////////////////////////
@@ -3179,4 +3181,28 @@ object CelebornConf extends Logging {
         labels => labels.map(_ => Try(Utils.parseMetricLabels(_))).forall(_.isSuccess),
         "Allowed pattern is: `<label1_key>:<label1_value>[,<label2_key>:<label2_value>]*`")
       .createWithDefault(Seq.empty)
+
+  val WORKER_PUSH_HEARTBEAT_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.worker.push.heartbeat.enabled")
+      .categories("worker")
+      .version("0.3.0")
+      .doc("enable the heartbeat from worker to client when pushing data")
+      .booleanConf
+      .createWithDefault(true)
+
+  val WORKER_FETCH_HEARTBEAT_ENABLED: ConfigEntry[Boolean] =
+    buildConf("celeborn.worker.fetch.heartbeat.enabled")
+      .categories("worker")
+      .version("0.3.0")
+      .doc("enable the heartbeat from worker to client when fetching data")
+      .booleanConf
+      .createWithDefault(true)
+
+  val CLIENT_HEARTBEAT_INTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.client.heartbeat.interval")
+      .categories("client", "worker")
+      .version("0.3.0")
+      .doc("the heartbeat interval between worker and client")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("60s")
 }

--- a/common/src/test/java/org/apache/celeborn/common/network/TransportClientFactorySuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TransportClientFactorySuiteJ.java
@@ -177,7 +177,7 @@ public class TransportClientFactorySuiteJ {
     CelebornConf _conf = new CelebornConf();
     _conf.set("celeborn.shuffle.io.connectionTimeout", "1s");
     TransportConf conf = new TransportConf("shuffle", _conf);
-    TransportContext context = new TransportContext(conf, new BaseMessageHandler(), true);
+    TransportContext context = new TransportContext(conf, new BaseMessageHandler(), true, false);
     try (TransportClientFactory factory = context.createClientFactory()) {
       TransportClient c1 = factory.createClient(getLocalHost(), server1.getPort());
       assertTrue(c1.isActive());

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -23,6 +23,7 @@ license: |
 | celeborn.application.heartbeatInterval | 10s | Interval for client to send heartbeat message to master. | 0.2.0 | 
 | celeborn.client.blacklistSlave.enabled | true | When true, Celeborn will add partition's peer worker into blacklist when push data to slave failed. | 0.3.0 | 
 | celeborn.client.closeIdleConnections | true | Whether client will close idle connections. | 0.3.0 | 
+| celeborn.client.heartbeat.interval | 60s | the heartbeat interval between worker and client | 0.3.0 | 
 | celeborn.client.maxRetries | 15 | Max retry times for client to connect master endpoint | 0.2.0 | 
 | celeborn.fetch.maxReqsInFlight | 3 | Amount of in-flight chunk fetch request. | 0.2.0 | 
 | celeborn.fetch.maxRetriesForEachReplica | 3 | Max retry times of fetch chunk on each replica | 0.2.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -19,6 +19,7 @@ license: |
 <!--begin-include-->
 | Key | Default | Description | Since |
 | --- | ------- | ----------- | ----- |
+| celeborn.client.heartbeat.interval | 60s | the heartbeat interval between worker and client | 0.3.0 | 
 | celeborn.client.maxRetries | 15 | Max retry times for client to connect master endpoint | 0.2.0 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
 | celeborn.metrics.capacity | 4096 | The maximum number of metrics which a source can use to generate output strings. | 0.2.0 | 
@@ -51,6 +52,7 @@ license: |
 | celeborn.worker.disk.checkFileClean.timeout | 1000ms | The wait time per retry for a worker to check if the working directory is cleaned up before registering with the master. | 0.2.0 | 
 | celeborn.worker.disk.reserve.size | 5G | Celeborn worker reserved space for each disk. | 0.2.0 | 
 | celeborn.worker.diskTime.slidingWindow.size | 20 | The size of sliding windows used to calculate statistics about flushed time and count. | 0.2.1 | 
+| celeborn.worker.fetch.heartbeat.enabled | true | enable the heartbeat from worker to client when fetching data | 0.3.0 | 
 | celeborn.worker.fetch.io.threads | &lt;undefined&gt; | Netty IO thread number of worker to handle client fetch data. The default threads number is the number of flush thread. | 0.2.0 | 
 | celeborn.worker.fetch.port | 0 | Server port for Worker to receive fetch data request from ShuffleClient. | 0.2.0 | 
 | celeborn.worker.flusher.buffer.size | 256k | Size of buffer used by a single flusher. | 0.2.0 | 
@@ -85,6 +87,7 @@ license: |
 | celeborn.worker.partitionSorter.reservedMemoryPerPartition | 1mb | Reserved memory when sorting a shuffle file off-heap. | 0.2.0 | 
 | celeborn.worker.partitionSorter.sort.timeout | 220s | Timeout for a shuffle file to sort. | 0.2.0 | 
 | celeborn.worker.partitionSorter.threads | &lt;undefined&gt; | PartitionSorter's thread counts. | 0.3.0 | 
+| celeborn.worker.push.heartbeat.enabled | true | enable the heartbeat from worker to client when pushing data | 0.3.0 | 
 | celeborn.worker.push.io.threads | &lt;undefined&gt; | Netty IO thread number of worker to handle client push data. The default threads number is the number of flush thread. | 0.2.0 | 
 | celeborn.worker.push.port | 0 | Server port for Worker to receive push data request from ShuffleClient. | 0.2.0 | 
 | celeborn.worker.readBuffer.allocationWait | 50ms | The time to wait when buffer dispatcher can not allocate a buffer. | 0.3.0 | 

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/HeartbeatTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/HeartbeatTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.tests.flink
+
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.plugin.flink.readclient.FlinkShuffleClientImpl
+import org.apache.celeborn.service.deploy.{HeartbeatFeature, MiniClusterFeature}
+import org.apache.celeborn.service.deploy.worker.memory.MemoryManager;
+
+class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature with HeartbeatFeature
+  with BeforeAndAfterAll with BeforeAndAfterEach {
+
+  test("celeborn flink hearbeat test - client <- worker") {
+    val (_, clientConf) = getTestHeartbeatFromWorker2ClientConf()
+    val flinkShuffleClientImpl =
+      new FlinkShuffleClientImpl("", 0, clientConf, new UserIdentifier("1", "1"))
+    testHeartbeatFromWorker2Client(flinkShuffleClientImpl.getDataClientFactory)
+  }
+
+  test("celeborn flink hearbeat test - client <- worker no heartbeat") {
+    val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithNoHeartbeatConf()
+    val flinkShuffleClientImpl =
+      new FlinkShuffleClientImpl("", 0, clientConf, new UserIdentifier("1", "1"))
+    testHeartbeatFromWorker2ClientWithNoHeartbeat(flinkShuffleClientImpl.getDataClientFactory)
+  }
+
+  test("celeborn flink hearbeat test - client <- worker timeout") {
+    val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithCloseChannelConf()
+    val flinkShuffleClientImpl =
+      new FlinkShuffleClientImpl("", 0, clientConf, new UserIdentifier("1", "1"))
+    testHeartbeatFromWorker2ClientWithCloseChannel(flinkShuffleClientImpl.getDataClientFactory)
+  }
+}

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HeartbeatTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HeartbeatTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.tests.spark
+
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.client.{ShuffleClient, ShuffleClientImpl}
+import org.apache.celeborn.common.identity.UserIdentifier
+import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.service.deploy.{HeartbeatFeature, MiniClusterFeature};
+
+class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature with HeartbeatFeature
+  with BeforeAndAfterAll with BeforeAndAfterEach {
+
+  override def beforeEach(): Unit = {
+    ShuffleClient.reset()
+  }
+
+  override def afterEach(): Unit = {
+    System.gc()
+  }
+
+  test("celeborn spark heartbeat test - client <- worker") {
+    val (_, clientConf) = getTestHeartbeatFromWorker2ClientConf()
+    val shuffleClientImpl =
+      new ShuffleClientImpl(clientConf, new UserIdentifier("1", "1"))
+    testHeartbeatFromWorker2Client(shuffleClientImpl.getDataClientFactory)
+  }
+
+  test("celeborn spark heartbeat test - client <- worker on heartbeat") {
+    val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithNoHeartbeatConf()
+    val shuffleClientImpl =
+      new ShuffleClientImpl(clientConf, new UserIdentifier("1", "1"))
+    testHeartbeatFromWorker2ClientWithNoHeartbeat(shuffleClientImpl.getDataClientFactory)
+  }
+
+  test("celeborn spark heartbeat test - client <- worker timeout") {
+    val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithCloseChannelConf()
+    val shuffleClientImpl =
+      new ShuffleClientImpl(clientConf, new UserIdentifier("1", "1"))
+    testHeartbeatFromWorker2ClientWithCloseChannel(shuffleClientImpl.getDataClientFactory)
+  }
+}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.PlatformDependent;
@@ -426,6 +427,11 @@ public class MemoryManager {
     actionService.shutdown();
     readBufferTargetChangeListeners.clear();
     readBufferDispatcher.close();
+  }
+
+  @VisibleForTesting
+  public static void reset() {
+    _INSTANCE = null;
   }
 
   public interface MemoryPressureListener {

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/network/RequestTimeoutIntegrationSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/network/RequestTimeoutIntegrationSuiteJ.java
@@ -107,7 +107,7 @@ public class RequestTimeoutIntegrationSuiteJ {
           }
         };
 
-    TransportContext context = new TransportContext(conf, handler, true);
+    TransportContext context = new TransportContext(conf, handler, true, false);
     server = context.createServer();
     clientFactory = context.createClientFactory();
     TransportClient client = clientFactory.createClient(getLocalHost(), server.getPort());
@@ -157,7 +157,7 @@ public class RequestTimeoutIntegrationSuiteJ {
           }
         };
 
-    TransportContext context = new TransportContext(conf, handler, true);
+    TransportContext context = new TransportContext(conf, handler, true, false);
     server = context.createServer();
     clientFactory = context.createClientFactory();
 
@@ -208,7 +208,7 @@ public class RequestTimeoutIntegrationSuiteJ {
           }
         };
 
-    TransportContext context = new TransportContext(conf, handler, true);
+    TransportContext context = new TransportContext(conf, handler, true, false);
     server = context.createServer();
     clientFactory = context.createClientFactory();
     TransportClient client = clientFactory.createClient(getLocalHost(), server.getPort());

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/HeartbeatFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/HeartbeatFeature.scala
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy
+
+import org.junit.Assert
+
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.network.client.{TransportClient, TransportClientFactory}
+import org.apache.celeborn.common.util.Utils
+import org.apache.celeborn.service.deploy.master.Master
+import org.apache.celeborn.service.deploy.worker.Worker
+
+trait HeartbeatFeature extends MiniClusterFeature {
+
+  def testCore(
+      workerConf: Map[String, String],
+      dataClientFactory: TransportClientFactory,
+      assertFunc: (TransportClient, TransportClient) => Unit): Unit = {
+    logInfo("test initialized , setup rss mini cluster")
+    val masterConf = Map(
+      "celeborn.master.host" -> "localhost",
+      "celeborn.master.port" -> "9097")
+    var master: Master = null
+    var workers: collection.Set[Worker] = null
+    try {
+      val (_master, _workers) = setUpMiniCluster(masterConf, workerConf, workerNum = 1)
+      master = _master
+      workers = _workers
+      workers.map(w => {
+        val (pushPort, fetchPort) = w.getPushFetchServerPort
+        logInfo(s"worker port1:$pushPort $fetchPort")
+        val clientPush =
+          dataClientFactory.createClient(Utils.localHostName, pushPort, 0)
+        val clientFetch =
+          dataClientFactory.createClient(
+            Utils.localHostName,
+            fetchPort,
+            0)
+        logInfo(s"worker port2:$clientPush $clientFetch")
+        // At Beggining, the client is active
+        Assert.assertTrue(clientPush.isActive)
+        Assert.assertTrue(clientFetch.isActive)
+        assertFunc(clientPush, clientFetch)
+      })
+    } finally {
+      if (master != null && workers != null)
+        shutdownMiniCluster()
+    }
+  }
+
+  def getTestHeartbeatFromWorker2ClientConf(): (Map[String, String], CelebornConf) = {
+    val workerConf = Map(
+      "celeborn.master.endpoints" -> "localhost:9097",
+      "celeborn.client.heartbeat.interval" -> "4s")
+    val clientConf = new CelebornConf()
+    clientConf.set("celeborn.data.io.connectionTimeout", "6s")
+    clientConf.set("celeborn.client.heartbeat.interval", "3s")
+    (workerConf, clientConf)
+  }
+  def testHeartbeatFromWorker2Client(dataClientFactory: TransportClientFactory): Unit = {
+    val (workerConf, _) = getTestHeartbeatFromWorker2ClientConf()
+    // client <- worker:default client do not send heartbeat to worker, and worker sends hearbeat to client
+    // client active: after connection timeout, the channel still be active
+    testCore(
+      workerConf,
+      dataClientFactory,
+      (pushClient, fetchClient) => {
+        Thread.sleep(7 * 1000)
+        Assert.assertTrue(fetchClient.isActive)
+        // because worker don't send heartbeat when pushdata, so client's channel is false
+        Assert.assertTrue(pushClient.isActive)
+      })
+  }
+
+  def getTestHeartbeatFromWorker2ClientWithNoHeartbeatConf()
+      : (Map[String, String], CelebornConf) = {
+    val workerConf = Map(
+      "celeborn.master.endpoints" -> "localhost:9097",
+      "celeborn.client.heartbeat.interval" -> "4s",
+      "celeborn.worker.push.heartbeat.enabled" -> "false",
+      "celeborn.worker.fetch.heartbeat.enabled" -> "false")
+    val clientConf = new CelebornConf()
+    clientConf.set("celeborn.data.io.connectionTimeout", "6s")
+    (workerConf, clientConf)
+  }
+
+  def testHeartbeatFromWorker2ClientWithNoHeartbeat(dataClientFactory: TransportClientFactory)
+      : Unit = {
+    val (workerConf, _) = getTestHeartbeatFromWorker2ClientWithNoHeartbeatConf()
+
+    // client <- worker:default client do not send heartbeat to worker, and worker sends hearbeat to client
+    // client active: after connection timeout, the channel still be active
+    testCore(
+      workerConf,
+      dataClientFactory,
+      (pushClient, fetchClient) => {
+        Thread.sleep(7 * 1000)
+        Assert.assertFalse(fetchClient.isActive)
+        // because worker don't send heartbeat when pushdata, so client's channel is false
+        Assert.assertFalse(pushClient.isActive)
+      })
+  }
+
+  def getTestHeartbeatFromWorker2ClientWithCloseChannelConf()
+      : (Map[String, String], CelebornConf) = {
+    val workerConf = Map(
+      "celeborn.master.endpoints" -> "localhost:9097",
+      "celeborn.fetch.io.connectionTimeout" -> "9s",
+      "celeborn.push.io.connectionTimeout" -> "9s",
+      "celeborn.client.heartbeat.interval" -> "4s",
+      "celeborn.worker.closeIdleConnections" -> "true")
+    val clientConf = new CelebornConf()
+    clientConf.set("celeborn.data.io.connectionTimeout", "6s")
+    (workerConf, clientConf)
+  }
+
+  def testHeartbeatFromWorker2ClientWithCloseChannel(dataClientFactory: TransportClientFactory)
+      : Unit = {
+    val (workerConf, _) = getTestHeartbeatFromWorker2ClientWithCloseChannelConf
+
+    // client <- worker:default client do not send heartbeat to worker, and worker sends hearbeat to client
+    // client inactive: after client connection timeout, client still be active(because worker send heartbeat to client);
+    // but after worker connectionTimeout, worker will close the channel, then client will be inactive
+    testCore(
+      workerConf,
+      dataClientFactory,
+      (pushClient, fetchClient) => {
+        Thread.sleep(7 * 1000)
+        Assert.assertTrue(fetchClient.isActive)
+        Assert.assertTrue(pushClient.isActive)
+
+        Thread.sleep(4 * 1000)
+        Assert.assertFalse(fetchClient.isActive)
+        Assert.assertFalse(pushClient.isActive)
+      })
+  }
+}

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -27,6 +27,7 @@ import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.Utils
 import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
 import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
+import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
 
 trait MiniClusterFeature extends Logging {
   val workerPrometheusPort = new AtomicInteger(12378)
@@ -104,7 +105,6 @@ trait MiniClusterFeature extends Logging {
     masterThread.start()
     masterInfo = (master, masterThread)
     Thread.sleep(5000L)
-
     for (_ <- 1 to workerNum) {
       val worker = createWorker(workerConfs)
       val workerThread = runnerWrap(worker.initialize())
@@ -137,7 +137,8 @@ trait MiniClusterFeature extends Logging {
       case (_, thread) =>
         thread.interrupt()
     }
-
+    workerInfos.clear()
     masterInfo._2.interrupt()
+    MemoryManager.reset()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. worker's channel inactive occurs: client close/ kill -9 then os close tcp ;
if os is died or network is not usable, then worker's channel wait about 2hours (depending os's tcp keeping alive duration) 
So this pr adds heartbeat to worker, worker will be channel inactive afer readidle timeout (it's more quickly to close connection when os is died or network is not usable)

2. if client is busy and no free time to shuffle read, we often see client will close connection after idletimeout(4min by default) and reconnect to worker . this pr add hearts from work to client to avoid closing connectiton and reconnecting

3. by default ,flink client set heartbeat enabled and idlestatechannel will be changed from allidle to readidle.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

