### PR TITLE
[CELEBORN-668][FOLLOWUP] Handle unknown worker should also reply WorkerLostResponse

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -465,7 +465,7 @@ private[celeborn] class Master(
       logWarning(s"Unknown worker $host:$rpcPort:$pushPort:$fetchPort:$replicatePort" +
         s" for WorkerLost handler!")
       if (context != null) {
-        context.reply(WorkerLostResponse(false))
+        context.reply(WorkerLostResponse(true))
       }
     } else {
       statusSystem.handleWorkerLost(host, rpcPort, pushPort, fetchPort, replicatePort, requestId)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -464,13 +464,14 @@ private[celeborn] class Master(
     if (worker == null) {
       logWarning(s"Unknown worker $host:$rpcPort:$pushPort:$fetchPort:$replicatePort" +
         s" for WorkerLost handler!")
-      return
-    }
-
-    statusSystem.handleWorkerLost(host, rpcPort, pushPort, fetchPort, replicatePort, requestId)
-
-    if (context != null) {
-      context.reply(WorkerLostResponse(true))
+      if (context != null) {
+        context.reply(WorkerLostResponse(false))
+      }
+    } else {
+      statusSystem.handleWorkerLost(host, rpcPort, pushPort, fetchPort, replicatePort, requestId)
+      if (context != null) {
+        context.reply(WorkerLostResponse(true))
+      }
     }
   }
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -464,14 +464,11 @@ private[celeborn] class Master(
     if (worker == null) {
       logWarning(s"Unknown worker $host:$rpcPort:$pushPort:$fetchPort:$replicatePort" +
         s" for WorkerLost handler!")
-      if (context != null) {
-        context.reply(WorkerLostResponse(true))
-      }
     } else {
       statusSystem.handleWorkerLost(host, rpcPort, pushPort, fetchPort, replicatePort, requestId)
-      if (context != null) {
-        context.reply(WorkerLostResponse(true))
-      }
+    }
+    if (context != null) {
+      context.reply(WorkerLostResponse(true))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Now worker will send WorkLost too, master should also reply WorkerLostResponse when it's unknown worker


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

