### PR TITLE
[CELEBORN-560][BUG] Rerun task in spark later then RSS stageEnd cause NPE then job failed

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -569,7 +569,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     }
 
     if (commitManager.tryFinalCommit(shuffleId)) {
-      // release resources and clear worker info
       requestReleaseSlots(
         rssHARetryClient,
         ReleaseSlots(applicationId, shuffleId, List.empty.asJava, List.empty.asJava))

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -570,8 +570,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
     if (commitManager.tryFinalCommit(shuffleId)) {
       // release resources and clear worker info
-      shuffleAllocatedWorkers.remove(shuffleId)
-
       requestReleaseSlots(
         rssHARetryClient,
         ReleaseSlots(applicationId, shuffleId, List.empty.asJava, List.empty.asJava))
@@ -631,7 +629,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     if (shuffleResourceExists(shuffleId)) {
       logWarning(s"Partition exists for shuffle $shuffleId, " +
         "maybe caused by task rerun or speculative.")
-      shuffleAllocatedWorkers.remove(shuffleId)
       requestReleaseSlots(
         rssHARetryClient,
         ReleaseSlots(appId, shuffleId, List.empty.asJava, List.empty.asJava))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark rerun a success task (may be caused by TaskSuccess rpc delay)
![image](https://user-images.githubusercontent.com/46485123/234547874-7f499b05-e0b7-413a-9f4a-ffcec1ae42c0.png)

But Celeborn side have handledStageEnd and remove shuffle key from `shuffleAllocatedWorker`
 then the rerun task throw NPE
 ```
23/04/25 11:08:44 ERROR ShuffleClientImpl: Exception raised while registering shuffle 19 with 201 mapper and 200 partitions.
com.aliyun.emr.rss.common.exception.RssException: Exception thrown in awaitResult: 
	at com.aliyun.emr.rss.common.util.ThreadUtils$.awaitResult(ThreadUtils.scala:224)
	at com.aliyun.emr.rss.common.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:74)
	at com.aliyun.emr.rss.common.rpc.RpcEndpointRef.askSync(RpcEndpointRef.scala:90)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.registerShuffle(ShuffleClientImpl.java:329)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.lambda$getPartitionLocation$2(ShuffleClientImpl.java:379)
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
	at com.aliyun.emr.rss.common.network.util.JavaUtils$ConcurrentHashMapForJDK8.computeIfAbsent(JavaUtils.java:427)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.getPartitionLocation(ShuffleClientImpl.java:378)
	at com.aliyun.emr.rss.client.write.DataPushQueue.takePushTasks(DataPushQueue.java:97)
	at com.aliyun.emr.rss.client.write.DataPusher$1.run(DataPusher.java:125)
Caused by: java.lang.NullPointerException
	at com.aliyun.emr.rss.client.write.LifecycleManager.handleRegisterShuffle(LifecycleManager.scala:475)
	at com.aliyun.emr.rss.client.write.LifecycleManager$$anonfun$receiveAndReply$1.applyOrElse(LifecycleManager.scala:429)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:110)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.safelyCall(Inbox.scala:214)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.process(Inbox.scala:107)
	at com.aliyun.emr.rss.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:223)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
23/04/25 11:08:44 ERROR ShuffleClientImpl: Exception raised while registering shuffle 19 with 201 mapper and 200 partitions.
com.aliyun.emr.rss.common.exception.RssException: Exception thrown in awaitResult: 
	at com.aliyun.emr.rss.common.util.ThreadUtils$.awaitResult(ThreadUtils.scala:224)
	at com.aliyun.emr.rss.common.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:74)
	at com.aliyun.emr.rss.common.rpc.RpcEndpointRef.askSync(RpcEndpointRef.scala:90)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.registerShuffle(ShuffleClientImpl.java:329)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.lambda$getPartitionLocation$2(ShuffleClientImpl.java:379)
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
	at com.aliyun.emr.rss.common.network.util.JavaUtils$ConcurrentHashMapForJDK8.computeIfAbsent(JavaUtils.java:427)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.getPartitionLocation(ShuffleClientImpl.java:378)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.pushOrMergeData(ShuffleClientImpl.java:514)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.pushData(ShuffleClientImpl.java:783)
	at com.aliyun.emr.rss.client.write.DataPusher.pushData(DataPusher.java:191)
	at com.aliyun.emr.rss.client.write.DataPusher.access$500(DataPusher.java:38)
	at com.aliyun.emr.rss.client.write.DataPusher$1.run(DataPusher.java:128)
Caused by: java.lang.NullPointerException
	at com.aliyun.emr.rss.client.write.LifecycleManager.handleRegisterShuffle(LifecycleManager.scala:475)
	at com.aliyun.emr.rss.client.write.LifecycleManager$$anonfun$receiveAndReply$1.applyOrElse(LifecycleManager.scala:429)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:110)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.safelyCall(Inbox.scala:214)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.process(Inbox.scala:107)
	at com.aliyun.emr.rss.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:223)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748) 
```
In this pr we remove the behavior of remove shuffle key from `shuffleAllocatedWorkers` before unregister shuffle to avoid this.

Finally this will be remove during handle `removeExpiredShuffle()`, keep remove together with `registeredShuffle`

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

