### PR TITLE
[CELEBORN-604][SPARK] Support Spark 3.4

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -56,6 +56,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
     steps:
     - uses: actions/checkout@v2
     - name: Setup JDK ${{ matrix.java }}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Celeborn supports Spark 2.4/3.0/3.1/3.2/3.3 and only tested under Java 8.
 
 Build for Spark
 ```
-./build/make-distribution.sh -Pspark-2.4/-Pspark-3.0/-Pspark-3.1/-Pspark-3.2/-Pspark-3.3
+./build/make-distribution.sh -Pspark-2.4/-Pspark-3.0/-Pspark-3.1/-Pspark-3.2/-Pspark-3.3/-Pspark-3.4
 ```
 
 package apache-celeborn-${project.version}-bin.tgz will be generated.

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -39,7 +39,6 @@ import org.apache.spark.serializer.SerializerInstance;
 import org.apache.spark.shuffle.ShuffleWriteMetricsReporter;
 import org.apache.spark.shuffle.ShuffleWriter;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
-import org.apache.spark.sql.execution.PartitionIdPassthrough;
 import org.apache.spark.sql.execution.UnsafeRowSerializer;
 import org.apache.spark.sql.execution.metric.SQLMetric;
 import org.apache.spark.storage.BlockManagerId;
@@ -157,8 +156,13 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
 
   @VisibleForTesting
   boolean canUseFastWrite() {
-    return dep.serializer() instanceof UnsafeRowSerializer
-        && partitioner instanceof PartitionIdPassthrough;
+    boolean keyIsPartitionId = false;
+    if (dep.serializer() instanceof UnsafeRowSerializer) {
+      // SPARK-39391 renames PartitionIdPassthrough's package
+      String partitionerClassName = partitioner.getClass().getSimpleName();
+      keyIsPartitionId = "PartitionIdPassthrough".equals(partitionerClassName);
+    }
+    return keyIsPartitionId;
   }
 
   private void fastWrite0(scala.collection.Iterator iterator) throws IOException {

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/RssShuffleWriterSuiteJ.java
@@ -51,7 +51,6 @@ import org.apache.spark.serializer.Serializer;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
-import org.apache.spark.sql.execution.PartitionIdPassthrough;
 import org.apache.spark.sql.execution.UnsafeRowSerializer;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.IntegerType$;
@@ -76,6 +75,7 @@ import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.network.util.JavaUtils;
 import org.apache.celeborn.common.util.Utils;
+import org.apache.celeborn.reflect.DynConstructors;
 
 public class RssShuffleWriterSuiteJ {
 
@@ -93,7 +93,7 @@ public class RssShuffleWriterSuiteJ {
   private final UserIdentifier userIdentifier = new UserIdentifier("mock", "mock");
 
   private final int numMaps = 10;
-  private final int numPartitions = 10;
+  private final Integer numPartitions = 10;
   private final SparkConf sparkConf = new SparkConf(false);
   private final BlockManagerId bmId = BlockManagerId.apply("execId", "host", 1, None$.empty());
 
@@ -202,8 +202,17 @@ public class RssShuffleWriterSuiteJ {
       throws Exception {
     final boolean useUnsafe = serializer instanceof UnsafeRowSerializer;
 
+    DynConstructors.Ctor<Partitioner> partitionIdPassthroughCtor =
+        DynConstructors.builder()
+            // for Spark 3.3 and previous
+            .impl("org.apache.spark.sql.execution.PartitionIdPassthrough", int.class)
+            // for Spark 3.4
+            .impl("org.apache.spark.PartitionIdPassthrough", int.class)
+            .build();
     final Partitioner partitioner =
-        useUnsafe ? new PartitionIdPassthrough(numPartitions) : new HashPartitioner(numPartitions);
+        useUnsafe
+            ? partitionIdPassthroughCtor.newInstance(numPartitions)
+            : new HashPartitioner(numPartitions);
     Mockito.doReturn(partitioner).when(dependency).partitioner();
     Mockito.doReturn(serializer).when(dependency).serializer();
 

--- a/pom.xml
+++ b/pom.xml
@@ -961,6 +961,25 @@
     </profile>
 
     <profile>
+      <id>spark-3.4</id>
+      <modules>
+        <module>client-spark/common</module>
+        <module>client-spark/spark-3</module>
+        <module>client-spark/spark-3-shaded</module>
+        <module>tests/spark-it</module>
+      </modules>
+      <properties>
+        <jackson.version>2.14.2</jackson.version>
+        <jackson.databind.version>2.14.2</jackson.databind.version>
+        <lz4-java.version>1.8.0</lz4-java.version>
+        <scala.version>2.12.17</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <spark.version>3.4.0</spark.version>
+        <zstd-jni.version>1.5.2-5</zstd-jni.version>
+      </properties>
+    </profile>
+
+    <profile>
       <id>jdk-8</id>
       <activation>
         <jdk>1.8</jdk>

--- a/tests/spark-it/pom.xml
+++ b/tests/spark-it/pom.xml
@@ -136,5 +136,16 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>spark-3.4</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.celeborn</groupId>
+          <artifactId>celeborn-client-spark-3_${scala.binary.version}</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Cherry-picked from main.

- Add new profile `spark-3.4`
- Change code to adapt SPARK-39391
- Test Celeborn against Spark 3.4.0

### Why are the changes needed?

Support the latest Spark 3.4

### Does this PR introduce _any_ user-facing change?

Yes, brings Spark 3.4 support officially.

### How was this patch tested?

Pass GA