### PR TITLE
[CELEBORN-621][BUG] Push merged data task timeout and mapended should also remove push states

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -817,6 +817,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                   pushState.onCongestControl(loc.hostAndPushPort());
                   callback.onSuccess(response);
                 } else {
+                  // StageEnd.
                   response.rewind();
                   pushState.onSuccess(loc.hostAndPushPort());
                   callback.onSuccess(response);
@@ -1203,9 +1204,8 @@ public class ShuffleClientImpl extends ShuffleClient {
                 pushState.onCongestControl(hostPort);
                 callback.onSuccess(response);
               } else {
-                // Should not happen in current architecture.
+                // StageEnd.
                 response.rewind();
-                logger.error("Push merged data should not receive this response.");
                 pushState.onSuccess(hostPort);
                 callback.onSuccess(response);
               }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1260,6 +1260,18 @@ public class ShuffleClientImpl extends ShuffleClient {
                           cause,
                           groupedBatchId,
                           finalRemainReviveTimes));
+            } else {
+              pushState.removeBatch(groupedBatchId, hostPort);
+              logger.info(
+                  "Push merged data to {} failed but mapper already ended for shuffle {} map {} attempt {} partition {} groupedBatch {} batch {}, remain revive times {}.",
+                  hostPort,
+                  shuffleId,
+                  mapId,
+                  attemptId,
+                  Arrays.toString(partitionIds),
+                  groupedBatchId,
+                  Arrays.toString(batchIds),
+                  remainReviveTimes);
             }
           }
         };


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Push merged data task timeout and mapended should also remove push states, or it will cause push task timeout 

#### Case one:

Worker side log shows Map eneded.
```
23/05/30 03:24:07,034 INFO [replicate-server-9-12] Worker: Receive push data from speculative task(shuffle application_1684207607609_2728653_1-2, map 5744, attempt 3), but this mapper has already been ended.
23/05/30 03:27:37,388 INFO [replicate-server-9-12] Worker: Receive push data from speculative task(shuffle application_1684207607609_2728653_1-2, map 5744, attempt 4), but this mapper has already been ended.
```

Client side timeout
```
23/05/30 03:33:27 ERROR Executor: Exception in task 5744.4 in stage 3.0 (TID 10124)
com.aliyun.emr.rss.common.exception.RssIOException: wait timeout for task 2-5744-4
	at com.aliyun.emr.rss.client.ShuffleClientImpl.limitZeroInFlight(ShuffleClientImpl.java:399)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.mapperEnd(ShuffleClientImpl.java:1026)
	at org.apache.spark.shuffle.rss.SortBasedShuffleWriter.close(SortBasedShuffleWriter.java:269)
	at org.apache.spark.shuffle.rss.SortBasedShuffleWriter.write(SortBasedShuffleWriter.java:166)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1532)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

#### Case two
PushMerged data return MapEnded, then not remove the push states.
Push state is full for that target machine and `DataPushQueue.takePushTasks()` keep wait since capacity is zero.
Pusher close earlier than  ShuffleClient
```
dataPusher.waitOnTermination();
rssShuffleClient.prepareForMergeData(shuffleId, mapId, taskContext.attemptNumber()); 
```

then a dead lock

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

