### PR TITLE
[CELEBORN-597][FLINK] Support flink floating buffer for input gate and output gate.

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/AbstractRemoteShuffleResultPartitionFactory.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/AbstractRemoteShuffleResultPartitionFactory.java
@@ -190,8 +190,8 @@ public abstract class AbstractRemoteShuffleResultPartitionFactory {
 
     List<SupplierWithException<BufferPool, IOException>> factories = new ArrayList<>();
     if (supportFloatingBuffers) {
-      factories.add(() -> bufferPoolFactory.createBufferPool(1, numForResultPartition));
-      factories.add(() -> bufferPoolFactory.createBufferPool(1, numForOutputGate));
+      factories.add(() -> bufferPoolFactory.createBufferPool(2, numForResultPartition));
+      factories.add(() -> bufferPoolFactory.createBufferPool(2, numForOutputGate));
     } else {
       factories.add(
           () -> bufferPoolFactory.createBufferPool(numForResultPartition, numForResultPartition));

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/config/PluginConf.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/config/PluginConf.java
@@ -28,7 +28,11 @@ public enum PluginConf {
       "remote-shuffle.job.concurrent-readings-per-gate", "", String.valueOf(Integer.MAX_VALUE)),
   MEMORY_PER_RESULT_PARTITION("remote-shuffle.job.memory-per-partition", "", "64m"),
   MEMORY_PER_INPUT_GATE("remote-shuffle.job.memory-per-gate", "", "32m"),
+  SUPPORT_FLOATING_BUFFER_PER_INPUT_GATE(
+      "remote-shuffle.job.support-floating-buffer-per-input-gate", "", "false"),
   ENABLE_DATA_COMPRESSION("remote-shuffle.job.enable-data-compression", "", "true"),
+  SUPPORT_FLOATING_BUFFER_PER_OUTPUT_GATE(
+      "remote-shuffle.job.support-floating-buffer-per-output-gate", "", "false"),
   REMOTE_SHUFFLE_COMPRESSION_CODEC(
       "remote-shuffle.job.compression.codec",
       CelebornConf.SHUFFLE_COMPRESSION_CODEC().key(),

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/config/PluginConf.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/config/PluginConf.java
@@ -29,10 +29,10 @@ public enum PluginConf {
   MEMORY_PER_RESULT_PARTITION("remote-shuffle.job.memory-per-partition", "", "64m"),
   MEMORY_PER_INPUT_GATE("remote-shuffle.job.memory-per-gate", "", "32m"),
   SUPPORT_FLOATING_BUFFER_PER_INPUT_GATE(
-      "remote-shuffle.job.support-floating-buffer-per-input-gate", "", "false"),
+      "remote-shuffle.job.support-floating-buffer-per-input-gate", "", "true"),
   ENABLE_DATA_COMPRESSION("remote-shuffle.job.enable-data-compression", "", "true"),
   SUPPORT_FLOATING_BUFFER_PER_OUTPUT_GATE(
-      "remote-shuffle.job.support-floating-buffer-per-output-gate", "", "false"),
+      "remote-shuffle.job.support-floating-buffer-per-output-gate", "", "true"),
   REMOTE_SHUFFLE_COMPRESSION_CODEC(
       "remote-shuffle.job.compression.codec",
       CelebornConf.SHUFFLE_COMPRESSION_CODEC().key(),

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
@@ -58,4 +58,8 @@ public class FlinkUtils {
   public static long byteStringValueAsBytes(Configuration flinkConf, PluginConf pluginConf) {
     return Utils.byteStringAsBytes(PluginConf.getValue(flinkConf, pluginConf));
   }
+
+  public static boolean stringValueAsBoolean(Configuration flinkConf, PluginConf pluginConf) {
+    return Boolean.valueOf(PluginConf.getValue(flinkConf, pluginConf));
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Flink does support floating buffers for input and output channels. Celeborn will consume quite noticeable memory when initializing channels. So I added new configs to make Celeborn plugin works the same as Flink task manager to make sure that Flink applications behave the same.


### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT.
