### PR TITLE
[CELEBORN-641] Upgrade flink scala version to 2.12.15.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -997,7 +997,6 @@
       </modules>
       <properties>
         <flink.version>1.14.6</flink.version>
-        <scala.version>2.12.7</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-1.14_${scala.binary.version}</celeborn.flink.plugin.artifact>
         <flink.streamig.artifact>flink-streaming-java_${scala.binary.version}</flink.streamig.artifact>
@@ -1018,7 +1017,6 @@
       <properties>
         <flink.version>1.15.4</flink.version>
         <flink.binary.version>1.15</flink.binary.version>
-        <scala.version>2.12.7</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-1.15_${scala.binary.version}</celeborn.flink.plugin.artifact>
         <flink.streamig.artifact>flink-streaming-java</flink.streamig.artifact>
@@ -1039,7 +1037,6 @@
       <properties>
         <flink.version>1.17.0</flink.version>
         <flink.binary.version>1.17</flink.binary.version>
-        <scala.version>2.12.7</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-1.17_${scala.binary.version}</celeborn.flink.plugin.artifact>
         <flink.streamig.artifact>flink-streaming-java</flink.streamig.artifact>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Use scala 2.12.15 as default scala version for flink.

### Why are the changes needed?
There is incompatible serialize problem between scala 2.12.7 to scala 2.12.15/scala 2.11.12,  when use different scala version, the generated serialVersionUID is different, Then we may encounter deserialize problem between client/server rpc, refer [scala ](https://users.scala-lang.org/t/serialversionuid-change-between-scala-2-12-6-and-2-12-7/3478/3)

![image](https://github.com/apache/incubator-celeborn/assets/28799061/19ddd25e-7db5-458d-95d0-bc6ab66cd40b)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test use Flink scala2.12.7 runtime with Celeborn scala 2.12.15 compiled Flink client
