### PR TITLE
[CELEBORN-708] Fix commit metrics in application heartbeat

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -214,8 +214,7 @@ class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: Lif
       attemptId,
       numMappers,
       partitionId,
-      r =>
-        lifecycleManager.workerStatusTracker.recordWorkerFailure(r))
+      r => lifecycleManager.workerStatusTracker.recordWorkerFailure(r))
   }
 
   def releasePartitionResource(shuffleId: Int, partitionId: Int): Unit = {
@@ -270,21 +269,23 @@ class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: Lif
     } else {
       commitHandlers.computeIfAbsent(
         partitionType,
-        {
-          case PartitionType.REDUCE => new ReducePartitionCommitHandler(
-              appId,
-              conf,
-              lifecycleManager.shuffleAllocatedWorkers,
-              committedPartitionInfo,
-              lifecycleManager.workerStatusTracker)
-          case PartitionType.MAP => new MapPartitionCommitHandler(
-              appId,
-              conf,
-              lifecycleManager.shuffleAllocatedWorkers,
-              committedPartitionInfo,
-              lifecycleManager.workerStatusTracker)
-          case partitionType => throw new UnsupportedOperationException(
-              s"Unexpected ShufflePartitionType for CommitManager: $partitionType")
+        (partitionType: PartitionType) => {
+          partitionType match {
+            case PartitionType.REDUCE => new ReducePartitionCommitHandler(
+                appId,
+                conf,
+                lifecycleManager.shuffleAllocatedWorkers,
+                committedPartitionInfo,
+                lifecycleManager.workerStatusTracker)
+            case PartitionType.MAP => new MapPartitionCommitHandler(
+                appId,
+                conf,
+                lifecycleManager.shuffleAllocatedWorkers,
+                committedPartitionInfo,
+                lifecycleManager.workerStatusTracker)
+            case _ => throw new UnsupportedOperationException(
+                s"Unexpected ShufflePartitionType for CommitManager: $partitionType")
+          }
         })
     }
   }

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -220,7 +220,7 @@ class WorkerInfo(
     userResourceConsumption
   }
 
-  override def toString(): String = {
+  override def toString: String = {
     val (diskInfosString, slots) =
       if (diskInfos == null || diskInfos.isEmpty) {
         ("empty", 0)
@@ -246,7 +246,7 @@ class WorkerInfo(
        |ReplicatePort: $replicatePort
        |SlotsUsed: $slots
        |LastHeartbeat: $lastHeartbeat
-       |HeartBeatElapsedSeconds: ${(System.currentTimeMillis() - lastHeartbeat) / 1000}
+       |HeartbeatElapsedSeconds: ${(System.currentTimeMillis() - lastHeartbeat) / 1000}
        |Disks: $diskInfosString
        |UserResourceConsumption: $userResourceConsumptionString
        |WorkerRef: $endpoint

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -296,9 +296,9 @@ class WorkerInfoSuite extends CelebornFunSuite {
     println(worker3)
     println(worker4)
 
-    assertEquals(exp1, worker1.toString.replaceAll("HeartBeatElapsedSeconds:.*\n", ""))
-    assertEquals(exp2, worker2.toString.replaceAll("HeartBeatElapsedSeconds:.*\n", ""))
-    assertEquals(exp3, worker3.toString.replaceAll("HeartBeatElapsedSeconds:.*\n", ""))
-    assertEquals(exp4, worker4.toString.replaceAll("HeartBeatElapsedSeconds:.*\n", ""))
+    assertEquals(exp1, worker1.toString.replaceAll("HeartbeatElapsedSeconds:.*\n", ""))
+    assertEquals(exp2, worker2.toString.replaceAll("HeartbeatElapsedSeconds:.*\n", ""))
+    assertEquals(exp3, worker3.toString.replaceAll("HeartbeatElapsedSeconds:.*\n", ""))
+    assertEquals(exp4, worker4.toString.replaceAll("HeartbeatElapsedSeconds:.*\n", ""))
   }
 }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -190,7 +190,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
         new WorkerInfo(
             host, rpcPort, pushPort, fetchPort, replicatePort, disks, userResourceConsumption);
     AtomicLong availableSlots = new AtomicLong();
-    LOG.debug("update worker {}:{} heart beat {}", host, rpcPort, disks);
+    LOG.debug("update worker {}:{} heartbeat {}", host, rpcPort, disks);
     synchronized (workers) {
       Optional<WorkerInfo> workerInfo = workers.stream().filter(w -> w.equals(worker)).findFirst();
       workerInfo.ifPresent(

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
@@ -156,7 +156,7 @@ public class HAMasterMetaManager extends AbstractMetaManager {
                       .build())
               .build());
     } catch (CelebornRuntimeException e) {
-      LOG.error("Handle heart beat for {} failed!", appId, e);
+      LOG.error("Handle heartbeat for {} failed!", appId, e);
       throw e;
     }
   }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
@@ -106,10 +106,7 @@ public class MetaHandler {
           request
               .getRequestSlotsRequest()
               .getWorkerAllocationsMap()
-              .forEach(
-                  (k, v) -> {
-                    workerAllocations.put(k, new HashMap<>(v.getSlotMap()));
-                  });
+              .forEach((k, v) -> workerAllocations.put(k, new HashMap<>(v.getSlotMap())));
           LOG.debug("Handle request slots for {}", shuffleKey);
           metaSystem.updateRequestSlotsMeta(
               shuffleKey, request.getRequestSlotsRequest().getHostName(), workerAllocations);

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -269,7 +269,7 @@ private[celeborn] class Worker(
     WorkerSource.ReadBufferAllocatedCount,
     _ => memoryManager.getAllocatedReadBuffers)
 
-  private def heartBeatToMaster(): Unit = {
+  private def heartbeatToMaster(): Unit = {
     val activeShuffleKeys = new JHashSet[String]()
     val estimatedAppDiskUsage = new JHashMap[String, JLong]()
     activeShuffleKeys.addAll(partitionLocationInfo.shuffleKeySet)
@@ -322,7 +322,7 @@ private[celeborn] class Worker(
     sendHeartbeatTask = forwardMessageScheduler.scheduleAtFixedRate(
       new Runnable {
         override def run(): Unit = Utils.tryLogNonFatalError {
-          heartBeatToMaster()
+          heartbeatToMaster()
         }
       },
       HEARTBEAT_MILLIS,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- Fix commit metrics in application heartbeat
- Change client side application heartbeat message log level to info
- Improve heartbeat log by unify the word "heartbeat"

### Why are the changes needed?

`commitHandler.commitMetrics()` has side effects, multiple calls to get values independently is incorrect.

```
def commitMetrics(): (Long, Long) = (totalWritten.sumThenReset(), fileCount.sumThenReset())
```

### Does this PR introduce _any_ user-facing change?

Yes, bug fix.

### How was this patch tested?

Review.