### PR TITLE
[CELEBORN-612][HELM] Tackle hostPath directory permission

### DIFF
--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -34,7 +34,7 @@ data:
     celeborn.ha.master.node.{{ . }}.host=celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local
     {{- end }}
     {{- $dirs := .Values.volumes.master }}
-    celeborn.ha.master.ratis.raft.server.storage.dir={{ (index $dirs 0).path }}/master
+    celeborn.ha.master.ratis.raft.server.storage.dir={{ (index $dirs 0).path }}
     {{- $path := "" }}
     {{- range $worker := .Values.volumes.worker }}
     {{- if eq $path "" }}

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -75,7 +75,7 @@ spec:
       {{- $dirs := .Values.volumes.master }}
       {{- if eq "hostPath" (index $dirs 0).type }}
       - name: chown-celeborn-master-volume
-        image: alpine:3.18.0
+        image: alpine:3.18
         imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
         securityContext:
           runAsUser: 0

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -71,6 +71,22 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+      {{- $dirs := .Values.volumes.master }}
+      {{- if eq "hostPath" (index $dirs 0).type }}
+      - name: chown-celeborn-master-volume
+        image: alpine:3.18.0
+        imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+        securityContext:
+          runAsUser: 0
+        command:
+        - chown
+        - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
+        - {{ (index $dirs 0).path }}
+        volumeMounts:
+          - name: celeborn-master-vol-0
+            mountPath: {{ (index $dirs 0).path }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -75,7 +75,7 @@ spec:
       {{- $dirs := .Values.volumes.worker }}
       {{- if eq "hostPath" (index $dirs 0).type }}
       - name: chown-celeborn-worker-volume
-        image: alpine:3.18.0
+        image: alpine:3.18
         imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
         securityContext:
           runAsUser: 0

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -71,6 +71,26 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+      {{- $dirs := .Values.volumes.worker }}
+      {{- if eq "hostPath" (index $dirs 0).type }}
+      - name: chown-celeborn-worker-volume
+        image: alpine:3.18.0
+        imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+        securityContext:
+          runAsUser: 0
+        command:
+        - chown
+        - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
+        {{- range $dir := $dirs }}
+        - {{ $dir.path }}
+        {{- end}}
+        volumeMounts:
+        {{- range $index, $dir := $dirs }}
+        - name: celeborn-worker-vol-{{ $index }}
+          mountPath: {{ $dir.path }}
+        {{- end}}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -23,17 +23,19 @@
 # TODO rebuild celeborn official image
 image:
   repository: aliyunemr/remote-shuffle-service
-  pullPolicy: Always
+  pullPolicy: Never
   tag: 0.1.1-6badd20
 
 imagePullSecrets: {}
 
 # master replicas should not less than 3
-masterReplicas: 3
+masterReplicas: 1
 # worker replicas set on demand, should less than node number
-workerReplicas: 5
+workerReplicas: 1
 
 securityContext:
+  runAsUser: 10006
+  runAsGroup: 10006
   fsGroup: 10006
 
 # Current Celeborn support followings volume type:

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -23,15 +23,15 @@
 # TODO rebuild celeborn official image
 image:
   repository: aliyunemr/remote-shuffle-service
-  pullPolicy: Never
+  pullPolicy: Always
   tag: 0.1.1-6badd20
 
 imagePullSecrets: {}
 
 # master replicas should not less than 3
-masterReplicas: 1
+masterReplicas: 3
 # worker replicas set on demand, should less than node number
-workerReplicas: 1
+workerReplicas: 5
 
 securityContext:
   runAsUser: 10006


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add `initContainer` to `chown` volumes dir for master and worker.


### Why are the changes needed?
Previously, when users deployed celeborn on kubernetes for the first time (with the default HostPath mount), they encountered permission issues that could not be written.

Due to k8s create dir with start kubelet user and 0755, but Celeborn run as celeborn user(uid: 10006)

>DirectoryOrCreate | If nothing exists at the given path, an empty directory will be created there as needed with permission set to 0755, having the same group and ownership with Kubelet.

See more in [HostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Ack tested.

![popo_2023-05-29  17-37-59](https://github.com/apache/incubator-celeborn/assets/52876270/7b9a7859-cb0d-4286-8c1e-ebd3a15e420a)
![popo_2023-05-29  17-50-39](https://github.com/apache/incubator-celeborn/assets/52876270/485eddac-cc8c-4a20-8e6a-4c04825c55d5)

