### PR TITLE
[CELEBORN-660][FLINK] Gen unique app id for Celeborn

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -60,7 +60,7 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
     this.shuffleMasterContext = shuffleMasterContext;
     this.resultPartitionDelegation = resultPartitionDelegation;
     this.rssMetaServiceTimestamp = System.currentTimeMillis();
-    this.celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, new JobID());
+    this.celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, JobID.generate());
     LOG.info("CelebornAppId: {}", celebornAppId);
   }
 

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -67,7 +67,8 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
     if (lifecycleManager == null) {
       synchronized (RemoteShuffleMaster.class) {
         if (lifecycleManager == null) {
-          // Use first none ZERO_JOB_ID as celeborn shared appId for all other flink jobs
+          // Workaround for FLINK-19358, use first none ZERO_JOB_ID as celeborn shared appId for all
+          // other flink jobs
           if (!ZERO_JOB_ID.equals(jobID)) {
             this.celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, jobID);
           } else {

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -71,7 +71,8 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
           if (!ZERO_JOB_ID.equals(jobID)) {
             this.celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, jobID);
           } else {
-            this.celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, JobID.generate());
+            this.celebornAppId =
+                FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, JobID.generate());
           }
 
           LOG.info("CelebornAppId: {}", celebornAppId);

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -38,7 +38,6 @@ import org.apache.celeborn.plugin.flink.utils.ThreadUtils;
 
 public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescriptor> {
   private static final Logger LOG = LoggerFactory.getLogger(RemoteShuffleMaster.class);
-  private static final JobID ZERO_JOB_ID = new JobID(0, 0);
   private final ShuffleMasterContext shuffleMasterContext;
   // Flink JobId -> Celeborn register shuffleIds
   private Map<JobID, Set<Integer>> jobShuffleIds = JavaUtils.newConcurrentHashMap();
@@ -67,15 +66,7 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
     if (lifecycleManager == null) {
       synchronized (RemoteShuffleMaster.class) {
         if (lifecycleManager == null) {
-          // Workaround for FLINK-19358, use first none ZERO_JOB_ID as celeborn shared appId for all
-          // other flink jobs
-          if (!ZERO_JOB_ID.equals(jobID)) {
-            this.celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, jobID);
-          } else {
-            this.celebornAppId =
-                FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, JobID.generate());
-          }
-
+          celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, jobID);
           LOG.info("CelebornAppId: {}", celebornAppId);
           CelebornConf celebornConf =
               FlinkUtils.toCelebornConf(shuffleMasterContext.getConfiguration());

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -60,6 +60,8 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
     this.shuffleMasterContext = shuffleMasterContext;
     this.resultPartitionDelegation = resultPartitionDelegation;
     this.rssMetaServiceTimestamp = System.currentTimeMillis();
+    this.celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, new JobID());
+    LOG.info("CelebornAppId: {}", celebornAppId);
   }
 
   @Override
@@ -69,7 +71,6 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
       synchronized (RemoteShuffleMaster.class) {
         if (lifecycleManager == null) {
           // use first jobID as celeborn shared appId for all other flink jobs
-          celebornAppId = FlinkUtils.toCelebornAppId(rssMetaServiceTimestamp, jobID);
           CelebornConf celebornConf =
               FlinkUtils.toCelebornConf(shuffleMasterContext.getConfiguration());
           // if not set, set to true as default for flink

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/utils/FlinkUtils.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.celeborn.common.CelebornConf;
 
 public class FlinkUtils {
-
+  private static final JobID ZERO_JOB_ID = new JobID(0, 0);
   public static final Set<String> pluginConfNames =
       new HashSet<String>() {
         {
@@ -59,7 +59,13 @@ public class FlinkUtils {
   }
 
   public static String toCelebornAppId(long rssMetaServiceTimestamp, JobID jobID) {
-    return rssMetaServiceTimestamp + "-" + jobID.toString();
+    // Workaround for FLINK-19358, use first none ZERO_JOB_ID as celeborn shared appId for all
+    // other flink jobs
+    if (!ZERO_JOB_ID.equals(jobID)) {
+      return rssMetaServiceTimestamp + "-" + jobID.toString();
+    }
+
+    return rssMetaServiceTimestamp + "-" + JobID.generate();
   }
 
   public static String toShuffleId(JobID jobID, IntermediateDataSetID dataSetID) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Use System.currentTimeMillis() + JobID.generate() as CelebornAppId.


### Why are the changes needed?
Flink Application mode with HA may use fixed id(00000000000000000000000000000000) as jobId. see [FLINK-19358](https://issues.apache.org/jira/browse/FLINK-19358).


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual
