### PR TITLE
[CELEBORN-565] FETCH_MAX_RETRIES should double when enable replicates

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -106,7 +106,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
         new TransportContext(
             dataTransportConf, readClientHandler, conf.clientCloseIdleConnections());
     this.flinkTransportClientFactory =
-        new FlinkTransportClientFactory(context, conf.fetchMaxRetries());
+        new FlinkTransportClientFactory(context, conf.fetchMaxRetriesForEachPeer());
   }
 
   public RssBufferStream readBufferedPartition(

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -106,7 +106,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
         new TransportContext(
             dataTransportConf, readClientHandler, conf.clientCloseIdleConnections());
     this.flinkTransportClientFactory =
-        new FlinkTransportClientFactory(context, conf.fetchMaxRetriesForEachPeer());
+        new FlinkTransportClientFactory(context, conf.fetchMaxRetriesForEachReplica());
   }
 
   public RssBufferStream readBufferedPartition(

--- a/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
@@ -153,9 +153,9 @@ public abstract class RssInputStream extends InputStream {
       decompressor = Decompressor.getDecompressor(conf);
 
       if (conf.pushReplicateEnabled()) {
-        fetchChunkMaxRetry = conf.fetchMaxRetriesForEachPeer() * 2;
+        fetchChunkMaxRetry = conf.fetchMaxRetriesForEachReplica() * 2;
       } else {
-        fetchChunkMaxRetry = conf.fetchMaxRetriesForEachPeer();
+        fetchChunkMaxRetry = conf.fetchMaxRetriesForEachReplica();
       }
       TransportConf transportConf =
           Utils.fromCelebornConf(conf, TransportModuleConstants.DATA_MODULE, 0);

--- a/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/RssInputStream.java
@@ -152,7 +152,11 @@ public abstract class RssInputStream extends InputStream {
 
       decompressor = Decompressor.getDecompressor(conf);
 
-      fetchChunkMaxRetry = conf.fetchMaxRetries();
+      if (conf.pushReplicateEnabled()) {
+        fetchChunkMaxRetry = conf.fetchMaxRetriesForEachPeer() * 2;
+      } else {
+        fetchChunkMaxRetry = conf.fetchMaxRetriesForEachPeer();
+      }
       TransportConf transportConf =
           Utils.fromCelebornConf(conf, TransportModuleConstants.DATA_MODULE, 0);
       retryWaitMs = transportConf.ioRetryWaitTimeMs();

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1396,7 +1396,7 @@ object CelebornConf extends Logging {
       .withAlternative("celeborn.fetch.maxRetries")
       .categories("client")
       .version("0.2.0")
-      .doc("Max retry times of fetch chunk on same peer")
+      .doc("Max retry times of fetch chunk on each replica")
       .intConf
       .createWithDefault(3)
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -659,7 +659,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   // //////////////////////////////////////////////////////
   def fetchTimeoutMs: Long = get(FETCH_TIMEOUT)
   def fetchMaxReqsInFlight: Int = get(FETCH_MAX_REQS_IN_FLIGHT)
-  def fetchMaxRetriesForEachPeer: Int = get(FETCH_MAX_RETRIES_FOR_EACH_PEER)
+  def fetchMaxRetriesForEachReplica: Int = get(FETCH_MAX_RETRIES_FOR_EACH_REPLICA)
 
   // //////////////////////////////////////////////////////
   //               Shuffle Client Push                   //
@@ -1391,8 +1391,8 @@ object CelebornConf extends Logging {
       .intConf
       .createWithDefault(1024)
 
-  val FETCH_MAX_RETRIES_FOR_EACH_PEER: ConfigEntry[Int] =
-    buildConf("celeborn.fetch.maxRetriesForEachPeer")
+  val FETCH_MAX_RETRIES_FOR_EACH_REPLICA: ConfigEntry[Int] =
+    buildConf("celeborn.fetch.maxRetriesForEachReplica")
       .withAlternative("celeborn.fetch.maxRetries")
       .categories("client")
       .version("0.2.0")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -659,7 +659,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   // //////////////////////////////////////////////////////
   def fetchTimeoutMs: Long = get(FETCH_TIMEOUT)
   def fetchMaxReqsInFlight: Int = get(FETCH_MAX_REQS_IN_FLIGHT)
-  def fetchMaxRetries: Int = get(FETCH_MAX_RETRIES)
+  def fetchMaxRetriesForEachPeer: Int = get(FETCH_MAX_RETRIES_FOR_EACH_PEER)
 
   // //////////////////////////////////////////////////////
   //               Shuffle Client Push                   //
@@ -1391,11 +1391,12 @@ object CelebornConf extends Logging {
       .intConf
       .createWithDefault(1024)
 
-  val FETCH_MAX_RETRIES: ConfigEntry[Int] =
-    buildConf("celeborn.fetch.maxRetries")
+  val FETCH_MAX_RETRIES_FOR_EACH_PEER: ConfigEntry[Int] =
+    buildConf("celeborn.fetch.maxRetriesForEachPeer")
+      .withAlternative("celeborn.fetch.maxRetries")
       .categories("client")
       .version("0.2.0")
-      .doc("Max retries of fetch chunk")
+      .doc("Max retry times of fetch chunk on same peer")
       .intConf
       .createWithDefault(3)
 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -25,7 +25,7 @@ license: |
 | celeborn.client.closeIdleConnections | true | Whether client will close idle connections. | 0.3.0 | 
 | celeborn.client.maxRetries | 15 | Max retry times for client to connect master endpoint | 0.2.0 | 
 | celeborn.fetch.maxReqsInFlight | 3 | Amount of in-flight chunk fetch request. | 0.2.0 | 
-| celeborn.fetch.maxRetriesForEachPeer | 3 | Max retry times of fetch chunk on same peer | 0.2.0 | 
+| celeborn.fetch.maxRetriesForEachReplica | 3 | Max retry times of fetch chunk on same peer | 0.2.0 | 
 | celeborn.fetch.timeout | 120s | Timeout for a task to fetch chunk. | 0.2.0 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
 | celeborn.push.buffer.initial.size | 8k |  | 0.2.0 | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -25,7 +25,7 @@ license: |
 | celeborn.client.closeIdleConnections | true | Whether client will close idle connections. | 0.3.0 | 
 | celeborn.client.maxRetries | 15 | Max retry times for client to connect master endpoint | 0.2.0 | 
 | celeborn.fetch.maxReqsInFlight | 3 | Amount of in-flight chunk fetch request. | 0.2.0 | 
-| celeborn.fetch.maxRetries | 3 | Max retries of fetch chunk | 0.2.0 | 
+| celeborn.fetch.maxRetriesForEachPeer | 3 | Max retry times of fetch chunk on same peer | 0.2.0 | 
 | celeborn.fetch.timeout | 120s | Timeout for a task to fetch chunk. | 0.2.0 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
 | celeborn.push.buffer.initial.size | 8k |  | 0.2.0 | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -25,7 +25,7 @@ license: |
 | celeborn.client.closeIdleConnections | true | Whether client will close idle connections. | 0.3.0 | 
 | celeborn.client.maxRetries | 15 | Max retry times for client to connect master endpoint | 0.2.0 | 
 | celeborn.fetch.maxReqsInFlight | 3 | Amount of in-flight chunk fetch request. | 0.2.0 | 
-| celeborn.fetch.maxRetriesForEachReplica | 3 | Max retry times of fetch chunk on same peer | 0.2.0 | 
+| celeborn.fetch.maxRetriesForEachReplica | 3 | Max retry times of fetch chunk on each replica | 0.2.0 | 
 | celeborn.fetch.timeout | 120s | Timeout for a task to fetch chunk. | 0.2.0 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
 | celeborn.push.buffer.initial.size | 8k |  | 0.2.0 | 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fetch max retry times should double when enable replicates

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

