### PR TITLE
[CELEBORN-596] Worker don't need to update disk max slots

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -208,12 +208,12 @@ class WorkerInfo(
         curDisk.avgFlushTime_$eq(newDisk.avgFlushTime)
         curDisk.avgFetchTime_$eq(newDisk.avgFetchTime)
         if (estimatedPartitionSize.nonEmpty) {
-          curDisk.maxSlots_$eq(curDisk.actualUsableSpace / estimatedPartitionSize)
+          curDisk.maxSlots_$eq(curDisk.actualUsableSpace / estimatedPartitionSize.get)
         }
         curDisk.setStatus(newDisk.status)
       } else {
         if (estimatedPartitionSize.nonEmpty) {
-          newDisk.maxSlots_$eq(newDisk.actualUsableSpace / estimatedPartitionSize)
+          newDisk.maxSlots_$eq(newDisk.actualUsableSpace / estimatedPartitionSize.get)
         }
         diskInfos.put(mountPoint, newDisk)
       }

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -196,8 +196,8 @@ class WorkerInfo(
   }
 
   def updateThenGetDiskInfos(
-    newDiskInfos: java.util.Map[String, DiskInfo],
-    estimatedPartitionSize: Option[Long] = None): util.Map[String, DiskInfo] = this.synchronized {
+      newDiskInfos: java.util.Map[String, DiskInfo],
+      estimatedPartitionSize: Option[Long] = None): util.Map[String, DiskInfo] = this.synchronized {
     import scala.collection.JavaConverters._
     for (newDisk <- newDiskInfos.values().asScala) {
       val mountPoint: String = newDisk.mountPoint

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -195,26 +195,6 @@ class WorkerInfo(
     diskInfos.asScala.map(_._2.availableSlots()).sum
   }
 
-  def updateThenGetDiskInfos(newDiskInfos: java.util.Map[String, DiskInfo])
-      : util.Map[String, DiskInfo] = this.synchronized {
-    diskInfos.clear()
-    for ((mountPoint, newDisk) <- newDiskInfos.asScala) {
-      diskInfos.put(mountPoint, newDisk)
-    }
-    JavaUtils.newConcurrentHashMap[String, DiskInfo](diskInfos)
-  }
-
-  def updateThenGetDiskInfos(
-      newDiskInfos: java.util.Map[String, DiskInfo],
-      estimatedPartitionSize: Long): util.Map[String, DiskInfo] = this.synchronized {
-    diskInfos.clear()
-    for ((mountPoint, newDisk) <- newDiskInfos.asScala) {
-      newDisk.maxSlots_$eq(newDisk.actualUsableSpace / estimatedPartitionSize)
-      diskInfos.put(mountPoint, newDisk)
-    }
-    JavaUtils.newConcurrentHashMap[String, DiskInfo](diskInfos)
-  }
-
   def updateThenGetUserResourceConsumption(consumption: util.Map[
     UserIdentifier,
     ResourceConsumption]): util.Map[UserIdentifier, ResourceConsumption] = {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -49,6 +49,7 @@ import org.apache.celeborn.common.util.JavaUtils;
 import org.apache.celeborn.common.util.PbSerDeUtils;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.master.network.CelebornRackResolver;
+import scala.Option;
 
 public abstract class AbstractMetaManager implements IMetadataHandler {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractMetaManager.class);
@@ -200,7 +201,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       Optional<WorkerInfo> workerInfo = workers.stream().filter(w -> w.equals(worker)).findFirst();
       workerInfo.ifPresent(
           info -> {
-            info.updateThenGetDiskInfos(disks, estimatedPartitionSize);
+            info.updateThenGetDiskInfos(disks, Option.apply(estimatedPartitionSize));
             info.updateThenGetUserResourceConsumption(userResourceConsumption);
             availableSlots.set(info.totalAvailableSlots());
             info.lastHeartbeat_$eq(time);

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -33,6 +33,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
+import scala.Option;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +51,6 @@ import org.apache.celeborn.common.util.JavaUtils;
 import org.apache.celeborn.common.util.PbSerDeUtils;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.master.network.CelebornRackResolver;
-import scala.Option;
 
 public abstract class AbstractMetaManager implements IMetadataHandler {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractMetaManager.class);

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -285,9 +285,9 @@ private[celeborn] class Worker(
         Seq.empty[DiskInfo]
       } else {
         storageManager.updateDiskInfos()
-        workerInfo.updateThenGetDiskInfos(
-          storageManager.disksSnapshot().map { disk => disk.mountPoint -> disk }.toMap.asJava,
-          conf.initialEstimatedPartitionSize).values().asScala.toSeq
+        workerInfo.updateThenGetDiskInfos(storageManager.disksSnapshot().map { disk =>
+          disk.mountPoint -> disk
+        }.toMap.asJava).values().asScala.toSeq
       }
     val resourceConsumption = workerInfo.updateThenGetUserResourceConsumption(
       storageManager.userResourceConsumptionSnapshot().asJava)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Two main points:

1. Avoid using estimatedPartitionSize in the worker side, unnecessary
2. Make the method simple



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

