### PR TITLE
[CELEBORN-557] HA_CLIENT_RPC_ASK_TIMEOUT should fallback to RPC_ASK_TIMEOUT

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1116,7 +1116,7 @@ object CelebornConf extends Logging {
       .categories("network")
       .version("0.2.0")
       .doc("Timeout for HA client RPC ask operations.")
-      .fallbackConf(NETWORK_TIMEOUT)
+      .fallbackConf(RPC_ASK_TIMEOUT)
 
   val NETWORK_IO_MODE: ConfigEntry[String] =
     buildConf("celeborn.<module>.io.mode")

--- a/docs/configuration/network.md
+++ b/docs/configuration/network.md
@@ -38,7 +38,7 @@ license: |
 | celeborn.port.maxRetries | 1 | When port is occupied, we will retry for max retry times. | 0.2.0 | 
 | celeborn.rpc.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.connect.threads | 64 |  | 0.2.0 | 
-| celeborn.rpc.haClient.askTimeout | &lt;value of celeborn.network.timeout&gt; | Timeout for HA client RPC ask operations. | 0.2.0 | 
+| celeborn.rpc.haClient.askTimeout | &lt;value of celeborn.rpc.askTimeout&gt; | Timeout for HA client RPC ask operations. | 0.2.0 | 
 | celeborn.rpc.io.threads | &lt;undefined&gt; | Netty IO thread number of NettyRpcEnv to handle RPC request. The default threads number is the number of runtime available processors. | 0.2.0 | 
 | celeborn.rpc.lookupTimeout | 30s | Timeout for RPC lookup operations. | 0.2.0 | 
 | celeborn.shuffle.maxChunksBeingTransferred | 9223372036854775807 | The max number of chunks allowed to be transferred at the same time on shuffle service. Note that new incoming connections will be closed when the max number is hit. The client will retry according to the shuffle retry configs (see `celeborn.shuffle.io.maxRetries` and `celeborn.shuffle.io.retryWait`), if those limits are reached the task will fail with fetch failure. | 0.2.0 | 


### PR DESCRIPTION
### What changes were proposed in this pull request?
HA_CLIENT_RPC_ASK_TIMEOUT should fallback to RPC_ASK_TIMEOUT


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

