### PR TITLE
[CELEBORN-583] Merge pooled memory allocators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ management service for intermediate data including shuffle data, spilled data, r
 ### Architecture
 ![Celeborn architecture](assets/img/rss.jpg)
 Celeborn has three primary components: Master, Worker, and Client.
-Master manages all resources and syncs shard states with each other based on Raft.
+Master manages all resources and syncs shared states with each other based on Raft.
 Worker processes read-write requests and merges data for each reducer.
 LifecycleManager maintains metadata of each shuffle and runs within the Spark driver.
 

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -94,7 +94,7 @@ public class TransportClientFactory implements Closeable {
   }
 
   protected void initializeMemoryAllocator() {
-    this.pooledAllocator = NettyUtils.getShardPooledByteBufAllocator();
+    this.pooledAllocator = NettyUtils.getShardPooledByteBufAllocator(null);
   }
 
   /**

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -94,7 +94,7 @@ public class TransportClientFactory implements Closeable {
   }
 
   protected void initializeMemoryAllocator() {
-    this.pooledAllocator = NettyUtils.getShardPooledByteBufAllocator(null);
+    this.pooledAllocator = NettyUtils.getShardPooledByteBufAllocator(conf.getCelebornConf(), null);
   }
 
   /**

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -94,9 +94,7 @@ public class TransportClientFactory implements Closeable {
   }
 
   protected void initializeMemoryAllocator() {
-    this.pooledAllocator =
-        NettyUtils.createPooledByteBufAllocator(
-            conf.preferDirectBufs(), false /* allowCache */, conf.clientThreads());
+    this.pooledAllocator = NettyUtils.getShardPooledByteBufAllocator();
   }
 
   /**

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -94,7 +94,7 @@ public class TransportClientFactory implements Closeable {
   }
 
   protected void initializeMemoryAllocator() {
-    this.pooledAllocator = NettyUtils.getShardPooledByteBufAllocator(conf.getCelebornConf(), null);
+    this.pooledAllocator = NettyUtils.getPooledByteBufAllocator(conf, null, false);
   }
 
   /**

--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
@@ -81,7 +81,8 @@ public class TransportServer implements Closeable {
     EventLoopGroup workerGroup =
         NettyUtils.createEventLoop(ioMode, conf.serverThreads(), conf.getModuleName() + "-server");
 
-    PooledByteBufAllocator allocator = NettyUtils.getShardPooledByteBufAllocator(source);
+    PooledByteBufAllocator allocator =
+        NettyUtils.getShardPooledByteBufAllocator(conf.getCelebornConf(), source);
 
     bootstrap =
         new ServerBootstrap()

--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
@@ -46,7 +46,6 @@ public class TransportServer implements Closeable {
 
   private ServerBootstrap bootstrap;
   private ChannelFuture channelFuture;
-  private NettyMemoryMetrics nettyMetric;
   private AbstractSource source;
   private int port = -1;
 
@@ -82,7 +81,7 @@ public class TransportServer implements Closeable {
     EventLoopGroup workerGroup =
         NettyUtils.createEventLoop(ioMode, conf.serverThreads(), conf.getModuleName() + "-server");
 
-    PooledByteBufAllocator allocator = NettyUtils.getShardPooledByteBufAllocator();
+    PooledByteBufAllocator allocator = NettyUtils.getShardPooledByteBufAllocator(source);
 
     bootstrap =
         new ServerBootstrap()
@@ -93,9 +92,6 @@ public class TransportServer implements Closeable {
             .childOption(ChannelOption.TCP_NODELAY, true)
             .childOption(ChannelOption.SO_KEEPALIVE, true)
             .childOption(ChannelOption.ALLOCATOR, allocator);
-
-    this.nettyMetric =
-        new NettyMemoryMetrics(allocator, conf.getModuleName() + "-server", conf, source);
 
     if (conf.backLog() > 0) {
       bootstrap.option(ChannelOption.SO_BACKLOG, conf.backLog());

--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
@@ -82,9 +82,7 @@ public class TransportServer implements Closeable {
     EventLoopGroup workerGroup =
         NettyUtils.createEventLoop(ioMode, conf.serverThreads(), conf.getModuleName() + "-server");
 
-    PooledByteBufAllocator allocator =
-        NettyUtils.createPooledByteBufAllocator(
-            conf.preferDirectBufs(), true /* allowCache */, conf.serverThreads());
+    PooledByteBufAllocator allocator = NettyUtils.getShardPooledByteBufAllocator();
 
     bootstrap =
         new ServerBootstrap()

