### PR TITLE
[CELEBORN-623][FOLLUPUP] Refine doc about use ratis shell with RSS cluster

### DIFF
--- a/docs/celeborn_ratis_shell.md
+++ b/docs/celeborn_ratis_shell.md
@@ -71,7 +71,11 @@ It support the following content:
 $ celeborn-ratis sh -D<property=value> ...
 ```
 
-For example: use `-Draft.rpc.type=NETTY` to set the RPC type of Ratis to Netty, the default is gRPC.
+**Note:**
+
+Celeborn HA use `NETTY` as default rpc type, users can refer to configuration `celeborn.ha.master.ratis.raft.rpc.type`.
+But Ratis use `GRPC` as default rpc type. So if user want to use Ratis shell with Ratis cluster use `NETTY` rpc type,
+users can use generic option `-Draft.rpc.type=NETTY` to set the RPC type of Ratis shell to Netty.
 
 ## election
 The `election` command manages leader election.

--- a/docs/celeborn_ratis_shell.md
+++ b/docs/celeborn_ratis_shell.md
@@ -73,9 +73,7 @@ $ celeborn-ratis sh -D<property=value> ...
 
 **Note:**
 
-Celeborn HA use `NETTY` as default rpc type, users can refer to configuration `celeborn.ha.master.ratis.raft.rpc.type`.
-But Ratis use `GRPC` as default rpc type. So if user want to use Ratis shell with Ratis cluster use `NETTY` rpc type,
-users can use generic option `-Draft.rpc.type=NETTY` to set the RPC type of Ratis shell to Netty.
+Celeborn HA uses `NETTY` as the default RPC type, for details please refer to configuration `celeborn.ha.master.ratis.raft.rpc.type`. But Ratis uses `GRPC` as the default RPC type. So if the user wants to use Ratis shell to access Ratis cluster which uses `NETTY` RPC type, the generic option `-Draft.rpc.type=NETTY` should be set to change the RPC type of Ratis shell to Netty.
 
 ## election
 The `election` command manages leader election.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refine this doc since:

1. It didn't mention our cluster default RPC type is  `NETTY`
2. If the user use the ratis shell with `GRPC` but didn't know the ratis cluster is `NETTY`, the error is not clear and hard to debug.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

