### PR TITLE
[CELEBORN-698] Fix LocalDeviceMonitor::readWriteError judge

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -137,7 +137,7 @@ class LocalDeviceMonitor(
                     s"${device.deviceInfo.name}, notify observers")
                   device.notifyObserversOnNonCriticalError(mountPoints, DiskStatus.IO_HANG)
                 } else {
-                  device.diskInfos.values().asScala.foreach { case diskInfo =>
+                  device.diskInfos.values().asScala.foreach { diskInfo =>
                     if (checkDiskUsage && DeviceMonitor.highDiskUsage(conf, diskInfo)) {
                       logger.error(
                         s"${diskInfo.mountPoint} high_disk_usage error, notify observers")
@@ -273,12 +273,15 @@ object DeviceMonitor {
    * @return true if disk has read-write problem
    */
   def readWriteError(conf: CelebornConf, dataDir: File): Boolean = {
-    if (null == dataDir || !dataDir.isDirectory) {
+    if (null == dataDir) {
       return false
     }
 
     tryWithTimeoutAndCallback({
       try {
+        if (!dataDir.exists()) {
+          dataDir.mkdirs()
+        }
         val file = new File(dataDir, s"_SUCCESS_${System.currentTimeMillis()}")
         if (!file.exists() && !file.createNewFile()) {
           true


### PR DESCRIPTION
### What changes were proposed in this pull request?
If dataDir not exists, will skip check. 
It will cause that a disk found READ_OR_WRITE_FAILURE when creating FileWriter error, may change to be healthy in the subsequent disk checker.
```
23/06/19 19:09:52,718 ERROR [dispatcher-event-loop-16] StorageManager: Create FileWriter for /data7/rss_storage/rss-worker/shuffle_data/application_1684305681931_1943199/180/79-0-0 of mount /data7 failed, report to DeviceMonitor
java.io.IOException: No such file or directory
        at java.io.UnixFileSystem.createFileExclusively(Native Method)
        at java.io.File.createNewFile(File.java:1012)
        at org.apache.celeborn.service.deploy.worker.storage.StorageManager.createWriter(StorageManager.scala:330)
        ...
        at java.lang.Thread.run(Thread.java:745)
23/06/19 19:09:52,718 ERROR [dispatcher-event-loop-16] LocalDeviceMonitor: Receive non-critical exception, disk: /data7, java.io.IOException: java.io.IOException: No such file or directory 

updated state
DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: /data7, usableSpace: 536870912000, avgFlushTime: 0, avgFetchTime: 0, activeSlots: 0) status: READ_OR_WRITE_FAILURE dirs /data7/rss_storage/rss-worker/shuffle_data


after disk checker, updated stated
DiskInfo(maxSlots: 0, committed shuffles 0 shuffleAllocations: Map(), mountPoint: /data7, usableSpace: 536870912000, avgFlushTime: 0, avgFetchTime: 0, activeSlots: 0) status: HEALTHY dirs /data7/rss_storage/rss-worker/shuffle_data
```


### Why are the changes needed?
ditto


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Cluster test
