### PR TITLE
[CELEBORN-585] Create if not exists worker recoverPath when graceful shutdown is enabled

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -81,10 +81,15 @@ private[celeborn] class Worker(
       conf.workerPushPort != 0 && conf.workerReplicatePort != 0),
     "If enable graceful shutdown, the worker should use stable server port.")
   if (gracefulShutdown) {
-    val recoverRoot = new File(conf.workerRecoverPath)
-    if (!recoverRoot.exists()) {
-      logInfo(s"Recover root path ${conf.workerRecoverPath} does not exists, create it first.")
-      recoverRoot.mkdirs()
+    try {
+      val recoverRoot = new File(conf.workerRecoverPath)
+      if (!recoverRoot.exists()) {
+        logInfo(s"Recover root path ${conf.workerRecoverPath} does not exists, create it first.")
+        recoverRoot.mkdirs()
+      }
+    } catch {
+      case e: Exception =>
+        logError("Check or create recover root path failed: ", e)
     }
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.service.deploy.worker
 
+import java.io.File
 import java.lang.{Long => JLong}
 import java.util.{HashMap => JHashMap, HashSet => JHashSet}
 import java.util.concurrent._
@@ -79,6 +80,13 @@ private[celeborn] class Worker(
       conf.workerRpcPort != 0 && conf.workerFetchPort != 0 &&
       conf.workerPushPort != 0 && conf.workerReplicatePort != 0),
     "If enable graceful shutdown, the worker should use stable server port.")
+  if (gracefulShutdown) {
+    val recoverRoot = new File(conf.workerRecoverPath)
+    if (!recoverRoot.exists()) {
+      logInfo(s"Recover root path ${conf.workerRecoverPath} does not exists, create it first.")
+      recoverRoot.mkdirs()
+    }
+  }
 
   val workerSource = new WorkerSource(conf)
   metricsSystem.registerSource(workerSource)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -90,6 +90,7 @@ private[celeborn] class Worker(
     } catch {
       case e: Exception =>
         logError("Check or create recover root path failed: ", e)
+        throw e
     }
   }
 


### PR DESCRIPTION



### What changes were proposed in this pull request?
When worker graceful shutdown is enabled and defined recoverPath `celeborn.worker.graceful.shutdown.recoverPath` does not exists, init leveldb will fail in `NativeDB.open`(caused by: IO error: /tmp/recover/recovery.ldb/LOCK: No such file or directory),  and then recover function is not actually enabled.
We can create the recoverPath before init leveldb to avoid this error.

### Why are the changes needed?
Improve user experience


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Use the company test env
