### PR TITLE
[CELEBORN-594] Eliminate Ratis noisy logs.

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -622,6 +622,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def haMasterRatisRetryCacheExpiryTime: Long = get(HA_MASTER_RATIS_SERVER_RETRY_CACHE_EXPIRY_TIME)
   def haMasterRatisRpcTimeoutMin: Long = get(HA_MASTER_RATIS_RPC_TIMEOUT_MIN)
   def haMasterRatisRpcTimeoutMax: Long = get(HA_MASTER_RATIS_RPC_TIMEOUT_MAX)
+  def haMasterRatisFirstElectionTimeoutMin: Long = get(HA_MASTER_RATIS_FIRSTELECTION_TIMEOUT_MIN)
+  def haMasterRatisFristElectionTimeoutMax: Long = get(HA_MASTER_RATIS_FIRSTELECTION_TIMEOUT_MAX)
   def haMasterRatisNotificationNoLeaderTimeout: Long =
     get(HA_MASTER_RATIS_NOTIFICATION_NO_LEADER_TIMEOUT)
   def haMasterRatisRpcSlownessTimeout: Long = get(HA_MASTER_RATIS_RPC_SLOWNESS_TIMEOUT)
@@ -1732,6 +1734,22 @@ object CelebornConf extends Logging {
       .internal
       .categories("master")
       .version("0.2.0")
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefaultString("5s")
+
+  val HA_MASTER_RATIS_FIRSTELECTION_TIMEOUT_MIN: ConfigEntry[Long] =
+    buildConf("celeborn.ha.master.ratis.first.election.timeout.min")
+      .internal
+      .categories("master")
+      .version("0.3.0")
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefaultString("3s")
+
+  val HA_MASTER_RATIS_FIRSTELECTION_TIMEOUT_MAX: ConfigEntry[Long] =
+    buildConf("celeborn.ha.master.ratis.first.election.timeout.max")
+      .internal
+      .categories("master")
+      .version("0.3.0")
       .timeConf(TimeUnit.SECONDS)
       .createWithDefaultString("5s")
 

--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -53,5 +53,9 @@
             <Appender-ref ref="stdout" level="WARN" />
             <Appender-ref ref="file" level="WARN"/>
         </Logger>
+        <Logger name="org.apache.ratis.server.RaftServerConfigKeys" level="WARN" additivity="false">
+              <Appender-ref ref="stdout" level="WARN" />
+             <Appender-ref ref="file" level="WARN"/>
+        </Logger>
     </Loggers>
 </Configuration>

--- a/conf/log4j2.xml.template
+++ b/conf/log4j2.xml.template
@@ -54,7 +54,7 @@
             <Appender-ref ref="file" level="WARN"/>
         </Logger>
         <Logger name="org.apache.ratis.server.RaftServerConfigKeys" level="WARN" additivity="false">
-              <Appender-ref ref="stdout" level="WARN" />
+             <Appender-ref ref="stdout" level="WARN" />
              <Appender-ref ref="file" level="WARN"/>
         </Logger>
     </Loggers>

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -347,6 +347,13 @@ public class HARaftServer {
     RaftServerConfigKeys.Rpc.setTimeoutMin(properties, rpcTimeoutMin);
     RaftServerConfigKeys.Rpc.setTimeoutMax(properties, rpcTimeoutMax);
 
+    TimeDuration firstElectionTimeoutMin =
+        TimeDuration.valueOf(conf.haMasterRatisFirstElectionTimeoutMin(), TimeUnit.SECONDS);
+    TimeDuration firstElectionTimeoutMax =
+        TimeDuration.valueOf(conf.haMasterRatisFristElectionTimeoutMax(), TimeUnit.SECONDS);
+    RaftServerConfigKeys.Rpc.setFirstElectionTimeoutMin(properties, firstElectionTimeoutMin);
+    RaftServerConfigKeys.Rpc.setFirstElectionTimeoutMax(properties, firstElectionTimeoutMax);
+
     // Set the number of maximum cached segments
     RaftServerConfigKeys.Log.setSegmentCacheNumMax(properties, 2);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. To add new configs introduced by the recent Ratis upgrade.
2. Remove noisy logs.


### Why are the changes needed?
Ratis 2.5.1 introduced new features but the implementation is strange. If a node becomes a follower, this node will continue to log raft config "first-election.timeout.min" and "first-election.timeout.max" repeatedly until this node becomes a leader.

<img width="830" alt="g1" src="https://github.com/apache/incubator-celeborn/assets/4150993/aee18d51-309f-4e7d-bfe9-a0a903f70dce">
<img width="804" alt="g2" src="https://github.com/apache/incubator-celeborn/assets/4150993/3ed31fef-893c-4ceb-a26f-66a0238b4a86">


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
Cluster and UT.
