### PR TITLE
[CELEBORN-567] Timeout workers/app need consider long leader election period

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAHelper.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAHelper.java
@@ -34,8 +34,8 @@ public class HAHelper {
 
   public static boolean checkShouldProcess(
       RpcCallContext context, AbstractMetaManager masterStatusSystem) {
-    if ((masterStatusSystem instanceof HAMasterMetaManager)) {
-      HARaftServer ratisServer = ((HAMasterMetaManager) masterStatusSystem).getRatisServer();
+    HARaftServer ratisServer = getRatisServer(masterStatusSystem);
+    if (ratisServer != null) {
       if (ratisServer.isLeader()) {
         return true;
       }
@@ -54,6 +54,33 @@ public class HAHelper {
       return false;
     }
     return true;
+  }
+
+  public static long getWorkerTimeoutDeadline(AbstractMetaManager masterStatusSystem) {
+    HARaftServer ratisServer = getRatisServer(masterStatusSystem);
+    if (ratisServer != null) {
+      return ratisServer.getWorkerTimeoutDeadline();
+    } else {
+      return -1;
+    }
+  }
+
+  public static long getAppTimeoutDeadline(AbstractMetaManager masterStatusSystem) {
+    HARaftServer ratisServer = getRatisServer(masterStatusSystem);
+    if (ratisServer != null) {
+      return ratisServer.getAppTimeoutDeadline();
+    } else {
+      return -1;
+    }
+  }
+
+  public static HARaftServer getRatisServer(AbstractMetaManager masterStatusSystem) {
+    if ((masterStatusSystem instanceof HAMasterMetaManager)) {
+      HARaftServer ratisServer = ((HAMasterMetaManager) masterStatusSystem).getRatisServer();
+      return ratisServer;
+    }
+
+    return null;
   }
 
   public static ByteString convertRequestToByteString(ResourceProtos.ResourceRequest request) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
increase timeout deadline when leader changed to avoid app/worker status unexpected changes.

### Why are the changes needed?
Consider the situation in ha mode，if master election period exceeds the workerHeartbeatTimeout or appHeartbeatTimeout, all workers/apps may timeout immediately when new leader elected。And This will also cause every shuffle of the apps timeout, every register/every change partition fail and all data would be lost in worker. For Flink same system, It's  also bad as the resource of Flink dataset would be timeout while even Flink app retry to connect the master. (Flink support long time retry strategy for one job, then this job would fail because of shuffle expired in Celeborn Cluster)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Would test in k8s environment.
