### PR TITLE
[CELEBORN-624] StorageManager should only remove expired app dirs

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -600,7 +600,6 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerFetchIoThreads: Option[Int] = get(WORKER_FETCH_IO_THREADS)
   def workerReplicateIoThreads: Option[Int] = get(WORKER_REPLICATE_IO_THREADS)
   def registerWorkerTimeout: Long = get(WORKER_REGISTER_TIMEOUT)
-  def workerApplicationDataKeepAliveTime: Long = get(WORKER_APPLICATION_DATA_KEEP_ALIVE_TIME)
   def workerWorkingDir: String = get(WORKER_WORKING_DIR)
   def workerCloseIdleConnections: Boolean = get(WORKER_CLOSE_IDLE_CONNECTIONS)
   def workerReplicateFastFailDuration: Long = get(WORKER_REPLICATE_FAST_FAIL_DURATION)
@@ -1903,16 +1902,6 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("5G")
-
-  val WORKER_APPLICATION_DATA_KEEP_ALIVE_TIME: ConfigEntry[Long] =
-    buildConf("celeborn.worker.storage.applicationData.keepAliveTime")
-      .withAlternative("celeborn.worker.noneEmptyDirExpireDuration")
-      .withAlternative("rss.expire.nonEmptyDir.duration")
-      .categories("worker")
-      .doc("If a non-empty application shuffle data dir have not been operated during le duration time, will mark this application as expired.")
-      .version("0.3.0")
-      .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("1d")
 
   val WORKER_CHECK_FILE_CLEAN_MAX_RETRIES: ConfigEntry[Int] =
     buildConf("celeborn.worker.storage.checkDirsEmpty.maxRetries")

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -86,7 +86,6 @@ license: |
 | celeborn.worker.sortPartition.reservedMemoryPerPartition | 1mb | Reserved memory when sorting a shuffle file off-heap. | 0.3.0 | 
 | celeborn.worker.sortPartition.threads | &lt;undefined&gt; | PartitionSorter's thread counts. | 0.3.0 | 
 | celeborn.worker.sortPartition.timeout | 220s | Timeout for a shuffle file to sort. | 0.3.0 | 
-| celeborn.worker.storage.applicationData.keepAliveTime | 1d | If a non-empty application shuffle data dir have not been operated during le duration time, will mark this application as expired. | 0.3.0 | 
 | celeborn.worker.storage.checkDirsEmpty.maxRetries | 3 | The number of retries for a worker to check if the working directory is cleaned up before registering with the master. | 0.3.0 | 
 | celeborn.worker.storage.checkDirsEmpty.timeout | 1000ms | The wait time per retry for a worker to check if the working directory is cleaned up before registering with the master. | 0.3.0 | 
 | celeborn.worker.storage.dirs | &lt;undefined&gt; | Directory list to store shuffle data. It's recommended to configure one directory on each disk. Storage size limit can be set for each directory. For the sake of performance, there should be no more than 2 flush threads on the same disk partition if you are using HDD, and should be 8 or more flush threads on the same disk partition if you are using SSD. For example: `dir1[:capacity=][:disktype=][:flushthread=],dir2[:capacity=][:disktype=][:flushthread=]` | 0.2.0 | 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current code has two problems:
1.  If the application running too long and it running longer than `workerApplicationDataKeepAliveTime`, it will cause job failed and it's not what we want
2. Now we support the graceful shutdown and we can recover file info from levelDB then we can still fetch data after restarting. If we don't enable the graceful shutdown. Even if we reserve the application data, we can't read it's data too

In this pr, we simplify the cleanup logic. We just remove all app directories that not have file info(If not, means we can't read the data)


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

