### PR TITLE
[CELEBORN-656] Batch revive RPCs in client to avoid too many requests

### DIFF
--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -86,7 +86,7 @@ if [ -z "$JAVA_HOME" ]; then
   exit -1
 fi
 
-MVN="$PROJECT_DIR/build/mvn"
+MVN="mvn"
 export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=1g}"
 
 if [ ! "$(command -v "$MVN")" ] ; then

--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -86,7 +86,7 @@ if [ -z "$JAVA_HOME" ]; then
   exit -1
 fi
 
-MVN="mvn"
+MVN="$PROJECT_DIR/build/mvn"
 export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=1g}"
 
 if [ ! "$(command -v "$MVN")" ] ; then

--- a/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
+++ b/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
@@ -50,7 +50,7 @@ class ReviveManager {
         () -> {
           Map<Integer, Set<ReviveRequest>> shuffleMap = new HashMap<>();
           int count = 0;
-          while (!requests.isEmpty()) {
+          do {
             ReviveRequest request = requests.poll();
             while (request != null && count < batchSize) {
               Set<ReviveRequest> set =
@@ -115,7 +115,9 @@ class ReviveManager {
                 }
               }
             }
-          }
+            // break the loop if remaining requests is less than half of
+            // `celeborn.client.push.revive.batchSize`
+          } while (requests.size() > batchSize / 2);
         },
         interval,
         interval,

