### PR TITLE
[CELEBORN-554][Tuning]  Improve For LM to avoid reserve/commit empty worker resources

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -662,8 +662,9 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       slots: WorkerResource): util.List[WorkerInfo] = {
     val reserveSlotFailedWorkers = new ShuffleFailedWorkers()
     val failureInfos = new util.concurrent.CopyOnWriteArrayList[String]()
-    val parallelism = Math.min(Math.max(1, slots.size()), conf.rpcMaxParallelism)
-    ThreadUtils.parmap(slots.asScala.to, "ReserveSlot", parallelism) {
+    val workerPartitionLocations = slots.asScala.filter(p => !p._2._1.isEmpty || !p._2._2.isEmpty)
+    val parallelism = Math.min(Math.max(1, workerPartitionLocations.size), conf.rpcMaxParallelism)
+    ThreadUtils.parmap(workerPartitionLocations.to, "ReserveSlot", parallelism) {
       case (workerInfo, (masterLocations, slaveLocations)) =>
         val res = requestReserveSlots(
           workerInfo.endpoint,

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -99,25 +99,25 @@ class WorkerStatusTracker(
         case _ =>
       }
     }
-    if (!failedWorker.isEmpty) {
-      recordWorkerFailure(failedWorker)
-    }
+    recordWorkerFailure(failedWorker)
   }
 
   def recordWorkerFailure(failures: ShuffleFailedWorkers): Unit = {
-    val failedWorker = new ShuffleFailedWorkers(failures)
-    logInfo(s"Report Worker Failure: ${failedWorker.asScala}, current blacklist $blacklist")
-    failedWorker.asScala.foreach { case (worker, (statusCode, registerTime)) =>
-      if (!blacklist.containsKey(worker)) {
-        blacklist.put(worker, (statusCode, registerTime))
-      } else {
-        statusCode match {
-          case StatusCode.WORKER_SHUTDOWN |
-              StatusCode.NO_AVAILABLE_WORKING_DIR |
-              StatusCode.RESERVE_SLOTS_FAILED |
-              StatusCode.UNKNOWN_WORKER =>
-            blacklist.put(worker, (statusCode, blacklist.get(worker)._2))
-          case _ => // Not cover
+    if (!failures.isEmpty) {
+      val failedWorker = new ShuffleFailedWorkers(failures)
+      logInfo(s"Report Worker Failure: ${failedWorker.asScala}, current blacklist $blacklist")
+      failedWorker.asScala.foreach { case (worker, (statusCode, registerTime)) =>
+        if (!blacklist.containsKey(worker)) {
+          blacklist.put(worker, (statusCode, registerTime))
+        } else {
+          statusCode match {
+            case StatusCode.WORKER_SHUTDOWN |
+                StatusCode.NO_AVAILABLE_WORKING_DIR |
+                StatusCode.RESERVE_SLOTS_FAILED |
+                StatusCode.UNKNOWN_WORKER =>
+              blacklist.put(worker, (statusCode, blacklist.get(worker)._2))
+            case _ => // Not cover
+          }
         }
       }
     }

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -99,25 +99,25 @@ class WorkerStatusTracker(
         case _ =>
       }
     }
-    recordWorkerFailure(failedWorker)
+    if (!failedWorker.isEmpty) {
+      recordWorkerFailure(failedWorker)
+    }
   }
 
   def recordWorkerFailure(failures: ShuffleFailedWorkers): Unit = {
-    if (!failures.isEmpty) {
-      val failedWorker = new ShuffleFailedWorkers(failures)
-      logInfo(s"Report Worker Failure: ${failedWorker.asScala}, current blacklist $blacklist")
-      failedWorker.asScala.foreach { case (worker, (statusCode, registerTime)) =>
-        if (!blacklist.containsKey(worker)) {
-          blacklist.put(worker, (statusCode, registerTime))
-        } else {
-          statusCode match {
-            case StatusCode.WORKER_SHUTDOWN |
-                StatusCode.NO_AVAILABLE_WORKING_DIR |
-                StatusCode.RESERVE_SLOTS_FAILED |
-                StatusCode.UNKNOWN_WORKER =>
-              blacklist.put(worker, (statusCode, blacklist.get(worker)._2))
-            case _ => // Not cover
-          }
+    val failedWorker = new ShuffleFailedWorkers(failures)
+    logInfo(s"Report Worker Failure: ${failedWorker.asScala}, current blacklist $blacklist")
+    failedWorker.asScala.foreach { case (worker, (statusCode, registerTime)) =>
+      if (!blacklist.containsKey(worker)) {
+        blacklist.put(worker, (statusCode, registerTime))
+      } else {
+        statusCode match {
+          case StatusCode.WORKER_SHUTDOWN |
+              StatusCode.NO_AVAILABLE_WORKING_DIR |
+              StatusCode.RESERVE_SLOTS_FAILED |
+              StatusCode.UNKNOWN_WORKER =>
+            blacklist.put(worker, (statusCode, blacklist.get(worker)._2))
+          case _ => // Not cover
         }
       }
     }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -193,9 +193,10 @@ abstract class CommitHandler(
     }
 
     val commitFileStartTime = System.nanoTime()
-    val parallelism = Math.min(allocatedWorkers.size(), conf.rpcMaxParallelism)
+    val workerPartitionLocations = allocatedWorkers.asScala.filter(!_._2.isEmpty)
+    val parallelism = Math.min(workerPartitionLocations.size, conf.rpcMaxParallelism)
     ThreadUtils.parmap(
-      allocatedWorkers.asScala.to,
+      workerPartitionLocations.to,
       "CommitFiles",
       parallelism) { case (worker, partitionLocationInfo) =>
       val masterParts =

--- a/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
@@ -48,6 +48,10 @@ class ShufflePartitionLocationInfo {
     getPartitions(slavePartitionLocations, partitionIdOpt)
   }
 
+  def isEmpty(): Boolean = {
+    masterPartitionLocations.isEmpty && slavePartitionLocations.isEmpty
+  }
+
   def containsPartition(partitionId: Int): Boolean = {
     masterPartitionLocations.containsKey(partitionId) ||
     slavePartitionLocations.containsKey(partitionId)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1.Filter out empty workers when reserver/commit.

### Why are the changes needed?
1.Master will potentially offer extra empty slots for LifecycleManager, And these can filter out to avoid useless reserve/commit

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
