### PR TITLE
[CELEBORN-622] Relax isRssEnabled condition to compatible with gluten celeborn shuffle manager

### DIFF
--- a/assets/spark-patch/RSS_RDA_spark2.patch
+++ b/assets/spark-patch/RSS_RDA_spark2.patch
@@ -99,7 +99,7 @@ diff --git a/core/src/main/scala/org/apache/spark/util/Utils.scala b/core/src/ma
    }
 +
 +  def isRssEnabled(conf: SparkConf): Boolean =
-+    conf.get("spark.shuffle.manager", "sort") == "org.apache.spark.shuffle.celeborn.RssShuffleManager"
++    conf.get("spark.shuffle.manager", "sort").contains("celeborn")
 +
  }
  

--- a/assets/spark-patch/RSS_RDA_spark3.patch
+++ b/assets/spark-patch/RSS_RDA_spark3.patch
@@ -27,7 +27,7 @@ diff --git a/core/src/main/scala/org/apache/spark/util/Utils.scala b/core/src/ma
    }
 +
 +  def isRssEnabled(conf: SparkConf): Boolean =
-+    conf.get("spark.shuffle.manager", "sort") == "org.apache.spark.shuffle.celeborn.RssShuffleManager"
++    conf.get("spark.shuffle.manager", "sort").contains("celeborn")
  }
  
  private[util] object CallerContext extends Logging {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
According to 
https://github.com/oap-project/gluten/blob/e012b50e3dc2f082c82b324f0be2b1d6f277511b/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java#L24-L25

The celeborn shuffle manager of gluten is not `org.apache.spark.shuffle.celeborn.RssShuffleManager`, then it breaks the result of isRssEnabled.

This pr relax it to `contains("celeborn")` to compatible with gluten celeborn shuffle manager.

### Why are the changes needed?
Make dra work with gluten + celeborn


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
manually test
