### PR TITLE
[CELEBORN-591] RatisSystem need decrease no leader timeout configuration.

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1733,7 +1733,7 @@ object CelebornConf extends Logging {
       .categories("master")
       .version("0.2.0")
       .timeConf(TimeUnit.SECONDS)
-      .createWithDefaultString("120s")
+      .createWithDefaultString("30s")
 
   val HA_MASTER_RATIS_RPC_SLOWNESS_TIMEOUT: ConfigEntry[Long] =
     buildConf("celeborn.ha.master.ratis.raft.server.rpc.slowness.timeout")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Change default from 120s to 30s, then if no leader in ratis system would be notified and wait another 120s(default heartbeat timeout).

### Why are the changes needed?
With current config, if two master(not leader) have a similar shut-down time,  the current leader will be notified to change it's role only when ratis reach the no-leader timeout, this would cause lost workers/apps. As when followers come back and current leader also may be elected as the leader, then the leader would not wait another app/worker heartbeat timeout. Although this situation rarely occurs, Celeborn should still try to avoid it.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT & Manual Test
