### PR TITLE
[CELEBORN-623][DOCS] Document how to change RPC type in `celeborn-ratis`

### DIFF
--- a/bin/celeborn-ratis
+++ b/bin/celeborn-ratis
@@ -71,6 +71,8 @@ function main {
   CELEBORN_RATIS_SHELL_JAVA_OPTS+=" -Dorg.apache.jasper.compiler.disablejsr199=true"
   CELEBORN_RATIS_SHELL_JAVA_OPTS+=" -Djava.net.preferIPv4Stack=true"
   CELEBORN_RATIS_SHELL_JAVA_OPTS+=" -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false"
+  # Netty is supported by default
+  CELEBORN_RATIS_SHELL_JAVA_OPTS+=" -Draft.rpc.type=NETTY"
 
   PARAMETER=""
 

--- a/bin/celeborn-ratis
+++ b/bin/celeborn-ratis
@@ -71,8 +71,6 @@ function main {
   CELEBORN_RATIS_SHELL_JAVA_OPTS+=" -Dorg.apache.jasper.compiler.disablejsr199=true"
   CELEBORN_RATIS_SHELL_JAVA_OPTS+=" -Djava.net.preferIPv4Stack=true"
   CELEBORN_RATIS_SHELL_JAVA_OPTS+=" -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false"
-  # Netty is supported by default
-  CELEBORN_RATIS_SHELL_JAVA_OPTS+=" -Draft.rpc.type=NETTY"
 
   PARAMETER=""
 

--- a/docs/celeborn_ratis_shell.md
+++ b/docs/celeborn_ratis_shell.md
@@ -65,7 +65,8 @@ Usage: celeborn-ratis sh [generic options]
 ## generic options
 The `generic options` pass values for a given ratis-shell property.
 It support the following content:
-`-D*`, `-X*`, `-agentlib*`, `-javaagent*`
+`-D*`, `-X*`, `-agentlib*`, `-javaagent*`  
+For example: Using `-Draft.rpc.type=NETTY` to set the rpc type of ratis to netty, the default is grpc.
 
 ```
 $ celeborn-ratis sh -D<property=value> ...

--- a/docs/celeborn_ratis_shell.md
+++ b/docs/celeborn_ratis_shell.md
@@ -70,7 +70,8 @@ It support the following content:
 ```
 $ celeborn-ratis sh -D<property=value> ...
 ```
-For example: Use `-Draft.rpc.type=NETTY` to set the rpc type of ratis to netty, the default is grpc.
+
+For example: use `-Draft.rpc.type=NETTY` to set the RPC type of Ratis to Netty, the default is gRPC.
 
 ## election
 The `election` command manages leader election.

--- a/docs/celeborn_ratis_shell.md
+++ b/docs/celeborn_ratis_shell.md
@@ -65,12 +65,12 @@ Usage: celeborn-ratis sh [generic options]
 ## generic options
 The `generic options` pass values for a given ratis-shell property.
 It support the following content:
-`-D*`, `-X*`, `-agentlib*`, `-javaagent*`  
-For example: Using `-Draft.rpc.type=NETTY` to set the rpc type of ratis to netty, the default is grpc.
+`-D*`, `-X*`, `-agentlib*`, `-javaagent*`
 
 ```
 $ celeborn-ratis sh -D<property=value> ...
 ```
+For example: Using `-Draft.rpc.type=NETTY` to set the rpc type of ratis to netty, the default is grpc.
 
 ## election
 The `election` command manages leader election.

--- a/docs/celeborn_ratis_shell.md
+++ b/docs/celeborn_ratis_shell.md
@@ -70,7 +70,7 @@ It support the following content:
 ```
 $ celeborn-ratis sh -D<property=value> ...
 ```
-For example: Using `-Draft.rpc.type=NETTY` to set the rpc type of ratis to netty, the default is grpc.
+For example: Use `-Draft.rpc.type=NETTY` to set the rpc type of ratis to netty, the default is grpc.
 
 ## election
 The `election` command manages leader election.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ratis-shell use GRPC by default. Celeborn support Netty for ratis, if `raft.rpc.type` is not specified, commands may fail.
e.g.
```
org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException: DEADLINE_EXCEEDED: deadline exceeded after 14.947369960s. [closed=[], open=[[buffered_nanos=14962358255, waiting_for_connection]]] 
```
So I think we should update the document to mention how to change the RPC type to in `celeborn-ratis`.


### Why are the changes needed?

Improve user experience


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually test
