### PR TITLE
[CELEBORN-608][BUILD] Exclude macOS fflags in make-distribution.sh

### DIFF
--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -260,7 +260,7 @@ rm -rf "$TARDIR"
 cp -R "$DIST_DIR" "$TARDIR"
 TAR="tar"
 if [ "$(uname -s)" = "Darwin" ]; then
-  TAR="tar --no-mac-metadata --no-xattrs"
+  TAR="tar --no-mac-metadata --no-xattrs --no-fflags"
 fi
 $TAR -czf "apache-celeborn-$VERSION-$NAME.tgz" -C "$PROJECT_DIR" "$TARDIR_NAME"
 rm -rf "$TARDIR"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Add option `--no-fflags` to macOS tar command in `build/make-distribution.sh`

### Why are the changes needed?

Create binary tarball on macOS then unarchive on Linux, may print warnings

```
➜  ~ tar -xzf apache-celebron-0.3.0-SNAPSHOT-bin.tgz
tar: Ignoring unknown extended header keyword `SCHILY.fflags'
```

`--no-mac-metadata` is for excluding AppleDouble files; `--no-xattrs` is for excluding xattrs like `LIBARCHIVE.xattr.com.apple.FinderInfo`; `--no-fflags` is for excluding fflags like `SCHILY.fflags`

Reference from macOS `man tar`

```
     --no-fflags
             (c, r, u, x modes only) Do not archive or extract file attributes or file flags.  This is the reverse of --fflags and the default behavior if tar is run as non-root in x mode.

     --no-mac-metadata
             (x mode only) Mac OS X specific.  Do not archive or extract ACLs and extended file attributes using copyfile(3) in AppleDouble format.  This is the reverse of --mac-metadata.  and the default behavior if tar is run as non-root in
             x mode.

     --no-xattrs
             (c, r, u, x modes only) Do not archive or extract extended file attributes.  This is the reverse of --xattrs and the default behavior if tar is run as non-root in x mode.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Create binary tarball on macOS then unarchive on Linux, warnings disappear after this change.