### PR TITLE
[CELEBORN-690][MINOR] Cleanup code

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
@@ -21,7 +21,7 @@ import org.apache.spark.{InterruptibleIterator, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle.{ShuffleReader, ShuffleReadMetricsReporter}
 import org.apache.spark.sql.execution.UnsafeRowSerializer
-import org.apache.spark.sql.execution.columnar.{RssBatchBuilder, RssColumnarBatchBuilder, RssColumnarBatchSerializer}
+import org.apache.spark.sql.execution.columnar.{RssBatchBuilder, RssColumnarBatchSerializer}
 import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection.ExternalSorter
 

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -412,7 +412,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
 
     // First, request to get allocated slots from Master
     val ids = new util.ArrayList[Integer](numPartitions)
-    (0 until numPartitions).foreach(idx => ids.add(new Integer(idx)))
+    (0 until numPartitions).foreach(idx => ids.add(Integer.valueOf(idx)))
     val res = requestMasterRequestSlotsWithRetry(applicationId, shuffleId, ids)
 
     res.status match {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -18,7 +18,7 @@
 package org.apache.celeborn.client
 
 import java.util
-import java.util.{function, HashSet => JHashSet, List => JList, Set => JSet}
+import java.util.{function, List => JList}
 import java.util.concurrent.{ConcurrentHashMap, ScheduledFuture, TimeUnit}
 
 import scala.collection.JavaConverters._
@@ -297,6 +297,8 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
             attemptId,
             partitionId,
             numMappers)
+        case _ =>
+          throw new UnsupportedOperationException(s"Not support $partitionType yet")
       }
 
     case GetReducerFileGroup(applicationId: String, shuffleId: Int) =>
@@ -340,6 +342,8 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
                 initialLocs)
             case PartitionType.REDUCE =>
               context.reply(RegisterShuffleResponse(StatusCode.SUCCESS, initialLocs))
+            case _ =>
+              throw new UnsupportedOperationException(s"Not support $partitionType yet")
           }
           return
         }
@@ -398,6 +402,8 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
                   context.reply(response)
                 }
               case PartitionType.REDUCE => context.reply(response)
+              case _ =>
+                throw new UnsupportedOperationException(s"Not support $partitionType yet")
             }
           }))
         registeringShuffleRequest.remove(shuffleId)

--- a/client/src/main/scala/org/apache/celeborn/client/ReleasePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ReleasePartitionManager.scala
@@ -18,7 +18,7 @@
 package org.apache.celeborn.client
 
 import java.util
-import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, ScheduledFuture, TimeUnit}
+import java.util.concurrent.{ScheduledExecutorService, ScheduledFuture, TimeUnit}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.DurationInt

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable
 
 import org.apache.celeborn.client.{ShuffleCommittedInfo, WorkerStatusTracker}
 import org.apache.celeborn.client.CommitManager.CommittedPartitionInfo
-import org.apache.celeborn.client.LifecycleManager.{ShuffleAllocatedWorkers, ShuffleFailedWorkers, ShuffleFileGroups}
+import org.apache.celeborn.client.LifecycleManager.{ShuffleFailedWorkers, ShuffleFileGroups}
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{ShufflePartitionLocationInfo, WorkerInfo}

--- a/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigBuilder.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigBuilder.scala
@@ -22,7 +22,6 @@ import java.util.regex.PatternSyntaxException
 
 import scala.util.matching.Regex
 
-import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.network.util.ByteUnit
 import org.apache.celeborn.common.util.{JavaUtils, Utils}
 

--- a/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigEntry.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/internal/config/ConfigEntry.scala
@@ -17,8 +17,6 @@
 
 package org.apache.celeborn.common.internal.config
 
-import java.util.concurrent.ConcurrentHashMap
-
 import org.apache.celeborn.common.internal.config.ConfigHelpers.AlternativesTransfer
 import org.apache.celeborn.common.util.JavaUtils
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/ShufflePartitionLocationInfo.scala
@@ -19,7 +19,6 @@ package org.apache.celeborn.common.meta
 
 import java.util
 import java.util.concurrent.ConcurrentHashMap
-import java.util.stream.Collectors
 
 import scala.collection.JavaConverters._
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -18,8 +18,6 @@
 package org.apache.celeborn.common.meta
 
 import java.util
