### PR TITLE
[CELEBORN-692] WorkerStatusTracker should handle WORKER_SHUTDOWN properly

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -130,8 +130,7 @@ class WorkerStatusTracker(
             blacklist.put(worker, (statusCode, registerTime))
           } else {
             statusCode match {
-              case StatusCode.WORKER_SHUTDOWN |
-                  StatusCode.NO_AVAILABLE_WORKING_DIR |
+              case StatusCode.NO_AVAILABLE_WORKING_DIR |
                   StatusCode.RESERVE_SLOTS_FAILED |
                   StatusCode.UNKNOWN_WORKER =>
                 blacklist.put(worker, (statusCode, blacklist.get(worker)._2))

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -125,18 +125,14 @@ class WorkerStatusTracker(
       failedWorker.asScala.foreach {
         case (worker, (StatusCode.WORKER_SHUTDOWN, _)) =>
           shuttingWorkers.add(worker)
-        case (worker, (statusCode, registerTime)) =>
-          if (!blacklist.containsKey(worker)) {
-            blacklist.put(worker, (statusCode, registerTime))
-          } else {
-            statusCode match {
-              case StatusCode.NO_AVAILABLE_WORKING_DIR |
-                  StatusCode.RESERVE_SLOTS_FAILED |
-                  StatusCode.UNKNOWN_WORKER =>
-                blacklist.put(worker, (statusCode, blacklist.get(worker)._2))
-              case _ => // Not cover
-            }
-          }
+        case (worker, (statusCode, registerTime)) if !blacklist.containsKey(worker) =>
+          blacklist.put(worker, (statusCode, registerTime))
+        case (worker, (statusCode, _))
+            if statusCode == StatusCode.NO_AVAILABLE_WORKING_DIR ||
+              statusCode == StatusCode.RESERVE_SLOTS_FAILED ||
+              statusCode == StatusCode.UNKNOWN_WORKER =>
+          blacklist.put(worker, (statusCode, blacklist.get(worker)._2))
+        case _ => // Not cover
       }
     }
   }

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -123,16 +123,20 @@ class WorkerStatusTracker(
            |$blacklistMsg
                """.stripMargin)
       failedWorker.asScala.foreach { case (worker, (statusCode, registerTime)) =>
-        if (!blacklist.containsKey(worker)) {
-          blacklist.put(worker, (statusCode, registerTime))
+        if (StatusCode.WORKER_SHUTDOWN == statusCode) {
+          shuttingWorkers.add(worker)
         } else {
-          statusCode match {
-            case StatusCode.WORKER_SHUTDOWN |
-                StatusCode.NO_AVAILABLE_WORKING_DIR |
-                StatusCode.RESERVE_SLOTS_FAILED |
-                StatusCode.UNKNOWN_WORKER =>
-              blacklist.put(worker, (statusCode, blacklist.get(worker)._2))
-            case _ => // Not cover
+          if (!blacklist.containsKey(worker)) {
+            blacklist.put(worker, (statusCode, registerTime))
+          } else {
+            statusCode match {
+              case StatusCode.WORKER_SHUTDOWN |
+                  StatusCode.NO_AVAILABLE_WORKING_DIR |
+                  StatusCode.RESERVE_SLOTS_FAILED |
+                  StatusCode.UNKNOWN_WORKER =>
+                blacklist.put(worker, (statusCode, blacklist.get(worker)._2))
+              case _ => // Not cover
+            }
           }
         }
       }

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -122,10 +122,10 @@ class WorkerStatusTracker(
            |Current blacklist:
            |$blacklistMsg
                """.stripMargin)
-      failedWorker.asScala.foreach { case (worker, (statusCode, registerTime)) =>
-        if (StatusCode.WORKER_SHUTDOWN == statusCode) {
+      failedWorker.asScala.foreach {
+        case (worker, (StatusCode.WORKER_SHUTDOWN, _)) =>
           shuttingWorkers.add(worker)
-        } else {
+        case (worker, (statusCode, registerTime)) =>
           if (!blacklist.containsKey(worker)) {
             blacklist.put(worker, (statusCode, registerTime))
           } else {
@@ -137,7 +137,6 @@ class WorkerStatusTracker(
               case _ => // Not cover
             }
           }
-        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR put workers with WORKER_SHUTDOWN status into shuttingWorkers instead of blacklist.


### Why are the changes needed?
If WORKER_SHUTDOWN workers are put into blacklist, it will not trigger commit files, see ```CommitHandler::commitFiles```


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual test.
