### PR TITLE
[CELEBORN-556][BUG] ReserveSlot should not use default RPC time out since register shuffle max timeout is network timeout

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1049,7 +1049,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       message: ReserveSlots): ReserveSlotsResponse = {
     val shuffleKey = Utils.makeShuffleKey(message.applicationId, message.shuffleId)
     try {
-      endpoint.askSync[ReserveSlotsResponse](message)
+      endpoint.askSync[ReserveSlotsResponse](message, conf.reserveSlotsRpcTimeout)
     } catch {
       case e: Exception =>
         val msg = s"Exception when askSync ReserveSlots for $shuffleKey " +

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -659,6 +659,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   // //////////////////////////////////////////////////////
   def reserveSlotsRpcTimeout: RpcTimeout =
     new RpcTimeout(get(RESERVE_SLOTS_RPC_TIMEOUT).milli, RESERVE_SLOTS_RPC_TIMEOUT.key)
+
   def registerShuffleRpcAskTimeout: RpcTimeout =
     new RpcTimeout(
       get(REGISTER_SHUFFLE_RPC_ASK_TIMEOUT).map(_.milli)

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -55,6 +55,7 @@ license: |
 | celeborn.rpc.registerShuffle.askTimeout | &lt;undefined&gt; | Timeout for ask operations during register shuffle. Default value should be `celeborn.rpc.askTimeout * (celeborn.slots.reserve.maxRetries + 1 + 1)`. | 0.2.0 | 
 | celeborn.rpc.requestCommitFiles.maxRetries | 2 | Max retry times for requestCommitFiles RPC. | 1.0.0 | 
 | celeborn.rpc.requestPartition.askTimeout | &lt;undefined&gt; | Timeout for ask operations during request change partition location, such as revive or split partition. Default value should be `celeborn.rpc.askTimeout * (celeborn.slots.reserve.maxRetries + 1)`. | 0.2.0 | 
+| celeborn.rpc.reserveSlots.askTimeout | 30s | Timeout for LifecycleManager request reserve slots. | 0.3.0 | 
 | celeborn.shuffle.batchHandleChangePartition.enabled | false | When true, LifecycleManager will handle change partition request in batch. Otherwise, LifecycleManager will process the requests one by one | 0.2.0 | 
 | celeborn.shuffle.batchHandleChangePartition.interval | 100ms | Interval for LifecycleManager to schedule handling change partition requests in batch. | 0.2.0 | 
 | celeborn.shuffle.batchHandleChangePartition.threads | 8 | Threads number for LifecycleManager to handle change partition request in batch. | 0.2.0 | 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, reserve slot uses same timeout with default RPC_ASK_TIMEOUT, 
we know that the register shuffle's max time out should be the min value of (RPC_ASK_TIMEOUT, REGISTER_SHUFFLE_RPC_ASK_TIMEOUT), if one worker is being reserving slots stuck, the the register shuffle process time must greater than the min value of (RPC_ASK_TIMEOUT, REGISTER_SHUFFLE_RPC_ASK_TIMEOUT).

The ShuffleClient side will throw register shuffle timeout exception,  so we should support customize the reserve slots rpc timeout, if worker stuck, we can give this process a chance to retry according to the timeout configuration


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

