### PR TITLE
[CELEBORN-673][SPARK][PERF] Improve the perf of sort-based shuffle write

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -200,6 +200,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     SQLMetric dataSize =
         SparkUtils.getUnsafeRowSerializerDataSizeMetric((UnsafeRowSerializer) dep.serializer());
 
+    long shuffleWriteTimeSum = 0L;
     while (records.hasNext()) {
       final Product2<Integer, UnsafeRow> record = records.next();
       final int partitionId = record._1();
@@ -211,6 +212,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         dataSize.add(serializedRecordSize);
       }
 
+      long insertAndPushStartTime = System.nanoTime();
       if (serializedRecordSize > pushBufferMaxSize) {
         byte[] giantBuffer = new byte[serializedRecordSize];
         Platform.putInt(giantBuffer, Platform.BYTE_ARRAY_OFFSET, Integer.reverseBytes(rowSize));
@@ -222,7 +224,6 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             rowSize);
         pushGiantRecord(partitionId, giantBuffer, serializedRecordSize);
       } else {
-        long insertStartTime = System.nanoTime();
         boolean success =
             currentPusher.insertRecord(
                 row.getBaseObject(), row.getBaseOffset(), rowSize, partitionId, true);
@@ -235,10 +236,11 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             throw new IOException("Unable to push after switching pusher!");
           }
         }
-        writeMetrics.incWriteTime(System.nanoTime() - insertStartTime);
       }
+      shuffleWriteTimeSum += System.nanoTime() - insertAndPushStartTime;
       tmpRecords[partitionId] += 1;
     }
+    writeMetrics.incWriteTime(shuffleWriteTimeSum);
   }
 
   private void pushAndSwitch() throws IOException {
@@ -254,6 +256,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private void write0(scala.collection.Iterator iterator) throws IOException {
     final scala.collection.Iterator<Product2<K, ?>> records = iterator;
 
+    long shuffleWriteTimeSum = 0L;
     while (records.hasNext()) {
       final Product2<K, ?> record = records.next();
       final K key = record._1();
@@ -266,10 +269,10 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       final int serializedRecordSize = serBuffer.size();
       assert (serializedRecordSize > 0);
 
+      long insertAndPushStartTime = System.nanoTime();
       if (serializedRecordSize > pushBufferMaxSize) {
         pushGiantRecord(partitionId, serBuffer.getBuf(), serializedRecordSize);
       } else {
-        long insertStartTime = System.nanoTime();
         boolean success =
             currentPusher.insertRecord(
                 serBuffer.getBuf(),
@@ -292,13 +295,14 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         }
         writeMetrics.incWriteTime(System.nanoTime() - insertStartTime);
       }
+      shuffleWriteTimeSum += System.nanoTime() - insertAndPushStartTime;
       tmpRecords[partitionId] += 1;
     }
+    writeMetrics.incWriteTime(shuffleWriteTimeSum);
   }
 
   private void pushGiantRecord(int partitionId, byte[] buffer, int numBytes) throws IOException {
     logger.debug("Push giant record, size {}.", Utils.bytesToString(numBytes));
-    long pushStartTime = System.nanoTime();
     int bytesWritten =
         rssShuffleClient.pushData(
             appId,
@@ -313,7 +317,6 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             numPartitions);
     mapStatusLengths[partitionId].add(bytesWritten);
     writeMetrics.incBytesWritten(bytesWritten);
-    writeMetrics.incWriteTime(System.nanoTime() - pushStartTime);
   }
 
   private void close() throws IOException {

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -293,7 +293,6 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             throw new IOException("Unable to push after switching pusher!");
           }
         }
-        writeMetrics.incWriteTime(System.nanoTime() - insertStartTime);
       }
       shuffleWriteTimeSum += System.nanoTime() - insertAndPushStartTime;
       tmpRecords[partitionId] += 1;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

1. `SQLShuffleWriteMetricsReporter#incWriteTime` is a performance killer, stop calling it once we insert a record
2. simplify the `incWriteTime` logic for handling large records, also including the time required for memory copying



### Why are the changes needed?

frame graph and stage duration before:

![截屏2023-06-13 下午3 30 53](https://github.com/apache/incubator-celeborn/assets/8537877/5fb0a242-82d1-4348-aeaa-4af75a012308)


![截屏2023-06-13 下午3 31 26](https://github.com/apache/incubator-celeborn/assets/8537877/3ded2f16-1c17-4120-8d10-31ea7b5182a2)

frame graph and stage duration after:

![截屏2023-06-13 下午3 33 08](https://github.com/apache/incubator-celeborn/assets/8537877/fbe45cf2-4d23-4d6c-a476-64338e1610f1)

![截屏2023-06-13 下午3 33 59](https://github.com/apache/incubator-celeborn/assets/8537877/9129d771-ad36-42e9-86b7-e454d2f8e0b0)

### Does this PR introduce _any_ user-facing change?

No, only perf improvement

### How was this patch tested?

tested locally.
