### PR TITLE
[CELEBORN-657][BUG] DataPushQueue return task should always remove iterator

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -112,9 +112,11 @@ public class DataPushQueue {
               workerCapacity.put(loc.hostAndPushPort(), oldCapacity - 1);
             }
           } else {
+            iterator.remove();
             tasks.add(task);
           }
         } else {
+          iterator.remove();
           tasks.add(task);
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
 DataPushQueue return task should always remove iterator
Related to 
https://github.com/apache/incubator-celeborn/commit/251b923b5beb0bd13cdf8059a39edc7d6e435364
https://github.com/apache/incubator-celeborn/commit/cb19ed1c66a8ece834fc6aea10b8b57627d2eec6

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

