### PR TITLE
[CELEBORN-586] Add SystemMiscSource to indicate system running status

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/SystemMiscSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/SystemMiscSource.scala
@@ -24,7 +24,7 @@ import com.codahale.metrics.Gauge
 import org.apache.celeborn.common.CelebornConf
 
 class SystemMiscSource(conf: CelebornConf, role: String) extends AbstractSource(conf, role) {
-  override val sourceName = "CPU"
+  override val sourceName = "system"
 
   import SystemMiscSource._
 

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/SystemMiscSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/SystemMiscSource.scala
@@ -48,6 +48,6 @@ class SystemMiscSource(conf: CelebornConf, role: String) extends AbstractSource(
 }
 
 object SystemMiscSource {
-  val SYSTEM_LOAD = "SystemLoad"
+  val SYSTEM_LOAD = "LastMinuteSystemLoad"
   val AVAILABLE_PROCESSORS = "AvailableProcessors"
 }

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/SystemMiscSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/SystemMiscSource.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.metrics.source
+
+import java.lang.management.ManagementFactory
+
+import com.codahale.metrics.Gauge
+
+import org.apache.celeborn.common.CelebornConf
+
+class SystemMiscSource(conf: CelebornConf, role: String) extends AbstractSource(conf, role) {
+  override val sourceName = "CPU"
+
+  import SystemMiscSource._
+
+  addGauge(
+    SYSTEM_LOAD,
+    new Gauge[Double] {
+      override def getValue: Double = {
+        ManagementFactory.getOperatingSystemMXBean.getSystemLoadAverage
+      }
+    })
+
+  addGauge(
+    AVAILABLE_PROCESSORS,
+    new Gauge[Int] {
+      override def getValue: Int = {
+        ManagementFactory.getOperatingSystemMXBean.getAvailableProcessors
+      }
+    })
+  // start cleaner
+  startCleaner()
+}
+
+object SystemMiscSource {
+  val SYSTEM_LOAD = "SystemLoad"
+  val AVAILABLE_PROCESSORS = "AvailableProcessors"
+}

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -103,6 +103,10 @@ These metrics are exposed by Celeborn master.
   - namespace=CPU
     - JVMCPUTime
 
+  - namespace=system
+    - SystemLoad
+    - AvailableProcessors
+
   - namespace=JVM
     - This source provides information on JVM metrics using the
     [Dropwizard/Codahale Metric Sets for JVM instrumentation](https://metrics.dropwizard.io/4.2.0/manual/jvm.html)
@@ -185,6 +189,10 @@ These metrics are exposed by Celeborn worker.
 
   - namespace=CPU
     - JVMCPUTime
+
+  - namespace=system
+    - SystemLoad
+    - AvailableProcessors
 
   - namespace=JVM
     - This source provides information on JVM metrics using the

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -104,7 +104,8 @@ These metrics are exposed by Celeborn master.
     - JVMCPUTime
 
   - namespace=system
-    - SystemLoad
+    - LastMinuteSystemLoad
+      - Returns the system load average for the last minute.
     - AvailableProcessors
 
   - namespace=JVM
@@ -191,7 +192,8 @@ These metrics are exposed by Celeborn worker.
     - JVMCPUTime
 
   - namespace=system
-    - SystemLoad
+    - LastMinuteSystemLoad
+      - Returns the system load average for the last minute.
     - AvailableProcessors
 
   - namespace=JVM

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -32,7 +32,7 @@ import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskInfo, WorkerInfo}
 import org.apache.celeborn.common.metrics.MetricsSystem
-import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource}
+import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource, SystemMiscSource}
 import org.apache.celeborn.common.protocol._
 import org.apache.celeborn.common.protocol.message.{ControlMessages, StatusCode}
 import org.apache.celeborn.common.protocol.message.ControlMessages._
@@ -157,6 +157,7 @@ private[celeborn] class Master(
   metricsSystem.registerSource(masterSource)
   metricsSystem.registerSource(new JVMSource(conf, MetricsSystem.ROLE_MASTER))
   metricsSystem.registerSource(new JVMCPUSource(conf, MetricsSystem.ROLE_MASTER))
+  metricsSystem.registerSource(new SystemMiscSource(conf, MetricsSystem.ROLE_MASTER))
 
   rpcEnv.setupEndpoint(RpcNameConstants.MASTER_EP, this)
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -35,7 +35,7 @@ import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskInfo, WorkerInfo, WorkerPartitionLocationInfo}
 import org.apache.celeborn.common.metrics.MetricsSystem
-import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource}
+import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, SystemMiscSource}
 import org.apache.celeborn.common.network.TransportContext
 import org.apache.celeborn.common.protocol.{PartitionType, PbRegisterWorkerResponse, RpcNameConstants, TransportModuleConstants}
 import org.apache.celeborn.common.protocol.message.ControlMessages._
@@ -84,6 +84,7 @@ private[celeborn] class Worker(
   metricsSystem.registerSource(workerSource)
   metricsSystem.registerSource(new JVMSource(conf, MetricsSystem.ROLE_WORKER))
   metricsSystem.registerSource(new JVMCPUSource(conf, MetricsSystem.ROLE_WORKER))
+  metricsSystem.registerSource(new SystemMiscSource(conf, MetricsSystem.ROLE_WORKER))
 
   val storageManager = new StorageManager(conf, workerSource)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add SystemMiscSource to indicate system running status

<img width="859" alt="截屏2023-05-15 下午6 53 53" src="https://github.com/apache/incubator-celeborn/assets/46485123/3e00291a-a913-4b6b-a704-4a75faa3835c">

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

