### PR TITLE
[CELEBORN-639][BUG] ShuffleClient get push exception cause should handle NPE

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1534,7 +1534,10 @@ public class ShuffleClientImpl extends ShuffleClient {
   private StatusCode getPushDataFailCause(String message) {
     logger.debug("Push data failed cause message: " + message);
     StatusCode cause;
-    if (message.startsWith(StatusCode.PUSH_DATA_WRITE_FAIL_SLAVE.name())) {
+    if (message == null) {
+      logger.error("Push data throw unexpected exception: " + message);
+      cause = StatusCode.PUSH_DATA_FAIL_NON_CRITICAL_CAUSE;
+    } else if (message.startsWith(StatusCode.PUSH_DATA_WRITE_FAIL_SLAVE.name())) {
       cause = StatusCode.PUSH_DATA_WRITE_FAIL_SLAVE;
     } else if (message.startsWith(StatusCode.PUSH_DATA_WRITE_FAIL_MASTER.name())) {
       cause = StatusCode.PUSH_DATA_WRITE_FAIL_MASTER;


### PR DESCRIPTION
### What changes were proposed in this pull request?
If we meet some unexpected exception, `getPushDataFailCause ` will throw NPE and broke the process of revive and remove push states. Here we should handle the NPE


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

