### PR TITLE
[CELEBORN-555][REFACTOR] Avoid prin noisy blacklist info when record blacklist

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -105,19 +105,33 @@ class WorkerStatusTracker(
   }
 
   def recordWorkerFailure(failures: ShuffleFailedWorkers): Unit = {
-    val failedWorker = new ShuffleFailedWorkers(failures)
-    logInfo(s"Report Worker Failure: ${failedWorker.asScala}, current blacklist $blacklist")
-    failedWorker.asScala.foreach { case (worker, (statusCode, registerTime)) =>
-      if (!blacklist.containsKey(worker)) {
-        blacklist.put(worker, (statusCode, registerTime))
-      } else {
-        statusCode match {
-          case StatusCode.WORKER_SHUTDOWN |
-              StatusCode.NO_AVAILABLE_WORKING_DIR |
-              StatusCode.RESERVE_SLOTS_FAILED |
-              StatusCode.UNKNOWN_WORKER =>
-            blacklist.put(worker, (statusCode, blacklist.get(worker)._2))
-          case _ => // Not cover
+    if (!failures.isEmpty) {
+      val failedWorker = new ShuffleFailedWorkers(failures)
+      val failedWorkerMsg = failedWorker.asScala.map { case (worker, (status, time)) =>
+        s"${worker.readableAddress()}   ${status.name()}   $time"
+      }.mkString("\n")
+      val blacklistMsg = blacklist.asScala.map { case (worker, (status, time)) =>
+        s"${worker.readableAddress()}   ${status.name()}   $time"
+      }.mkString("\n")
+      logInfo(
+        s"""
+           |Reporting Worker Failure:
+           |$failedWorkerMsg
+           |Current blacklist:
+           |$blacklistMsg
+               """.stripMargin)
+      failedWorker.asScala.foreach { case (worker, (statusCode, registerTime)) =>
+        if (!blacklist.containsKey(worker)) {
+          blacklist.put(worker, (statusCode, registerTime))
+        } else {
+          statusCode match {
+            case StatusCode.WORKER_SHUTDOWN |
+                StatusCode.NO_AVAILABLE_WORKING_DIR |
+                StatusCode.RESERVE_SLOTS_FAILED |
+                StatusCode.UNKNOWN_WORKER =>
+              blacklist.put(worker, (statusCode, blacklist.get(worker)._2))
+            case _ => // Not cover
+          }
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Always failedWorker is null but still prints blacklist, and so many lines during upgrade or some other case.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

