### PR TITLE
[CELEBORN-584] Worker side should expose push/replicate/fetch Netty allocator metrics

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/TransportContext.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/TransportContext.java
@@ -25,6 +25,7 @@ import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.client.TransportClientFactory;
 import org.apache.celeborn.common.network.client.TransportResponseHandler;
@@ -55,6 +56,7 @@ public class TransportContext {
   private final ChannelDuplexHandler channelsLimiter;
   private final boolean closeIdleConnections;
   private final boolean enableHeartbeat;
+  private final AbstractSource source;
 
   private static final MessageEncoder ENCODER = MessageEncoder.INSTANCE;
 
@@ -63,29 +65,32 @@ public class TransportContext {
       BaseMessageHandler msgHandler,
       boolean closeIdleConnections,
       ChannelDuplexHandler channelsLimiter,
-      boolean enableHeartbeat) {
+      boolean enableHeartbeat,
+      AbstractSource source) {
     this.conf = conf;
     this.msgHandler = msgHandler;
     this.closeIdleConnections = closeIdleConnections;
     this.channelsLimiter = channelsLimiter;
     this.enableHeartbeat = enableHeartbeat;
+    this.source = source;
   }
 
   public TransportContext(
       TransportConf conf,
       BaseMessageHandler msgHandler,
       boolean closeIdleConnections,
-      boolean enableHeartbeat) {
-    this(conf, msgHandler, closeIdleConnections, null, enableHeartbeat);
+      boolean enableHeartbeat,
+      AbstractSource source) {
+    this(conf, msgHandler, closeIdleConnections, null, enableHeartbeat, source);
   }
 
   public TransportContext(
       TransportConf conf, BaseMessageHandler msgHandler, boolean closeIdleConnections) {
-    this(conf, msgHandler, closeIdleConnections, null, false);
+    this(conf, msgHandler, closeIdleConnections, null, false, null);
   }
 
   public TransportContext(TransportConf conf, BaseMessageHandler msgHandler) {
-    this(conf, msgHandler, false, false);
+    this(conf, msgHandler, false, false, null);
   }
 
   public TransportClientFactory createClientFactory() {
@@ -94,7 +99,7 @@ public class TransportContext {
 
   /** Create a server which will attempt to bind to a specific host and port. */
   public TransportServer createServer(String host, int port) {
-    return new TransportServer(this, host, port);
+    return new TransportServer(this, host, port, source);
   }
 
   public TransportServer createServer(int port) {

--- a/common/src/test/java/org/apache/celeborn/common/network/TransportClientFactorySuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TransportClientFactorySuiteJ.java
@@ -177,7 +177,7 @@ public class TransportClientFactorySuiteJ {
     CelebornConf _conf = new CelebornConf();
     _conf.set("celeborn.shuffle.io.connectionTimeout", "1s");
     TransportConf conf = new TransportConf("shuffle", _conf);
-    TransportContext context = new TransportContext(conf, new BaseMessageHandler(), true, false);
+    TransportContext context = new TransportContext(conf, new BaseMessageHandler(), true);
     try (TransportClientFactory factory = context.createClientFactory()) {
       TransportClient c1 = factory.createClient(getLocalHost(), server1.getPort());
       assertTrue(c1.isActive());

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -187,6 +187,60 @@ These metrics are exposed by Celeborn worker.
     - DeviceCelebornTotalCapacity(B)
     - PotentialConsumeSpeed
     - UserProduceSpeed
+    - push_server_usedHeapMemory 
+    - push_server_usedDirectMemory
+    - push_server_numAllocations 
+    - push_server_numTinyAllocations
+    - push_server_numSmallAllocations
+    - push_server_numNormalAllocations
+    - push_server_numHugeAllocations
+    - push_server_numDeallocations
+    - push_server_numTinyDeallocations
+    - push_server_numSmallDeallocations
+    - push_server_numNormalDeallocations
+    - push_server_numHugeDeallocations
+    - push_server_numActiveAllocations
+    - push_server_numActiveTinyAllocations
+    - push_server_numActiveSmallAllocations
+    - push_server_numActiveNormalAllocations
+    - push_server_numActiveHugeAllocations
+    - push_server_numActiveBytes
+    - replicate_server_usedHeapMemory
+    - replicate_server_usedDirectMemory
+    - replicate_server_numAllocations 
+    - replicate_server_numTinyAllocations
+    - replicate_server_numSmallAllocations
+    - replicate_server_numNormalAllocations
+    - replicate_server_numHugeAllocations
+    - replicate_server_numDeallocations
+    - replicate_server_numTinyDeallocations
+    - replicate_server_numSmallDeallocations
+    - replicate_server_numNormalDeallocations
+    - replicate_server_numHugeDeallocations
+    - replicate_server_numActiveAllocations
+    - replicate_server_numActiveTinyAllocations
+    - replicate_server_numActiveSmallAllocations
+    - replicate_server_numActiveNormalAllocations
+    - replicate_server_numActiveHugeAllocations
+    - replicate_server_numActiveBytes
+    - fetch_server_usedHeapMemory
+    - fetch_server_usedDirectMemory
+    - fetch_server_numAllocations 
+    - fetch_server_numTinyAllocations
+    - fetch_server_numSmallAllocations
+    - fetch_server_numNormalAllocations
+    - fetch_server_numHugeAllocations
+    - fetch_server_numDeallocations
+    - fetch_server_numTinyDeallocations
+    - fetch_server_numSmallDeallocations
+    - fetch_server_numNormalDeallocations
+    - fetch_server_numHugeDeallocations
+    - fetch_server_numActiveAllocations
+    - fetch_server_numActiveTinyAllocations
+    - fetch_server_numActiveSmallAllocations
+    - fetch_server_numActiveNormalAllocations
+    - fetch_server_numActiveHugeAllocations
+    - fetch_server_numActiveBytes
 
   - namespace=CPU
     - JVMCPUTime

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -122,7 +122,8 @@ private[celeborn] class Worker(
         pushDataHandler,
         closeIdleConnections,
         pushServerLimiter,
-        conf.workerPushHeartbeatEnabled)
+        conf.workerPushHeartbeatEnabled,
+        workerSource)
     (
       transportContext.createServer(conf.workerPushPort),
       transportContext.createClientFactory())
@@ -142,7 +143,8 @@ private[celeborn] class Worker(
         replicateHandler,
         closeIdleConnections,
         replicateLimiter,
-        false)
+        false,
+        workerSource)
     transportContext.createServer(conf.workerReplicatePort)
   }
 
@@ -158,7 +160,8 @@ private[celeborn] class Worker(
         transportConf,
         fetchHandler,
         closeIdleConnections,
-        conf.workerFetchHeartbeatEnabled)
+        conf.workerFetchHeartbeatEnabled,
+        workerSource)
     transportContext.createServer(conf.workerFetchPort)
   }
 

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/network/RequestTimeoutIntegrationSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/network/RequestTimeoutIntegrationSuiteJ.java
@@ -107,7 +107,7 @@ public class RequestTimeoutIntegrationSuiteJ {
           }
         };
 
-    TransportContext context = new TransportContext(conf, handler, true, false);
+    TransportContext context = new TransportContext(conf, handler, true);
     server = context.createServer();
     clientFactory = context.createClientFactory();
     TransportClient client = clientFactory.createClient(getLocalHost(), server.getPort());
@@ -157,7 +157,7 @@ public class RequestTimeoutIntegrationSuiteJ {
           }
         };
 
-    TransportContext context = new TransportContext(conf, handler, true, false);
+    TransportContext context = new TransportContext(conf, handler, true);
     server = context.createServer();
     clientFactory = context.createClientFactory();
 
@@ -208,7 +208,7 @@ public class RequestTimeoutIntegrationSuiteJ {
           }
         };
 
-    TransportContext context = new TransportContext(conf, handler, true, false);
+    TransportContext context = new TransportContext(conf, handler, true);
     server = context.createServer();
     clientFactory = context.createClientFactory();
     TransportClient client = clientFactory.createClient(getLocalHost(), server.getPort());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Worker side should expose Netty allocator metrics


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

