### PR TITLE
[CELEBORN-628][HELM] Separate mount & host path on hostPath case

### DIFF
--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -34,13 +34,13 @@ data:
     celeborn.ha.master.node.{{ . }}.host=celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local
     {{- end }}
     {{- $dirs := .Values.volumes.master }}
-    celeborn.ha.master.ratis.raft.server.storage.dir={{ (index $dirs 0).path }}
+    celeborn.ha.master.ratis.raft.server.storage.dir={{ (index $dirs 0).mountPath }}
     {{- $path := "" }}
     {{- range $worker := .Values.volumes.worker }}
     {{- if eq $path "" }}
-    {{- $path = $worker.path }}
+    {{- $path = $worker.mountPath }}
     {{- else }}
-    {{- $path = ( list $path $worker.path | join ",") }}
+    {{- $path = ( list $path $worker.mountPath | join ",") }}
     {{- end }}
     {{- end }}
     celeborn.worker.storage.dirs={{ $path }}

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -130,7 +130,7 @@ spec:
             sizeLimit: {{ $volume.size }}
         {{- else if eq "hostPath" $volume.type }}
           hostPath:
-            path: {{ $volume.mountPath | default $volume.path }}/master
+            path: {{ $volume.volumePath | default $volume.path }}/master
             type: DirectoryOrCreate
         {{- else }}
         {{ fail "For now Celeborn Helm only support emptyDir or hostPath volume types" }}

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -130,7 +130,7 @@ spec:
             sizeLimit: {{ $volume.size }}
         {{- else if eq "hostPath" $volume.type }}
           hostPath:
-            path: {{ $volume.path }}/master
+            path: {{ $volume.mountPath | default $volume.path }}/master
             type: DirectoryOrCreate
         {{- else }}
         {{ fail "For now Celeborn Helm only support emptyDir or hostPath volume types" }}

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -130,7 +130,7 @@ spec:
             sizeLimit: {{ $volume.size }}
         {{- else if eq "hostPath" $volume.type }}
           hostPath:
-            path: {{ $volume.volumePath | default $volume.mountPath }}/master
+            path: {{ $volume.hostPath | default $volume.mountPath }}/master
             type: DirectoryOrCreate
         {{- else }}
         {{ fail "For now Celeborn Helm only support emptyDir or hostPath volume types" }}

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -82,10 +82,10 @@ spec:
         command:
         - chown
         - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
-        - {{ (index $dirs 0).path }}
+        - {{ (index $dirs 0).mountPath }}
         volumeMounts:
           - name: celeborn-master-vol-0
