### PR TITLE
[CELEBORN-576] Add static identity provider and manually settable identity provider for non-hadoop environment.

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2658,7 +2658,7 @@ object CelebornConf extends Logging {
   val QUOTA_USER_SPECIFIC_TENANT: ConfigEntry[String] =
     buildConf("celeborn.quota.identity.user-specific.tenant")
       .categories("quota")
-      .doc(s"Tenant id if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.UserSpecifiedIdentity.")
+      .doc(s"Tenant id if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.DefaultIdentityProvider.")
       .version("0.3.0")
       .stringConf
       .createWithDefault(IdentityProvider.DEFAULT_TENANT_ID)
@@ -2666,7 +2666,7 @@ object CelebornConf extends Logging {
   val QUOTA_USER_SPECIFIC_USERNAME: ConfigEntry[String] =
     buildConf("celeborn.quota.identity.user-specific.userName")
       .categories("quota")
-      .doc(s"User name if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.UserSpecifiedIdentity.")
+      .doc(s"User name if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.DefaultIdentityProvider.")
       .version("0.3.0")
       .stringConf
       .createWithDefault(IdentityProvider.DEFAULT_USERNAME)

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -19,19 +19,17 @@ package org.apache.celeborn.common
 
 import java.io.IOException
 import java.util.{Collection => JCollection, Collections, HashMap => JHashMap, Locale, Map => JMap}
-import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
+import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.Try
 
-import org.apache.hadoop.security.UserGroupInformation
-
-import org.apache.celeborn.common.identity.{DefaultIdentityProvider, UserIdentifier}
+import org.apache.celeborn.common.identity.{DefaultIdentityProvider, IdentityProvider}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.internal.config._
 import org.apache.celeborn.common.network.util.ByteUnit
-import org.apache.celeborn.common.protocol.{CompressionCodec, PartitionSplitMode, PartitionType, ShuffleMode, SlotsAssignPolicy, TransportModuleConstants}
+import org.apache.celeborn.common.protocol._
 import org.apache.celeborn.common.protocol.StorageInfo.Type
 import org.apache.celeborn.common.protocol.StorageInfo.Type.{HDD, SSD}
 import org.apache.celeborn.common.quota.DefaultQuotaManager
@@ -653,6 +651,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def quotaIdentityProviderClass: String = get(QUOTA_IDENTITY_PROVIDER)
   def quotaManagerClass: String = get(QUOTA_MANAGER)
   def quotaConfigurationPath: Option[String] = get(QUOTA_CONFIGURATION_PATH)
+  def quotaUserSpecificTenant: String = get(QUOTA_USER_SPECIFIC_TENANT)
+  def quotaUserSpecificUserName: String = get(QUOTA_USER_SPECIFIC_USERNAME)
 
   // //////////////////////////////////////////////////////
   //               Shuffle Client Fetch                  //
@@ -2647,11 +2647,29 @@ object CelebornConf extends Logging {
       .withAlternative("rss.identity.provider")
       .categories("quota")
       .doc(s"IdentityProvider class name. Default class is " +
-        s"`${classOf[DefaultIdentityProvider].getName}`, return `${classOf[UserIdentifier].getName}` " +
-        s"with default tenant id and username from `${classOf[UserGroupInformation].getName}`. ")
+        s"`${classOf[DefaultIdentityProvider].getName}`. " +
+        s"Optional values: " +
+        s"org.apache.celeborn.common.identity.HadoopBasedIdentityProvider user name will be obtained by UserGroupInformation.getUserName; " +
+        s"org.apache.celeborn.common.identity.DefaultIdentityProvider uesr name and tenant id are default values or user-specific values.")
       .version("0.2.0")
       .stringConf
       .createWithDefault(classOf[DefaultIdentityProvider].getName)
+
+  val QUOTA_USER_SPECIFIC_TENANT: ConfigEntry[String] =
+    buildConf("celeborn.quota.identity.user-specific.tenant")
+      .categories("quota")
+      .doc(s"Tenant id if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.UserSpecifiedIdentity.")
+      .version("0.3.0")
+      .stringConf
+      .createWithDefault(IdentityProvider.DEFAULT_TENANT_ID)
+
+  val QUOTA_USER_SPECIFIC_USERNAME: ConfigEntry[String] =
+    buildConf("celeborn.quota.identity.user-specific.userName")
+      .categories("quota")
+      .doc(s"User name if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.UserSpecifiedIdentity.")
+      .version("0.3.0")
+      .stringConf
+      .createWithDefault(IdentityProvider.DEFAULT_USERNAME)
 
   val QUOTA_MANAGER: ConfigEntry[String] =
     buildConf("celeborn.quota.manager")

--- a/common/src/main/scala/org/apache/celeborn/common/identity/HadoopBasedIdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/HadoopBasedIdentityProvider.scala
@@ -17,13 +17,12 @@
 
 package org.apache.celeborn.common.identity
 
-import org.apache.celeborn.common.CelebornConf
+import org.apache.hadoop.security.UserGroupInformation
 
-class DefaultIdentityProvider extends IdentityProvider {
+class HadoopBasedIdentityProvider extends IdentityProvider {
   override def provide(): UserIdentifier = {
-    val conf = new CelebornConf();
     UserIdentifier(
-      conf.quotaUserSpecificTenant,
-      conf.quotaUserSpecificUserName)
+      IdentityProvider.DEFAULT_TENANT_ID,
+      UserGroupInformation.getCurrentUser.getShortUserName)
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/identity/IdentityProvider.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/identity/IdentityProvider.scala
@@ -26,6 +26,7 @@ abstract class IdentityProvider {
 
 object IdentityProvider extends Logging {
   val DEFAULT_TENANT_ID = "default"
+  val DEFAULT_USERNAME = "default"
 
   def instantiate(conf: CelebornConf): IdentityProvider = {
     val className = conf.quotaIdentityProviderClass

--- a/docs/configuration/quota.md
+++ b/docs/configuration/quota.md
@@ -22,7 +22,7 @@ license: |
 | celeborn.quota.configuration.path | &lt;undefined&gt; | Quota configuration file path. The file format should be yaml. Quota configuration file template can be found under conf directory. | 0.2.0 | 
 | celeborn.quota.enabled | true | When true, before registering shuffle, LifecycleManager should check if current user have enough quota space, if cluster don't have enough quota space for current user, fallback to Spark's default shuffle | 0.2.0 | 
 | celeborn.quota.identity.provider | org.apache.celeborn.common.identity.DefaultIdentityProvider | IdentityProvider class name. Default class is `org.apache.celeborn.common.identity.DefaultIdentityProvider`. Optional values: org.apache.celeborn.common.identity.HadoopBasedIdentityProvider user name will be obtained by UserGroupInformation.getUserName; org.apache.celeborn.common.identity.DefaultIdentityProvider uesr name and tenant id are default values or user-specific values. | 0.2.0 | 
-| celeborn.quota.identity.user-specific.tenant | default | Tenant id if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.UserSpecifiedIdentity. | 0.3.0 | 
-| celeborn.quota.identity.user-specific.userName | default | User name if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.UserSpecifiedIdentity. | 0.3.0 | 
+| celeborn.quota.identity.user-specific.tenant | default | Tenant id if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.DefaultIdentityProvider. | 0.3.0 | 
+| celeborn.quota.identity.user-specific.userName | default | User name if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.DefaultIdentityProvider. | 0.3.0 | 
 | celeborn.quota.manager | org.apache.celeborn.common.quota.DefaultQuotaManager | QuotaManger class name. Default class is `org.apache.celeborn.common.quota.DefaultQuotaManager`. | 0.2.0 | 
 <!--end-include-->

--- a/docs/configuration/quota.md
+++ b/docs/configuration/quota.md
@@ -21,6 +21,8 @@ license: |
 | --- | ------- | ----------- | ----- |
 | celeborn.quota.configuration.path | &lt;undefined&gt; | Quota configuration file path. The file format should be yaml. Quota configuration file template can be found under conf directory. | 0.2.0 | 
 | celeborn.quota.enabled | true | When true, before registering shuffle, LifecycleManager should check if current user have enough quota space, if cluster don't have enough quota space for current user, fallback to Spark's default shuffle | 0.2.0 | 
-| celeborn.quota.identity.provider | org.apache.celeborn.common.identity.DefaultIdentityProvider | IdentityProvider class name. Default class is `org.apache.celeborn.common.identity.DefaultIdentityProvider`, return `org.apache.celeborn.common.identity.UserIdentifier` with default tenant id and username from `org.apache.hadoop.security.UserGroupInformation`.  | 0.2.0 | 
+| celeborn.quota.identity.provider | org.apache.celeborn.common.identity.DefaultIdentityProvider | IdentityProvider class name. Default class is `org.apache.celeborn.common.identity.DefaultIdentityProvider`. Optional values: org.apache.celeborn.common.identity.HadoopBasedIdentityProvider user name will be obtained by UserGroupInformation.getUserName; org.apache.celeborn.common.identity.DefaultIdentityProvider uesr name and tenant id are default values or user-specific values. | 0.2.0 | 
+| celeborn.quota.identity.user-specific.tenant | default | Tenant id if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.UserSpecifiedIdentity. | 0.3.0 | 
+| celeborn.quota.identity.user-specific.userName | default | User name if celeborn.quota.identity.provider is org.apache.celeborn.common.identity.UserSpecifiedIdentity. | 0.3.0 | 
 | celeborn.quota.manager | org.apache.celeborn.common.quota.DefaultQuotaManager | QuotaManger class name. Default class is `org.apache.celeborn.common.quota.DefaultQuotaManager`. | 0.2.0 | 
 <!--end-include-->


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add DefaultIdentityProvider to eliminate Hadoop dependency.
2. Add manually settable IdentityProvider to let the users decide their own tenant and username.
3. Rename the previous DefaultIdentityProvider to HadoopBasedIdentityProvider.


### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
Yes, config's default value has been changed.


### How was this patch tested?
UT.
