### PR TITLE
[CELEBORN-581][Flink] Support JobManager failover.

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
@@ -156,7 +156,7 @@ public class RemoteShuffleInputGateDelegation {
           FlinkShuffleClientImpl.get(
               shuffleResource.getRssMetaServiceHost(),
               shuffleResource.getRssMetaServicePort(),
-              shuffleResource.getRssMetaServiceTimeStamp(),
+              shuffleResource.getRssMetaServiceTimestamp(),
               celebornConf,
               new UserIdentifier("default", "default"));
     } catch (DriverChangedException e) {

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.exception.DriverChangedException;
 import org.apache.celeborn.common.exception.PartitionUnRetryAbleException;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.plugin.flink.buffer.BufferPacker;
@@ -148,12 +149,19 @@ public class RemoteShuffleInputGateDelegation {
 
     RemoteShuffleDescriptor remoteShuffleDescriptor =
         (RemoteShuffleDescriptor) gateDescriptor.getShuffleDescriptors()[0];
-    this.shuffleClient =
-        FlinkShuffleClientImpl.get(
-            remoteShuffleDescriptor.getShuffleResource().getRssMetaServiceHost(),
-            remoteShuffleDescriptor.getShuffleResource().getRssMetaServicePort(),
-            celebornConf,
-            new UserIdentifier("default", "default"));
+    RemoteShuffleResource shuffleResource = remoteShuffleDescriptor.getShuffleResource();
+
+    try {
+      this.shuffleClient =
+          FlinkShuffleClientImpl.get(
+              shuffleResource.getRssMetaServiceHost(),
+              shuffleResource.getRssMetaServicePort(),
+              shuffleResource.getRssMetaServiceTimeStamp(),
+              celebornConf,
+              new UserIdentifier("default", "default"));
+    } catch (DriverChangedException e) {
+      throw new RuntimeException(e.getMessage(), e);
+    }
 
     this.startSubIndex = startSubIndex;
     this.endSubIndex = endSubIndex;

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
@@ -160,7 +160,7 @@ public class RemoteShuffleInputGateDelegation {
               celebornConf,
               new UserIdentifier("default", "default"));
     } catch (DriverChangedException e) {
-      throw new RuntimeException(e.getMessage(), e);
+      throw new RuntimeException(e.getMessage());
     }
 
     this.startSubIndex = startSubIndex;

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -60,13 +60,13 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
           ThreadUtils.createFactoryWithDefaultExceptionHandler(
               "remote-shuffle-master-executor", LOG));
   private final ResultPartitionAdapter resultPartitionDelegation;
-  private final long rssMetaServiceTimeStamp;
+  private final long rssMetaServiceTimestamp;
 
   public RemoteShuffleMaster(
       ShuffleMasterContext shuffleMasterContext, ResultPartitionAdapter resultPartitionDelegation) {
     this.shuffleMasterContext = shuffleMasterContext;
     this.resultPartitionDelegation = resultPartitionDelegation;
-    this.rssMetaServiceTimeStamp = System.currentTimeMillis();
+    this.rssMetaServiceTimestamp = System.currentTimeMillis();
   }
 
   @Override
@@ -76,7 +76,7 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
       synchronized (RemoteShuffleMaster.class) {
         if (lifecycleManager == null) {
           // use first jobID as celeborn shared appId for all other flink jobs
-          celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimeStamp, jobID);
+          celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, jobID);
           CelebornConf celebornConf =
               FlinkUtils.toCelebornConf(shuffleMasterContext.getConfiguration());
           // if not set, set to true as default for flink