-            mountPath: {{ (index $dirs 0).path }}
+            mountPath: {{ (index $dirs 0).mountPath }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
@@ -111,7 +111,7 @@ spec:
             readOnly: true
           {{- range $index, $volume := .Values.volumes.master }}
           - name: celeborn-master-vol-{{ $index }}
-            mountPath: {{ .path }}
+            mountPath: {{ .mountPath }}
           {{- end }}
         env:
           {{- range $key, $val := .Values.environments }}
@@ -130,7 +130,7 @@ spec:
             sizeLimit: {{ $volume.size }}
         {{- else if eq "hostPath" $volume.type }}
           hostPath:
-            path: {{ $volume.volumePath | default $volume.path }}/master
+            path: {{ $volume.volumePath | default $volume.mountPath }}/master
             type: DirectoryOrCreate
         {{- else }}
         {{ fail "For now Celeborn Helm only support emptyDir or hostPath volume types" }}

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -136,7 +136,7 @@ spec:
         {{- else if eq "hostPath" $volume.type }}
         - name: celeborn-worker-vol-{{ $index }}
           hostPath:
-            path: {{ $volume.volumePath | default $volume.mountPath }}/worker
+            path: {{ $volume.hostPath | default $volume.mountPath }}/worker
             type: DirectoryOrCreate
         {{- else }}
         {{ fail "Currently, Celeborn chart only supports 'emptyDir' and 'hostPath' volume types" }}

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -136,7 +136,7 @@ spec:
         {{- else if eq "hostPath" $volume.type }}
         - name: celeborn-worker-vol-{{ $index }}
           hostPath:
-            path: {{ $volume.path }}/worker
+            path: {{ $volume.mountPath | default $volume.path }}/worker
             type: DirectoryOrCreate
         {{- else }}
         {{ fail "Currently, Celeborn chart only supports 'emptyDir' and 'hostPath' volume types" }}

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -83,12 +83,12 @@ spec:
         - chown
         - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
         {{- range $dir := $dirs }}
-        - {{ $dir.path }}
+        - {{ $dir.mountPath }}
         {{- end}}
         volumeMounts:
         {{- range $index, $dir := $dirs }}
         - name: celeborn-worker-vol-{{ $index }}
-          mountPath: {{ $dir.path }}
+          mountPath: {{ $dir.mountPath }}
         {{- end}}
       {{- end }}
       containers:
@@ -116,7 +116,7 @@ spec:
           {{- end }}
           {{- range $index, $volume := .Values.volumes.worker }}
           - name: celeborn-worker-vol-{{ $index }}
-            mountPath: {{ .path }}
+            mountPath: {{ .mountPath }}
           {{- end }}
         env:
           {{- range $key, $val := .Values.environments }}
@@ -136,7 +136,7 @@ spec:
         {{- else if eq "hostPath" $volume.type }}
         - name: celeborn-worker-vol-{{ $index }}
           hostPath:
-            path: {{ $volume.volumePath | default $volume.path }}/worker
+            path: {{ $volume.volumePath | default $volume.mountPath }}/worker
             type: DirectoryOrCreate
         {{- else }}
         {{ fail "Currently, Celeborn chart only supports 'emptyDir' and 'hostPath' volume types" }}

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -136,7 +136,7 @@ spec:
         {{- else if eq "hostPath" $volume.type }}
         - name: celeborn-worker-vol-{{ $index }}
           hostPath:
-            path: {{ $volume.mountPath | default $volume.path }}/worker
+            path: {{ $volume.volumePath | default $volume.path }}/worker
             type: DirectoryOrCreate
         {{- else }}
         {{ fail "Currently, Celeborn chart only supports 'emptyDir' and 'hostPath' volume types" }}

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -46,25 +46,25 @@ securityContext:
 # Celeborn Master will pick first volumes for store raft log
 volumes:
   master:
-    - path: /mnt/rss_ratis
+    - mountPath: /mnt/rss_ratis
       volumePath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
   worker:
-    - path: /mnt/disk1
-      volumePath: /mnt/rss_ratis
+    - mountPath: /mnt/disk1
+      volumePath: /mnt/disk1
       type: hostPath
       size: 1Gi
-    - path: /mnt/disk2
-      volumePath: /mnt/rss_ratis
+    - mountPath: /mnt/disk2
+      volumePath: /mnt/disk2
       type: hostPath
       size: 1Gi
-    - path: /mnt/disk3
-      volumePath: /mnt/rss_ratis
+    - mountPath: /mnt/disk3
+      volumePath: /mnt/disk3
       type: hostPath
       size: 1Gi
-    - path: /mnt/disk4
-      volumePath: /mnt/rss_ratis
+    - mountPath: /mnt/disk4
+      volumePath: /mnt/disk4
       type: hostPath
       size: 1Gi
 

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -42,23 +42,29 @@ securityContext:
 # - emptyDir
 # - hostPath
 # Note: size only works in emptyDir type
+# mountPath works in hostPath type using to set `volumes hostPath path`
 # Celeborn Master will pick first volumes for store raft log
 volumes:
   master:
     - path: /mnt/rss_ratis
+      mountPath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
   worker:
     - path: /mnt/disk1
+      mountPath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
     - path: /mnt/disk2
+      mountPath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
     - path: /mnt/disk3
+      mountPath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
     - path: /mnt/disk4
+      mountPath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
 

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -42,29 +42,29 @@ securityContext:
 # - emptyDir
 # - hostPath
 # Note: size only works in emptyDir type
-# mountPath works in hostPath type using to set `volumes hostPath path`
+# hostPath only works in hostPath type using to set `volumes hostPath path`
 # Celeborn Master will pick first volumes for store raft log
 volumes:
   master:
     - mountPath: /mnt/rss_ratis
-      volumePath: /mnt/rss_ratis
+      hostPath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
   worker:
     - mountPath: /mnt/disk1
-      volumePath: /mnt/disk1
+      hostPath: /mnt/disk1
       type: hostPath
       size: 1Gi
     - mountPath: /mnt/disk2
-      volumePath: /mnt/disk2
+      hostPath: /mnt/disk2
       type: hostPath
       size: 1Gi
     - mountPath: /mnt/disk3
-      volumePath: /mnt/disk3
+      hostPath: /mnt/disk3
       type: hostPath
       size: 1Gi
     - mountPath: /mnt/disk4
-      volumePath: /mnt/disk4
+      hostPath: /mnt/disk4
       type: hostPath
       size: 1Gi
 

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -47,24 +47,24 @@ securityContext:
 volumes:
   master:
     - path: /mnt/rss_ratis
-      mountPath: /mnt/rss_ratis
+      volumePath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
   worker:
     - path: /mnt/disk1
-      mountPath: /mnt/rss_ratis
+      volumePath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
     - path: /mnt/disk2
-      mountPath: /mnt/rss_ratis
+      volumePath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
     - path: /mnt/disk3
-      mountPath: /mnt/rss_ratis
+      volumePath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
     - path: /mnt/disk4
-      mountPath: /mnt/rss_ratis
+      volumePath: /mnt/rss_ratis
       type: hostPath
       size: 1Gi
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Seperate Mount & Volumes Path On Kubernete Case


### Why are the changes needed?
See detail in https://github.com/apache/incubator-celeborn/pull/1508#discussion_r1208803085


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
Local Test

> Values.yaml
```yaml
volumes:
  master:
    - mountPath: /mnt/rss_ratis
      hostPath: /spark/data1
      type: hostPath
      size: 1Gi
  worker:
    - mountPath: /mnt/disk1
      hostPath: /spark/data1
      type: hostPath
      size: 1Gi
    - mountPath: /mnt/disk2
      hostPath: /spark/data2
      type: hostPath
      size: 1Gi
```

>Celeborn Worker Pod
```yaml
containers:
  volumeMounts:
    - mountPath: /mnt/disk1
      name: celeborn-worker-vol-0
    - mountPath: /mnt/disk2
      name: celeborn-worker-vol-1
volumes:
  - hostPath:
      path: /spark/data1/worker
      type: DirectoryOrCreate
    name: celeborn-worker-vol-0
  - hostPath:
      path: /spark/data2/worker
      type: DirectoryOrCreate
    name: celeborn-worker-vol-1
```
