### PR TITLE
[CELEBORN-696] Fix bugs related with shutting down and excluded workers

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -444,7 +444,6 @@ public class ShuffleClientImpl extends ShuffleClient {
           for (int i = 0; i < response.getPartitionLocationsList().size(); i++) {
             PartitionLocation partitionLoc =
                 PbSerDeUtils.fromPbPartitionLocation(response.getPartitionLocationsList().get(i));
-            // remove from blacklist
             blacklist.remove(partitionLoc.hostAndPushPort());
 
             result.put(partitionLoc.getId(), partitionLoc);
@@ -590,6 +589,9 @@ public class ShuffleClientImpl extends ShuffleClient {
               ClassTag$.MODULE$.apply(PbChangeLocationResponse.class));
       // per partitionKey only serve single PartitionLocation in Client Cache.
       StatusCode respStatus = Utils.toStatusCode(response.getStatus());
+      if (!response.getExcluded()) {
+        blacklist.remove(oldLocation.hostAndPushPort());
+      }
       if (StatusCode.SUCCESS.equals(respStatus)) {
         map.put(partitionId, PbSerDeUtils.fromPbPartitionLocation(response.getLocation()));
         return true;

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -589,11 +589,14 @@ public class ShuffleClientImpl extends ShuffleClient {
               ClassTag$.MODULE$.apply(PbChangeLocationResponse.class));
       // per partitionKey only serve single PartitionLocation in Client Cache.
       StatusCode respStatus = Utils.toStatusCode(response.getStatus());
-      if (!response.getExcluded()) {
+      if (response.getAvailable()) {
         blacklist.remove(oldLocation.hostAndPushPort());
       }
       if (StatusCode.SUCCESS.equals(respStatus)) {
-        map.put(partitionId, PbSerDeUtils.fromPbPartitionLocation(response.getLocation()));
+        PartitionLocation newLocation =
+            PbSerDeUtils.fromPbPartitionLocation(response.getLocation());
+        map.put(partitionId, newLocation);
+        blacklist.remove(newLocation.hostAndPushPort());
         return true;
       } else if (StatusCode.MAP_ENDED.equals(respStatus)) {
         logger.debug(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -444,6 +444,9 @@ public class ShuffleClientImpl extends ShuffleClient {
           for (int i = 0; i < response.getPartitionLocationsList().size(); i++) {
             PartitionLocation partitionLoc =
                 PbSerDeUtils.fromPbPartitionLocation(response.getPartitionLocationsList().get(i));
+            // remove from blacklist
+            blacklist.remove(partitionLoc.hostAndPushPort());
+
             result.put(partitionLoc.getId(), partitionLoc);
           }
           return result;

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -167,7 +167,7 @@ class ChangePartitionManager(
           context.reply(
             StatusCode.SUCCESS,
             Some(latestLoc),
-            lifecycleManager.workerStatusTracker.excluded(oldPartition))
+            lifecycleManager.workerStatusTracker.workerExcluded(oldPartition))
           logDebug(s"New partition found, old partition $partitionId-$oldEpoch return it." +
             s" shuffleId: $shuffleId $latestLoc")
           return
@@ -229,11 +229,12 @@ class ChangePartitionManager(
           location -> Option(requestsMap.remove(location.getId))
         }
       }.foreach { case (newLocation, requests) =>
-        requests.map(_.asScala.toList.foreach(req =>
+        requests.flatMap(_.asScala.toList).foreach { req =>
           req.context.reply(
             StatusCode.SUCCESS,
             Option(newLocation),
-            lifecycleManager.workerStatusTracker.excluded(req.oldPartition))))
+            lifecycleManager.workerStatusTracker.workerExcluded(req.oldPartition))
+        }
       }
     }
 
@@ -251,7 +252,7 @@ class ChangePartitionManager(
           req.context.reply(
             status,
             None,
-            lifecycleManager.workerStatusTracker.excluded(req.oldPartition))))
+            lifecycleManager.workerStatusTracker.workerExcluded(req.oldPartition))))
       }
     }
 

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -229,12 +229,12 @@ class ChangePartitionManager(
           location -> Option(requestsMap.remove(location.getId))
         }
       }.foreach { case (newLocation, requests) =>
-        requests.flatMap(_.asScala.toList).foreach { req =>
+        requests.foreach(_.asScala.foreach { req =>
           req.context.reply(
             StatusCode.SUCCESS,
             Option(newLocation),
             lifecycleManager.workerStatusTracker.workerExcluded(req.oldPartition))
-        }
+        })
       }
     }
 

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -167,7 +167,7 @@ class ChangePartitionManager(
           context.reply(
             StatusCode.SUCCESS,
             Some(latestLoc),
-            lifecycleManager.workerStatusTracker.workerExcluded(oldPartition))
+            lifecycleManager.workerStatusTracker.workerAvailable(oldPartition))
           logDebug(s"New partition found, old partition $partitionId-$oldEpoch return it." +
             s" shuffleId: $shuffleId $latestLoc")
           return
