### PR TITLE
[CELEBORN-699][Client] Log info to expose celeborn use which compress

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -113,7 +113,9 @@ public class ShuffleClientImpl extends ShuffleClient {
       new ThreadLocal<Compressor>() {
         @Override
         protected Compressor initialValue() {
-          return Compressor.getCompressor(conf);
+          Compressor compressor = Compressor.getCompressor(conf);
+          logger.info("Celeborn use {} for shuffle compress.", compressor.getCompressType());
+          return compressor;
         }
       };
 

--- a/client/src/main/java/org/apache/celeborn/client/compress/Compressor.java
+++ b/client/src/main/java/org/apache/celeborn/client/compress/Compressor.java
@@ -30,6 +30,8 @@ public interface Compressor {
 
   byte[] getCompressedBuffer();
 
+  String getCompressType();
+
   default void writeIntLE(int i, byte[] buf, int off) {
     buf[off++] = (byte) i;
     buf[off++] = (byte) (i >>> 8);

--- a/client/src/main/java/org/apache/celeborn/client/compress/RssLz4Compressor.java
+++ b/client/src/main/java/org/apache/celeborn/client/compress/RssLz4Compressor.java
@@ -23,6 +23,8 @@ import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.xxhash.XXHashFactory;
 
+import org.apache.celeborn.common.protocol.CompressionCodec;
+
 public class RssLz4Compressor extends RssLz4Trait implements Compressor {
   private final LZ4Compressor compressor;
   private final Checksum checksum;
@@ -78,5 +80,10 @@ public class RssLz4Compressor extends RssLz4Trait implements Compressor {
   @Override
   public byte[] getCompressedBuffer() {
     return compressedBuffer;
+  }
+
+  @Override
+  public String getCompressType() {
+    return CompressionCodec.LZ4.name();
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/compress/RssZstdCompressor.java
+++ b/client/src/main/java/org/apache/celeborn/client/compress/RssZstdCompressor.java
@@ -22,6 +22,8 @@ import java.util.zip.Checksum;
 
 import com.github.luben.zstd.Zstd;
 
+import org.apache.celeborn.common.protocol.CompressionCodec;
+
 public class RssZstdCompressor extends RssZstdTrait implements Compressor {
   private final int compressionLevel;
   private final Checksum checksum;
@@ -85,5 +87,10 @@ public class RssZstdCompressor extends RssZstdTrait implements Compressor {
   @Override
   public byte[] getCompressedBuffer() {
     return compressedBuffer;
+  }
+
+  @Override
+  public String getCompressType() {
+    return CompressionCodec.ZSTD.name();
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
- Add Compressor#getCompressType function
- Log  `Celeborn use ${compressor.getCompressType()} for shuffle compress.` for user info

### Why are the changes needed?
expose compress info for user.


### Does this PR introduce _any_ user-facing change?
Half


### How was this patch tested?
No
