### PR TITLE
[CELEBORN-564] stop-all.sh has wrong comment

### DIFF
--- a/sbin/stop-all.sh
+++ b/sbin/stop-all.sh
@@ -35,7 +35,7 @@ if [ "$CELEBORN_SSH_OPTS" = "" ]; then
   CELEBORN_SSH_OPTS="-o StrictHostKeyChecking=no"
 fi
 
-# start masters
+# stop masters
 for host in `echo "$HOST_LIST" | sed  "s/#.*$//;/^$/d" | grep '\[master\]' | awk '{print $NF}'`
 do
   if [ -n "${CELEBORN_SSH_FOREGROUND}" ]; then
@@ -48,7 +48,7 @@ do
   fi
 done
 
-# start workers
+# stop workers
 for host in `echo "$HOST_LIST"| sed  "s/#.*$//;/^$/d" | grep '\[worker\]' | awk '{print $NF}'`
 do
   if [ -n "${CELEBORN_SSH_FOREGROUND}" ]; then


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Modify comments in `stop-all.sh`, the right comments should be `stop masters` and `stop workers`.  

### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
No need to add any UT.
