### PR TITLE
[CELEBORN-459] Remove chunkTracker from FileManagedBuffers to avoid c…

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/server/ChunkStreamManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/ChunkStreamManager.java
@@ -86,23 +86,7 @@ public class ChunkStreamManager {
     }
 
     FileManagedBuffers buffers = state.buffers;
-    if (buffers.hasAlreadyRead(chunkIndex)) {
-      throw new IllegalStateException(
-          String.format("Chunk %s for stream %s has already been read.", chunkIndex, streamId));
-    }
     ManagedBuffer nextChunk = buffers.chunk(chunkIndex, offset, len);
-
-    if (state.buffers.isFullyRead()) {
-      // Normally, when all chunks are returned to the client, the stream should be removed here.
-      // But if there is a switch on the client side, it will not go here at this time, so we need
-      // to remove the stream when the shuffle is expired, and release the unused buffer.
-      logger.trace("Removing stream id {}", streamId);
-      streams.remove(streamId);
-      Set<Long> streamIds = shuffleStreamIds.get(state.shuffleKey);
-      if (streamIds != null) {
-        streamIds.remove(streamId);
-      }
-    }
 
     return nextChunk;
   }


### PR DESCRIPTION
…onflict with stream reuse (#1372)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Cherry-picked from main https://github.com/apache/incubator-celeborn/commit/885e0cef32601eb51e14a7f2c3f044f76f171173

Currently ```WorkerPartitionReader.fetchChunks()``` will call ```clientFactory.createClient```, and 
this method will create a new connection if previous connection is inactive. The new connection will reuse the
streamId and read the successive chunkIndex, as follows:
```
 client.fetchChunk(streamHandle.streamId, chunkIndex, callback);
```
ChunkStreamManager tracks whether a chunk has been fetched through chunkTracker, it will throw exception
for duplicate read, and delete the streamId when all chunks are read. However, such tracking logic can conflict with
stream reuse.

Consider the situation that old connection successfully read chunk c1, and then connection failed before
returning to WorkerPartitionReader, then WorkerPartitionReader creates a new connection and retry c1, at this time
ChunkStreamManager will throw exception of duplicate read.

Consider another situation that old connection successfully read the last chunk and WorkerPartitionReader deletes
the streamId, but the connection fails before returning to WorkerPartitionReader, when the new client retries
ChunkStreamManager will throw exception that streamId not found.

Although the partition-level retry will overcome the two cases described above, it is better to avoid them.

The streams in ChunkStreamManager will be cleaned up when shuffle expires.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
