### PR TITLE
[CELEBORN-616] Avoid rpc failure response cause memory leak

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
@@ -49,7 +49,9 @@ public final class ChunkFetchFailure extends ResponseMessage {
   public static ChunkFetchFailure decode(ByteBuf buf) {
     StreamChunkSlice streamChunkSlice = StreamChunkSlice.decode(buf);
     String errorString = Encoders.Strings.decode(buf);
-    return new ChunkFetchFailure(streamChunkSlice, errorString);
+    ChunkFetchFailure chunkFetchFailure = new ChunkFetchFailure(streamChunkSlice, errorString);
+    chunkFetchFailure.setBody(buf);
+    return chunkFetchFailure;
   }
 
   @Override

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcFailure.java
@@ -49,7 +49,9 @@ public final class RpcFailure extends ResponseMessage {
   public static RpcFailure decode(ByteBuf buf) {
     long requestId = buf.readLong();
     String errorString = Encoders.Strings.decode(buf);
-    return new RpcFailure(requestId, errorString);
+    RpcFailure rpcFailure = new RpcFailure(requestId, errorString);
+    rpcFailure.setBody(buf);
+    return rpcFailure;
   }
 
   @Override

--- a/common/src/test/java/org/apache/celeborn/common/network/TransportResponseHandlerSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TransportResponseHandlerSuiteJ.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.*;
 
 import java.nio.ByteBuffer;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.local.LocalChannel;
 import org.junit.Test;
@@ -65,7 +67,11 @@ public class TransportResponseHandlerSuiteJ {
     handler.addFetchRequest(streamChunkSlice, callback);
     assertEquals(1, handler.numOutstandingRequests());
 
-    handler.handle(new ChunkFetchFailure(streamChunkSlice, "some error msg"));
+    ChunkFetchFailure chunkFetchFailure = new ChunkFetchFailure(streamChunkSlice, "some error msg");
+    ByteBuf buf = Unpooled.buffer(chunkFetchFailure.encodedLength() + 1);
+    chunkFetchFailure.encode(buf);
+    chunkFetchFailure.setBody(buf);
+    handler.handle(chunkFetchFailure);
     verify(callback, times(1)).onFailure(eq(0), any());
     assertEquals(0, handler.numOutstandingRequests());
   }
@@ -122,10 +128,18 @@ public class TransportResponseHandlerSuiteJ {
     handler.addRpcRequest(12345, callback);
     assertEquals(1, handler.numOutstandingRequests());
 
-    handler.handle(new RpcFailure(54321, "uh-oh!")); // should be ignored
+    RpcFailure rpcFailure1 = new RpcFailure(54321, "uh-oh!");
+    ByteBuf buf1 = Unpooled.buffer(rpcFailure1.encodedLength() + 1);
+    rpcFailure1.encode(buf1);
+    rpcFailure1.setBody(buf1);
+    handler.handle(rpcFailure1); // should be ignored
     assertEquals(1, handler.numOutstandingRequests());
 
-    handler.handle(new RpcFailure(12345, "oh no"));
+    RpcFailure rpcFailure2 = new RpcFailure(12345, "uh-oh!");
+    ByteBuf buf2 = Unpooled.buffer(rpcFailure2.encodedLength() + 1);
+    rpcFailure2.encode(buf2);
+    rpcFailure2.setBody(buf2);
+    handler.handle(rpcFailure2);
     verify(callback, times(1)).onFailure(any());
     assertEquals(0, handler.numOutstandingRequests());
   }
@@ -164,10 +178,18 @@ public class TransportResponseHandlerSuiteJ {
     handler.addPushRequest(12345, info);
     assertEquals(1, handler.numOutstandingRequests());
 
-    handler.handle(new RpcFailure(54321, "uh-oh!")); // should be ignored
+    RpcFailure rpcFailure1 = new RpcFailure(54321, "uh-oh!");
+    ByteBuf buf1 = Unpooled.buffer(rpcFailure1.encodedLength() + 1);
+    rpcFailure1.encode(buf1);
+    rpcFailure1.setBody(buf1);
+    handler.handle(rpcFailure1); // should be ignored
     assertEquals(1, handler.numOutstandingRequests());
 
-    handler.handle(new RpcFailure(12345, "oh no"));
+    RpcFailure rpcFailure2 = new RpcFailure(12345, "uh-oh!");
+    ByteBuf buf2 = Unpooled.buffer(rpcFailure2.encodedLength() + 1);
+    rpcFailure2.encode(buf2);
+    rpcFailure2.setBody(buf2);
+    handler.handle(rpcFailure2);
     verify(callback, times(1)).onFailure(any());
     assertEquals(0, handler.numOutstandingRequests());
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
We meet a case in which worker A triggers pause push data and nearly 200w replicate data requests to worker B failed and revived many of the RpcFailure responses. 

Although worker A trims many times, it's till keeps the same direct memory usage. Here the RpcFailure only cleaned after GC, but this memory usage won't cause GC and  the usage won't release. Keep this worker trim and trim again, won't recover. In this pr, we also release RPC failure responses's body quickly.
 .
```
23/05/23 11:19:15,240 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :26860.00000667572/40960.0,disk buffer size:112.91416263580322, sort memory size : 0.0
23/05/23 11:19:25,322 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :26632.00000667572/40960.0,disk buffer size:111.59745025634766, sort memory size : 0.0
23/05/23 11:19:35,413 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :26548.00000667572/40960.0,disk buffer size:116.29310417175293, sort memory size : 0.0
23/05/23 11:19:45,465 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :26524.00000667572/40960.0,disk buffer size:573.5329294204712, sort memory size : 0.0
23/05/23 11:19:55,666 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :26520.00000667572/40960.0,disk buffer size:1106.257067680359, sort memory size : 0.0
23/05/23 11:20:05,668 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :27240.00000667572/40960.0,disk buffer size:1985.0912733078003, sort memory size : 0.0
23/05/23 11:20:15,708 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :30780.00000667572/40960.0,disk buffer size:2212.156195640564, sort memory size : 0.0
23/05/23 11:20:25,711 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :30780.00000667572/40960.0,disk buffer size:25.4876651763916, sort memory size : 0.0
23/05/23 11:20:35,715 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :30320.00000667572/40960.0,disk buffer size:30.625568389892578, sort memory size : 0.0
23/05/23 11:20:46,218 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :28416.00000667572/40960.0,disk buffer size:28.170005798339844, sort memory size : 0.0
23/05/23 11:20:56,225 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25836.00000667572/40960.0,disk buffer size:20.839608192443848, sort memory size : 0.0
23/05/23 11:21:06,225 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25732.00000667572/40960.0,disk buffer size:16.916643142700195, sort memory size : 0.0
23/05/23 11:21:16,225 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25660.00000667572/40960.0,disk buffer size:14.602804183959961, sort memory size : 0.0
23/05/23 11:21:26,227 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25608.00000667572/40960.0,disk buffer size:16.413521766662598, sort memory size : 0.0
23/05/23 11:21:36,230 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25592.00000667572/40960.0,disk buffer size:14.356255531311035, sort memory size : 0.0
23/05/23 11:21:46,232 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25564.00000667572/40960.0,disk buffer size:16.167262077331543, sort memory size : 0.0
23/05/23 11:21:56,233 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25564.00000667572/40960.0,disk buffer size:14.535367012023926, sort memory size : 0.0
23/05/23 11:22:06,233 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25556.00000667572/40960.0,disk buffer size:10.594958305358887, sort memory size : 0.0
23/05/23 11:22:16,408 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25556.00000667572/40960.0,disk buffer size:12.997883796691895, sort memory size : 0.0
23/05/23 11:22:26,412 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25556.00000667572/40960.0,disk buffer size:20.91703701019287, sort memory size : 0.0
23/05/23 11:22:36,412 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25556.00000667572/40960.0,disk buffer size:21.703519821166992, sort memory size : 16.0
23/05/23 11:22:46,412 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25556.00000667572/40960.0,disk buffer size:21.98106098175049, sort memory size : 16.0
23/05/23 11:22:56,412 INFO [MemoryTracker-report-thread] MemoryTracker: Track all direct memory usage :25556.00000667572/40960.0,disk buffer size:20.05210590362549, sort memory size : 16.0 
```


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

