### PR TITLE
[CELEBORN-599] Consolidate calculation of mount point

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
@@ -231,7 +231,7 @@ object DeviceInfo {
       getMountPoint(f._1.getAbsolutePath, mountPointToDeviceInfo.keySet())
     }.foreach {
       case (mountPoint, dirs) =>
-        if (mountPoint != "") {
+        if (mountPoint.nonEmpty) {
           val deviceInfo = mountPointToDeviceInfo.get(mountPoint)
           val diskInfo = new DiskInfo(
             mountPoint,

--- a/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/DeviceInfo.scala
@@ -19,7 +19,6 @@ package org.apache.celeborn.common.meta
 
 import java.io.File
 import java.util
-import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
@@ -227,8 +226,8 @@ object DeviceInfo {
     val retDeviceInfos = JavaUtils.newConcurrentHashMap[String, DeviceInfo]()
     val retDiskInfos = JavaUtils.newConcurrentHashMap[String, DiskInfo]()
 
-    workingDirs.groupBy { f =>
-      getMountPoint(f._1.getAbsolutePath, mountPointToDeviceInfo.keySet())
+    workingDirs.groupBy { case (dir, _, _, _) =>
+      getMountPoint(dir.getCanonicalPath, mountPointToDeviceInfo.keySet())
     }.foreach {
       case (mountPoint, dirs) =>
         if (mountPoint.nonEmpty) {
@@ -245,7 +244,8 @@ object DeviceInfo {
           deviceInfo.addDiskInfo(diskInfo)
           retDiskInfos.put(mountPoint, diskInfo)
         } else {
-          logger.warn(s"Can't find mount point for ${dirs.map(_._1.getAbsolutePath).mkString(",")}")
+          logger.warn(
+            s"Can't find mount point for ${dirs.map(_._1.getCanonicalPath).mkString(",")}")
         }
     }
     deviceNameToDeviceInfo.asScala.foreach {

--- a/common/src/test/scala/org/apache/celeborn/common/meta/DeviceInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/DeviceInfoSuite.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.meta
+
+import java.util
+
+import org.junit.Assert.assertEquals
+
+import org.apache.celeborn.CelebornFunSuite
+
+class DeviceInfoSuite extends CelebornFunSuite {
+
+  test("test getMountPoint") {
+    val mountPoints = new util.HashSet[String]()
+    mountPoints.add("/")
+    mountPoints.add("/mnt/disk1")
+    mountPoints.add("/mnt/disk2")
+    mountPoints.add("/data")
+
+    assertEquals(DeviceInfo.getMountPoint("/mnt/disk1/data", mountPoints), "/mnt/disk1")
+    assertEquals(DeviceInfo.getMountPoint("/mnt/disk2/data", mountPoints), "/mnt/disk2")
+    assertEquals(DeviceInfo.getMountPoint("/data", mountPoints), "/data")
+    assertEquals(DeviceInfo.getMountPoint("/data/data", mountPoints), "/data")
+    assertEquals(DeviceInfo.getMountPoint("/data1/data", mountPoints), "/")
+
+  }
+}

--- a/common/src/test/scala/org/apache/celeborn/common/meta/DeviceInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/DeviceInfoSuite.scala
@@ -19,8 +19,6 @@ package org.apache.celeborn.common.meta
 
 import java.util
 
-import org.junit.Assert.assertEquals
-
 import org.apache.celeborn.CelebornFunSuite
 
 class DeviceInfoSuite extends CelebornFunSuite {
@@ -32,11 +30,12 @@ class DeviceInfoSuite extends CelebornFunSuite {
     mountPoints.add("/mnt/disk2")
     mountPoints.add("/data")
 
-    assertEquals(DeviceInfo.getMountPoint("/mnt/disk1/data", mountPoints), "/mnt/disk1")
-    assertEquals(DeviceInfo.getMountPoint("/mnt/disk2/data", mountPoints), "/mnt/disk2")
-    assertEquals(DeviceInfo.getMountPoint("/data", mountPoints), "/data")
-    assertEquals(DeviceInfo.getMountPoint("/data/data", mountPoints), "/data")
-    assertEquals(DeviceInfo.getMountPoint("/data1/data", mountPoints), "/")
-
+    assert(DeviceInfo.getMountPoint("/mnt/disk1/data", mountPoints) === "/mnt/disk1")
+    assert(DeviceInfo.getMountPoint("/mnt/disk1/data", mountPoints) === "/mnt/disk1")
+    assert(DeviceInfo.getMountPoint("/mnt/disk2/data", mountPoints) === "/mnt/disk2")
+    assert(DeviceInfo.getMountPoint("/mnt/disk3/data", mountPoints) === "/")
+    assert(DeviceInfo.getMountPoint("/data", mountPoints) === "/data")
+    assert(DeviceInfo.getMountPoint("/data/data", mountPoints) === "/data")
+    assert(DeviceInfo.getMountPoint("/data1/data", mountPoints) === "/")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently `DeviceInfo#getMountPoint` match the longest string to determine which mount point a directory attached. May get wrong judges in some scenarios.

Assume mount points are /, /data,and dir is /data1. /data1 will attach to /data(should be /), and actually create shuffle dir in /.  


### Why are the changes needed?
Improve usage, and avoid filling the wrong mount point


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT and cluster test
