### PR TITLE
[CELEBORN-664][SPARK][PERF] Improve the perf of columnar shuffle write

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/sql/execution/columnar/RssColumnarBatchBuilder.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/sql/execution/columnar/RssColumnarBatchBuilder.scala
@@ -85,12 +85,16 @@ class RssColumnarBatchBuilder(
     val giantBuffer = new ByteArrayOutputStream
     val rowCntBytes = int2ByteArray(rowCnt)
     giantBuffer.write(rowCntBytes)
-    columnBuilders.foreach { builder =>
+    val builderLen = columnBuilders.length
+    var i = 0
+    while (i < builderLen) {
+      val builder = columnBuilders(i)
       val buffers = builder.build()
       val bytes = JavaUtils.bufferToArray(buffers)
       val columnBuilderBytes = int2ByteArray(bytes.length)
       giantBuffer.write(columnBuilderBytes)
       giantBuffer.write(bytes)
+      i += 1
     }
     giantBuffer.toByteArray
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

per https://github.com/databricks/scala-style-guide#traversal-and-zipwithindex, use `while` loop for performance-sensitive code

framegraph and shuffle write time before:

![截屏2023-06-12 下午4 18 24](https://github.com/apache/incubator-celeborn/assets/8537877/59d94e05-71b5-4474-bebe-66df554ccc48)

![截屏2023-06-12 下午4 19 56](https://github.com/apache/incubator-celeborn/assets/8537877/e24bb8b2-5b16-431b-92ae-cb8216e69d16)

framegraph and shuffle write time after:

![截屏2023-06-12 下午4 18 38](https://github.com/apache/incubator-celeborn/assets/8537877/18a84774-2197-487d-aa51-b33445619210)

![截屏2023-06-12 下午4 21 39](https://github.com/apache/incubator-celeborn/assets/8537877/26d95e5a-6e68-46b7-8c8c-49eb2d2e252f)

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

