### PR TITLE
[CELEBORN-560][FOLLOWUP] Follow the original design for handling rerun & speculative task after handleStageEnd  

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -650,8 +650,9 @@ public class ShuffleClientImpl extends ShuffleClient {
     }
 
     // get location
+    // If rerun or speculation task running after LifecycleManager call stageEnd,
+    // register shuffle will return an empty location map, client need revive for a new location.
     if (!map.containsKey(partitionId)) {
-      logger.warn("It should never reach here!");
       if (!revive(
           applicationId,
           shuffleId,

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -630,7 +630,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     }
 
     if (shuffleResourceExists(shuffleId)) {
-      logWarning(s"Partition may exists for shuffle $shuffleId, " +
+      logWarning(s"Partition exists for shuffle $shuffleId, " +
         "maybe caused by task rerun or speculative.")
       requestMasterReleaseSlots(
         ReleaseSlots(appId, shuffleId, List.empty.asJava, List.empty.asJava))

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -569,7 +569,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     }
 
     if (commitManager.tryFinalCommit(shuffleId)) {
-      // release resources and clear worker info
       requestReleaseSlots(
         rssHARetryClient,
         ReleaseSlots(applicationId, shuffleId, List.empty.asJava, List.empty.asJava))

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -625,13 +625,13 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       }
     }
 
-    if (shuffleResourceExists(shuffleId)) {
-      logWarning(s"Partition exists for shuffle $shuffleId, " +
-        "maybe caused by task rerun or speculative.")
-      requestReleaseSlots(
-        rssHARetryClient,
-        ReleaseSlots(appId, shuffleId, List.empty.asJava, List.empty.asJava))
-    }
+    logWarning(s"Partition may exists for shuffle $shuffleId, " +
+      "maybe caused by task rerun or speculative.")
+    // ReleaseSlots only remove the master side workers meta's shuffle key related slots.
+    // For one shuffle key may request twice, but won't impact the cluster.
+    requestReleaseSlots(
+      rssHARetryClient,
+      ReleaseSlots(appId, shuffleId, List.empty.asJava, List.empty.asJava))
 
     // add shuffleKey to delay shuffle removal set
     unregisterShuffleTime.put(shuffleId, System.currentTimeMillis())

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -569,6 +569,12 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     }
 
     if (commitManager.tryFinalCommit(shuffleId)) {
+      // Here we only clear PartitionLocation info in shuffleAllocatedWorkers.
+      // Since rerun or speculation task may running after we handle StageEnd.
+      workerSnapshots(shuffleId).asScala.foreach { case (_, partitionLocationInfo) =>
+        partitionLocationInfo.removeAllMasterPartitions()
+        partitionLocationInfo.removeAllSlavePartitions()
+      }
       requestReleaseSlots(
         rssHARetryClient,
         ReleaseSlots(applicationId, shuffleId, List.empty.asJava, List.empty.asJava))
@@ -625,13 +631,13 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       }
     }
 
-    logWarning(s"Partition may exists for shuffle $shuffleId, " +
-      "maybe caused by task rerun or speculative.")
-    // ReleaseSlots only remove the master side workers meta's shuffle key related slots.
-    // For one shuffle key may request twice, but won't impact the cluster.
-    requestReleaseSlots(
-      rssHARetryClient,
-      ReleaseSlots(appId, shuffleId, List.empty.asJava, List.empty.asJava))
+    if (shuffleResourceExists(shuffleId)) {
+      logWarning(s"Partition may exists for shuffle $shuffleId, " +
+        "maybe caused by task rerun or speculative.")
+      requestReleaseSlots(
+        rssHARetryClient,
+        ReleaseSlots(appId, shuffleId, List.empty.asJava, List.empty.asJava))
+    }
 
     // add shuffleKey to delay shuffle removal set
     unregisterShuffleTime.put(shuffleId, System.currentTimeMillis())

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -570,8 +570,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
     if (commitManager.tryFinalCommit(shuffleId)) {
       // release resources and clear worker info
-      shuffleAllocatedWorkers.remove(shuffleId)
-
       requestReleaseSlots(
         rssHARetryClient,
         ReleaseSlots(applicationId, shuffleId, List.empty.asJava, List.empty.asJava))
@@ -631,7 +629,6 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     if (shuffleResourceExists(shuffleId)) {
       logWarning(s"Partition exists for shuffle $shuffleId, " +
         "maybe caused by task rerun or speculative.")
-      shuffleAllocatedWorkers.remove(shuffleId)
       requestReleaseSlots(
         rssHARetryClient,
         ReleaseSlots(appId, shuffleId, List.empty.asJava, List.empty.asJava))

--- a/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
@@ -57,6 +57,14 @@ class ShufflePartitionLocationInfo {
     slavePartitionLocations.containsKey(partitionId)
   }
 
+  def removeAllMasterPartitions(): Unit = {
+    masterPartitionLocations.clear()
+  }
+
+  def removeAllSlavePartitions(): Unit = {
+    slavePartitionLocations.clear()
+  }
+
   def removeMasterPartitions(partitionId: Int): util.Set[PartitionLocation] = {
     removePartitions(masterPartitionLocations, partitionId)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
The original design  for handling rerun & speculative task after handleStageEnd is

1. shuffle StageEnd handled and remove PartitionLocations in shuffleAllocatedWorkers
2. rerun & speculative task running and call registerShuffle
3. registergedShuffle contains shuffle id and shuffleAllocatedWorkers also contains shuffle id, return an empty location map
4. ShuffleClient side get partitionId corresponding location return null (since we change the DataPushQueue so we also need merge https://github.com/apache/incubator-celeborn/pull/1404)
5. ShuffleClient side revive for a new PartitionLocation
6. New partitionLocation will add to shuffleAllocatedWorkers
7. Stage finished an call unregister shuffle, then partitionResourceExists return true and re-release allocated slots.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