@@ -147,7 +147,7 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
                   new RemoteShuffleResource(
                       lifecycleManager.getRssMetaServiceHost(),
                       lifecycleManager.getRssMetaServicePort(),
-                      rssMetaServiceTimeStamp,
+                      rssMetaServiceTimestamp,
                       shuffleResourceDescriptor);
 
               shuffleResourceTracker.addPartitionResource(

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
@@ -77,7 +77,7 @@ public class RemoteShuffleOutputGate {
   private int partitionId;
   private String rssMetaServiceHost;
   private int rssMetaServicePort;
-  private long rssMetaServiceTimeStamp;
+  private long rssMetaServiceTimestamp;
   private UserIdentifier userIdentifier;
   private boolean isFirstHandShake = true;
 
@@ -111,7 +111,7 @@ public class RemoteShuffleOutputGate {
         shuffleDesc.getShuffleResource().getMapPartitionShuffleDescriptor().getPartitionId();
     this.rssMetaServiceHost = shuffleDesc.getShuffleResource().getRssMetaServiceHost();
     this.rssMetaServicePort = shuffleDesc.getShuffleResource().getRssMetaServicePort();
-    this.rssMetaServiceTimeStamp = shuffleDesc.getShuffleResource().getRssMetaServiceTimeStamp();
+    this.rssMetaServiceTimestamp = shuffleDesc.getShuffleResource().getRssMetaServiceTimestamp();
     this.flinkShuffleClient = getShuffleClient();
   }
 
@@ -226,7 +226,7 @@ public class RemoteShuffleOutputGate {
       return FlinkShuffleClientImpl.get(
           rssMetaServiceHost,
           rssMetaServicePort,
-          rssMetaServiceTimeStamp,
+          rssMetaServiceTimestamp,
           celebornConf,
           userIdentifier);
     } catch (DriverChangedException e) {

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
-import org.apache.celeborn.common.exception.CelebornRuntimeException;
 import org.apache.celeborn.common.exception.DriverChangedException;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.protocol.PartitionLocation;
@@ -232,7 +231,7 @@ public class RemoteShuffleOutputGate {
           userIdentifier);
     } catch (DriverChangedException e) {
       // would generate a new attempt to retry output gate
-      throw new CelebornRuntimeException(e.getMessage(), e);
+      throw new RuntimeException(e.getMessage());
     }
   }
 

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResource.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResource.java
@@ -23,17 +23,17 @@ public class RemoteShuffleResource implements ShuffleResource {
 
   private final String rssMetaServiceHost;
   private final int rssMetaServicePort;
-  private final long rssMetaServiceTimeStamp;
+  private final long rssMetaServiceTimestamp;
   private ShuffleResourceDescriptor shuffleResourceDescriptor;
 
   public RemoteShuffleResource(
       String rssMetaServiceHost,
       int rssMetaServicePort,
-      long rssMetaServiceTimeStamp,
+      long rssMetaServiceTimestamp,
       ShuffleResourceDescriptor remoteShuffleDescriptor) {
     this.rssMetaServiceHost = rssMetaServiceHost;
     this.rssMetaServicePort = rssMetaServicePort;
-    this.rssMetaServiceTimeStamp = rssMetaServiceTimeStamp;
+    this.rssMetaServiceTimestamp = rssMetaServiceTimestamp;
     this.shuffleResourceDescriptor = remoteShuffleDescriptor;
   }
 
@@ -50,8 +50,8 @@ public class RemoteShuffleResource implements ShuffleResource {
     return rssMetaServicePort;
   }
 
-  public long getRssMetaServiceTimeStamp() {
-    return rssMetaServiceTimeStamp;
+  public long getRssMetaServiceTimestamp() {
+    return rssMetaServiceTimestamp;
   }
 
   @Override
@@ -59,7 +59,7 @@ public class RemoteShuffleResource implements ShuffleResource {
     final StringBuilder sb = new StringBuilder("RemoteShuffleResource{");
     sb.append("rssMetaServiceHost='").append(rssMetaServiceHost).append('\'');
     sb.append(", rssMetaServicePort=").append(rssMetaServicePort);
-    sb.append(", rssMetaServiceTimeStamp=").append(rssMetaServiceTimeStamp);
+    sb.append(", rssMetaServiceTimestamp=").append(rssMetaServiceTimestamp);
     sb.append(", shuffleResourceDescriptor=").append(shuffleResourceDescriptor);
     sb.append('}');
     return sb.toString();

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResource.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResource.java
@@ -23,15 +23,17 @@ public class RemoteShuffleResource implements ShuffleResource {
 
   private final String rssMetaServiceHost;
   private final int rssMetaServicePort;
-
+  private final long rssMetaServiceTimeStamp;
   private ShuffleResourceDescriptor shuffleResourceDescriptor;
 
   public RemoteShuffleResource(
       String rssMetaServiceHost,
       int rssMetaServicePort,
+      long rssMetaServiceTimeStamp,
       ShuffleResourceDescriptor remoteShuffleDescriptor) {
     this.rssMetaServiceHost = rssMetaServiceHost;
     this.rssMetaServicePort = rssMetaServicePort;
+    this.rssMetaServiceTimeStamp = rssMetaServiceTimeStamp;
     this.shuffleResourceDescriptor = remoteShuffleDescriptor;
   }
 
@@ -48,11 +50,16 @@ public class RemoteShuffleResource implements ShuffleResource {
     return rssMetaServicePort;
   }
 
+  public long getRssMetaServiceTimeStamp() {
+    return rssMetaServiceTimeStamp;
+  }
+
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("RemoteShuffleResource{");
     sb.append("rssMetaServiceHost='").append(rssMetaServiceHost).append('\'');
     sb.append(", rssMetaServicePort=").append(rssMetaServicePort);
+    sb.append(", rssMetaServiceTimeStamp=").append(rssMetaServiceTimeStamp);
     sb.append(", shuffleResourceDescriptor=").append(shuffleResourceDescriptor);
     sb.append('}');
     return sb.toString();

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -93,7 +93,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
     }
 
     if (driverTimeStamp < _instance.driverTimeStamp) {
-      String format = "Driver reinitialized or changed driverHost-port-driverTimeStamp to {}-{}-{}";
+      String format = "Driver reinitialized or changed driverHost-port-driverTimeStamp to %s-%s-%s";
       String message = String.format(format, driverHost, port, driverTimeStamp);
       logger.warn(message);
       throw new DriverChangedException(message);

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -68,33 +68,33 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   private ReadClientHandler readClientHandler = new ReadClientHandler();
   private ConcurrentHashMap<String, TransportClient> currentClient =
       JavaUtils.newConcurrentHashMap();
-  private long driverTimeStamp;
+  private long driverTimestamp;
 
   public static FlinkShuffleClientImpl get(
       String driverHost,
       int port,
-      long driverTimeStamp,
+      long driverTimestamp,
       CelebornConf conf,
       UserIdentifier userIdentifier)
       throws DriverChangedException {
-    if (null == _instance || !initialized || _instance.driverTimeStamp < driverTimeStamp) {
+    if (null == _instance || !initialized || _instance.driverTimestamp < driverTimestamp) {
       synchronized (FlinkShuffleClientImpl.class) {
         if (null == _instance) {
           _instance =
-              new FlinkShuffleClientImpl(driverHost, port, driverTimeStamp, conf, userIdentifier);
+              new FlinkShuffleClientImpl(driverHost, port, driverTimestamp, conf, userIdentifier);
           initialized = true;
-        } else if (!initialized || _instance.driverTimeStamp < driverTimeStamp) {
+        } else if (!initialized || _instance.driverTimestamp < driverTimestamp) {
           _instance.shutdown();
           _instance =
-              new FlinkShuffleClientImpl(driverHost, port, driverTimeStamp, conf, userIdentifier);
+              new FlinkShuffleClientImpl(driverHost, port, driverTimestamp, conf, userIdentifier);
           initialized = true;
         }
       }
     }
 
-    if (driverTimeStamp < _instance.driverTimeStamp) {
-      String format = "Driver reinitialized or changed driverHost-port-driverTimeStamp to %s-%s-%s";
-      String message = String.format(format, driverHost, port, driverTimeStamp);
+    if (driverTimestamp < _instance.driverTimestamp) {
+      String format = "Driver reinitialized or changed driverHost-port-driverTimestamp to %s-%s-%s";
+      String message = String.format(format, driverHost, port, driverTimestamp);
       logger.warn(message);
       throw new DriverChangedException(message);
     }
@@ -116,7 +116,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   public FlinkShuffleClientImpl(
       String driverHost,
       int port,
-      long driverTimeStamp,
+      long driverTimestamp,
       CelebornConf conf,
       UserIdentifier userIdentifier) {
     super(conf, userIdentifier);
@@ -129,7 +129,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
     this.flinkTransportClientFactory =
         new FlinkTransportClientFactory(context, conf.fetchMaxRetriesForEachReplica());
     this.setupMetaServiceRef(driverHost, port);
-    this.driverTimeStamp = driverTimeStamp;
+    this.driverTimestamp = driverTimestamp;
   }
 
   public RssBufferStream readBufferedPartition(

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
@@ -43,8 +43,8 @@ public class FlinkUtils {
     return tmpCelebornConf;
   }
 
-  public static String toCelebornAppId(long rssMetaServiceTimeStamp, JobID jobID) {
-    return rssMetaServiceTimeStamp + "-" + jobID.toString();
+  public static String toCelebornAppId(long rssMetaServiceTimestamp, JobID jobID) {
+    return rssMetaServiceTimestamp + "-" + jobID.toString();
   }
 
   public static String toShuffleId(JobID jobID, IntermediateDataSetID dataSetID) {

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
@@ -43,8 +43,8 @@ public class FlinkUtils {
     return tmpCelebornConf;
   }
 
-  public static String toCelebornAppId(JobID jobID) {
-    return jobID.toString();
+  public static String toCelebornAppId(long rssMetaServiceTimeStamp, JobID jobID) {
+    return rssMetaServiceTimeStamp + "-" + jobID.toString();
   }
 
   public static String toShuffleId(JobID jobID, IntermediateDataSetID dataSetID) {

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
@@ -55,7 +55,7 @@ public class FlinkShuffleClientImplSuiteJ {
   public void setup() throws IOException, InterruptedException {
     conf = new CelebornConf();
     shuffleClient =
-        new FlinkShuffleClientImpl("localhost", 1232, conf, null) {
+        new FlinkShuffleClientImpl("localhost", 1232, System.currentTimeMillis(), conf, null) {
           @Override
           public void setupMetaServiceRef(String host, int port) {}
         };

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -561,7 +561,8 @@ public class RemoteShuffleResultPartitionSuiteJ {
         new JobID(bytes),
         new JobID(bytes).toString(),
         new ResultPartitionID(),
-        new RemoteShuffleResource("1", 2, new ShuffleResourceDescriptor(1, 1, 1, 0)));
+        new RemoteShuffleResource(
+            "1", 2, System.currentTimeMillis(), new ShuffleResourceDescriptor(1, 1, 1, 0)));
   }
 
   /** Data written and its {@link Buffer.DataType}. */

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -561,7 +561,8 @@ public class RemoteShuffleResultPartitionSuiteJ {
         new JobID(bytes),
         new JobID(bytes).toString(),
         new ResultPartitionID(),
-        new RemoteShuffleResource("1", 2, new ShuffleResourceDescriptor(1, 1, 1, 0)));
+        new RemoteShuffleResource(
+            "1", 2, System.currentTimeMillis(), new ShuffleResourceDescriptor(1, 1, 1, 0)));
   }
 
   /** Data written and its {@link Buffer.DataType}. */

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -561,7 +561,8 @@ public class RemoteShuffleResultPartitionSuiteJ {
         new JobID(bytes),
         new JobID(bytes).toString(),
         new ResultPartitionID(),
-        new RemoteShuffleResource("1", 2, new ShuffleResourceDescriptor(1, 1, 1, 0)));
+        new RemoteShuffleResource(
+            "1", 2, System.currentTimeMillis(), new ShuffleResourceDescriptor(1, 1, 1, 0)));
   }
 
   /** Data written and its {@link Buffer.DataType}. */

--- a/common/src/main/scala/org/apache/celeborn/common/exception/DriverChangedException.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/exception/DriverChangedException.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.exception
+
+class DriverChangedException(message: String, cause: Throwable)
+  extends CelebornIOException(message, cause) {
+
+  def this(message: String) = this(message, null)
+}

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/HeartbeatTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/HeartbeatTest.scala
@@ -32,21 +32,36 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
   test("celeborn flink hearbeat test - client <- worker") {
     val (_, clientConf) = getTestHeartbeatFromWorker2ClientConf()
     val flinkShuffleClientImpl =
-      new FlinkShuffleClientImpl("", 0, clientConf, new UserIdentifier("1", "1"))
+      new FlinkShuffleClientImpl(
+        "",
+        0,
+        System.currentTimeMillis(),
+        clientConf,
+        new UserIdentifier("1", "1"))
     testHeartbeatFromWorker2Client(flinkShuffleClientImpl.getDataClientFactory)
   }
 
   test("celeborn flink hearbeat test - client <- worker no heartbeat") {
     val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithNoHeartbeatConf()
     val flinkShuffleClientImpl =
-      new FlinkShuffleClientImpl("", 0, clientConf, new UserIdentifier("1", "1"))
+      new FlinkShuffleClientImpl(
+        "",
+        0,
+        System.currentTimeMillis(),
+        clientConf,
+        new UserIdentifier("1", "1"))
     testHeartbeatFromWorker2ClientWithNoHeartbeat(flinkShuffleClientImpl.getDataClientFactory)
   }
 
   test("celeborn flink hearbeat test - client <- worker timeout") {
     val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithCloseChannelConf()
     val flinkShuffleClientImpl =
-      new FlinkShuffleClientImpl("", 0, clientConf, new UserIdentifier("1", "1"))
+      new FlinkShuffleClientImpl(
+        "",
+        0,
+        System.currentTimeMillis(),
+        clientConf,
+        new UserIdentifier("1", "1"))
     testHeartbeatFromWorker2ClientWithCloseChannel(flinkShuffleClientImpl.getDataClientFactory)
   }
 }

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/HeartbeatTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/HeartbeatTest.scala
@@ -37,7 +37,9 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
         0,
         System.currentTimeMillis(),
         clientConf,
-        new UserIdentifier("1", "1"))
+        new UserIdentifier("1", "1")) {
+        override def setupMetaServiceRef(host: String, port: Int): Unit = {}
+      }
     testHeartbeatFromWorker2Client(flinkShuffleClientImpl.getDataClientFactory)
   }
 
@@ -49,7 +51,9 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
         0,
         System.currentTimeMillis(),
         clientConf,
-        new UserIdentifier("1", "1"))
+        new UserIdentifier("1", "1")) {
+        override def setupMetaServiceRef(host: String, port: Int): Unit = {}
+      }
     testHeartbeatFromWorker2ClientWithNoHeartbeat(flinkShuffleClientImpl.getDataClientFactory)
   }
 
@@ -61,7 +65,9 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
         0,
         System.currentTimeMillis(),
         clientConf,
-        new UserIdentifier("1", "1"))
+        new UserIdentifier("1", "1")) {
+        override def setupMetaServiceRef(host: String, port: Int): Unit = {}
+      }
     testHeartbeatFromWorker2ClientWithCloseChannel(flinkShuffleClientImpl.getDataClientFactory)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. Introduce timestamp version for ShuffleMaster(LifecycleManager).
2. Add timestamp with first jobId, to expire exist shuffles when jobManager failover.
3. Refresh client when lifecycleManager changed.

### Why are the changes needed?
1. In Session Mode, When Flink JobManager failover, the host-port of LifecycleManager would change to new host-port, so we need refresh the client instance in TaskManager for new launching tasks.
3.For job recovering when Flink JobManager failover, Flink will reschedule the whole job from the start(but still keep the job id as the same),  so shuffle framework need guarantee all previous shuffles belong this jobId need to be expired.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT & jobManager HA in ecs & k8s
