### PR TITLE
[CELEBORN-590] Remove hadoop prefix of WORKER_WORKING_DIR

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1905,7 +1905,7 @@ object CelebornConf extends Logging {
       .doc("Worker's working dir path name.")
       .version("0.2.0")
       .stringConf
-      .createWithDefault("hadoop/rss-worker/shuffle_data")
+      .createWithDefault("rss-worker/shuffle_data")
 
   val WORKER_CLOSE_IDLE_CONNECTIONS: ConfigEntry[Boolean] =
     buildConf("celeborn.worker.closeIdleConnections")

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -106,7 +106,7 @@ license: |
 | celeborn.worker.storage.baseDir.number | 16 | How many directories will be used if `celeborn.worker.storage.dirs` is not set. The directory name is a combination of `celeborn.worker.storage.baseDir.prefix` and from one(inclusive) to `celeborn.worker.storage.baseDir.number`(inclusive) step by one. | 0.2.0 | 
 | celeborn.worker.storage.baseDir.prefix | /mnt/disk | Base directory for Celeborn worker to write if `celeborn.worker.storage.dirs` is not set. | 0.2.0 | 
 | celeborn.worker.storage.dirs | &lt;undefined&gt; | Directory list to store shuffle data. It's recommended to configure one directory on each disk. Storage size limit can be set for each directory. For the sake of performance, there should be no more than 2 flush threads on the same disk partition if you are using HDD, and should be 8 or more flush threads on the same disk partition if you are using SSD. For example: `dir1[:capacity=][:disktype=][:flushthread=],dir2[:capacity=][:disktype=][:flushthread=]` | 0.2.0 | 
-| celeborn.worker.workingDir | hadoop/rss-worker/shuffle_data | Worker's working dir path name. | 0.2.0 | 
+| celeborn.worker.workingDir | rss-worker/shuffle_data | Worker's working dir path name. | 0.2.0 | 
 | celeborn.worker.writer.close.timeout | 120s | Timeout for a file writer to close | 0.2.0 | 
 | celeborn.worker.writer.create.maxAttempts | 3 | Retry count for a file writer to create if its creation was failed. | 0.2.0 | 
 <!--end-include-->

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -21,7 +21,9 @@ license: |
 
 ## Upgrading from 0.2.1 to 0.3.0
 
-From 0.3.0 on the default value for `celeborn.push.replicate.enabled` is changed from `true` to `false`, users
-who want replication on should explicitly enable replication. For example, to enable replication for Spark
-users should add the spark config when submitting job: `spark.celeborn.push.replicate.enabled=true`
+ - From 0.3.0 on the default value for `celeborn.push.replicate.enabled` is changed from `true` to `false`, users
+   who want replication on should explicitly enable replication. For example, to enable replication for Spark
+   users should add the spark config when submitting job: `spark.celeborn.push.replicate.enabled=true`
 
+ - From 0.3.0 on the default value for `celeborn.worker.workingDir` is changed from `hadoop/rss-worker/shuffle_data` to `rss-worker/shuffle_data`,
+   users who want to use origin working dir path should set this configuration.

--- a/toolkit/reg.sh
+++ b/toolkit/reg.sh
@@ -316,10 +316,10 @@ function updateCeleborn() {
     echo -e "update ${host} \n"
     ssh ${host} "export CELEBORN_CONF_DIR=/home/hadoop/conf ; /home/hadoop/${CELEBORN_DIST}/sbin/stop-worker.sh"
     ssh ${host} "rm -rf /home/hadoop/${CELEBORN_DIST}"
-    ssh ${host} "rm -rf /mnt/disk1/hadoop/rss-worker/shuffle_data/*"
-    ssh ${host} "rm -rf /mnt/disk2/hadoop/rss-worker/shuffle_data/*"
-    ssh ${host} "rm -rf /mnt/disk3/hadoop/rss-worker/shuffle_data/*"
-    ssh ${host} "rm -rf /mnt/disk4/hadoop/rss-worker/shuffle_data/*"
+    ssh ${host} "rm -rf /mnt/disk1/rss-worker/shuffle_data/*"
+    ssh ${host} "rm -rf /mnt/disk2/rss-worker/shuffle_data/*"
+    ssh ${host} "rm -rf /mnt/disk3/rss-worker/shuffle_data/*"
+    ssh ${host} "rm -rf /mnt/disk4/rss-worker/shuffle_data/*"
     scp -r ${REG_CELEBORN_DIST}/${CELEBORN_DIST}/ ${host}:~/ > /dev/null 2>&1
     scp -r ${REG_CELEBORN_DIST}/${CELEBORN_DIST}/spark/* ${host}:${CELEBORN_CLIENT_INSTALL_DIR}/ > /dev/null 2>&1
   done


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove hadoop prefix of WORKER_WORKING_DIR


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