-import java.util.Objects
-import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
 

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/MetricsSystem.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/MetricsSystem.scala
@@ -109,7 +109,7 @@ class MetricsSystem(
     sourceConfigs.foreach { kv =>
       val classPath = kv._2.getProperty("class")
       try {
-        val source = Utils.classForName(classPath).newInstance()
+        val source = Utils.classForName(classPath).getDeclaredConstructor().newInstance()
         registerSource(source.asInstanceOf[Source])
       } catch {
         case e: Exception => logError("Source class " + classPath + " cannot be instantiated", e)

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -421,7 +421,7 @@ class TimerSupplier(val slidingWindowSize: Int)
 class GaugeSupplier[T](f: Unit => T) extends MetricRegistry.MetricSupplier[Gauge[_]] {
   override def newMetric(): Gauge[T] = {
     new Gauge[T] {
-      override def getValue: T = f()
+      override def getValue: T = f(())
     }
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/JVMSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/JVMSource.scala
@@ -37,6 +37,7 @@ class JVMSource(conf: CelebornConf, role: String) extends AbstractSource(conf, r
     .map { x =>
       x.getMetrics.asScala.map {
         case (name: String, metric: Gauge[_]) => addGauge(name, metric)
+        case (name, metric) => new IllegalArgumentException(s"Unknown metric type: $name: $metric")
       }
     }
   // start cleaner

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -574,7 +574,7 @@ object ControlMessages extends Logging {
             PbFileGroup.newBuilder().addAllLocations(fileGroup.asScala.map(PbSerDeUtils
               .toPbPartitionLocation).toList.asJava).build())
         }.asJava)
-      builder.addAllAttempts(attempts.map(new Integer(_)).toIterable.asJava)
+      builder.addAllAttempts(attempts.map(Integer.valueOf).toIterable.asJava)
       builder.addAllPartitionIds(partitionIds)
       val payload = builder.build().toByteArray
       new TransportMessage(MessageType.GET_REDUCER_FILE_GROUP_RESPONSE, payload)
@@ -734,7 +734,7 @@ object ControlMessages extends Logging {
         .setShuffleId(shuffleId)
         .addAllMasterIds(masterIds)
         .addAllSlaveIds(slaveIds)
-        .addAllMapAttempts(mapAttempts.map(new Integer(_)).toIterable.asJava)
+        .addAllMapAttempts(mapAttempts.map(Integer.valueOf).toIterable.asJava)
         .setEpoch(epoch)
         .build().toByteArray
       new TransportMessage(MessageType.COMMIT_FILES, payload)

--- a/common/src/main/scala/org/apache/celeborn/common/util/FunctionConverter.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/FunctionConverter.scala
@@ -17,6 +17,8 @@
 
 package org.apache.celeborn.common.util
 
+import scala.language.implicitConversions
+
 /**
  * Implicit conversion for scala(2.11) function to java function
  */
@@ -24,9 +26,7 @@ object FunctionConverter {
 
   implicit def scalaFunctionToJava[From, To](function: (From) => To)
       : java.util.function.Function[From, To] = {
-    new java.util.function.Function[From, To] {
-      override def apply(input: From): To = function(input)
-    }
+    (input: From) => function(input)
   }
 
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/FunctionConverter.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/FunctionConverter.scala
@@ -26,7 +26,9 @@ object FunctionConverter {
 
   implicit def scalaFunctionToJava[From, To](function: (From) => To)
       : java.util.function.Function[From, To] = {
-    (input: From) => function(input)
+    new java.util.function.Function[From, To] {
+      override def apply(input: From): To = function(input)
+    }
   }
 
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
@@ -18,12 +18,12 @@
 package org.apache.celeborn.common.util
 
 import java.util.concurrent._
+import java.util.concurrent.{ForkJoinPool => SForkJoinPool, ForkJoinWorkerThread => SForkJoinWorkerThread}
 
 import scala.collection.TraversableLike
 import scala.collection.generic.CanBuildFrom
 import scala.concurrent.{Awaitable, ExecutionContext, ExecutionContextExecutor, Future}
 import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.concurrent.forkjoin.{ForkJoinPool => SForkJoinPool, ForkJoinWorkerThread => SForkJoinWorkerThread}
 import scala.language.higherKinds
 import scala.util.control.NonFatal
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -27,7 +27,7 @@ import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
 import java.util
 import java.util.{Locale, Properties, Random, UUID}
-import java.util.concurrent.{Callable, ConcurrentHashMap, ThreadPoolExecutor, TimeoutException, TimeUnit}
+import java.util.concurrent.{Callable, ThreadPoolExecutor, TimeoutException, TimeUnit}
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -19,7 +19,7 @@ package org.apache.celeborn.common.meta
 
 import java.util
 import java.util.{Map => jMap}
-import java.util.concurrent.{ConcurrentHashMap, Future, ThreadLocalRandom}
+import java.util.concurrent.{Future, ThreadLocalRandom}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.ArrayBuffer

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -26,7 +26,6 @@ import scala.collection.JavaConverters._
 import scala.util.Random
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.exception.CelebornRuntimeException
 import org.apache.celeborn.common.haclient.RssHARetryClient
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterArguments.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterArguments.scala
@@ -20,7 +20,6 @@ package org.apache.celeborn.service.deploy.master
 import scala.annotation.tailrec
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.CelebornConf._
 import org.apache.celeborn.common.util.{IntParam, Utils}
 import org.apache.celeborn.service.deploy.master.clustermeta.ha.MasterClusterInfo
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterNode.scala
@@ -20,8 +20,6 @@ package org.apache.celeborn.service.deploy.master.clustermeta.ha
 import java.io.IOException
 import java.net.{InetAddress, InetSocketAddress}
 
-import scala.util.{Failure, Success}
-
 import org.apache.ratis.util.NetUtils
 
 import org.apache.celeborn.common.internal.Logging

--- a/pom.xml
+++ b/pom.xml
@@ -680,6 +680,15 @@
             </execution>
             -->
           </executions>
+          <configuration>
+            <args>
+              <arg>-unchecked</arg>
+              <arg>-deprecation</arg>
+              <arg>-feature</arg>
+              <arg>-explaintypes</arg>
+              <arg>-Xfatal-warnings</arg>
+            </args>
+          </configuration>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -653,6 +653,15 @@
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
           <version>${maven.plugin.scala.version}</version>
+          <configuration>
+            <args>
+              <arg>-unchecked</arg>
+              <arg>-deprecation</arg>
+              <arg>-feature</arg>
+              <arg>-explaintypes</arg>
+              <arg>-Xfatal-warnings</arg>
+            </args>
+          </configuration>
           <executions>
             <execution>
               <id>scala-compile-first</id>
@@ -680,15 +689,6 @@
             </execution>
             -->
           </executions>
-          <configuration>
-            <args>
-              <arg>-unchecked</arg>
-              <arg>-deprecation</arg>
-              <arg>-feature</arg>
-              <arg>-explaintypes</arg>
-              <arg>-Xfatal-warnings</arg>
-            </args>
-          </configuration>
         </plugin>
 
         <plugin>

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/WordCountTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/WordCountTest.scala
@@ -60,7 +60,7 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
       "org.apache.celeborn.plugin.flink.RemoteShuffleServiceFactory")
     configuration.setString("celeborn.master.endpoints", "localhost:9097")
     configuration.setString("execution.batch-shuffle-mode", "ALL_EXCHANGES_BLOCKING")
-    configuration.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, true)
+    configuration.setBoolean("local.start-webserver", true)
     configuration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH)
     configuration.setString("taskmanager.memory.network.min", "1024m")
     configuration.setString(RestOptions.BIND_PORT, "8081-8089")

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/WordCountTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/WordCountTest.scala
@@ -70,7 +70,6 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
     val env = StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(configuration)
     env.getConfig.setExecutionMode(ExecutionMode.BATCH)
     env.getConfig.setParallelism(parallelism)
-    env.getConfig.setDefaultInputDependencyConstraint(InputDependencyConstraint.ALL)
     env.disableOperatorChaining()
     // make parameters available in the web interface
     WordCountHelper.execute(env, parallelism)

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/WordCountTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/WordCountTest.scala
@@ -60,7 +60,6 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
       "org.apache.celeborn.plugin.flink.RemoteShuffleServiceFactory")
     configuration.setString("celeborn.master.endpoints", "localhost:9097")
     configuration.setString("execution.batch-shuffle-mode", "ALL_EXCHANGES_BLOCKING")
-    configuration.setBoolean("local.start-webserver", true)
     configuration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH)
     configuration.setString("taskmanager.memory.network.min", "1024m")
     configuration.setString(RestOptions.BIND_PORT, "8081-8089")

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -94,7 +94,8 @@ class PushDataHandler extends BaseMessageHandler with Logging {
               client,
               pushData.requestId,
               pushData.shuffleKey)
-            val partitionType = shufflePartitionType.getOrDefault(pushData.shuffleKey, PartitionType.REDUCE)
+            val partitionType =
+              shufflePartitionType.getOrDefault(pushData.shuffleKey, PartitionType.REDUCE)
             partitionType match {
               case PartitionType.REDUCE => handlePushData(
                   pushData,

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -354,7 +354,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
                 deviceMonitor,
                 splitThreshold,
                 splitMode,
-              rangeReadFilter)
+                rangeReadFilter)
             case _ => throw new UnsupportedOperationException(s"Not support $partitionType yet")
           }
           deviceMonitor.registerFileWriter(fileWriter)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -311,6 +311,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
               splitThreshold,
               splitMode,
               rangeReadFilter)
+          case _ => throw new UnsupportedOperationException(s"Not support $partitionType yet")
         }
 
         fileInfos.computeIfAbsent(shuffleKey, newMapFunc).put(fileName, fileInfo)
@@ -353,7 +354,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
                 deviceMonitor,
                 splitThreshold,
                 splitMode,
-                rangeReadFilter)
+              rangeReadFilter)
+            case _ => throw new UnsupportedOperationException(s"Not support $partitionType yet")
           }
           deviceMonitor.registerFileWriter(fileWriter)
           val map = workingDirWriters.computeIfAbsent(dir, workingDirWriterListFunc)


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Use `<arg>-Ywarn-unused-import</arg>` to remove some unused imports
There is no way to use `<arg>-Ywarn-unused-import</arg>` at this stage
Because we have the following code
```
// Can Remove this if celeborn don't support scala211 in future
import org.apache.celeborn.common.util.FunctionConverter._
```
2. Fix scala case match not fully covered, avoid `scala.MatchError`
3. Fixed some scala compilation warnings


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

