### PR TITLE
[CELEBORN-655][SPARK][0.2] Rename newAppId to appUniqueId

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -109,7 +109,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException {
     this.mapId = mapId;
     this.dep = handle.dependency();
-    this.appId = handle.newAppId();
+    this.appId = handle.appUniqueId();
     this.shuffleId = dep.shuffleId();
     SerializerInstance serializer = dep.serializer().newInstance();
     this.partitioner = dep.partitioner();

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -107,7 +107,7 @@ public class SparkUtils {
     return tmpCelebornConf;
   }
 
-  public static String genNewAppId(SparkContext context) {
+  public static String appUniqueId(SparkContext context) {
     if (context.applicationAttemptId().isDefined()) {
       return context.applicationId() + "_" + context.applicationAttemptId().get();
     } else {

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleHandle.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleHandle.scala
@@ -23,7 +23,7 @@ import org.apache.spark.shuffle.BaseShuffleHandle
 import org.apache.celeborn.common.identity.UserIdentifier
 
 class RssShuffleHandle[K, V, C](
-    val newAppId: String,
+    val appUniqueId: String,
     val rssMetaServiceHost: String,
     val rssMetaServicePort: Int,
     val userIdentifier: UserIdentifier,

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
@@ -63,7 +63,7 @@ class RssShuffleReader[K, C](
       if (handle.numMaps > 0) {
         val start = System.currentTimeMillis()
         val inputStream = essShuffleClient.readPartition(
-          handle.newAppId,
+          handle.appUniqueId,
           handle.shuffleId,
           partitionId,
           context.attemptNumber(),

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -117,7 +117,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException {
     this.mapId = taskContext.partitionId();
     this.dep = handle.dependency();
-    this.appId = handle.newAppId();
+    this.appId = handle.appUniqueId();
     this.shuffleId = dep.shuffleId();
     SerializerInstance serializer = dep.serializer().newInstance();
     this.partitioner = dep.partitioner();

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -86,7 +86,7 @@ public class SparkUtils {
     return tmpCelebornConf;
   }
 
-  public static String genNewAppId(SparkContext context) {
+  public static String appUniqueId(SparkContext context) {
     return context
         .applicationAttemptId()
         .map(id -> context.applicationId() + "_" + id)

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleHandle.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleHandle.scala
@@ -23,7 +23,7 @@ import org.apache.spark.shuffle.BaseShuffleHandle
 import org.apache.celeborn.common.identity.UserIdentifier
 
 class RssShuffleHandle[K, V, C](
-    val newAppId: String,
+    val appUniqueId: String,
     val rssMetaServiceHost: String,
     val rssMetaServicePort: Int,
     val userIdentifier: UserIdentifier,

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
@@ -80,7 +80,7 @@ class RssShuffleReader[K, C](
       if (handle.numMappers > 0) {
         val start = System.currentTimeMillis()
         val inputStream = rssShuffleClient.readPartition(
-          handle.newAppId,
+          handle.appUniqueId,
           handle.shuffleId,
           partitionId,
           context.attemptNumber(),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename variable `newAppId` to `appUniqueId` in Spark client.

### Why are the changes needed?

Make the variable name intuitive.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass GA.

Closes #1565 from pan3793/CELEBORN-655.

Authored-by: Cheng Pan <chengpan@apache.org>
