### PR TITLE
[CELEBORN-703][WORKER][PERF] Avoid calling `CelebornConf#get` multi-time when `PushDataHandler` handle `PushData`/`PushMergedData`

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -61,6 +61,8 @@ class PushDataHandler extends BaseMessageHandler with Logging {
 
   @volatile private var pushMasterDataTimeoutTested = false
   @volatile private var pushSlaveDataTimeoutTested = false
+  private var testPushMasterDataTimeout: Boolean = false
+  private var testPushSlaveDataTimeout: Boolean = false
 
   def init(worker: Worker): Unit = {
     workerSource = worker.workerSource
@@ -77,8 +79,8 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     partitionSplitMinimumSize = worker.conf.partitionSplitMinimumSize
     storageManager = worker.storageManager
     shutdown = worker.shutdown
-    pushMasterDataTimeoutTested = worker.conf.testPushMasterDataTimeout
-    pushSlaveDataTimeoutTested = worker.conf.testPushSlaveDataTimeout
+    testPushMasterDataTimeout = worker.conf.testPushMasterDataTimeout
+    testPushSlaveDataTimeout = worker.conf.testPushSlaveDataTimeout
     workerPartitionSplitEnabled = worker.conf.workerPartitionSplitEnabled
     workerReplicateRandomConnectionEnabled = worker.conf.workerReplicateRandomConnectionEnabled
 
@@ -131,12 +133,12 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     val isMaster = mode == PartitionLocation.Mode.MASTER
 
     // For test
-    if (isMaster && !pushMasterDataTimeoutTested) {
+    if (isMaster && testPushMasterDataTimeout && !pushMasterDataTimeoutTested) {
       pushMasterDataTimeoutTested = true
       return
     }
 
-    if (!isMaster && !pushSlaveDataTimeoutTested) {
+    if (!isMaster && testPushSlaveDataTimeout && !pushSlaveDataTimeoutTested) {
       pushSlaveDataTimeoutTested = true
       return
     }
@@ -405,12 +407,12 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       }
 
     // For test
-    if (isMaster && !pushMasterDataTimeoutTested) {
+    if (isMaster && testPushMasterDataTimeout && !pushMasterDataTimeoutTested) {
       pushMasterDataTimeoutTested = true
       return
     }
 
-    if (!isMaster && !pushSlaveDataTimeoutTested) {
+    if (!isMaster && testPushSlaveDataTimeout && !pushSlaveDataTimeoutTested) {
       pushSlaveDataTimeoutTested = true
       return
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -61,8 +61,6 @@ class PushDataHandler extends BaseMessageHandler with Logging {
 
   @volatile private var pushMasterDataTimeoutTested = false
   @volatile private var pushSlaveDataTimeoutTested = false
-  private var testPushMasterDataTimeout: Boolean = false
-  private var testPushSlaveDataTimeout: Boolean = false
 
   def init(worker: Worker): Unit = {
     workerSource = worker.workerSource
@@ -79,8 +77,8 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     partitionSplitMinimumSize = worker.conf.partitionSplitMinimumSize
     storageManager = worker.storageManager
     shutdown = worker.shutdown
-    testPushMasterDataTimeout = worker.conf.testPushMasterDataTimeout
-    testPushSlaveDataTimeout = worker.conf.testPushSlaveDataTimeout
+    pushMasterDataTimeoutTested = worker.conf.testPushMasterDataTimeout
+    pushSlaveDataTimeoutTested = worker.conf.testPushSlaveDataTimeout
     workerPartitionSplitEnabled = worker.conf.workerPartitionSplitEnabled
     workerReplicateRandomConnectionEnabled = worker.conf.workerReplicateRandomConnectionEnabled
 
@@ -133,12 +131,12 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     val isMaster = mode == PartitionLocation.Mode.MASTER
 
     // For test
-    if (isMaster && testPushMasterDataTimeout && !pushMasterDataTimeoutTested) {
+    if (isMaster && !pushMasterDataTimeoutTested) {
       pushMasterDataTimeoutTested = true
       return
     }
 
-    if (!isMaster && testPushSlaveDataTimeout && !pushSlaveDataTimeoutTested) {
+    if (!isMaster && !pushSlaveDataTimeoutTested) {
       pushSlaveDataTimeoutTested = true
       return
     }
@@ -407,13 +405,13 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       }
 
     // For test
-    if (isMaster && testPushMasterDataTimeout && !PushDataHandler.pushMasterDataTimeoutTested) {
-      PushDataHandler.pushMasterDataTimeoutTested = true
+    if (isMaster && !pushMasterDataTimeoutTested) {
+      pushMasterDataTimeoutTested = true
       return
     }
 
-    if (!isMaster && testPushSlaveDataTimeout && !PushDataHandler.pushSlaveDataTimeoutTested) {
-      PushDataHandler.pushSlaveDataTimeoutTested = true
+    if (!isMaster && !pushSlaveDataTimeoutTested) {
+      pushSlaveDataTimeoutTested = true
       return
     }
 
@@ -1070,9 +1068,4 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       pushClientFactory.createClient(host, port, partitionId)
     }
   }
-}
-
-object PushDataHandler {
-  @volatile var pushMasterDataTimeoutTested = false
-  @volatile var pushSlaveDataTimeoutTested = false
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -49,7 +49,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
   private var replicateThreadPool: ThreadPoolExecutor = _
   private var unavailablePeers: ConcurrentHashMap[WorkerInfo, Long] = _
   private var pushClientFactory: TransportClientFactory = _
-  private var registered: AtomicBoolean = new AtomicBoolean(false)
+  private var registered: AtomicBoolean = _
   private var workerInfo: WorkerInfo = _
   private var diskReserveSize: Long = _
   private var partitionSplitMinimumSize: Long = _

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicIntegerArray}
 import com.google.common.base.Throwables
 import io.netty.buffer.ByteBuf
 
-import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.exception.{AlreadyClosedException, CelebornIOException}
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{WorkerInfo, WorkerPartitionLocationInfo}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title.

the worker's frame graph before:

![image](https://github.com/apache/incubator-celeborn/assets/8537877/68a0a1fd-34c2-4618-9146-a2d66c951645)

the worker's frame graph after:

![image](https://github.com/apache/incubator-celeborn/assets/8537877/268e8109-737d-4440-b2b8-60687ef090cb)

### Why are the changes needed?

improve the worker's perf.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

existing UT and manually tested.