@@ -233,7 +233,7 @@ class ChangePartitionManager(
           req.context.reply(
             StatusCode.SUCCESS,
             Option(newLocation),
-            lifecycleManager.workerStatusTracker.workerExcluded(req.oldPartition))
+            lifecycleManager.workerStatusTracker.workerAvailable(req.oldPartition))
         })
       }
     }
@@ -252,7 +252,7 @@ class ChangePartitionManager(
           req.context.reply(
             status,
             None,
-            lifecycleManager.workerStatusTracker.workerExcluded(req.oldPartition))))
+            lifecycleManager.workerStatusTracker.workerAvailable(req.oldPartition))))
       }
     }
 

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -515,7 +515,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       context.reply(ChangeLocationResponse(
         StatusCode.SHUFFLE_NOT_REGISTERED,
         None,
-        workerStatusTracker.excluded(oldPartition)))
+        workerStatusTracker.workerExcluded(oldPartition)))
       return
     }
 
@@ -524,7 +524,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       context.reply(ChangeLocationResponse(
         StatusCode.REVIVE_FAILED,
         None,
-        workerStatusTracker.excluded(oldPartition)))
+        workerStatusTracker.workerExcluded(oldPartition)))
       return
     }
 
@@ -534,7 +534,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       context.reply(ChangeLocationResponse(
         StatusCode.MAP_ENDED,
         None,
-        workerStatusTracker.excluded(oldPartition)))
+        workerStatusTracker.workerExcluded(oldPartition)))
       return
     }
 

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -512,20 +512,29 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
     // If shuffle not registered, reply ShuffleNotRegistered and return
     if (!registeredShuffle.contains(shuffleId)) {
       logError(s"[handleRevive] shuffle $shuffleId not registered!")
-      context.reply(ChangeLocationResponse(StatusCode.SHUFFLE_NOT_REGISTERED, None))
+      context.reply(ChangeLocationResponse(
+        StatusCode.SHUFFLE_NOT_REGISTERED,
+        None,
+        workerStatusTracker.excluded(oldPartition)))
       return
     }
 
     if (getPartitionType(shuffleId) == PartitionType.MAP) {
       logError(s"[handleRevive] shuffle $shuffleId revived filed, because map partition don't support revive!")
-      context.reply(ChangeLocationResponse(StatusCode.REVIVE_FAILED, None))
+      context.reply(ChangeLocationResponse(
+        StatusCode.REVIVE_FAILED,
+        None,
+        workerStatusTracker.excluded(oldPartition)))
       return
     }
 
     if (commitManager.isMapperEnded(shuffleId, mapId)) {
       logWarning(s"[handleRevive] Mapper ended, mapId $mapId, current attemptId $attemptId, " +
         s"ended attemptId ${commitManager.getMapperAttempts(shuffleId)(mapId)}, shuffleId $shuffleId.")
-      context.reply(ChangeLocationResponse(StatusCode.MAP_ENDED, None))
+      context.reply(ChangeLocationResponse(
+        StatusCode.MAP_ENDED,
+        None,
+        workerStatusTracker.excluded(oldPartition)))
       return
     }
 

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -515,7 +515,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       context.reply(ChangeLocationResponse(
         StatusCode.SHUFFLE_NOT_REGISTERED,
         None,
-        workerStatusTracker.workerExcluded(oldPartition)))
+        workerStatusTracker.workerAvailable(oldPartition)))
       return
     }
 
@@ -524,7 +524,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       context.reply(ChangeLocationResponse(
         StatusCode.REVIVE_FAILED,
         None,
-        workerStatusTracker.workerExcluded(oldPartition)))
+        workerStatusTracker.workerAvailable(oldPartition)))
       return
     }
 
@@ -534,7 +534,7 @@ class LifecycleManager(appId: String, val conf: CelebornConf) extends RpcEndpoin
       context.reply(ChangeLocationResponse(
         StatusCode.MAP_ENDED,
         None,
-        workerStatusTracker.workerExcluded(oldPartition)))
+        workerStatusTracker.workerAvailable(oldPartition)))
       return
     }
 

