### PR TITLE
[CELEBORN-650][TEST] Upgrade scalatest and unify mockito version

### DIFF
--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.plugin.flink;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,8 +30,6 @@ import io.netty.channel.ChannelFuture;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
 
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.network.client.RpcResponseCallback;
@@ -77,7 +76,7 @@ public class FlinkShuffleClientImplSuiteJ {
   @Test
   public void testPushDataByteBufSuccess() throws IOException {
     ByteBuf byteBuf = createByteBuf();
-    Mockito.when(client.pushData(Matchers.any(), Matchers.anyLong(), Matchers.any()))
+    when(client.pushData(any(), anyLong(), any()))
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback =
@@ -95,7 +94,7 @@ public class FlinkShuffleClientImplSuiteJ {
   @Test
   public void testPushDataByteBufHardSplit() throws IOException {
     ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
-    Mockito.when(client.pushData(Matchers.any(), Matchers.anyLong(), Matchers.any()))
+    when(client.pushData(any(), anyLong(), any()))
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback =
@@ -112,8 +111,7 @@ public class FlinkShuffleClientImplSuiteJ {
   @Test
   public void testPushDataByteBufFail() throws IOException {
     ByteBuf byteBuf = Unpooled.wrappedBuffer(TEST_BUF1);
-    Mockito.when(
-            client.pushData(Matchers.any(), Matchers.anyLong(), Matchers.any(), Matchers.any()))
+    when(client.pushData(any(), anyLong(), any(), any()))
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback =

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
@@ -79,8 +79,7 @@ public class FlinkShuffleClientImplSuiteJ {
     when(client.pushData(any(), anyLong(), any()))
         .thenAnswer(
             t -> {
-              RpcResponseCallback rpcResponseCallback =
-                  t.getArgument(1, RpcResponseCallback.class);
+              RpcResponseCallback rpcResponseCallback = t.getArgument(1, RpcResponseCallback.class);
               ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[0]);
               rpcResponseCallback.onSuccess(byteBuffer);
               return mockedFuture;
@@ -97,8 +96,7 @@ public class FlinkShuffleClientImplSuiteJ {
     when(client.pushData(any(), anyLong(), any()))
         .thenAnswer(
             t -> {
-              RpcResponseCallback rpcResponseCallback =
-                  t.getArgument(1, RpcResponseCallback.class);
+              RpcResponseCallback rpcResponseCallback = t.getArgument(1, RpcResponseCallback.class);
               ByteBuffer byteBuffer =
                   ByteBuffer.wrap(new byte[] {StatusCode.HARD_SPLIT.getValue()});
               rpcResponseCallback.onSuccess(byteBuffer);
@@ -114,8 +112,7 @@ public class FlinkShuffleClientImplSuiteJ {
     when(client.pushData(any(), anyLong(), any(), any()))
         .thenAnswer(
             t -> {
-              RpcResponseCallback rpcResponseCallback =
-                  t.getArgument(1, RpcResponseCallback.class);
+              RpcResponseCallback rpcResponseCallback = t.getArgument(1, RpcResponseCallback.class);
               rpcResponseCallback.onFailure(new Exception("pushDataFailed"));
               return mockedFuture;
             });

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
@@ -80,7 +80,7 @@ public class FlinkShuffleClientImplSuiteJ {
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback =
-                  t.getArgumentAt(1, RpcResponseCallback.class);
+                  t.getArgument(1, RpcResponseCallback.class);
               ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[0]);
               rpcResponseCallback.onSuccess(byteBuffer);
               return mockedFuture;
@@ -98,7 +98,7 @@ public class FlinkShuffleClientImplSuiteJ {
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback =
-                  t.getArgumentAt(1, RpcResponseCallback.class);
+                  t.getArgument(1, RpcResponseCallback.class);
               ByteBuffer byteBuffer =
                   ByteBuffer.wrap(new byte[] {StatusCode.HARD_SPLIT.getValue()});
               rpcResponseCallback.onSuccess(byteBuffer);
@@ -115,7 +115,7 @@ public class FlinkShuffleClientImplSuiteJ {
         .thenAnswer(
             t -> {
               RpcResponseCallback rpcResponseCallback =
-                  t.getArgumentAt(1, RpcResponseCallback.class);
+                  t.getArgument(1, RpcResponseCallback.class);
               rpcResponseCallback.onFailure(new Exception("pushDataFailed"));
               return mockedFuture;
             });

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGateSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGateSuiteJ.java
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.plugin.flink;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;

--- a/client-flink/flink-1.14/pom.xml
+++ b/client-flink/flink-1.14/pom.xml
@@ -51,11 +51,6 @@
     </dependency>
     <!-- Test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -19,9 +19,9 @@ package org.apache.celeborn.plugin.flink;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleServiceFactorySuitJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleServiceFactorySuitJ.java
@@ -17,8 +17,8 @@
 
 package org.apache.celeborn.plugin.flink;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/client-flink/flink-1.15/pom.xml
+++ b/client-flink/flink-1.15/pom.xml
@@ -51,11 +51,6 @@
     </dependency>
     <!-- Test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -19,9 +19,9 @@ package org.apache.celeborn.plugin.flink;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleServiceFactorySuitJ.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleServiceFactorySuitJ.java
@@ -17,8 +17,8 @@
 
 package org.apache.celeborn.plugin.flink;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/client-flink/flink-1.17/pom.xml
+++ b/client-flink/flink-1.17/pom.xml
@@ -51,11 +51,6 @@
     </dependency>
     <!-- Test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -19,9 +19,9 @@ package org.apache.celeborn.plugin.flink;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleServiceFactorySuitJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleServiceFactorySuitJ.java
@@ -17,8 +17,8 @@
 
 package org.apache.celeborn.plugin.flink;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/client-spark/spark-2/pom.xml
+++ b/client-spark/spark-2/pom.xml
@@ -75,8 +75,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/client-spark/spark-2/pom.xml
+++ b/client-spark/spark-2/pom.xml
@@ -75,23 +75,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.scalamock</groupId>
-      <artifactId>scalamock_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -17,8 +17,8 @@
 
 package org.apache.celeborn.client;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/common/src/test/java/org/apache/celeborn/common/haclient/RssHARetryClientSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/haclient/RssHARetryClientSuiteJ.java
@@ -228,15 +228,15 @@ public class RssHARetryClientSuiteJ {
     Mockito.doReturn(
             Future$.MODULE$.failed(new MasterNotLeaderException("host1:9097", "host2:9097")))
         .when(master1)
-        .ask(Mockito.anyObject(), Mockito.anyObject(), Mockito.anyObject());
+        .ask(Mockito.any(), Mockito.any(), Mockito.any());
 
     Mockito.doReturn(Future$.MODULE$.successful(mockResponse))
         .when(master3)
-        .ask(Mockito.anyObject(), Mockito.anyObject(), Mockito.anyObject());
+        .ask(Mockito.any(), Mockito.any(), Mockito.any());
 
     Mockito.doAnswer(
             (invocation) -> {
-              RpcAddress address = invocation.getArgumentAt(0, RpcAddress.class);
+              RpcAddress address = invocation.getArgument(0, RpcAddress.class);
               switch (address.host()) {
                 case "host1":
                   return master1;
@@ -276,19 +276,17 @@ public class RssHARetryClientSuiteJ {
     Mockito.doReturn(
             Future$.MODULE$.failed(new MasterNotLeaderException("host1:9097", "host2:9097")))
         .when(ref1)
-        .ask(Mockito.anyObject(), Mockito.anyObject(), Mockito.anyObject());
+        .ask(Mockito.any(), Mockito.any(), Mockito.any());
     // Assume host2 down.
     Mockito.doReturn(Future$.MODULE$.failed(new IOException("Test IOException")))
         .when(ref2)
-        .ask(Mockito.anyObject(), Mockito.anyObject(), Mockito.anyObject());
+        .ask(Mockito.any(), Mockito.any(), Mockito.any());
     // master leader switch to host3 after host2 down.
-    Mockito.doReturn(supplier.get())
-        .when(ref3)
-        .ask(Mockito.anyObject(), Mockito.anyObject(), Mockito.anyObject());
+    Mockito.doReturn(supplier.get()).when(ref3).ask(Mockito.any(), Mockito.any(), Mockito.any());
 
     Mockito.doAnswer(
             invocation -> {
-              RpcAddress address = invocation.getArgumentAt(0, RpcAddress.class);
+              RpcAddress address = invocation.getArgument(0, RpcAddress.class);
               if (address.port() == masterPort) {
                 switch (address.host()) {
                   case "host1":
@@ -316,7 +314,7 @@ public class RssHARetryClientSuiteJ {
   private void prepareForRpcEnvWithoutHA() {
     Mockito.doAnswer(
             (invocationOnMock) -> {
-              RpcAddress address = invocationOnMock.getArgumentAt(0, RpcAddress.class);
+              RpcAddress address = invocationOnMock.getArgument(0, RpcAddress.class);
               if (address.host().equals(masterHost) && address.port() == masterPort) {
                 return endpointRef;
               } else {
@@ -350,13 +348,13 @@ public class RssHARetryClientSuiteJ {
               }
             })
         .when(endpointRef)
-        .ask(Mockito.anyObject(), Mockito.anyObject(), Mockito.anyObject());
+        .ask(Mockito.any(), Mockito.any(), Mockito.any());
   }
 
   private void prepareForEndpointRefWithoutRetry(Supplier<Future<?>> supplier) {
     Mockito.doAnswer(invocation -> supplier.get())
         .when(endpointRef)
-        .ask(Mockito.anyObject(), Mockito.anyObject(), Mockito.anyObject());
+        .ask(Mockito.any(), Mockito.any(), Mockito.any());
   }
 
   private CelebornConf prepareForCelebornConfWithoutHA() {

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -85,13 +85,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-scala-scalatest_${scala.binary.version}</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,13 +79,12 @@
     <leveldb.version>1.8</leveldb.version>
     <log4j2.version>2.17.2</log4j2.version>
     <lz4-java.version>1.8.0</lz4-java.version>
-    <mockito.version>1.10.19</mockito.version>
-    <mockito-scalatest.version>1.16.37</mockito-scalatest.version>
+    <mockito.version>4.11.0</mockito.version>
+    <mockito-scalatest.version>1.17.14</mockito-scalatest.version>
     <netty.version>4.1.92.Final</netty.version>
     <protobuf.version>3.19.2</protobuf.version>
     <ratis.version>2.5.1</ratis.version>
-    <scalamock.version>5.1.0</scalamock.version>
-    <scalatest.version>3.2.3</scalatest.version>
+    <scalatest.version>3.2.16</scalatest.version>
     <slf4j.version>1.7.36</slf4j.version>
     <roaringbitmap.version>0.9.32</roaringbitmap.version>
     <snakeyaml.version>1.33</snakeyaml.version>
@@ -394,17 +393,6 @@
         <artifactId>scalatest_${scala.binary.version}</artifactId>
         <version>${scalatest.version}</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.scalatest</groupId>
-        <artifactId>scalatest-funsuite_${scala.binary.version}</artifactId>
-        <version>${scalatest.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.scalamock</groupId>
-        <artifactId>scalamock_${scala.binary.version}</artifactId>
-        <version>${scalamock.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/tests/flink-it/pom.xml
+++ b/tests/flink-it/pom.xml
@@ -63,23 +63,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-scala-scalatest_${scala.binary.version}</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>3.6.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-runtime</artifactId>
       <version>${flink.version}</version>

--- a/tests/spark-it/pom.xml
+++ b/tests/spark-it/pom.xml
@@ -63,17 +63,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-scala-scalatest_${scala.binary.version}</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>3.6.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <scope>test</scope>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -94,12 +94,6 @@
       <artifactId>mockito-scala-scalatest_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>3.6.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

This PR upgrades 

- `mockito` from 1.10.19 and 3.6.0 to 4.11.0
- `scalatest` from 3.2.3 to 3.2.16
- `mockito-scalatest` from 1.16.37 to 1.17.14

### Why are the changes needed?

Housekeeping, making test dependencies up-to-date and unified.

### Does this PR introduce _any_ user-facing change?

No, it only affects test.

### How was this patch tested?

Pass GA.