### PR TITLE
[CELEBORN-601] Consolidate configsWithAlternatives with `ConfigBuilder.withAlternative`

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -22,6 +22,7 @@ import java.util.{Collection => JCollection, Collections, HashMap => JHashMap, L
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -903,6 +904,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def testPushMasterDataTimeout: Boolean = get(TEST_PUSH_MASTER_DATA_TIMEOUT)
   def testPushSlaveDataTimeout: Boolean = get(TEST_PUSH_SLAVE_DATA_TIMEOUT)
   def testRetryRevive: Boolean = get(TEST_RETRY_REVIVE)
+  def testAlternative: String = get(TEST_ALTERNATIVE)
 }
 
 object CelebornConf extends Logging {
@@ -979,7 +981,7 @@ object CelebornConf extends Logging {
    * The alternates are used in the order defined in this map. If deprecated configs are
    * present in the user's configuration, a warning is logged.
    */
-  private val configsWithAlternatives = scala.collection.mutable.Map[String, Seq[AlternateConfig]](
+  private val configsWithAlternatives = mutable.Map[String, Seq[AlternateConfig]](
     "none" -> Seq(
       AlternateConfig("none", "1.0")))
 
@@ -3321,4 +3323,13 @@ object CelebornConf extends Logging {
       .doc("the heartbeat interval between worker and client")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("60s")
+
+  val TEST_ALTERNATIVE: ConfigEntry[String] =
+    buildConf("celeborn.testAlternative.value")
+      .withAlternative("celeborn.testAlternative.replaceKey")
+      .categories("test")
+      .internal
+      .version("0.3.0")
+      .stringConf
+      .createWithDefaultString("celeborn")
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -997,7 +997,7 @@ object CelebornConf extends Logging {
     }.toMap
   }
 
-  def addDeprecatedConfig(entry: ConfigEntry[_], alt: (String, String => String)): Unit = {
+  private def addDeprecatedConfig(entry: ConfigEntry[_], alt: (String, String => String)): Unit = {
     configsWithAlternatives.put(
       entry.key,
       configsWithAlternatives.getOrElse(entry.key, Seq.empty) :+ AlternateConfig(
@@ -1090,7 +1090,7 @@ object CelebornConf extends Logging {
     confEntries.containsKey(key)
   }
 
-  def buildConf(key: String): ConfigBuilder = ConfigBuilder(key).onCreate(register)
+  private def buildConf(key: String): ConfigBuilder = ConfigBuilder(key).onCreate(register)
 
   val NETWORK_TIMEOUT: ConfigEntry[Long] =
     buildConf("celeborn.network.timeout")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -996,13 +996,13 @@ object CelebornConf extends Logging {
   }
 
   def addDeprecatedConfig(entry: ConfigEntry[_], alt: (String, String => String)): Unit = {
-      configsWithAlternatives.put(
-        entry.key,
-        configsWithAlternatives.getOrElse(entry.key, Seq.empty) :+ AlternateConfig(
-          alt._1,
-          entry.version,
-          alt._2))
-    }
+    configsWithAlternatives.put(
+      entry.key,
+      configsWithAlternatives.getOrElse(entry.key, Seq.empty) :+ AlternateConfig(
+        alt._1,
+        entry.version,
+        alt._2))
+  }
 
   /**
    * Looks for available deprecated keys for the given config option, and return the first

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -904,7 +904,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def testPushMasterDataTimeout: Boolean = get(TEST_PUSH_MASTER_DATA_TIMEOUT)
   def testPushSlaveDataTimeout: Boolean = get(TEST_PUSH_SLAVE_DATA_TIMEOUT)
   def testRetryRevive: Boolean = get(TEST_RETRY_REVIVE)
-  def testAlternative: String = get(TEST_ALTERNATIVE)
+  def testAlternative: String = get(TEST_ALTERNATIVE.key, "celeborn")
 }
 
 object CelebornConf extends Logging {
@@ -3324,12 +3324,12 @@ object CelebornConf extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("60s")
 
-  val TEST_ALTERNATIVE: ConfigEntry[String] =
+  val TEST_ALTERNATIVE: OptionalConfigEntry[String] =
     buildConf("celeborn.testAlternative.value")
       .withAlternative("celeborn.testAlternative.replaceKey")
       .categories("test")
       .internal
       .version("0.3.0")
       .stringConf
-      .createWithDefaultString("celeborn")
+      .createOptional
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -3325,8 +3325,8 @@ object CelebornConf extends Logging {
       .createWithDefaultString("60s")
 
   val TEST_ALTERNATIVE: OptionalConfigEntry[String] =
-    buildConf("celeborn.testAlternative.value")
-      .withAlternative("celeborn.testAlternative.replaceKey")
+    buildConf("celeborn.test.alternative.key")
+      .withAlternative("celeborn.test.alternative.deprecatedKey")
       .categories("test")
       .internal
       .version("0.3.0")

--- a/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigBuilder.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigBuilder.scala
@@ -26,7 +26,9 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.network.util.ByteUnit
 import org.apache.celeborn.common.util.{JavaUtils, Utils}
 
-private object ConfigHelpers {
+private[celeborn] object ConfigHelpers {
+
+  type AlternativesTransfer = (String, String => String)
 
   def toNumber[T](s: String, converter: String => T, key: String, configType: String): T = {
     try {
@@ -228,7 +230,7 @@ case class ConfigBuilder(key: String) {
   private[config] var _categories = Seq.empty[String]
   private[config] var _version = ""
   private[config] var _onCreate: Option[ConfigEntry[_] => Unit] = None
-  private[config] var _alternatives = List.empty[String]
+  private[config] var _alternatives = List.empty[AlternativesTransfer]
 
   def internal: ConfigBuilder = {
     _public = false
@@ -265,8 +267,8 @@ case class ConfigBuilder(key: String) {
     this
   }
 
-  def withAlternative(key: String): ConfigBuilder = {
-    _alternatives = _alternatives :+ key
+  def withAlternative(key: String, translate: String => String = null): ConfigBuilder = {
+    _alternatives = _alternatives :+ (key, translate)
     this
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigEntry.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigEntry.scala
@@ -19,6 +19,7 @@ package org.apache.celeborn.common.internal.config
 
 import java.util.concurrent.ConcurrentHashMap
 
+import org.apache.celeborn.common.internal.config.ConfigHelpers.AlternativesTransfer
 import org.apache.celeborn.common.util.JavaUtils
 
 // ====================================================================================
@@ -78,7 +79,7 @@ abstract class ConfigEntry[T](
     val key: String,
     val prependedKey: Option[String],
     val prependSeparator: String,
-    val alternatives: List[String],
+    val alternatives: List[AlternativesTransfer],
     val valueConverter: String => T,
     val stringConverter: T => String,
     val doc: String,
@@ -96,7 +97,7 @@ abstract class ConfigEntry[T](
     val values = Seq(
       prependedKey.flatMap(reader.get),
       alternatives.foldLeft(reader.get(key))((res, nextKey) =>
-        res.orElse(reader.get(nextKey)))).flatten
+        res.orElse(reader.get(nextKey._1)))).flatten
     if (values.nonEmpty) {
       Some(values.mkString(prependSeparator))
     } else {
@@ -118,7 +119,7 @@ private class ConfigEntryWithDefault[T](
     key: String,
     prependedKey: Option[String],
     prependSeparator: String,
-    alternatives: List[String],
+    alternatives: List[AlternativesTransfer],
     _defaultValue: T,
     valueConverter: String => T,
     stringConverter: T => String,
@@ -151,7 +152,7 @@ private class ConfigEntryWithDefaultFunction[T](
     key: String,
     prependedKey: Option[String],
     prependSeparator: String,
-    alternatives: List[String],
+    alternatives: List[AlternativesTransfer],
     _defaultFunction: () => T,
     valueConverter: String => T,
     stringConverter: T => String,
@@ -184,7 +185,7 @@ private class ConfigEntryWithDefaultString[T](
     key: String,
     prependedKey: Option[String],
     prependSeparator: String,
-    alternatives: List[String],
+    alternatives: List[AlternativesTransfer],
     _defaultValue: String,
     valueConverter: String => T,
     stringConverter: T => String,
@@ -221,7 +222,7 @@ class OptionalConfigEntry[T](
     key: String,
     prependedKey: Option[String],
     prependSeparator: String,
-    alternatives: List[String],
+    alternatives: List[AlternativesTransfer],
     val rawValueConverter: String => T,
     val rawStringConverter: T => String,
     doc: String,
@@ -254,7 +255,7 @@ class FallbackConfigEntry[T](
     key: String,
     prependedKey: Option[String],
     prependSeparator: String,
-    alternatives: List[String],
+    alternatives: List[AlternativesTransfer],
     doc: String,
     isPublic: Boolean,
     categories: Seq[String],

--- a/common/src/test/scala/org/apache/celeborn/common/CelebornConfSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/CelebornConfSuite.scala
@@ -180,8 +180,8 @@ class CelebornConfSuite extends CelebornFunSuite {
 
   test("CELEBORN-601: Consolidate configsWithAlternatives with `ConfigBuilder.withAlternative`") {
     val conf = new CelebornConf()
-      .set("rss.network.timeout", "300s")
+      .set(CelebornConf.TEST_ALTERNATIVE.alternatives.head._1, "rss")
 
-    assert(conf.get(CelebornConf.NETWORK_TIMEOUT.key) == "300s")
+    assert(conf.testAlternative == "rss")
   }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/CelebornConfSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/CelebornConfSuite.scala
@@ -177,4 +177,11 @@ class CelebornConfSuite extends CelebornFunSuite {
     assert(conf.networkConnectTimeout.duration.toMillis == 2000L)
     assert(conf.networkIoConnectTimeoutMs("data") == 2000L)
   }
+
+  test("CELEBORN-601: Consolidate configsWithAlternatives with `ConfigBuilder.withAlternative`") {
+    val conf = new CelebornConf()
+      .set("rss.network.timeout", "300s")
+
+    assert(conf.get(CelebornConf.NETWORK_TIMEOUT.key) == "300s")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Consolidate configsWithAlternatives with `ConfigBuilder.withAlternative`
Current code if we use  below two function
```
  def get(key: String): String = {
    getOption(key).getOrElse(throw new NoSuchElementException(key))
  }


  def get(key: String, defaultValue: String): String = {
    getOption(key).getOrElse(defaultValue)
  }
```

They are not consist.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