--- a/client/src/main/scala/org/apache/celeborn/client/RequestLocationCallContext.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/RequestLocationCallContext.scala
@@ -23,17 +23,26 @@ import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc.RpcCallContext
 
 trait RequestLocationCallContext {
-  def reply(status: StatusCode, partitionLocationOpt: Option[PartitionLocation]): Unit
+  def reply(
+      status: StatusCode,
+      partitionLocationOpt: Option[PartitionLocation],
+      excluded: Boolean): Unit
 }
 
 case class ChangeLocationCallContext(context: RpcCallContext) extends RequestLocationCallContext {
-  override def reply(status: StatusCode, partitionLocationOpt: Option[PartitionLocation]): Unit = {
-    context.reply(ChangeLocationResponse(status, partitionLocationOpt))
+  override def reply(
+      status: StatusCode,
+      partitionLocationOpt: Option[PartitionLocation],
+      excluded: Boolean): Unit = {
+    context.reply(ChangeLocationResponse(status, partitionLocationOpt, excluded))
   }
 }
 
 case class ApplyNewLocationCallContext(context: RpcCallContext) extends RequestLocationCallContext {
-  override def reply(status: StatusCode, partitionLocationOpt: Option[PartitionLocation]): Unit = {
+  override def reply(
+      status: StatusCode,
+      partitionLocationOpt: Option[PartitionLocation],
+      excluded: Boolean = false): Unit = {
     partitionLocationOpt match {
       case Some(partitionLocation) =>
         context.reply(RegisterShuffleResponse(status, Array(partitionLocation)))

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -53,15 +53,15 @@ class WorkerStatusTracker(
     }
   }
 
-  def workerAvailable(worker: WorkerInfo) = {
+  def workerAvailable(worker: WorkerInfo): Boolean = {
     !blacklist.containsKey(worker) && !shuttingWorkers.contains(worker)
   }
 
-  def workerExcluded(loc: PartitionLocation): Boolean = {
+  def workerAvailable(loc: PartitionLocation): Boolean = {
     if (loc == null) {
       false
     } else {
-      blacklist.containsKey(loc.getWorker)
+      workerAvailable(loc.getWorker)
     }
   }
 

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -57,7 +57,7 @@ class WorkerStatusTracker(
     !blacklist.containsKey(worker) && !shuttingWorkers.contains(worker)
   }
 
-  def excluded(loc: PartitionLocation): Boolean = {
+  def workerExcluded(loc: PartitionLocation): Boolean = {
     if (loc == null) {
       false
     } else {

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -115,12 +115,15 @@ class WorkerStatusTracker(
       val blacklistMsg = blacklist.asScala.map { case (worker, (status, time)) =>
         s"${worker.readableAddress()}   ${status.name()}   $time"
       }.mkString("\n")
+      val shuttingDownMsg = shuttingWorkers.asScala.map { _.readableAddress() }.mkString(";")
       logInfo(
         s"""
            |Reporting Worker Failure:
            |$failedWorkerMsg
            |Current blacklist:
            |$blacklistMsg
+           |Current shutting down:
+           |$shuttingDownMsg
                """.stripMargin)
       failedWorker.asScala.foreach {
         case (worker, (StatusCode.WORKER_SHUTDOWN, _)) =>
@@ -198,6 +201,6 @@ class WorkerStatusTracker(
     shuttingWorkers.retainAll(newShutdownWorkers)
     val shutdownList = newShutdownWorkers.asScala.filterNot(shuttingWorkers.asScala.contains).asJava
     shuttingWorkers.addAll(newShutdownWorkers)
-    shutdownList
+    newShutdownWorkers
   }
 }

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -220,6 +220,7 @@ message PbRevive {
 message PbChangeLocationResponse {
   int32 status = 1;
   PbPartitionLocation location = 2;
+  bool excluded = 3;
 }
 
 message PbPartitionSplit {

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -220,7 +220,7 @@ message PbRevive {
 message PbChangeLocationResponse {
   int32 status = 1;
   PbPartitionLocation location = 2;
-  bool excluded = 3;
+  bool available = 3;
 }
 
 message PbPartitionSplit {

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -231,9 +231,11 @@ object ControlMessages extends Logging {
   object ChangeLocationResponse {
     def apply(
         status: StatusCode,
-        partitionLocationOpt: Option[PartitionLocation]): PbChangeLocationResponse = {
+        partitionLocationOpt: Option[PartitionLocation],
+        excluded: Boolean): PbChangeLocationResponse = {
       val builder = PbChangeLocationResponse.newBuilder()
       builder.setStatus(status.getValue)
+        .setExcluded(excluded)
       partitionLocationOpt.foreach { partitionLocation =>
         builder.setLocation(PbSerDeUtils.toPbPartitionLocation(partitionLocation))
       }

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -232,10 +232,10 @@ object ControlMessages extends Logging {
     def apply(
         status: StatusCode,
         partitionLocationOpt: Option[PartitionLocation],
-        excluded: Boolean): PbChangeLocationResponse = {
+        available: Boolean): PbChangeLocationResponse = {
       val builder = PbChangeLocationResponse.newBuilder()
       builder.setStatus(status.getValue)
-        .setExcluded(excluded)
+        .setAvailable(available)
       partitionLocationOpt.foreach { partitionLocation =>
         builder.setLocation(PbSerDeUtils.toPbPartitionLocation(partitionLocation))
       }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -202,7 +202,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
           });
     }
     appDiskUsageMetric.update(estimatedAppDiskUsage);
-    if (!blacklist.contains(worker) && disks.isEmpty() && !shutdownWorkers.contains(worker)) {
+    if (!blacklist.contains(worker) && disks.isEmpty()) {
       LOG.debug("Worker: {} num total slots is 0, add to blacklist", worker);
       blacklist.add(worker);
     } else if (availableSlots.get() > 0) {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -202,7 +202,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
           });
     }
     appDiskUsageMetric.update(estimatedAppDiskUsage);
-    if (!blacklist.contains(worker) && disks.isEmpty()) {
+    if (!blacklist.contains(worker) && disks.isEmpty() && !shutdownWorkers.contains(worker)) {
       LOG.debug("Worker: {} num total slots is 0, add to blacklist", worker);
       blacklist.add(worker);
     } else if (availableSlots.get() > 0) {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -280,14 +280,10 @@ private[celeborn] class Worker(
     // During shutdown, return an empty diskInfo list to mark this worker as unavailable,
     // and avoid remove this from master's blacklist.
     val diskInfos =
-      if (shutdown.get()) {
-        Seq.empty[DiskInfo]
-      } else {
-        storageManager.updateDiskInfos()
-        workerInfo.updateThenGetDiskInfos(storageManager.disksSnapshot().map { disk =>
-          disk.mountPoint -> disk
-        }.toMap.asJava).values().asScala.toSeq
-      }
+      storageManager.updateDiskInfos()
+    workerInfo.updateThenGetDiskInfos(storageManager.disksSnapshot().map { disk =>
+      disk.mountPoint -> disk
+    }.toMap.asJava).values().asScala.toSeq
     val resourceConsumption = workerInfo.updateThenGetUserResourceConsumption(
       storageManager.userResourceConsumptionSnapshot().asJava)
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -277,13 +277,11 @@ private[celeborn] class Worker(
     storageManager.topAppDiskUsage.asScala.foreach { case (shuffleId, usage) =>
       estimatedAppDiskUsage.put(shuffleId, usage)
     }
-    // During shutdown, return an empty diskInfo list to mark this worker as unavailable,
-    // and avoid remove this from master's blacklist.
+    storageManager.updateDiskInfos()
     val diskInfos =
-      storageManager.updateDiskInfos()
-    workerInfo.updateThenGetDiskInfos(storageManager.disksSnapshot().map { disk =>
-      disk.mountPoint -> disk
-    }.toMap.asJava).values().asScala.toSeq
+      workerInfo.updateThenGetDiskInfos(storageManager.disksSnapshot().map { disk =>
+        disk.mountPoint -> disk
+      }.toMap.asJava).values().asScala.toSeq
     val resourceConsumption = workerInfo.updateThenGetUserResourceConsumption(
       storageManager.userResourceConsumptionSnapshot().asJava)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. Foreach PartitionLocation returned from Register Shuffle, remove from worker's local excluded list to refresh the local information.
2. ChangeLocationResponse will also return whether oldPartition is excluded in LifecycleManager. If so, remove it from Executor's excluded list.
3. Always trigger commit files for shutting down workers returned from HeartbeatFromApplicationResponse.
4. HeartbeatFromWorker sends the correct disk infos regardless of shutting down or not.

After this PR, the priority of excluded list is Master > LifecycleManager > Executor.

### Why are the changes needed?
During test with graceful turned on(workers have static rpc/push/fetch/replicate ports) and consistently restart one out of three workers, I encountered several bugs.
1. First I killed worker A, then Executor's client's local excluded list will contain A, after A stopped, I started it again, then master will offer slots on A, so we should remove from the executor's excluded list then.
2. When I kill-and-start a worker twice in a short time smaller than the app heartbeat interval, the second time WorkerStatusTracker will not trigger commit files because the local cache for the worker has not been refreshed.
3. When a worker is shutting down, in its heartbeat it passes empty diskInfos, and master blindly added to excluded list. We want a worker be either in the excluded list, or in the shutting down list, exclusively. If a worker is in excluded list, then LIfecycleManager will not trigger commit files when handle heartbeat response; on the other hand, if a worker is in the shutting down list, LifecycleManager will trigger commit files on it. So we must make it correct that a shutting down worker be in the shutting down list.


### Does this PR introduce _any_ user-facing change?
Yes, it fixes several bugs described above.


### How was this patch tested?
Manual test.

