### PR TITLE
[CELEBORN-678] ShuffleClientImpl::mapperEnded should not consider attemptId

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -92,7 +92,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   protected final ConcurrentHashMap<Integer, Set<Integer>> mapperEndMap =
       JavaUtils.newConcurrentHashMap();
 
-  private final Set<Integer> stageEndShuffleSet = ConcurrentHashMap.newKeySet();
+  protected final Set<Integer> stageEndShuffleSet = ConcurrentHashMap.newKeySet();
 
   // key: shuffleId-mapId-attemptId
   protected final Map<String, PushState> pushStates = JavaUtils.newConcurrentHashMap();

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -93,6 +93,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   protected final ConcurrentHashMap<Integer, Set<Integer>> mapperEndMap =
       JavaUtils.newConcurrentHashMap();
 
+  // shuffleIds which have finished all map tasks
   protected final Set<Integer> stageEndShuffleSet = ConcurrentHashMap.newKeySet();
 
   // key: shuffleId-mapId-attemptId

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -89,6 +89,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   private final Map<Integer, ConcurrentHashMap<Integer, PartitionLocation>> reducePartitionMap =
       JavaUtils.newConcurrentHashMap();
 
+  // key: shuffleId, value: Set(mapId)
   protected final ConcurrentHashMap<Integer, Set<Integer>> mapperEndMap =
       JavaUtils.newConcurrentHashMap();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
ShuffleClientImpl::mapperEnded should not consider attemptId, speculation tasks will update attemptId.


### Why are the changes needed?
ditto


### Does this PR introduce _any_ user-facing change?
No 


### How was this patch tested?
Cluster test
