### PR TITLE
[CELEBORN-620] Columnar shuffle codegen gets compileError

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/sql/execution/columnar/RssBatchBuilder.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/sql/execution/columnar/RssBatchBuilder.scala
@@ -28,7 +28,20 @@ abstract class RssBatchBuilder {
 
   def writeRow(row: InternalRow): Unit
 
-  def getRowCnt(): Int
+  def getRowCnt: Int
+
+  def getTotalSize(columnBuilders: Array[RssColumnBuilder]): Int = {
+    var tempTotalSize = 0
+    for (builder <- columnBuilders) {
+      builder match {
+        case builder: RssCompressibleColumnBuilder[_] =>
+          tempTotalSize += builder.getTotalSize.toInt
+        case builder: RssNullableColumnBuilder => tempTotalSize += builder.getTotalSize.toInt
+        case _ =>
+      }
+    }
+    tempTotalSize + 4 + 4 * columnBuilders.length
+  }
 
   def int2ByteArray(i: Int): Array[Byte] = {
     val result = new Array[Byte](4)

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/sql/execution/columnar/RssColumnarBatchCodeGenBuild.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/sql/execution/columnar/RssColumnarBatchCodeGenBuild.scala
@@ -45,6 +45,7 @@ class RssColumnarBatchCodeGenBuild {
          |
          |  private Object[] references;
          |  int rowCnt = 0;
+         |  ${classOf[RssColumnBuilder].getName}[] columnBuilders;
          |  ${codes._1}
          |
          |  public SpecificRssColumnarBatchBuilder(Object[] references) {
@@ -53,11 +54,14 @@ class RssColumnarBatchCodeGenBuild {
          |
          |  public void newBuilders() throws Exception {
          |    rowCnt = 0;
+         |    columnBuilders = new ${classOf[RssColumnBuilder].getName}[${schema.length}];
          |    ${codes._2}
          |  }
          |
          |  public byte[] buildColumnBytes() throws Exception {
          |    int offset = 0;
+         |    int totalSize = getTotalSize(columnBuilders);
+         |
          |    byte[] giantBuffer = new byte[totalSize];
          |    byte[] rowCntBytes = int2ByteArray(rowCnt);
          |    System.arraycopy(rowCntBytes, 0, giantBuffer, offset, rowCntBytes.length);
@@ -111,6 +115,7 @@ class RssColumnarBatchCodeGenBuild {
             s"""
                |  b$index = new ${classOf[RssNullColumnBuilder].getName}();
                |  builder.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -126,6 +131,7 @@ class RssColumnarBatchCodeGenBuild {
             s"""
                |  b$index = new ${classOf[RssByteCodeGenColumnBuilder].getName}();
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -141,6 +147,7 @@ class RssColumnarBatchCodeGenBuild {
             s"""
                |  b$index  = new ${classOf[RssBooleanCodeGenColumnBuilder].getName}();
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -156,6 +163,7 @@ class RssColumnarBatchCodeGenBuild {
             s"""
                |  b$index = new ${classOf[RssShortCodeGenColumnBuilder].getName}();
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -171,6 +179,7 @@ class RssColumnarBatchCodeGenBuild {
             s"""
                |  b$index = new ${classOf[RssIntCodeGenColumnBuilder].getName}();
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -186,6 +195,7 @@ class RssColumnarBatchCodeGenBuild {
             s"""
                |  b$index = new ${classOf[RssLongCodeGenColumnBuilder].getName}();
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -201,6 +211,7 @@ class RssColumnarBatchCodeGenBuild {
             s"""
                |  b$index = new ${classOf[RssFloatCodeGenColumnBuilder].getName}();
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -216,6 +227,7 @@ class RssColumnarBatchCodeGenBuild {
             s"""
                |  b$index = new ${classOf[RssDoubleCodeGenColumnBuilder].getName}();
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -231,6 +243,7 @@ class RssColumnarBatchCodeGenBuild {
             s"""
                |  b$index = new ${classOf[RssStringCodeGenColumnBuilder].getName}();
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -248,6 +261,7 @@ class RssColumnarBatchCodeGenBuild {
                |  new ${classOf[RssCompactMiniDecimalCodeGenColumnBuilder].getName}(
                |  new ${classOf[DecimalType].getName}(${dt.precision}, ${dt.scale}));
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -265,6 +279,7 @@ class RssColumnarBatchCodeGenBuild {
                |  new ${classOf[RssCompactDecimalCodeGenColumnBuilder].getName}
                |  (new ${classOf[DecimalType].getName}(${dt.precision}, ${dt.scale}));
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(
@@ -281,6 +296,7 @@ class RssColumnarBatchCodeGenBuild {
                |  b$index = new ${classOf[RssDecimalCodeGenColumnBuilder].getName}
                |  (new ${classOf[DecimalType].getName}(${dt.precision}, ${dt.scale}));
                |  b$index.initialize($batchSize, "${schema.fields(index).name}", false);
+               |  columnBuilders[$index] = b$index;
           """.stripMargin)
           writeCode.append(genWriteCode(index))
           writeRowCode.append(

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/sql/execution/columnar/RssCompressibleColumnBuilder.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/sql/execution/columnar/RssCompressibleColumnBuilder.scala
@@ -95,7 +95,7 @@ trait RssCompressibleColumnBuilder[T <: AtomicType]
       else RssPassThrough.encoder(columnType)
     }
     if (encoder.compressedSize == 0) {
-      4 + 4 + columnStats.sizeInBytes
+      4 + nulls.position() + 4 + buffer.position()
     } else {
       4 + 4 * nullCount + 4 + encoder.compressedSize
     }

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/sql/execution/columnar/RssNullableColumnBuilder.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/sql/execution/columnar/RssNullableColumnBuilder.scala
@@ -73,6 +73,6 @@ trait RssNullableColumnBuilder extends RssColumnBuilder {
   }
 
   override def getTotalSize: Long = {
-    4 + columnStats.sizeInBytes
+    4 + nulls.position()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
when set --conf spark.celeborn.columnar.shuffle.enabled=true --conf spark.celeborn.columnar.shuffle.codegen.enabled=true, compile failed in `SpecificRssColumnarBatchBuilder#buildColumnBytes` caused by `totalSize`.

### Why are the changes needed?
Fix bug. Follow-up works may need to refine and improve columnar shuffle function.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Cluster test.
