### PR TITLE
[CELEBORN-661] Try avoid local blacklist when offer slots

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1040,7 +1040,8 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         lifecycleHost,
         pushReplicateEnabled,
         pushRackAwareEnabled,
-        userIdentifier)
+        userIdentifier,
+        workerStatusTracker.blacklist.keySet().asScala.toList.asJava)
     val res = requestMasterRequestSlots(req)
     if (res.status != StatusCode.SUCCESS) {
       requestMasterRequestSlots(req)

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1041,7 +1041,9 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
         pushReplicateEnabled,
         pushRackAwareEnabled,
         userIdentifier,
-        workerStatusTracker.blacklist.keySet().asScala.toList.asJava)
+        if (conf.clientRegisterShuffleAvoidLocalBlacklist)
+          workerStatusTracker.blacklist.keySet().asScala.toList.asJava
+        else new util.ArrayList[WorkerInfo]())
     val res = requestMasterRequestSlots(req)
     if (res.status != StatusCode.SUCCESS) {
       requestMasterRequestSlots(req)

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -183,6 +183,7 @@ message PbRequestSlots {
   int32 storageType = 7;
   PbUserIdentifier userIdentifier = 8;
   bool shouldRackAware = 9;
+  repeated PbWorkerInfo localBlacklist = 10;
 }
 
 message PbSlotInfo {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -654,6 +654,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   // //////////////////////////////////////////////////////
   def clientCloseIdleConnections: Boolean = get(CLIENT_CLOSE_IDLE_CONNECTIONS)
   def clientRegisterShuffleMaxRetry: Int = get(CLIENT_REGISTER_SHUFFLE_MAX_RETRIES)
+  def clientRegisterShuffleAvoidLocalBlacklist: Boolean =
+    get(CLIENT_REGISTER_SHUFFLE_AVOID_LOCAL_BLACKLIST)
   def clientRegisterShuffleRetryWaitMs: Long = get(CLIENT_REGISTER_SHUFFLE_RETRY_WAIT)
   def clientReserveSlotsRackAwareEnabled: Boolean = get(CLIENT_RESERVE_SLOTS_RACKAWARE_ENABLED)
   def clientReserveSlotsMaxRetries: Int = get(CLIENT_RESERVE_SLOTS_MAX_RETRIES)
@@ -2929,6 +2931,14 @@ object CelebornConf extends Logging {
       .doc("Max retry times for client to register shuffle.")
       .intConf
       .createWithDefault(3)
+
+  val CLIENT_REGISTER_SHUFFLE_AVOID_LOCAL_BLACKLIST: ConfigEntry[Boolean] =
+    buildConf("celeborn.client.registerShuffle.avoidLocalBlacklist")
+      .categories("client")
+      .version("0.3.0")
+      .doc("Whether to avoid workers in LifecycleManager's local blacklist when register shuffle.")
+      .booleanConf
+      .createWithDefault(true)
 
   val CLIENT_REGISTER_SHUFFLE_RETRY_WAIT: ConfigEntry[Long] =
     buildConf("celeborn.client.registerShuffle.retryWait")

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -168,6 +168,7 @@ object ControlMessages extends Logging {
       shouldReplicate: Boolean,
       shouldRackAware: Boolean,
       userIdentifier: UserIdentifier,
+      localBlacklist: util.List[WorkerInfo],
       override var requestId: String = ZERO_UUID)
     extends MasterRequestMessage
 
@@ -491,6 +492,7 @@ object ControlMessages extends Logging {
           shouldReplicate,
           shouldRackAware,
           userIdentifier,
+          localBlacklist,
           requestId) =>
       val payload = PbRequestSlots.newBuilder()
         .setApplicationId(applicationId)
@@ -501,6 +503,8 @@ object ControlMessages extends Logging {
         .setShouldRackAware(shouldRackAware)
         .setRequestId(requestId)
         .setUserIdentifier(PbSerDeUtils.toPbUserIdentifier(userIdentifier))
+        .addAllLocalBlacklist(localBlacklist.asScala.map(
+          PbSerDeUtils.toPbWorkerInfo(_, true)).toList.asJava)
         .build().toByteArray
       new TransportMessage(MessageType.REQUEST_SLOTS, payload)
 
@@ -880,6 +884,8 @@ object ControlMessages extends Logging {
           pbRequestSlots.getShouldReplicate,
           pbRequestSlots.getShouldRackAware,
           userIdentifier,
+          pbRequestSlots.getLocalBlacklistList.asScala.map(
+            PbSerDeUtils.fromPbWorkerInfo).toList.asJava,
           pbRequestSlots.getRequestId)
 
       case RELEASE_SLOTS =>

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -53,6 +53,7 @@ license: |
 | celeborn.client.push.stageEnd.timeout | &lt;value of celeborn.&lt;module&gt;.io.connectionTimeout&gt; | Timeout for waiting StageEnd. During this process, there are `celeborn.client.requestCommitFiles.maxRetries` times for retry opportunities for committing filesand 1 times for releasing slots request. User can customize this value according to your setting. By default, the value is the max timeout value `celeborn.<module>.io.connectionTimeout`. | 0.3.0 | 
 | celeborn.client.push.takeTaskMaxWaitAttempts | 1 | Max wait times if no task available to push to worker. | 0.3.0 | 
 | celeborn.client.push.takeTaskWaitInterval | 50ms | Wait interval if no task available to push to worker. | 0.3.0 | 
+| celeborn.client.registerShuffle.avoidLocalBlacklist | true | Whether to avoid workers in LifecycleManager's local blacklist when register shuffle. | 0.3.0 | 
 | celeborn.client.registerShuffle.maxRetries | 3 | Max retry times for client to register shuffle. | 0.3.0 | 
 | celeborn.client.registerShuffle.retryWait | 3s | Wait time before next retry if register shuffle failed. | 0.3.0 | 
 | celeborn.client.requestCommitFiles.maxRetries | 2 | Max retry times for requestCommitFiles RPC. | 0.3.0 | 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
In this PR, LifecycleManager passes local blacklist in ```RequestSlots```, master will try to avoid the workers in the blacklist when offer slots, and ignore the blacklist if offer slots fails.

### Why are the changes needed?
I was testing the case of three workers with replication on, and try to kill then start a worker without graceful shutdown, since master only considers a worker as lost after ```WORKER_HEARTBEAT_TIMEOUT```, which is default 120s, master will blindly assign slots to the dead worker, which causes further more revivings.
Before this PR, test time is ```245s```, after this PR, time is ```230s```.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual test.
