### PR TITLE
[CELEBORN-635] Exclude unused ssl dependency(netty-handler-ssl-ocsp) from netty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,12 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>${netty.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-ssl-ocsp</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
now our project  doesn't use netty's ssl feature, so it can be removed from netty dependencies.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