--- a/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
+++ b/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
@@ -73,13 +73,15 @@ class ReviveManager {
               ArrayList<ReviveRequest> filteredRequests = new ArrayList<>();
               Map<Integer, ReviveRequest> requestsToSend = new HashMap<>();
 
-              Map<Integer, PartitionLocation> partitionMap = shuffleClient.reducePartitionMap.get(shuffleId);
+              Map<Integer, PartitionLocation> partitionMap =
+                  shuffleClient.reducePartitionMap.get(shuffleId);
               // Insert request that is not MapperEnded and with the max epoch
               // into requestsToSend
               Iterator<ReviveRequest> iter = requests.iterator();
               while (iter.hasNext()) {
                 ReviveRequest req = iter.next();
-                if (shuffleClient.checkRevivedLocation(partitionMap, req.partitionId, req.epoch, false)
+                if (shuffleClient.checkRevivedLocation(
+                        partitionMap, req.partitionId, req.epoch, false)
                     || shuffleClient.mapperEnded(shuffleId, req.mapId)) {
                   req.reviveStatus = StatusCode.SUCCESS.getValue();
                 } else {

--- a/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
+++ b/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.client;
+
+import java.util.*;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.protocol.PartitionLocation;
+import org.apache.celeborn.common.protocol.ReviveRequest;
+import org.apache.celeborn.common.protocol.message.StatusCode;
+import org.apache.celeborn.common.util.ThreadUtils;
+
+class ReviveManager {
+  private static final Logger logger = LoggerFactory.getLogger(ShuffleClientImpl.class);
+
+  LinkedBlockingQueue<ReviveRequest> requests = new LinkedBlockingQueue<>();
+  ShuffleClientImpl shuffleClient;
+  private ScheduledExecutorService batchReviveRequestScheduler =
+      ThreadUtils.newDaemonSingleThreadScheduledExecutor("batch-revive-scheduler");
+
+  public ReviveManager(ShuffleClientImpl shuffleClient) {
+    this.shuffleClient = shuffleClient;
+
+    batchReviveRequestScheduler.scheduleAtFixedRate(
+        () -> {
+          Map<Integer, Set<ReviveRequest>> shuffleMap = new HashMap<>();
+          int count = 0;
+          ReviveRequest request = requests.poll();
+          while (request != null && count < 1000) {
+            Set<ReviveRequest> set =
+                shuffleMap.computeIfAbsent(request.shuffleId, id -> new HashSet<>());
+            set.add(request);
+            count++;
+            request = requests.poll();
+          }
+          if (request != null) {
+            Set<ReviveRequest> set =
+                shuffleMap.computeIfAbsent(request.shuffleId, id -> new HashSet<>());
+            set.add(request);
+            count++;
+          }
+          for (Map.Entry<Integer, Set<ReviveRequest>> shuffleEntry : shuffleMap.entrySet()) {
+            // Call reviveBatch for requests in the same (appId, shuffleId)
+            int shuffleId = shuffleEntry.getKey();
+            Set<ReviveRequest> requests = shuffleEntry.getValue();
+            Set<Integer> mapIds = new HashSet<>();
+            ArrayList<ReviveRequest> filteredRequests = new ArrayList<>();
+            Map<Integer, ReviveRequest> requestsToSend = new HashMap<>();
+
+            // Insert request that is not MapperEnded and with the max epoch
+            // into requestsToSend
+            Iterator<ReviveRequest> iter = requests.iterator();
+            while (iter.hasNext()) {
+              ReviveRequest req = iter.next();
+              if (shuffleClient.checkRevivedLocation(shuffleId, req.partitionId, req.epoch, false)
+                  || shuffleClient.mapperEnded(shuffleId, req.mapId)) {
+                req.reviveStatus = StatusCode.SUCCESS.getValue();
+              } else {
+                filteredRequests.add(req);
+                mapIds.add(req.mapId);
+                PartitionLocation loc = req.loc;
+                if (!requestsToSend.containsKey(req.partitionId)
+                    || requestsToSend.get(req.partitionId).epoch < req.epoch) {
+                  requestsToSend.put(req.partitionId, req);
+                }
+              }
+            }
+
+            if (!requestsToSend.isEmpty()) {
+              // Call reviveBatch. Return null means Exception caught or
+              // SHUFFLE_NOT_REGISTERED
+              Map<Integer, Integer> results =
+                  shuffleClient.reviveBatch(shuffleId, mapIds, requestsToSend.values());
+              if (results == null) {
+                for (ReviveRequest req : filteredRequests) {
+                  req.reviveStatus = StatusCode.REVIVE_FAILED.getValue();
+                }
+              } else {
+                for (ReviveRequest req : filteredRequests) {
+                  if (shuffleClient.mapperEnded(shuffleId, req.mapId)) {
+                    req.reviveStatus = StatusCode.SUCCESS.getValue();
+                  } else {
+                    req.reviveStatus = results.get(req.partitionId);
+                  }
+                }
+              }
+            }
+          }
+        },
+        100,
+        100,
+        TimeUnit.MILLISECONDS);
+  }
+
+  public void addRequest(ReviveRequest request) {
+    shuffleClient.excludeWorkerByCause(request.cause, request.loc);
+    // This sync is necessary to ensure the add action is atomic
+    try {
+      requests.put(request);
+    } catch (InterruptedException e) {
+      logger.error("Exception when put into requests!", e);
+    }
+  }
+}

--- a/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
+++ b/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
@@ -73,12 +73,13 @@ class ReviveManager {
               ArrayList<ReviveRequest> filteredRequests = new ArrayList<>();
               Map<Integer, ReviveRequest> requestsToSend = new HashMap<>();
 
+              Map<Integer, PartitionLocation> partitionMap = shuffleClient.reducePartitionMap.get(shuffleId);
               // Insert request that is not MapperEnded and with the max epoch
               // into requestsToSend
               Iterator<ReviveRequest> iter = requests.iterator();
               while (iter.hasNext()) {
                 ReviveRequest req = iter.next();
-                if (shuffleClient.checkRevivedLocation(shuffleId, req.partitionId, req.epoch, false)
+                if (shuffleClient.checkRevivedLocation(partitionMap, req.partitionId, req.epoch, false)
                     || shuffleClient.mapperEnded(shuffleId, req.mapId)) {
                   req.reviveStatus = StatusCode.SUCCESS.getValue();
                 } else {

--- a/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
+++ b/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
@@ -52,12 +52,11 @@ class ReviveManager {
           do {
             ArrayList<ReviveRequest> batchRequests = new ArrayList<>();
             requestQueue.drainTo(batchRequests, batchSize);
-            batchRequests.forEach(
-                (req) -> {
-                  Set<ReviveRequest> set =
-                      shuffleMap.computeIfAbsent(req.shuffleId, id -> new HashSet<>());
-                  set.add(req);
-                });
+            for (ReviveRequest req in batchRequests) {
+              Set<ReviveRequest> set =
+                  shuffleMap.computeIfAbsent(req.shuffleId, id -> new HashSet<>());
+              set.add(req);
+            }
             for (Map.Entry<Integer, Set<ReviveRequest>> shuffleEntry : shuffleMap.entrySet()) {
               // Call reviveBatch for requests in the same (appId, shuffleId)
               int shuffleId = shuffleEntry.getKey();

--- a/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
+++ b/client/src/main/java/org/apache/celeborn/client/ReviveManager.java
@@ -52,7 +52,7 @@ class ReviveManager {
           do {
             ArrayList<ReviveRequest> batchRequests = new ArrayList<>();
             requestQueue.drainTo(batchRequests, batchSize);
-            for (ReviveRequest req in batchRequests) {
+            for (ReviveRequest req : batchRequests) {
               Set<ReviveRequest> set =
                   shuffleMap.computeIfAbsent(req.shuffleId, id -> new HashSet<>());
               set.add(req);

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -111,13 +111,15 @@ public class ShuffleClientImpl extends ShuffleClient {
 
   protected final String appUniqueId;
 
-  ThreadLocal<Compressor> compressorThreadLocal =
+  private ThreadLocal<Compressor> compressorThreadLocal =
       new ThreadLocal<Compressor>() {
         @Override
         protected Compressor initialValue() {
           return Compressor.getCompressor(conf);
         }
       };
+
+  private final ReviveManager reviveManager = new ReviveManager(this);
 
   protected static class ReduceFileGroups {
     public Map<Integer, Set<PartitionLocation>> partitionGroups;
@@ -206,20 +208,34 @@ public class ShuffleClientImpl extends ShuffleClient {
 
   private void submitRetryPushData(
       int shuffleId,
-      int mapId,
-      int attemptId,
       byte[] body,
       int batchId,
-      PartitionLocation loc,
       RpcResponseCallback wrappedCallback,
       PushState pushState,
-      StatusCode cause,
+      ReviveRequest request,
       int remainReviveTimes) {
+    int mapId = request.mapId;
+    int attemptId = request.attemptId;
+    PartitionLocation loc = request.loc;
+    StatusCode cause = request.cause;
     int partitionId = loc.getId();
-    if (!revive(shuffleId, mapId, attemptId, partitionId, loc.getEpoch(), loc, cause)) {
-      wrappedCallback.onFailure(
-          new CelebornIOException(cause + " then revive but " + StatusCode.REVIVE_FAILED));
-    } else if (mapperEnded(shuffleId, mapId)) {
+    long reviveWaitTime =
+        conf.clientRpcRequestPartitionLocationRpcAskTimeout().duration().toMillis() + 1000;
+    final long delta = 50;
+    long accumulatedTime = 0;
+    while (request.reviveStatus == StatusCode.REVIVE_INITIALIZED.getValue()
+        && accumulatedTime <= reviveWaitTime) {
+      try {
+        Thread.sleep(delta);
+        accumulatedTime += delta;
+      } catch (InterruptedException e) {
+        logger.error("Interrupted while waiting for Revive result!");
+        wrappedCallback.onFailure(
+            new CelebornIOException(cause + " then revive but " + StatusCode.REVIVE_FAILED));
+        return;
+      }
+    }
+    if (mapperEnded(shuffleId, mapId)) {
       logger.debug(
           "Revive for push data success, but the mapper already ended for shuffle {} map {} attempt {} partition {} batch {} location {}.",
           shuffleId,
@@ -229,6 +245,14 @@ public class ShuffleClientImpl extends ShuffleClient {
           batchId,
           loc);
       pushState.removeBatch(batchId, loc.hostAndPushPort());
+    } else if (request.reviveStatus != StatusCode.SUCCESS.getValue()) {
+      wrappedCallback.onFailure(
+          new CelebornIOException(
+              cause
+                  + " then revive but "
+                  + StatusCode.REVIVE_FAILED
+                  + ", revive status "
+                  + request.reviveStatus));
     } else {
       PartitionLocation newLoc = reducePartitionMap.get(shuffleId).get(partitionId);
       logger.info(
@@ -272,6 +296,24 @@ public class ShuffleClientImpl extends ShuffleClient {
     }
   }
 
+  public ReviveRequest[] addAndGetReviveRequests(
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      ArrayList<DataBatches.DataBatch> batches,
+      StatusCode cause) {
+    ReviveRequest[] reviveRequests = new ReviveRequest[batches.size()];
+    for (int i = 0; i < batches.size(); i++) {
+      DataBatches.DataBatch batch = batches.get(i);
+      PartitionLocation loc = batch.loc;
+      ReviveRequest reviveRequest =
+          new ReviveRequest(shuffleId, mapId, attemptId, loc.getId(), loc.getEpoch(), loc, cause);
+      reviveManager.addRequest(reviveRequest);
+      reviveRequests[i] = reviveRequest;
+    }
+    return reviveRequests;
+  }
+
   private void submitRetryPushMergedData(
       PushState pushState,
       int shuffleId,
@@ -280,49 +322,77 @@ public class ShuffleClientImpl extends ShuffleClient {
       ArrayList<DataBatches.DataBatch> batches,
       StatusCode cause,
       Integer oldGroupedBatchId,
+      ReviveRequest[] reviveRequests,
       int remainReviveTimes) {
     HashMap<String, DataBatches> newDataBatchesMap = new HashMap<>();
     ArrayList<DataBatches.DataBatch> reviveFailedBatchesMap = new ArrayList<>();
-    for (DataBatches.DataBatch batch : batches) {
-      int partitionId = batch.loc.getId();
-      if (!revive(
-          shuffleId, mapId, attemptId, partitionId, batch.loc.getEpoch(), batch.loc, cause)) {
 
-        if (remainReviveTimes > 0) {
-          reviveFailedBatchesMap.add(batch);
+    long reviveWaitTime =
+        conf.clientRpcRequestPartitionLocationRpcAskTimeout().duration().toMillis() + 1000;
+    final long delta = 50;
+    long accumulatedTime = 0;
+    int index = 0;
+    while (index < reviveRequests.length && accumulatedTime <= reviveWaitTime) {
+      ReviveRequest request = reviveRequests[index];
+      DataBatches.DataBatch batch = batches.get(index);
+      if (request.reviveStatus != StatusCode.REVIVE_INITIALIZED.getValue()) {
+        if (mapperEnded(shuffleId, mapId)) {
+          logger.debug(
+              "Revive for push merged data success, but the mapper already ended for shuffle {} map {} attempt {} partition {} batch {}.",
+              shuffleId,
+              mapId,
+              attemptId,
+              request.partitionId,
+              oldGroupedBatchId);
+        } else if (request.reviveStatus == StatusCode.SUCCESS.getValue()) {
+          PartitionLocation newLoc = reducePartitionMap.get(shuffleId).get(request.partitionId);
+          DataBatches newDataBatches =
+              newDataBatchesMap.computeIfAbsent(genAddressPair(newLoc), (s) -> new DataBatches());
+          newDataBatches.addDataBatch(newLoc, batch.batchId, batch.body);
         } else {
-          String errorMsg =
-              String.format(
-                  "Revive failed while pushing merged for shuffle %d map %d attempt %d partition %d batch %d location %s.",
-                  shuffleId, mapId, attemptId, partitionId, oldGroupedBatchId, batch.loc);
-          pushState.exception.compareAndSet(
-              null,
-              new CelebornIOException(
-                  errorMsg,
-                  new CelebornIOException(cause + " then revive but " + StatusCode.REVIVE_FAILED)));
-          return;
+          if (remainReviveTimes > 0) {
+            reviveFailedBatchesMap.add(batch);
+          } else {
+            String errorMsg =
+                String.format(
+                    "Revive failed while pushing merged for shuffle %d map %d attempt %d partition %d batch %d location %s.",
+                    shuffleId, mapId, attemptId, request.partitionId, oldGroupedBatchId, batch.loc);
+            pushState.exception.compareAndSet(
+                null,
+                new CelebornIOException(
+                    errorMsg,
+                    new CelebornIOException(
+                        cause + " then revive but " + StatusCode.REVIVE_FAILED)));
+            return;
+          }
         }
-      } else if (mapperEnded(shuffleId, mapId)) {
-        logger.debug(
-            "Revive for push merged data success, but the mapper already ended for shuffle {} map {} attempt {} partition {} batch {}.",
-            shuffleId,
-            mapId,
-            attemptId,
-            partitionId,
-            oldGroupedBatchId);
+        index++;
       } else {
-        PartitionLocation newLoc = reducePartitionMap.get(shuffleId).get(partitionId);
-        logger.info(
-            "Revive for push merged data success, new location for shuffle {} map {} attempt {} partition {} batch {} is location {}.",
-            shuffleId,
-            mapId,
-            attemptId,
-            partitionId,
-            oldGroupedBatchId,
-            newLoc);
-        DataBatches newDataBatches =
-            newDataBatchesMap.computeIfAbsent(genAddressPair(newLoc), (s) -> new DataBatches());
-        newDataBatches.addDataBatch(newLoc, batch.batchId, batch.body);
+        try {
+          Thread.sleep(delta);
+        } catch (InterruptedException e) {
+          logger.warn("Interrupted while waiting for Revive result!");
+        }
+        accumulatedTime += delta;
+      }
+    }
+
+    for (int i = index; i < reviveRequests.length; i++) {
+      ReviveRequest request = reviveRequests[index];
+      DataBatches.DataBatch batch = batches.get(i);
+      if (remainReviveTimes > 0) {
+        reviveFailedBatchesMap.add(batch);
+      } else {
+        String errorMsg =
+            String.format(
+                "Revive failed while pushing merged for shuffle %d map %d attempt %d partition %d batch %d location %s.",
+                shuffleId, mapId, attemptId, request.partitionId, oldGroupedBatchId, batch.loc);
+        pushState.exception.compareAndSet(
+            null,
+            new CelebornIOException(
+                errorMsg,
+                new CelebornIOException(cause + " then revive but " + StatusCode.REVIVE_FAILED)));
+        return;
       }
     }
 
@@ -341,6 +411,8 @@ public class ShuffleClientImpl extends ShuffleClient {
     if (reviveFailedBatchesMap.isEmpty()) {
       pushState.removeBatch(oldGroupedBatchId, batches.get(0).loc.hostAndPushPort());
     } else {
+      ReviveRequest[] requests =
+          addAndGetReviveRequests(shuffleId, mapId, attemptId, reviveFailedBatchesMap, cause);
       pushDataRetryPool.submit(
           () ->
               submitRetryPushMergedData(
@@ -351,6 +423,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                   reviveFailedBatchesMap,
                   cause,
                   oldGroupedBatchId,
+                  requests,
                   remainReviveTimes - 1));
     }
   }
@@ -495,35 +568,30 @@ public class ShuffleClientImpl extends ShuffleClient {
     }
   }
 
-  private boolean waitRevivedLocation(
-      ConcurrentHashMap<Integer, PartitionLocation> map, int partitionId, int epoch) {
+  boolean checkRevivedLocation(int shuffleId, int partitionId, int epoch, boolean wait) {
+    ConcurrentHashMap<Integer, PartitionLocation> map = reducePartitionMap.get(shuffleId);
     PartitionLocation currentLocation = map.get(partitionId);
     if (currentLocation != null && currentLocation.getEpoch() > epoch) {
       return true;
-    }
-
-    long sleepTimeMs = RND.nextInt(50);
-    if (sleepTimeMs > 30) {
-      try {
-        TimeUnit.MILLISECONDS.sleep(sleepTimeMs);
-      } catch (InterruptedException e) {
-        logger.error("Waiting revived location was interrupted.", e);
-        Thread.currentThread().interrupt();
+    } else if (wait) {
+      long sleepTimeMs = RND.nextInt(50);
+      if (sleepTimeMs > 30) {
+        try {
+          TimeUnit.MILLISECONDS.sleep(sleepTimeMs);
+        } catch (InterruptedException e) {
+          logger.error("Waiting revived location was interrupted.", e);
+          Thread.currentThread().interrupt();
+        }
       }
-    }
 
-    currentLocation = map.get(partitionId);
-    return currentLocation != null && currentLocation.getEpoch() > epoch;
+      currentLocation = map.get(partitionId);
+      return currentLocation != null && currentLocation.getEpoch() > epoch;
+    } else {
+      return false;
+    }
   }
 
-  private boolean revive(
-      int shuffleId,
-      int mapId,
-      int attemptId,
-      int partitionId,
-      int epoch,
-      PartitionLocation oldLocation,
-      StatusCode cause) {
+  void excludeWorkerByCause(StatusCode cause, PartitionLocation oldLocation) {
     // Add ShuffleClient side blacklist
     if (shuffleClientPushBlacklistEnabled && oldLocation != null) {
       if (cause == StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_MASTER) {
@@ -540,18 +608,26 @@ public class ShuffleClientImpl extends ShuffleClient {
         blacklist.add(oldLocation.getPeer().hostAndPushPort());
       }
     }
+  }
 
-    ConcurrentHashMap<Integer, PartitionLocation> map = reducePartitionMap.get(shuffleId);
-    if (waitRevivedLocation(map, partitionId, epoch)) {
-      logger.debug(
-          "Revive already success for shuffle {} map {} attempt {} partition {} epoch {}, just return true(Assume revive successfully).",
-          shuffleId,
-          mapId,
-          attemptId,
-          partitionId,
-          epoch);
-      return true;
-    }
+  private boolean revive(
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int partitionId,
+      int epoch,
+      PartitionLocation oldLocation,
+      StatusCode cause) {
+    excludeWorkerByCause(cause, oldLocation);
+
+    Set<Integer> mapIds = new HashSet<>();
+    mapIds.add(mapId);
+    List<ReviveRequest> requests = new ArrayList<>();
+    ReviveRequest req =
+        new ReviveRequest(shuffleId, mapId, attemptId, partitionId, epoch, oldLocation, cause);
+    requests.add(req);
+    Map<Integer, Integer> results = reviveBatch(shuffleId, mapIds, requests);
+
     if (mapperEnded(shuffleId, mapId)) {
       logger.debug(
           "Revive success, but the mapper ended for shuffle {} map {} attempt {} partition {}, just return true(Assume revive successfully).",
@@ -560,48 +636,78 @@ public class ShuffleClientImpl extends ShuffleClient {
           attemptId,
           partitionId);
       return true;
+    } else if (results == null || results.get(partitionId) != StatusCode.SUCCESS.getValue()) {
+      return false;
+    } else {
+      return true;
     }
+  }
 
+  /** @return partitionId -> StatusCode#getValue */
+  Map<Integer, Integer> reviveBatch(
+      int shuffleId, Set<Integer> mapIds, Collection<ReviveRequest> requests) {
+    // partitionId -> StatusCode#getValue
+    Map<Integer, Integer> results = new HashMap<>();
+
+    ConcurrentHashMap<Integer, PartitionLocation> map = reducePartitionMap.get(shuffleId);
+
+    Map<Integer, PartitionLocation> oldLocMap = new HashMap<>();
+    Iterator<ReviveRequest> iter = requests.iterator();
+    while (iter.hasNext()) {
+      ReviveRequest req = iter.next();
+      oldLocMap.put(req.partitionId, req.loc);
+    }
     try {
       PbChangeLocationResponse response =
           driverRssMetaService.askSync(
-              Revive$.MODULE$.apply(
-                  shuffleId, mapId, attemptId, partitionId, epoch, oldLocation, cause),
+              Revive$.MODULE$.apply(shuffleId, mapIds, requests),
               conf.clientRpcRequestPartitionLocationRpcAskTimeout(),
               ClassTag$.MODULE$.apply(PbChangeLocationResponse.class));
-      // per partitionKey only serve single PartitionLocation in Client Cache.
-      StatusCode respStatus = Utils.toStatusCode(response.getStatus());
-      if (response.getAvailable()) {
-        blacklist.remove(oldLocation.hostAndPushPort());
-      }
-      if (StatusCode.SUCCESS.equals(respStatus)) {
-        PartitionLocation newLocation =
-            PbSerDeUtils.fromPbPartitionLocation(response.getLocation());
-        map.put(partitionId, newLocation);
-        blacklist.remove(newLocation.hostAndPushPort());
-        return true;
-      } else if (StatusCode.MAP_ENDED.equals(respStatus)) {
-        logger.debug(
-            "Revive success, but the mapper ended for shuffle {} map {} attempt {} partition {}, just return true(Assume revive successfully).",
-            shuffleId,
-            mapId,
-            attemptId,
-            partitionId);
+
+      for (int i = 0; i < response.getEndedMapIdCount(); i++) {
+        int mapId = response.getEndedMapId(i);
         mapperEndMap.computeIfAbsent(shuffleId, (id) -> ConcurrentHashMap.newKeySet()).add(mapId);
-        return true;
-      } else {
-        return false;
       }
+
+      for (int i = 0; i < response.getPartitionInfoCount(); i++) {
+        PbChangeLocationPartitionInfo partitionInfo = response.getPartitionInfo(i);
+        int partitionId = partitionInfo.getPartitionId();
+        int statusCode = partitionInfo.getStatus();
+        if (partitionInfo.getOldAvailable()) {
+          blacklist.remove(oldLocMap.get(partitionId).hostAndPushPort());
+        }
+
+        if (StatusCode.SUCCESS.getValue() == statusCode) {
+          PartitionLocation loc =
+              PbSerDeUtils.fromPbPartitionLocation(partitionInfo.getPartition());
+          map.put(partitionId, loc);
+          blacklist.remove(loc.hostAndPushPort());
+        } else if (StatusCode.STAGE_ENDED.getValue() == statusCode) {
+          stageEnded(shuffleId);
+          return results;
+        } else if (StatusCode.SHUFFLE_NOT_REGISTERED.getValue() == statusCode) {
+          logger.error("SHUFFLE_NOT_REGISTERED!");
+          return null;
+        }
+        results.put(partitionId, statusCode);
+      }
+
+      return results;
     } catch (Exception e) {
+      StringBuilder partitionIds = new StringBuilder();
+      StringBuilder epochs = new StringBuilder();
+      requests.forEach(
+          (req) -> {
+            partitionIds.append(req.partitionId).append(",");
+            epochs.append(req.epoch).append(",");
+          });
       logger.error(
-          "Exception raised while reviving for shuffle {} map {} attempt {} partition {} epoch {}.",
+          "Exception raised while reviving for shuffle {} partitionIds {} epochs {}.",
           shuffleId,
-          mapId,
-          attemptId,
-          partitionId,
-          epoch,
+          partitionIds,
+          epochs,
           e);
-      return false;
+      return null;
     }
   }
 
@@ -770,18 +876,25 @@ public class ShuffleClientImpl extends ShuffleClient {
                       attemptId,
                       partitionId,
                       nextBatchId);
+                  ReviveRequest reviveRequest =
+                      new ReviveRequest(
+                          shuffleId,
+                          mapId,
+                          attemptId,
+                          partitionId,
+                          loc.getEpoch(),
+                          loc,
+                          StatusCode.HARD_SPLIT);
+                  reviveManager.addRequest(reviveRequest);
                   pushDataRetryPool.submit(
                       () ->
                           submitRetryPushData(
                               shuffleId,
-                              mapId,
-                              attemptId,
                               body,
                               nextBatchId,
-                              loc,
                               this,
                               pushState,
-                              StatusCode.HARD_SPLIT,
+                              reviveRequest,
                               remainReviveTimes));
                 } else if (reason == StatusCode.PUSH_DATA_SUCCESS_MASTER_CONGESTED.getValue()) {
                   logger.debug(
@@ -850,18 +963,19 @@ public class ShuffleClientImpl extends ShuffleClient {
                 if (!pushStatusIsBlacklisted(cause)) {
                   remainReviveTimes = remainReviveTimes - 1;
                 }
+                ReviveRequest reviveRequest =
+                    new ReviveRequest(
+                        shuffleId, mapId, attemptId, partitionId, loc.getEpoch(), loc, cause);
+                reviveManager.addRequest(reviveRequest);
                 pushDataRetryPool.submit(
                     () ->
                         submitRetryPushData(
                             shuffleId,
-                            mapId,
-                            attemptId,
                             body,
                             nextBatchId,
-                            loc,
                             this,
                             pushState,
-                            cause,
+                            reviveRequest,
                             remainReviveTimes));
               } else {
                 pushState.removeBatch(nextBatchId, loc.hostAndPushPort());
@@ -1138,6 +1252,10 @@ public class ShuffleClientImpl extends ShuffleClient {
                     Arrays.toString(partitionIds),
                     groupedBatchId,
                     Arrays.toString(batchIds));
+
+                ReviveRequest[] requests =
+                    addAndGetReviveRequests(
+                        shuffleId, mapId, attemptId, batches, StatusCode.HARD_SPLIT);
                 pushDataRetryPool.submit(
                     () ->
                         submitRetryPushMergedData(
@@ -1148,6 +1266,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                             batches,
                             StatusCode.HARD_SPLIT,
                             groupedBatchId,
+                            requests,
                             remainReviveTimes));
               } else if (reason == StatusCode.PUSH_DATA_SUCCESS_MASTER_CONGESTED.getValue()) {
                 logger.debug(
@@ -1218,6 +1337,9 @@ public class ShuffleClientImpl extends ShuffleClient {
                 tmpRemainReviveTimes = tmpRemainReviveTimes - 1;
               }
               int finalRemainReviveTimes = tmpRemainReviveTimes;
+
+              ReviveRequest[] requests =
+                  addAndGetReviveRequests(shuffleId, mapId, attemptId, batches, cause);
               pushDataRetryPool.submit(
                   () ->
                       submitRetryPushMergedData(
@@ -1228,6 +1350,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                           batches,
                           cause,
                           groupedBatchId,
+                          requests,
                           finalRemainReviveTimes));
             } else {
               pushState.removeBatch(groupedBatchId, hostPort);
@@ -1471,7 +1594,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     driverRssMetaService = endpointRef;
   }
 
-  protected boolean mapperEnded(int shuffleId, int mapId) {
+  boolean mapperEnded(int shuffleId, int mapId) {
     return (mapperEndMap.containsKey(shuffleId) && mapperEndMap.get(shuffleId).contains(mapId))
         || stageEnded(shuffleId);
   }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -119,7 +119,7 @@ public class ShuffleClientImpl extends ShuffleClient {
         }
       };
 
-  private final ReviveManager reviveManager = new ReviveManager(this);
+  private final ReviveManager reviveManager = new ReviveManager(this, conf);
 
   protected static class ReduceFileGroups {
     public Map<Integer, Set<PartitionLocation>> partitionGroups;
@@ -230,9 +230,7 @@ public class ShuffleClientImpl extends ShuffleClient {
         accumulatedTime += delta;
       } catch (InterruptedException e) {
         logger.error("Interrupted while waiting for Revive result!");
-        wrappedCallback.onFailure(
-            new CelebornIOException(cause + " then revive but " + StatusCode.REVIVE_FAILED));
-        return;
+        Thread.currentThread().interrupt();
       }
     }
     if (mapperEnded(shuffleId, mapId)) {
@@ -371,7 +369,8 @@ public class ShuffleClientImpl extends ShuffleClient {
         try {
           Thread.sleep(delta);
         } catch (InterruptedException e) {
-          logger.warn("Interrupted while waiting for Revive result!");
+          logger.error("Interrupted while waiting for Revive result!");
+          Thread.currentThread().interrupt();
         }
         accumulatedTime += delta;
       }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -568,7 +568,8 @@ public class ShuffleClientImpl extends ShuffleClient {
     }
   }
 
-  boolean checkRevivedLocation(Map<Integer, PartitionLocation> shuffleMap, int partitionId, int epoch, boolean wait) {
+  boolean checkRevivedLocation(
+      Map<Integer, PartitionLocation> shuffleMap, int partitionId, int epoch, boolean wait) {
     PartitionLocation currentLocation = shuffleMap.get(partitionId);
     if (currentLocation != null && currentLocation.getEpoch() > epoch) {
       return true;

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -161,6 +161,7 @@ class ChangePartitionManager(
         // Else register and allocate for it.
         getLatestPartition(shuffleId, partitionId, oldEpoch).foreach { latestLoc =>
           context.reply(
+            partitionId,
             StatusCode.SUCCESS,
             Some(latestLoc),
             lifecycleManager.workerStatusTracker.workerAvailable(oldPartition))
@@ -224,12 +225,12 @@ class ChangePartitionManager(
           location -> Option(requestsMap.remove(location.getId))
         }
       }.foreach { case (newLocation, requests) =>
-        requests.foreach(_.asScala.foreach { req =>
+        requests.map(_.asScala.toList.foreach(req =>
           req.context.reply(
+            req.partitionId,
             StatusCode.SUCCESS,
             Option(newLocation),
-            lifecycleManager.workerStatusTracker.workerAvailable(req.oldPartition))
-        })
+            lifecycleManager.workerStatusTracker.workerAvailable(req.oldPartition))))
       }
     }
 
@@ -245,6 +246,7 @@ class ChangePartitionManager(
       }.foreach { requests =>
         requests.map(_.asScala.toList.foreach(req =>
           req.context.reply(
+            req.partitionId,
             status,
             None,
             lifecycleManager.workerStatusTracker.workerAvailable(req.oldPartition))))

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -75,10 +75,10 @@ class ChangePartitionManager(
           override def run(): Unit = {
             try {
               changePartitionRequests.asScala.foreach { case (shuffleId, requests) =>
-                requests.synchronized {
-                  batchHandleChangePartitionExecutors.submit {
-                    new Runnable {
-                      override def run(): Unit = {
+                batchHandleChangePartitionExecutors.submit {
+                  new Runnable {
+                    override def run(): Unit = {
+                      requests.synchronized {
                         // For each partition only need handle one request
                         val distinctPartitions = requests.asScala.filter { case (partitionId, _) =>
                           !inBatchPartitions.get(shuffleId).contains(partitionId)

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -238,10 +238,10 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       val mapIds = pb.getMapIdList
       val partitionInfos = pb.getPartitionInfoList
 
-      val partitionIds = new util.ArrayList[Integer](partitionInfos.size)
-      val epochs = new util.ArrayList[Integer](partitionInfos.size())
-      val oldPartitions = new util.ArrayList[PartitionLocation](partitionInfos.size());
-      val causes = new util.ArrayList[StatusCode](partitionInfos.size());
+      val partitionIds = new util.ArrayList[Integer]()
+      val epochs = new util.ArrayList[Integer]()
+      val oldPartitions = new util.ArrayList[PartitionLocation]()
+      val causes = new util.ArrayList[StatusCode]()
       (0 until partitionInfos.size()).foreach { idx =>
         val info = partitionInfos.get(idx)
         partitionIds.add(info.getPartitionId)

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -518,15 +518,15 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       return
     }
 
-    mapIds.asScala foreach (mapId => {
+    mapIds.asScala.foreach { mapId =>
       if (commitManager.isMapperEnded(shuffleId, mapId)) {
         logWarning(s"[handleRevive] Mapper ended, mapId $mapId, ended attemptId ${commitManager.getMapperAttempts(
           shuffleId)(mapId)}, shuffleId $shuffleId")
         contextWrapper.markMapperEnd(mapId)
       }
-    })
+    }
 
-    0 until partitionIds.size() foreach (idx => {
+    (0 until partitionIds.size()).foreach { idx =>
       changePartitionManager.handleRequestPartitionLocation(
         contextWrapper,
         shuffleId,
@@ -534,7 +534,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         oldEpochs.get(idx),
         oldPartitions.get(idx),
         Some(causes.get(idx)))
-    })
+    }
   }
 
   private def handleMapperEnd(

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -253,6 +253,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         }
         causes.add(Utils.toStatusCode(info.getStatus))
       }
+      logWarning(s"Received Revive request, number of partitions ${partitionIds.size()}")
       handleRevive(
         context,
         shuffleId,

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -153,7 +153,7 @@ class WorkerStatusTracker(
 
   def handleHeartbeatResponse(res: HeartbeatFromApplicationResponse): Unit = {
     if (res.statusCode == StatusCode.SUCCESS) {
-      logDebug(s"Received Blacklist from Master, blacklist: ${res.blacklist} " +
+      logInfo(s"Received Blacklist from Master, blacklist: ${res.blacklist} " +
         s"unknown workers: ${res.unknownWorkers}, shutdown workers: ${res.shuttingWorkers}")
       val current = System.currentTimeMillis()
 
@@ -200,7 +200,8 @@ class WorkerStatusTracker(
         }
       }
 
-      logDebug(s"Current blacklist $blacklist")
+      logInfo(s"Current blacklist $blacklist, Current shuttingDown ${shuttingWorkers.asScala.map(
+        _.readableAddress()).mkString("\n")}")
     }
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -143,6 +143,12 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
           if (info.channelFuture != null) {
             info.channelFuture.cancel(true);
           }
+          logger.info(
+              "Fail expire fetch request {},{},{},{}",
+              entry.getKey().streamId,
+              entry.getKey().chunkIndex,
+              entry.getKey().offset,
+              entry.getKey().len);
           info.callback.onFailure(
               entry.getKey().chunkIndex, new CelebornIOException(StatusCode.FETCH_DATA_TIMEOUT));
           info.channelFuture = null;

--- a/common/src/main/java/org/apache/celeborn/common/protocol/ReviveRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/ReviveRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.protocol;
+
+import org.apache.celeborn.common.protocol.message.StatusCode;
+
+public class ReviveRequest {
+  public int shuffleId;
+  public int mapId;
+  public int attemptId;
+  public int partitionId;
+  public int epoch;
+  public PartitionLocation loc;
+  public StatusCode cause;
+  public volatile int reviveStatus;
+
+  public ReviveRequest(
+      int shuffleId,
+      int mapId,
+      int attemptId,
+      int partitionId,
+      int epoch,
+      PartitionLocation loc,
+      StatusCode cause) {
+    this.shuffleId = shuffleId;
+    this.mapId = mapId;
+    this.attemptId = attemptId;
+    this.partitionId = partitionId;
+    this.epoch = epoch;
+    this.loc = loc;
+    this.cause = cause;
+    reviveStatus = StatusCode.REVIVE_INITIALIZED.getValue();
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
+++ b/common/src/main/java/org/apache/celeborn/common/protocol/message/StatusCode.java
@@ -77,7 +77,8 @@ public enum StatusCode {
   PUSH_DATA_MASTER_BLACKLISTED(44),
   PUSH_DATA_SLAVE_BLACKLISTED(45),
 
-  FETCH_DATA_TIMEOUT(46);
+  FETCH_DATA_TIMEOUT(46),
+  REVIVE_INITIALIZED(47);
 
   private final byte value;
 

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -205,20 +205,29 @@ message PbRequestSlotsResponse {
   map<string, PbWorkerResource> workerResource = 2;
 }
 
+message PbRevivePartitionInfo {
+  int32 partitionId = 1;
+  int32 epoch = 2;
+  PbPartitionLocation partition = 3;
+  int32 status = 4;
+}
+
 message PbRevive {
   int32 shuffleId = 1;
-  int32 mapId = 2;
-  int32 attemptId = 3;
-  int32 partitionId = 4;
-  int32 epoch = 5;
-  PbPartitionLocation oldPartition = 6;
-  int32 status = 7;
+  repeated int32 mapId = 2;
+  repeated PbRevivePartitionInfo partitionInfo = 3;
+}
+
+message PbChangeLocationPartitionInfo {
+  int32 partitionId = 1;
+  int32 status = 2;
+  PbPartitionLocation partition = 3;
+  bool oldAvailable = 4;
 }
 
 message PbChangeLocationResponse {
-  int32 status = 1;
-  PbPartitionLocation location = 2;
-  bool available = 3;
+  repeated int32 endedMapId = 1;
+  repeated PbChangeLocationPartitionInfo partitionInfo = 2;
 }
 
 message PbPartitionSplit {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -743,6 +743,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def clientPushQueueCapacity: Int = get(CLIENT_PUSH_QUEUE_CAPACITY)
   def clientPushMaxReqsInFlight: Int = get(CLIENT_PUSH_MAX_REQS_IN_FLIGHT)
   def clientPushMaxReviveTimes: Int = get(CLIENT_PUSH_MAX_REVIVE_TIMES)
+  def clientPushReviveInterval: Long = get(CLIENT_PUSH_REVIVE_INTERVAL)
+  def clientPushReviveBatchSize: Int = get(CLIENT_PUSH_REVIVE_BATCHSIZE)
   def clientPushSortMemoryThreshold: Long = get(CLIENT_PUSH_SORT_MEMORY_THRESHOLD)
   def clientPushSortPipelineEnabled: Boolean = get(CLIENT_PUSH_SORT_PIPELINE_ENABLED)
   def clientPushSortRandomizePartitionIdEnabled: Boolean =
@@ -2636,6 +2638,23 @@ object CelebornConf extends Logging {
       .doc("Max retry times for reviving when celeborn push data failed.")
       .intConf
       .createWithDefault(5)
+
+  val CLIENT_PUSH_REVIVE_INTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.client.push.revive.interval")
+      .categories("client")
+      .version("0.3.0")
+      .doc("Interval for client to trigger Revive to LifecycleManager. The number of partitions in one Revive " +
+        "request is `celeborn.client.push.revive.batchSize`.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("100ms")
+
+  val CLIENT_PUSH_REVIVE_BATCHSIZE: ConfigEntry[Int] =
+    buildConf("celeborn.client.push.revive.batchSize")
+      .categories("client")
+      .version("0.3.0")
+      .doc("Max number of partitions in one Revive request.")
+      .intConf
+      .createWithDefault(2048)
 
   val CLIENT_PUSH_BLACKLIST_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.client.push.blacklist.enabled")

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -193,7 +193,7 @@ object ControlMessages extends Logging {
         .setShuffleId(shuffleId)
         .addAllMapId(mapIds)
 
-      reviveRequests.asScala.foreach(req => {
+      reviveRequests.asScala.foreach { req =>
         val partitionInfoBuilder = PbRevivePartitionInfo.newBuilder()
           .setPartitionId(req.partitionId)
           .setEpoch(req.epoch)
@@ -202,7 +202,7 @@ object ControlMessages extends Logging {
           partitionInfoBuilder.setPartition(PbSerDeUtils.toPbPartitionLocation(req.loc))
         }
         builder.addPartitionInfo(partitionInfoBuilder.build())
-      })
+      }
 
       builder.build()
     }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -905,6 +905,8 @@ object Utils extends Logging {
         StatusCode.PUSH_DATA_SLAVE_BLACKLISTED
       case 46 =>
         StatusCode.FETCH_DATA_TIMEOUT
+      case 47 =>
+        StatusCode.REVIVE_INITIALIZED
       case _ =>
         null
     }

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -47,6 +47,8 @@ license: |
 | celeborn.client.push.queue.capacity | 512 | Push buffer queue size for a task. The maximum memory is `celeborn.push.buffer.max.size` * `celeborn.push.queue.capacity`, default: 64KiB * 512 = 32MiB | 0.3.0 | 
 | celeborn.client.push.replicate.enabled | false | When true, Celeborn worker will replicate shuffle data to another Celeborn worker asynchronously to ensure the pushed shuffle data won't be lost after the node failure. | 0.3.0 | 
 | celeborn.client.push.retry.threads | 8 | Thread number to process shuffle re-send push data requests. | 0.3.0 | 
+| celeborn.client.push.revive.batchSize | 2048 | Max number of partitions in one Revive request. | 0.3.0 | 
+| celeborn.client.push.revive.interval | 100ms | Interval for client to trigger Revive to LifecycleManager. The number of partitions in one Revive request is `celeborn.client.push.revive.batchSize`. | 0.3.0 | 
 | celeborn.client.push.revive.maxRetries | 5 | Max retry times for reviving when celeborn push data failed. | 0.3.0 | 
 | celeborn.client.push.slowStart.initialSleepTime | 500ms | The initial sleep time if the current max in flight requests is 0 | 0.3.0 | 
 | celeborn.client.push.slowStart.maxSleepTime | 2s | If celeborn.client.push.limit.strategy is set to SLOWSTART, push side will take a sleep strategy for each batch of requests, this controls the max sleep time if the max in flight requests limit is 1 for a long time | 0.3.0 | 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala
@@ -50,8 +50,9 @@ class RetryReviveTest extends AnyFunSuite
     val ss = SparkSession.builder()
       .config(updateSparkConf(sparkConf, ShuffleMode.HASH))
       .getOrCreate()
-    ss.sparkContext.parallelize(1 to 1000, 2)
+    val result = ss.sparkContext.parallelize(1 to 1000, 2)
       .map { i => (i, Range(1, 1000).mkString(",")) }.groupByKey(16).collect()
+    assert(result.size == 1000)
     ss.stop()
   }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -180,8 +180,9 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       if (shuffleMapperAttempts.containsKey(shuffleKey)) {
         if (-1 != shuffleMapperAttempts.get(shuffleKey).get(mapId)) {
           // partition data has already been committed
-          logInfo(s"Receive push data from speculative task(shuffle $shuffleKey, map $mapId, " +
-            s" attempt $attemptId), but this mapper has already been ended.")
+          logInfo(
+            s"[Case1] Receive push data from speculative task(shuffle $shuffleKey, map $mapId, " +
+              s" attempt $attemptId), but this mapper has already been ended.")
           callbackWithTimer.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.STAGE_ENDED.getValue)))
         } else {
           logInfo(
@@ -194,7 +195,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
           // If there is no shuffle key in shuffleMapperAttempts but there is shuffle key
           // in StorageManager. This partition should be HARD_SPLIT partition and
           // after worker restart, some task still push data to this HARD_SPLIT partition.
-          logInfo(s"Receive push data for committed hard split partition of " +
+          logInfo(s"[Case2] Receive push data for committed hard split partition of " +
             s"(shuffle $shuffleKey, map $mapId attempt $attemptId)")
           callbackWithTimer.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
         } else {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR batches revive requests and periodically send to LifecycleManager to reduce number or RPC requests.

To be more detailed. This PR changes Revive message to support multiple unique partitions, and also passes a set unique mapIds for checking MapEnd. Each time ShuffleClientImpl wants to revive, it adds a ReviveRquest to ReviveManager and wait for result. ReviveManager batches revive requests and periodically send to LifecycleManager (deduplicated by partitionId). LifecycleManager constructs ChangeLocationsCallContext and after all locations are notified, it replies to ShuffleClientImpl.


### Why are the changes needed?
In my test 3T TPCDS q23a with 3 Celeborn workers, when kill a worker, the LifecycleManger will receive 4.8w Revive requests:
```
[emr-user@master-1-1 logs]$ cat spark-emr-user-org.apache.spark.sql.hive.thriftserver.HiveThriftServer2-1-master-1-1.c-fa08904e94c028d1.out.1 |grep -i revive |wc -l
64364
```
After this PR, number of ReviveBatch requests reduces to 708:
```
[emr-user@master-1-1 logs]$ cat spark-emr-user-org.apache.spark.sql.hive.thriftserver.HiveThriftServer2-1-master-1-1.c-fa08904e94c028d1.out |grep -i revive |wc -l
2573
```

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual test. I have tested:

1. Disable graceful shutdown, kill one worker, job succeeds
2. Disable graceful shutdown, kill two workers successively, job fails as expected
3. Enable graceful shutdown, restart two workers successively, job succeeds
4. Enable graceful shutdown, restart two workers successively, then kill the third one, job succeeds