--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
@@ -81,8 +81,7 @@ public class TransportServer implements Closeable {
     EventLoopGroup workerGroup =
         NettyUtils.createEventLoop(ioMode, conf.serverThreads(), conf.getModuleName() + "-server");
 
-    PooledByteBufAllocator allocator =
-        NettyUtils.getShardPooledByteBufAllocator(conf.getCelebornConf(), source);
+    PooledByteBufAllocator allocator = NettyUtils.getPooledByteBufAllocator(conf, source, true);
 
     bootstrap =
         new ServerBootstrap()

--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyMemoryMetrics.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyMemoryMetrics.java
@@ -69,11 +69,11 @@ public class NettyMemoryMetrics {
   public NettyMemoryMetrics(
       PooledByteBufAllocator pooledAllocator,
       String metricPrefix,
-      TransportConf conf,
+      boolean verboseMetricsEnabled,
       AbstractSource source) {
     this.pooledAllocator = pooledAllocator;
     this.metricPrefix = metricPrefix;
-    this.verboseMetricsEnabled = conf.verboseMetrics();
+    this.verboseMetricsEnabled = verboseMetricsEnabled;
     this.source = source;
 
     registerMetrics(this.pooledAllocator);

--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -111,15 +111,13 @@ public class NettyUtils {
         allowCache ? PooledByteBufAllocator.defaultUseCacheForAllThreads() : false);
   }
 
-  public static PooledByteBufAllocator getShardPooledByteBufAllocator(AbstractSource source) {
+  public static PooledByteBufAllocator getShardPooledByteBufAllocator(
+      CelebornConf conf, AbstractSource source) {
     synchronized (PooledByteBufAllocator.class) {
       if (_allocator == null) {
-        CelebornConf conf = new CelebornConf();
         // each core should have one arena to allocate memory
-        int arenas = conf.pooledAllocatorArenas();
-        _allocator = createPooledByteBufAllocator(true, true, arenas);
-        new NettyMemoryMetrics(
-            _allocator, "common-pool", conf.pooledAllocatorVerboseMetric(), source);
+        _allocator = createPooledByteBufAllocator(true, true, conf.allocatorArenas());
+        new NettyMemoryMetrics(_allocator, "common-pool", conf.allocatorVerboseMetric(), source);
         return _allocator;
       } else {
         return _allocator;

--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -115,13 +115,13 @@ public class NettyUtils {
         allowCache && PooledByteBufAllocator.defaultUseCacheForAllThreads());
   }
 
-  private static PooledByteBufAllocator getShardPooledByteBufAllocator(
+  private static PooledByteBufAllocator getSharedPooledByteBufAllocator(
       CelebornConf conf, AbstractSource source) {
     synchronized (PooledByteBufAllocator.class) {
       if (_allocator == null) {
         // each core should have one arena to allocate memory
         _allocator = createPooledByteBufAllocator(true, true, conf.allocatorArenas());
-        new NettyMemoryMetrics(_allocator, "shard-pool", conf.allocatorVerboseMetric(), source);
+        new NettyMemoryMetrics(_allocator, "shared-pool", conf.allocatorVerboseMetric(), source);
       }
       return _allocator;
     }
@@ -130,7 +130,7 @@ public class NettyUtils {
   public static PooledByteBufAllocator getPooledByteBufAllocator(
       TransportConf conf, AbstractSource source, boolean allowCache) {
     if (conf.getCelebornConf().shareMemoryAllocator()) {
-      return getShardPooledByteBufAllocator(conf.getCelebornConf(), source);
+      return getSharedPooledByteBufAllocator(conf.getCelebornConf(), source);
     } else {
       PooledByteBufAllocator allocator =
           createPooledByteBufAllocator(conf.preferDirectBufs(), allowCache, conf.clientThreads());

--- a/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/NettyUtils.java
@@ -118,10 +118,8 @@ public class NettyUtils {
         // each core should have one arena to allocate memory
         _allocator = createPooledByteBufAllocator(true, true, conf.allocatorArenas());
         new NettyMemoryMetrics(_allocator, "common-pool", conf.allocatorVerboseMetric(), source);
-        return _allocator;
-      } else {
-        return _allocator;
       }
+      return _allocator;
     }
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -796,6 +796,13 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def readBufferTargetNotifyThreshold: Long = get(WORKER_READBUFFER_TARGET_NOTIFY_THRESHOLD)
   def readBuffersToTriggerReadMin: Int = get(WORKER_READBUFFERS_TOTRIGGERREAD_MIN)
 
+  def pooledAllocatorArenas: Int = get(MEMORY_POOLED_ALLOCATOR_ARENAS).getOrElse(
+    if (Runtime.getRuntime.availableProcessors() >= 2) {
+      Runtime.getRuntime.availableProcessors()
+    } else {
+      2
+    })
+
   // //////////////////////////////////////////////////////
   //                  Rate Limit controller              //
   // //////////////////////////////////////////////////////
@@ -3203,6 +3210,14 @@ object CelebornConf extends Logging {
       .doc("Min buffers count for map data partition to trigger read.")
       .intConf
       .createWithDefault(32)
+
+  val MEMORY_POOLED_ALLOCATOR_ARENAS: OptionalConfigEntry[Int] =
+    buildConf("celeborn.pooled.allocator.arenas")
+      .categories("worker", "client")
+      .version("0.3.0")
+      .doc("Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2.")
+      .intConf
+      .createOptional
 
   val METRICS_EXTRA_LABELS: ConfigEntry[Seq[String]] =
     buildConf("celeborn.metrics.extraLabels")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -803,6 +803,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
       2
     })
 
+  def pooledAllocatorVerboseMetric: Boolean = get(MEMORY_POOLED_ALLOCATOR_VERBOSE_METRIC)
+
   // //////////////////////////////////////////////////////
   //                  Rate Limit controller              //
   // //////////////////////////////////////////////////////
@@ -3210,6 +3212,14 @@ object CelebornConf extends Logging {
       .doc("Min buffers count for map data partition to trigger read.")
       .intConf
       .createWithDefault(32)
+
+  val MEMORY_POOLED_ALLOCATOR_VERBOSE_METRIC: ConfigEntry[Boolean] =
+    buildConf("celeborn.pooled.allocator.verbose.metric")
+      .categories("worker", "client")
+      .version("0.3.0")
+      .doc("Weather to enable verbose metric for pooled allocator.")
+      .booleanConf
+      .createWithDefault(false)
 
   val MEMORY_POOLED_ALLOCATOR_ARENAS: OptionalConfigEntry[Int] =
     buildConf("celeborn.pooled.allocator.arenas")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -796,14 +796,11 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def readBufferTargetNotifyThreshold: Long = get(WORKER_READBUFFER_TARGET_NOTIFY_THRESHOLD)
   def readBuffersToTriggerReadMin: Int = get(WORKER_READBUFFERS_TOTRIGGERREAD_MIN)
 
-  def pooledAllocatorArenas: Int = get(MEMORY_POOLED_ALLOCATOR_ARENAS).getOrElse(
-    if (Runtime.getRuntime.availableProcessors() >= 2) {
-      Runtime.getRuntime.availableProcessors()
-    } else {
-      2
-    })
+  def allocatorArenas: Int = get(MEMORY_ALLOCATOR_ARENAS).getOrElse(Math.max(
+    Runtime.getRuntime.availableProcessors(),
+    2))
 
-  def pooledAllocatorVerboseMetric: Boolean = get(MEMORY_POOLED_ALLOCATOR_VERBOSE_METRIC)
+  def allocatorVerboseMetric: Boolean = get(MEMORY_ALLOCATOR_VERBOSE_METRIC)
 
   // //////////////////////////////////////////////////////
   //                  Rate Limit controller              //
@@ -3213,21 +3210,21 @@ object CelebornConf extends Logging {
       .intConf
       .createWithDefault(32)
 
-  val MEMORY_POOLED_ALLOCATOR_VERBOSE_METRIC: ConfigEntry[Boolean] =
-    buildConf("celeborn.pooled.allocator.verbose.metric")
-      .categories("worker", "client")
-      .version("0.3.0")
-      .doc("Weather to enable verbose metric for pooled allocator.")
-      .booleanConf
-      .createWithDefault(false)
-
-  val MEMORY_POOLED_ALLOCATOR_ARENAS: OptionalConfigEntry[Int] =
-    buildConf("celeborn.pooled.allocator.arenas")
+  val MEMORY_ALLOCATOR_ARENAS: OptionalConfigEntry[Int] =
+    buildConf("celeborn.memory.allocator.numArenas")
       .categories("worker", "client")
       .version("0.3.0")
       .doc("Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2.")
       .intConf
       .createOptional
+
+  val MEMORY_ALLOCATOR_VERBOSE_METRIC: ConfigEntry[Boolean] =
+    buildConf("celeborn.memory.allocator.verbose.metric")
+      .categories("worker", "client")
+      .version("0.3.0")
+      .doc("Weather to enable verbose metric for pooled allocator.")
+      .booleanConf
+      .createWithDefault(false)
 
   val METRICS_EXTRA_LABELS: ConfigEntry[Seq[String]] =
     buildConf("celeborn.metrics.extraLabels")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -796,6 +796,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def readBufferTargetNotifyThreshold: Long = get(WORKER_READBUFFER_TARGET_NOTIFY_THRESHOLD)
   def readBuffersToTriggerReadMin: Int = get(WORKER_READBUFFERS_TOTRIGGERREAD_MIN)
 
+  def shareMemoryAllocator: Boolean = get(MEMORY_ALLOCATOR_SHARE)
   def allocatorArenas: Int = get(MEMORY_ALLOCATOR_ARENAS).getOrElse(Math.max(
     Runtime.getRuntime.availableProcessors(),
     2))
@@ -3209,6 +3210,14 @@ object CelebornConf extends Logging {
       .doc("Min buffers count for map data partition to trigger read.")
       .intConf
       .createWithDefault(32)
+
+  val MEMORY_ALLOCATOR_SHARE: ConfigEntry[Boolean] =
+    buildConf("celeborn.memory.allocator.share")
+      .categories("worker", "client")
+      .version("0.3.0")
+      .doc("Whether to share memory allocator.")
+      .booleanConf
+      .createWithDefault(false)
 
   val MEMORY_ALLOCATOR_ARENAS: OptionalConfigEntry[Int] =
     buildConf("celeborn.memory.allocator.numArenas")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -29,6 +29,7 @@ license: |
 | celeborn.fetch.maxRetriesForEachReplica | 3 | Max retry times of fetch chunk on each replica | 0.2.0 | 
 | celeborn.fetch.timeout | 120s | Timeout for a task to fetch chunk. | 0.2.0 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
+| celeborn.pooled.allocator.arenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 
 | celeborn.push.buffer.initial.size | 8k |  | 0.2.0 | 
 | celeborn.push.buffer.max.size | 64k | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. | 0.2.0 | 
 | celeborn.push.data.timeout | 120s | Timeout for a task to push data rpc message. This value should better be more than twice of `celeborn.push.timeoutCheck.interval` | 0.2.0 | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -30,6 +30,7 @@ license: |
 | celeborn.fetch.timeout | 120s | Timeout for a task to fetch chunk. | 0.2.0 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
 | celeborn.pooled.allocator.arenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 
+| celeborn.pooled.allocator.verbose.metric | false | Weather to enable verbose metric for pooled allocator. | 0.3.0 | 
 | celeborn.push.buffer.initial.size | 8k |  | 0.2.0 | 
 | celeborn.push.buffer.max.size | 64k | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. | 0.2.0 | 
 | celeborn.push.data.timeout | 120s | Timeout for a task to push data rpc message. This value should better be more than twice of `celeborn.push.timeoutCheck.interval` | 0.2.0 | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -29,8 +29,8 @@ license: |
 | celeborn.fetch.maxRetriesForEachReplica | 3 | Max retry times of fetch chunk on each replica | 0.2.0 | 
 | celeborn.fetch.timeout | 120s | Timeout for a task to fetch chunk. | 0.2.0 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
-| celeborn.pooled.allocator.arenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 
-| celeborn.pooled.allocator.verbose.metric | false | Weather to enable verbose metric for pooled allocator. | 0.3.0 | 
+| celeborn.memory.allocator.numArenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 
+| celeborn.memory.allocator.verbose.metric | false | Weather to enable verbose metric for pooled allocator. | 0.3.0 | 
 | celeborn.push.buffer.initial.size | 8k |  | 0.2.0 | 
 | celeborn.push.buffer.max.size | 64k | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. | 0.2.0 | 
 | celeborn.push.data.timeout | 120s | Timeout for a task to push data rpc message. This value should better be more than twice of `celeborn.push.timeoutCheck.interval` | 0.2.0 | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -30,6 +30,7 @@ license: |
 | celeborn.fetch.timeout | 120s | Timeout for a task to fetch chunk. | 0.2.0 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
 | celeborn.memory.allocator.numArenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 
+| celeborn.memory.allocator.share | false | Whether to share memory allocator. | 0.3.0 | 
 | celeborn.memory.allocator.verbose.metric | false | Weather to enable verbose metric for pooled allocator. | 0.3.0 | 
 | celeborn.push.buffer.initial.size | 8k |  | 0.2.0 | 
 | celeborn.push.buffer.max.size | 64k | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. | 0.2.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -22,14 +22,14 @@ license: |
 | celeborn.client.heartbeat.interval | 60s | the heartbeat interval between worker and client | 0.3.0 | 
 | celeborn.client.maxRetries | 15 | Max retry times for client to connect master endpoint | 0.2.0 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
+| celeborn.memory.allocator.numArenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 
+| celeborn.memory.allocator.verbose.metric | false | Weather to enable verbose metric for pooled allocator. | 0.3.0 | 
 | celeborn.metrics.capacity | 4096 | The maximum number of metrics which a source can use to generate output strings. | 0.2.0 | 
 | celeborn.metrics.collectPerfCritical.enabled | false | It controls whether to collect metrics which may affect performance. When enable, Celeborn collects them. | 0.2.0 | 
 | celeborn.metrics.enabled | true | When true, enable metrics system. | 0.2.0 | 
 | celeborn.metrics.extraLabels |  | If default metric labels are not enough, extra metric labels can be customized. Labels' pattern is: `<label1_key>=<label1_value>[,<label2_key>=<label2_value>]*`; e.g. `env=prod,version=1` | 0.3.0 | 
 | celeborn.metrics.sample.rate | 1.0 | It controls if Celeborn collect timer metrics for some operations. Its value should be in [0.0, 1.0]. | 0.2.0 | 
 | celeborn.metrics.timer.slidingWindow.size | 4096 | The sliding window size of timer metric. | 0.2.0 | 
-| celeborn.pooled.allocator.arenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 
-| celeborn.pooled.allocator.verbose.metric | false | Weather to enable verbose metric for pooled allocator. | 0.3.0 | 
 | celeborn.shuffle.chunk.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. | 0.2.0 | 
 | celeborn.shuffle.minPartitionSizeToEstimate | 8mb | Ignore partition size smaller than this configuration of partition size for estimation. | 0.2.0 | 
 | celeborn.shuffle.partitionSplit.min | 1m | Min size for a partition to split | 0.2.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -29,6 +29,7 @@ license: |
 | celeborn.metrics.sample.rate | 1.0 | It controls if Celeborn collect timer metrics for some operations. Its value should be in [0.0, 1.0]. | 0.2.0 | 
 | celeborn.metrics.timer.slidingWindow.size | 4096 | The sliding window size of timer metric. | 0.2.0 | 
 | celeborn.pooled.allocator.arenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 
+| celeborn.pooled.allocator.verbose.metric | false | Weather to enable verbose metric for pooled allocator. | 0.3.0 | 
 | celeborn.shuffle.chunk.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. | 0.2.0 | 
 | celeborn.shuffle.minPartitionSizeToEstimate | 8mb | Ignore partition size smaller than this configuration of partition size for estimation. | 0.2.0 | 
 | celeborn.shuffle.partitionSplit.min | 1m | Min size for a partition to split | 0.2.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -23,6 +23,7 @@ license: |
 | celeborn.client.maxRetries | 15 | Max retry times for client to connect master endpoint | 0.2.0 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
 | celeborn.memory.allocator.numArenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 
+| celeborn.memory.allocator.share | false | Whether to share memory allocator. | 0.3.0 | 
 | celeborn.memory.allocator.verbose.metric | false | Weather to enable verbose metric for pooled allocator. | 0.3.0 | 
 | celeborn.metrics.capacity | 4096 | The maximum number of metrics which a source can use to generate output strings. | 0.2.0 | 
 | celeborn.metrics.collectPerfCritical.enabled | false | It controls whether to collect metrics which may affect performance. When enable, Celeborn collects them. | 0.2.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -28,6 +28,7 @@ license: |
 | celeborn.metrics.extraLabels |  | If default metric labels are not enough, extra metric labels can be customized. Labels' pattern is: `<label1_key>=<label1_value>[,<label2_key>=<label2_value>]*`; e.g. `env=prod,version=1` | 0.3.0 | 
 | celeborn.metrics.sample.rate | 1.0 | It controls if Celeborn collect timer metrics for some operations. Its value should be in [0.0, 1.0]. | 0.2.0 | 
 | celeborn.metrics.timer.slidingWindow.size | 4096 | The sliding window size of timer metric. | 0.2.0 | 
+| celeborn.pooled.allocator.arenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 
 | celeborn.shuffle.chunk.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. | 0.2.0 | 
 | celeborn.shuffle.minPartitionSizeToEstimate | 8mb | Ignore partition size smaller than this configuration of partition size for estimation. | 0.2.0 | 
 | celeborn.shuffle.partitionSplit.min | 1m | Min size for a partition to split | 0.2.0 | 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -115,7 +115,6 @@ public class MemoryManager {
     double shuffleStorageRatio = conf.workerDirectMemoryRatioForShuffleStorage();
     long checkInterval = conf.workerDirectMemoryPressureCheckIntervalMs();
     long reportInterval = conf.workerDirectMemoryReportIntervalSecond();
-    long readBufferAllocationWait = conf.readBufferAllocationWait();
     double readBufferTargetRatio = conf.readBufferTargetRatio();
     long readBufferTargetUpdateInterval = conf.readBufferTargetUpdateInterval();
     long readBufferTargetNotifyThreshold = conf.readBufferTargetNotifyThreshold();
@@ -219,7 +218,7 @@ public class MemoryManager {
 
     if (readBufferThreshold > 0) {
       // if read buffer threshold is zero means that there will be no map data partitions
-      readBufferDispatcher = new ReadBufferDispatcher(this, readBufferAllocationWait);
+      readBufferDispatcher = new ReadBufferDispatcher(this, conf);
       readBufferTargetChangeListeners = new ArrayList<>();
       readBufferTargetUpdateService.scheduleWithFixedDelay(
           () -> {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
@@ -41,7 +41,7 @@ public class ReadBufferDispatcher extends Thread {
 
   public ReadBufferDispatcher(MemoryManager memoryManager, long readBufferAllocationWait) {
     this.readBufferAllocationWait = readBufferAllocationWait;
-    readBufferAllocator = NettyUtils.createPooledByteBufAllocator(true, true, 1);
+    readBufferAllocator = NettyUtils.getShardPooledByteBufAllocator();
     this.memoryManager = memoryManager;
     this.setName("Read-Buffer-Dispatcher");
     this.start();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
@@ -28,6 +28,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.network.util.NettyUtils;
 
 public class ReadBufferDispatcher extends Thread {
@@ -39,9 +40,9 @@ public class ReadBufferDispatcher extends Thread {
   private final long readBufferAllocationWait;
   private volatile boolean stopFlag = false;
 
-  public ReadBufferDispatcher(MemoryManager memoryManager, long readBufferAllocationWait) {
-    this.readBufferAllocationWait = readBufferAllocationWait;
-    readBufferAllocator = NettyUtils.getShardPooledByteBufAllocator(null);
+  public ReadBufferDispatcher(MemoryManager memoryManager, CelebornConf conf) {
+    this.readBufferAllocationWait = conf.readBufferAllocationWait();
+    readBufferAllocator = NettyUtils.getShardPooledByteBufAllocator(conf, null);
     this.memoryManager = memoryManager;
     this.setName("Read-Buffer-Dispatcher");
     this.start();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
@@ -41,7 +41,7 @@ public class ReadBufferDispatcher extends Thread {
 
   public ReadBufferDispatcher(MemoryManager memoryManager, long readBufferAllocationWait) {
     this.readBufferAllocationWait = readBufferAllocationWait;
-    readBufferAllocator = NettyUtils.getShardPooledByteBufAllocator();
+    readBufferAllocator = NettyUtils.getShardPooledByteBufAllocator(null);
     this.memoryManager = memoryManager;
     this.setName("Read-Buffer-Dispatcher");
     this.start();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ReadBufferDispatcher.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.network.util.NettyUtils;
+import org.apache.celeborn.common.network.util.TransportConf;
 
 public class ReadBufferDispatcher extends Thread {
   private final Logger logger = LoggerFactory.getLogger(ReadBufferDispatcher.class);
@@ -42,7 +43,9 @@ public class ReadBufferDispatcher extends Thread {
 
   public ReadBufferDispatcher(MemoryManager memoryManager, CelebornConf conf) {
     this.readBufferAllocationWait = conf.readBufferAllocationWait();
-    readBufferAllocator = NettyUtils.getShardPooledByteBufAllocator(conf, null);
+    // readBuffer is not a module name, it's a placeholder.
+    readBufferAllocator =
+        NettyUtils.getPooledByteBufAllocator(new TransportConf("readBuffer", conf), null, true);
     this.memoryManager = memoryManager;
     this.setName("Read-Buffer-Dispatcher");
     this.start();


### PR DESCRIPTION
### What changes were proposed in this pull request?
Merging pooled memory allocators to improve memory usage efficiency. Due to Netty's memory allocator, it will cause some fragments and cannot be used.


### Why are the changes needed?
Workload: 8x Flink TPC-DS 1TB 
Hardware: 8x 32vCPU 128GRam.
Celeborn Worker: 1G off-heap.

Before this patch, as you can see that workers have multiple memory allocators. Memory allocators will consume more memory than we thought it should be. And the workload will failed to run through q4.sql.
<img width="564" alt="截屏2023-05-17 11 06 52" src="https://github.com/apache/incubator-celeborn/assets/4150993/c683ed14-8ba0-4842-a1ee-53162f40776b">
<img width="1661" alt="截屏2023-05-15 17 51 30" src="https://github.com/apache/incubator-celeborn/assets/4150993/2231f7f8-8434-4f9a-a72d-cc1a891f59e5">

After this Path, running the same workload will not cause PausePushData state and q4.sql is passed.
<img width="566" alt="截屏2023-05-17 12 28 32" src="https://github.com/apache/incubator-celeborn/assets/4150993/1cfb62e8-57a8-4feb-ae20-751c5969ca08">


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT and cluster.

