### PR TITLE
[CELEBORN-712] Make appUniqueId a member of ShuffleClientImpl and refactor code

### DIFF
--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -86,7 +86,7 @@ if [ -z "$JAVA_HOME" ]; then
   exit -1
 fi
 
-MVN="$PROJECT_DIR/build/mvn"
+MVN="mvn"
 export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=1g}"
 
 if [ ! "$(command -v "$MVN")" ] ; then

--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -86,7 +86,7 @@ if [ -z "$JAVA_HOME" ]; then
   exit -1
 fi
 
-MVN="mvn"
+MVN="$PROJECT_DIR/build/mvn"
 export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=1g}"
 
 if [ ! "$(command -v "$MVN")" ] ; then

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
@@ -37,7 +37,6 @@ public class RemoteBufferStreamReader extends CreditListener {
   private static Logger logger = LoggerFactory.getLogger(RemoteBufferStreamReader.class);
   private TransferBufferPool bufferPool;
   private FlinkShuffleClientImpl client;
-  private String applicationId;
   private int shuffleId;
   private int partitionId;
   private int subPartitionIndexStart;
@@ -53,14 +52,12 @@ public class RemoteBufferStreamReader extends CreditListener {
   public RemoteBufferStreamReader(
       FlinkShuffleClientImpl client,
       ShuffleResourceDescriptor shuffleDescriptor,
-      String applicationId,
       int startSubIdx,
       int endSubIdx,
       TransferBufferPool bufferPool,
       Consumer<ByteBuf> dataListener,
       Consumer<Throwable> failureListener) {
     this.client = client;
-    this.applicationId = applicationId;
     this.shuffleId = shuffleDescriptor.getShuffleId();
     this.partitionId = shuffleDescriptor.getPartitionId();
     this.bufferPool = bufferPool;
@@ -84,7 +81,7 @@ public class RemoteBufferStreamReader extends CreditListener {
     try {
       this.bufferStream =
           client.readBufferedPartition(
-              applicationId, shuffleId, partitionId, subPartitionIndexStart, subPartitionIndexEnd);
+              shuffleId, partitionId, subPartitionIndexStart, subPartitionIndexEnd);
       bufferStream.open(
           RemoteBufferStreamReader.this::requestBuffer, initialCredit, messageConsumer);
     } catch (Exception e) {

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
@@ -152,10 +152,12 @@ public class RemoteShuffleInputGateDelegation {
     RemoteShuffleResource shuffleResource = remoteShuffleDescriptor.getShuffleResource();
 
     try {
-      String appUniqueId = ((RemoteShuffleDescriptor)(gateDescriptor.getShuffleDescriptors()[0])).getCelebornAppId();
+      String appUniqueId =
+          ((RemoteShuffleDescriptor) (gateDescriptor.getShuffleDescriptors()[0]))
+              .getCelebornAppId();
       this.shuffleClient =
           FlinkShuffleClientImpl.get(
-            appUniqueId,
+              appUniqueId,
               shuffleResource.getRssMetaServiceHost(),
               shuffleResource.getRssMetaServicePort(),
               shuffleResource.getRssMetaServiceTimestamp(),

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
@@ -152,8 +152,10 @@ public class RemoteShuffleInputGateDelegation {
     RemoteShuffleResource shuffleResource = remoteShuffleDescriptor.getShuffleResource();
 
     try {
+      String appUniqueId = ((RemoteShuffleDescriptor)(gateDescriptor.getShuffleDescriptors()[0])).getCelebornAppId();
       this.shuffleClient =
           FlinkShuffleClientImpl.get(
+            appUniqueId,
               shuffleResource.getRssMetaServiceHost(),
               shuffleResource.getRssMetaServicePort(),
               shuffleResource.getRssMetaServiceTimestamp(),
@@ -191,13 +193,11 @@ public class RemoteShuffleInputGateDelegation {
           remoteDescriptor.getShuffleResource().getMapPartitionShuffleDescriptor();
 
       LOG.debug("create shuffle reader for descriptor {}", shuffleDescriptor);
-      String applicationId = remoteDescriptor.getCelebornAppId();
 
       RemoteBufferStreamReader reader =
           new RemoteBufferStreamReader(
               shuffleClient,
               shuffleDescriptor,
-              applicationId,
               startSubIndex,
               endSubIndex,
               transferBufferPool,

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -100,7 +100,7 @@ public class RemoteShuffleMaster implements ShuffleMaster<RemoteShuffleDescripto
           () -> {
             try {
               for (Integer shuffleId : shuffleIds) {
-                lifecycleManager.handleUnregisterShuffle(celebornAppId, shuffleId);
+                lifecycleManager.handleUnregisterShuffle(shuffleId);
                 shuffleTaskInfo.removeExpiredShuffle(shuffleId);
               }
               shuffleResourceTracker.unRegisterJob(jobID);

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
@@ -158,7 +158,6 @@ public class RemoteShuffleOutputGate {
 
       newPartitionLoc =
           flinkShuffleClient.regionStart(
-              applicationId,
               shuffleId,
               mapId,
               attemptId,
@@ -172,7 +171,6 @@ public class RemoteShuffleOutputGate {
         handshake(false);
         // send regionstart again
         flinkShuffleClient.regionStart(
-            applicationId,
             shuffleId,
             mapId,
             attemptId,
@@ -193,7 +191,7 @@ public class RemoteShuffleOutputGate {
     bufferPacker.drain();
     try {
       flinkShuffleClient.regionFinish(
-          applicationId, shuffleId, mapId, attemptId, partitionLocation);
+          shuffleId, mapId, attemptId, partitionLocation);
       currentRegionIndex++;
     } catch (IOException e) {
       Utils.rethrowAsRuntimeException(e);
@@ -203,7 +201,7 @@ public class RemoteShuffleOutputGate {
   /** Indicates the writing/spilling is finished. */
   public void finish() throws InterruptedException, IOException {
     flinkShuffleClient.mapPartitionMapperEnd(
-        applicationId, shuffleId, mapId, attemptId, numMappers, partitionLocation.getId());
+        shuffleId, mapId, attemptId, numMappers, partitionLocation.getId());
   }
 
   /** Close the transportation gate. */
@@ -212,7 +210,7 @@ public class RemoteShuffleOutputGate {
       bufferPool.lazyDestroy();
     }
     bufferPacker.close();
-    flinkShuffleClient.cleanup(applicationId, shuffleId, mapId, attemptId);
+    flinkShuffleClient.cleanup(shuffleId, mapId, attemptId);
   }
 
   /** Returns shuffle descriptor. */
@@ -224,6 +222,7 @@ public class RemoteShuffleOutputGate {
   FlinkShuffleClientImpl getShuffleClient() {
     try {
       return FlinkShuffleClientImpl.get(
+        applicationId,
           rssMetaServiceHost,
           rssMetaServicePort,
           rssMetaServiceTimestamp,
@@ -239,7 +238,6 @@ public class RemoteShuffleOutputGate {
   public void write(ByteBuf byteBuf, int subIdx) {
     try {
       flinkShuffleClient.pushDataToLocation(
-          applicationId,
           shuffleId,
           mapId,
           attemptId,
@@ -256,14 +254,14 @@ public class RemoteShuffleOutputGate {
     if (isFirstHandShake) {
       partitionLocation =
           flinkShuffleClient.registerMapPartitionTask(
-              applicationId, shuffleId, numMappers, mapId, attemptId, partitionId);
+              shuffleId, numMappers, mapId, attemptId, partitionId);
       Utils.checkNotNull(partitionLocation);
 
       currentRegionIndex = 0;
     }
     try {
       flinkShuffleClient.pushDataHandShake(
-          applicationId, shuffleId, mapId, attemptId, numSubs, bufferSize, partitionLocation);
+          shuffleId, mapId, attemptId, numSubs, bufferSize, partitionLocation);
     } catch (IOException e) {
       Utils.rethrowAsRuntimeException(e);
     }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGate.java
@@ -158,12 +158,7 @@ public class RemoteShuffleOutputGate {
 
       newPartitionLoc =
           flinkShuffleClient.regionStart(
-              shuffleId,
-              mapId,
-              attemptId,
-              partitionLocation,
-              currentRegionIndex,
-              isBroadcast);
+              shuffleId, mapId, attemptId, partitionLocation, currentRegionIndex, isBroadcast);
       // revived
       if (newPartitionLoc.isPresent()) {
         partitionLocation = newPartitionLoc.get();
@@ -171,12 +166,7 @@ public class RemoteShuffleOutputGate {
         handshake(false);
         // send regionstart again
         flinkShuffleClient.regionStart(
-            shuffleId,
-            mapId,
-            attemptId,
-            newPartitionLoc.get(),
-            currentRegionIndex,
-            isBroadcast);
+            shuffleId, mapId, attemptId, newPartitionLoc.get(), currentRegionIndex, isBroadcast);
       }
     } catch (IOException e) {
       Utils.rethrowAsRuntimeException(e);
@@ -190,8 +180,7 @@ public class RemoteShuffleOutputGate {
   public void regionFinish() throws InterruptedException {
     bufferPacker.drain();
     try {
-      flinkShuffleClient.regionFinish(
-          shuffleId, mapId, attemptId, partitionLocation);
+      flinkShuffleClient.regionFinish(shuffleId, mapId, attemptId, partitionLocation);
       currentRegionIndex++;
     } catch (IOException e) {
       Utils.rethrowAsRuntimeException(e);
@@ -222,7 +211,7 @@ public class RemoteShuffleOutputGate {
   FlinkShuffleClientImpl getShuffleClient() {
     try {
       return FlinkShuffleClientImpl.get(
-        applicationId,
+          applicationId,
           rssMetaServiceHost,
           rssMetaServicePort,
           rssMetaServiceTimestamp,

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -72,7 +72,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   private final String appUniqueId;
 
   public static FlinkShuffleClientImpl get(
-    String appUniqueId,
+      String appUniqueId,
       String driverHost,
       int port,
       long driverTimestamp,
@@ -83,12 +83,14 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
       synchronized (FlinkShuffleClientImpl.class) {
         if (null == _instance) {
           _instance =
-              new FlinkShuffleClientImpl(appUniqueId, driverHost, port, driverTimestamp, conf, userIdentifier);
+              new FlinkShuffleClientImpl(
+                  appUniqueId, driverHost, port, driverTimestamp, conf, userIdentifier);
           initialized = true;
         } else if (!initialized || _instance.driverTimestamp < driverTimestamp) {
           _instance.shutdown();
           _instance =
-              new FlinkShuffleClientImpl(appUniqueId, driverHost, port, driverTimestamp, conf, userIdentifier);
+              new FlinkShuffleClientImpl(
+                  appUniqueId, driverHost, port, driverTimestamp, conf, userIdentifier);
           initialized = true;
         }
       }
@@ -116,7 +118,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   }
 
   public FlinkShuffleClientImpl(
-    String appUniqueId,
+      String appUniqueId,
       String driverHost,
       int port,
       long driverTimestamp,
@@ -137,10 +139,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   }
 
   public RssBufferStream readBufferedPartition(
-      int shuffleId,
-      int partitionId,
-      int subPartitionIndexStart,
-      int subPartitionIndexEnd)
+      int shuffleId, int partitionId, int subPartitionIndexStart, int subPartitionIndexEnd)
       throws IOException {
     String shuffleKey = Utils.makeShuffleKey(appUniqueId, shuffleId);
     ReduceFileGroups fileGroups = loadFileGroup(shuffleId, partitionId);
@@ -161,15 +160,13 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   }
 
   @Override
-  protected ReduceFileGroups updateFileGroup(
-      int shuffleId, int partitionId) throws IOException {
+  protected ReduceFileGroups updateFileGroup(int shuffleId, int partitionId) throws IOException {
     ReduceFileGroups reduceFileGroups =
         reduceFileGroupsMap.computeIfAbsent(shuffleId, (id) -> new ReduceFileGroups());
     if (reduceFileGroups.partitionIds != null
         && reduceFileGroups.partitionIds.contains(partitionId)) {
       logger.debug(
-          "use cached file groups for partition: {}",
-          Utils.makeReducerKey(shuffleId, partitionId));
+          "use cached file groups for partition: {}", Utils.makeReducerKey(shuffleId, partitionId));
     } else {
       synchronized (reduceFileGroups) {
         if (reduceFileGroups.partitionIds != null
@@ -182,8 +179,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
           ReduceFileGroups newGroups = loadFileGroupInternal(shuffleId);
           if (newGroups == null || !newGroups.partitionIds.contains(partitionId)) {
             throw new IOException(
-                "shuffle data lost for partition: "
-                    + Utils.makeReducerKey(shuffleId, partitionId));
+                "shuffle data lost for partition: " + Utils.makeReducerKey(shuffleId, partitionId));
           }
           reduceFileGroups.update(newGroups);
         }
@@ -414,8 +410,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
         });
   }
 
-  public void regionFinish(
-      int shuffleId, int mapId, int attemptId, PartitionLocation location)
+  public void regionFinish(int shuffleId, int mapId, int attemptId, PartitionLocation location)
       throws IOException {
     final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
     final PushState pushState = pushStates.computeIfAbsent(mapKey, (s) -> new PushState(conf));

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -69,7 +69,6 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
   private ConcurrentHashMap<String, TransportClient> currentClient =
       JavaUtils.newConcurrentHashMap();
   private long driverTimestamp;
-  private final String appUniqueId;
 
   public static FlinkShuffleClientImpl get(
       String appUniqueId,
@@ -135,7 +134,6 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
         new FlinkTransportClientFactory(context, conf.clientFetchMaxRetriesForEachReplica());
     this.setupMetaServiceRef(driverHost, port);
     this.driverTimestamp = driverTimestamp;
-    this.appUniqueId = appUniqueId;
   }
 
   public RssBufferStream readBufferedPartition(

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
@@ -54,7 +54,7 @@ public class FlinkShuffleClientImplSuiteJ {
   public void setup() throws IOException, InterruptedException {
     conf = new CelebornConf();
     shuffleClient =
-        new FlinkShuffleClientImpl("localhost", 1232, System.currentTimeMillis(), conf, null) {
+        new FlinkShuffleClientImpl("APP", "localhost", 1232, System.currentTimeMillis(), conf, null) {
           @Override
           public void setupMetaServiceRef(String host, int port) {}
         };
@@ -86,7 +86,7 @@ public class FlinkShuffleClientImplSuiteJ {
             });
 
     int pushDataLen =
-        shuffleClient.pushDataToLocation("1", 2, 3, 4, 5, byteBuf, masterLocation, () -> {});
+        shuffleClient.pushDataToLocation(2, 3, 4, 5, byteBuf, masterLocation, () -> {});
     Assert.assertEquals(BufferSize, pushDataLen);
   }
 
@@ -103,7 +103,7 @@ public class FlinkShuffleClientImplSuiteJ {
               return mockedFuture;
             });
     int pushDataLen =
-        shuffleClient.pushDataToLocation("1", 2, 3, 4, 5, byteBuf, masterLocation, () -> {});
+        shuffleClient.pushDataToLocation(2, 3, 4, 5, byteBuf, masterLocation, () -> {});
   }
 
   @Test
@@ -117,12 +117,12 @@ public class FlinkShuffleClientImplSuiteJ {
               return mockedFuture;
             });
     // first push just  set pushdata.exception
-    shuffleClient.pushDataToLocation("1", 2, 3, 4, 5, byteBuf, masterLocation, () -> {});
+    shuffleClient.pushDataToLocation(2, 3, 4, 5, byteBuf, masterLocation, () -> {});
 
     boolean isFailed = false;
     // second push will throw exception
     try {
-      shuffleClient.pushDataToLocation("1", 2, 3, 4, 5, byteBuf, masterLocation, () -> {});
+      shuffleClient.pushDataToLocation(2, 3, 4, 5, byteBuf, masterLocation, () -> {});
     } catch (IOException e) {
       isFailed = true;
     } finally {

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/FlinkShuffleClientImplSuiteJ.java
@@ -54,7 +54,8 @@ public class FlinkShuffleClientImplSuiteJ {
   public void setup() throws IOException, InterruptedException {
     conf = new CelebornConf();
     shuffleClient =
-        new FlinkShuffleClientImpl("APP", "localhost", 1232, System.currentTimeMillis(), conf, null) {
+        new FlinkShuffleClientImpl(
+            "APP", "localhost", 1232, System.currentTimeMillis(), conf, null) {
           @Override
           public void setupMetaServiceRef(String host, int port) {}
         };

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGateSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGateSuiteJ.java
@@ -54,16 +54,16 @@ public class RemoteShuffleOutputGateSuiteJ {
     PartitionLocation partitionLocation =
         new PartitionLocation(1, 0, "localhost", 123, 245, 789, 238, PartitionLocation.Mode.MASTER);
     when(shuffleClient.registerMapPartitionTask(
-            any(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
+            anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
         .thenAnswer(t -> partitionLocation);
     doNothing()
         .when(remoteShuffleOutputGate.flinkShuffleClient)
-        .pushDataHandShake(anyString(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), any());
+        .pushDataHandShake(anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), any());
 
     remoteShuffleOutputGate.handshake(true);
 
     when(remoteShuffleOutputGate.flinkShuffleClient.regionStart(
-            any(), anyInt(), anyInt(), anyInt(), any(), anyInt(), anyBoolean()))
+            anyInt(), anyInt(), anyInt(), any(), anyInt(), anyBoolean()))
         .thenAnswer(t -> Optional.empty());
     remoteShuffleOutputGate.regionStart(false);
 
@@ -71,12 +71,12 @@ public class RemoteShuffleOutputGateSuiteJ {
 
     doNothing()
         .when(remoteShuffleOutputGate.flinkShuffleClient)
-        .regionFinish(any(), anyInt(), anyInt(), anyInt(), any());
+        .regionFinish(anyInt(), anyInt(), anyInt(), any());
     remoteShuffleOutputGate.regionFinish();
 
     doNothing()
         .when(remoteShuffleOutputGate.flinkShuffleClient)
-        .mapperEnd(any(), anyInt(), anyInt(), anyInt(), anyInt());
+        .mapperEnd(anyInt(), anyInt(), anyInt(), anyInt());
     remoteShuffleOutputGate.finish();
 
     doNothing().when(remoteShuffleOutputGate.flinkShuffleClient).shutdown();

--- a/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGateSuiteJ.java
+++ b/client-flink/common/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleOutputGateSuiteJ.java
@@ -53,8 +53,7 @@ public class RemoteShuffleOutputGateSuiteJ {
 
     PartitionLocation partitionLocation =
         new PartitionLocation(1, 0, "localhost", 123, 245, 789, 238, PartitionLocation.Mode.MASTER);
-    when(shuffleClient.registerMapPartitionTask(
-            anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
+    when(shuffleClient.registerMapPartitionTask(anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
         .thenAnswer(t -> partitionLocation);
     doNothing()
         .when(remoteShuffleOutputGate.flinkShuffleClient)

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -455,7 +454,7 @@ public class RemoteShuffleResultPartitionSuiteJ {
     @Override
     FlinkShuffleClientImpl getShuffleClient() {
       FlinkShuffleClientImpl client = mock(FlinkShuffleClientImpl.class);
-      doNothing().when(client).cleanup(anyString(), anyInt(), anyInt(), anyInt());
+      doNothing().when(client).cleanup(anyInt(), anyInt(), anyInt());
       return client;
     }
 

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -455,7 +454,7 @@ public class RemoteShuffleResultPartitionSuiteJ {
     @Override
     FlinkShuffleClientImpl getShuffleClient() {
       FlinkShuffleClientImpl client = mock(FlinkShuffleClientImpl.class);
-      doNothing().when(client).cleanup(anyString(), anyInt(), anyInt(), anyInt());
+      doNothing().when(client).cleanup(anyInt(), anyInt(), anyInt());
       return client;
     }
 

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionSuiteJ.java
@@ -455,7 +455,7 @@ public class RemoteShuffleResultPartitionSuiteJ {
     @Override
     FlinkShuffleClientImpl getShuffleClient() {
       FlinkShuffleClientImpl client = mock(FlinkShuffleClientImpl.class);
-      doNothing().when(client).cleanup(anyString(), anyInt(), anyInt(), anyInt());
+      doNothing().when(client).cleanup(anyInt(), anyInt(), anyInt());
       return client;
     }
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedPusher.java
@@ -117,7 +117,6 @@ public class SortBasedPusher extends MemoryConsumer {
     try {
       dataPusher =
           new DataPusher(
-              appId,
               shuffleId,
               mapId,
               attemptNumber,
@@ -162,7 +161,6 @@ public class SortBasedPusher extends MemoryConsumer {
           } else {
             int bytesWritten =
                 rssShuffleClient.mergeData(
-                    appId,
                     shuffleId,
                     mapId,
                     attemptNumber,

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -103,6 +103,7 @@ public class RssShuffleManager implements ShuffleManager {
           lifecycleManager = new LifecycleManager(appId, celebornConf);
           rssShuffleClient =
               ShuffleClient.get(
+                  appUniqueId,
                   lifecycleManager.getRssMetaServiceHost(),
                   lifecycleManager.getRssMetaServicePort(),
                   celebornConf,
@@ -149,7 +150,7 @@ public class RssShuffleManager implements ShuffleManager {
     if (rssShuffleClient == null) {
       return false;
     }
-    return rssShuffleClient.unregisterShuffle(appUniqueId, shuffleId, isDriver());
+    return rssShuffleClient.unregisterShuffle(shuffleId, isDriver());
   }
 
   @Override
@@ -179,7 +180,11 @@ public class RssShuffleManager implements ShuffleManager {
         RssShuffleHandle<K, V, ?> h = ((RssShuffleHandle<K, V, ?>) handle);
         ShuffleClient client =
             ShuffleClient.get(
-                h.rssMetaServiceHost(), h.rssMetaServicePort(), celebornConf, h.userIdentifier());
+                appUniqueId,
+                h.rssMetaServiceHost(),
+                h.rssMetaServicePort(),
+                celebornConf,
+                h.userIdentifier());
         if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())) {
           ExecutorService pushThread =
               celebornConf.clientPushSortPipelineEnabled() ? getPusherThread() : null;

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -61,7 +61,6 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private final ShuffleDependency<K, V, C> dep;
   private final Partitioner partitioner;
   private final ShuffleWriteMetrics writeMetrics;
-  private final String appId;
   private final int shuffleId;
   private final int mapId;
   private final TaskContext taskContext;
@@ -105,7 +104,6 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException {
     this.mapId = taskContext.partitionId();
     this.dep = dep;
-    this.appId = appId;
     this.shuffleId = dep.shuffleId();
     SerializerInstance serializer = dep.serializer().newInstance();
     this.partitioner = dep.partitioner();
@@ -304,7 +302,6 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     logger.debug("Push giant record, size {}.", Utils.bytesToString(numBytes));
     int bytesWritten =
         rssShuffleClient.pushData(
-            appId,
             shuffleId,
             mapId,
             taskContext.attemptNumber(),
@@ -338,12 +335,12 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
     writeMetrics.incWriteTime(System.nanoTime() - pushStartTime);
 
-    rssShuffleClient.pushMergedData(appId, shuffleId, mapId, taskContext.attemptNumber());
+    rssShuffleClient.pushMergedData(shuffleId, mapId, taskContext.attemptNumber());
 
     updateMapStatus();
 
     long waitStartTime = System.nanoTime();
-    rssShuffleClient.mapperEnd(appId, shuffleId, mapId, taskContext.attemptNumber(), numMappers);
+    rssShuffleClient.mapperEnd(shuffleId, mapId, taskContext.attemptNumber(), numMappers);
     writeMetrics.incWriteTime(System.nanoTime() - waitStartTime);
   }
 
@@ -379,7 +376,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     } catch (IOException e) {
       return Option.apply(null);
     } finally {
-      rssShuffleClient.cleanup(appId, shuffleId, mapId, taskContext.attemptNumber());
+      rssShuffleClient.cleanup(shuffleId, mapId, taskContext.attemptNumber());
     }
   }
 

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
@@ -40,6 +40,7 @@ class RssShuffleReader[K, C](
 
   private val dep = handle.dependency
   private val essShuffleClient = ShuffleClient.get(
+    handle.appUniqueId,
     handle.rssMetaServiceHost,
     handle.rssMetaServicePort,
     conf,
@@ -63,7 +64,6 @@ class RssShuffleReader[K, C](
       if (handle.numMaps > 0) {
         val start = System.currentTimeMillis()
         val inputStream = essShuffleClient.readPartition(
-          handle.appUniqueId,
           handle.shuffleId,
           partitionId,
           context.attemptNumber(),

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -67,7 +67,6 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private final ShuffleDependency<K, V, C> dep;
   private final Partitioner partitioner;
   private final ShuffleWriteMetricsReporter writeMetrics;
-  private final String appId;
   private final int shuffleId;
   private final int mapId;
   private final TaskContext taskContext;
@@ -130,7 +129,6 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException {
     this.mapId = taskContext.partitionId();
     this.dep = handle.dependency();
-    this.appId = handle.appUniqueId();
     this.shuffleId = dep.shuffleId();
     SerializerInstance serializer = dep.serializer().newInstance();
     this.partitioner = dep.partitioner();
@@ -161,7 +159,6 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     try {
       dataPusher =
           new DataPusher(
-              appId,
               shuffleId,
               mapId,
               taskContext.attemptNumber(),
@@ -357,7 +354,6 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     logger.debug("Push giant record, size {}.", numBytes);
     int bytesWritten =
         rssShuffleClient.pushData(
-            appId,
             shuffleId,
             mapId,
             taskContext.attemptNumber(),
@@ -410,7 +406,6 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         }
         int bytesWritten =
             rssShuffleClient.mergeData(
-                appId,
                 shuffleId,
                 mapId,
                 taskContext.attemptNumber(),
@@ -437,7 +432,6 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       if (size > 0) {
         int bytesWritten =
             rssShuffleClient.mergeData(
-                appId,
                 shuffleId,
                 mapId,
                 taskContext.attemptNumber(),
@@ -468,13 +462,13 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     } else {
       closeRowWrite();
     }
-    rssShuffleClient.pushMergedData(appId, shuffleId, mapId, taskContext.attemptNumber());
+    rssShuffleClient.pushMergedData(shuffleId, mapId, taskContext.attemptNumber());
     writeMetrics.incWriteTime(System.nanoTime() - pushMergedDataTime);
 
     updateMapStatus();
 
     long waitStartTime = System.nanoTime();
-    rssShuffleClient.mapperEnd(appId, shuffleId, mapId, taskContext.attemptNumber(), numMappers);
+    rssShuffleClient.mapperEnd(shuffleId, mapId, taskContext.attemptNumber(), numMappers);
     writeMetrics.incWriteTime(System.nanoTime() - waitStartTime);
 
     BlockManagerId bmId = SparkEnv.get().blockManager().shuffleServerId();
@@ -511,7 +505,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         }
       }
     } finally {
-      rssShuffleClient.cleanup(appId, shuffleId, mapId, taskContext.attemptNumber());
+      rssShuffleClient.cleanup(shuffleId, mapId, taskContext.attemptNumber());
     }
   }
 

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -101,7 +101,7 @@ public class RssShuffleManager implements ShuffleManager {
           lifecycleManager = new LifecycleManager(appId, celebornConf);
           rssShuffleClient =
               ShuffleClient.get(
-                appId,
+                  appId,
                   lifecycleManager.getRssMetaServiceHost(),
                   lifecycleManager.getRssMetaServicePort(),
                   celebornConf,
@@ -181,8 +181,12 @@ public class RssShuffleManager implements ShuffleManager {
         @SuppressWarnings("unchecked")
         RssShuffleHandle<K, V, ?> h = ((RssShuffleHandle<K, V, ?>) handle);
         ShuffleClient client =
-            ShuffleClient.get(h.appUniqueId(),
-                h.rssMetaServiceHost(), h.rssMetaServicePort(), celebornConf, h.userIdentifier());
+            ShuffleClient.get(
+                h.appUniqueId(),
+                h.rssMetaServiceHost(),
+                h.rssMetaServicePort(),
+                celebornConf,
+                h.userIdentifier());
         if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())) {
           ExecutorService pushThread =
               celebornConf.clientPushSortPipelineEnabled() ? getPusherThread() : null;

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -90,7 +90,7 @@ public class RssShuffleManager implements ShuffleManager {
     return _sortShuffleManager;
   }
 
-  private void initializeLifecycleManager(String appId) {
+  private void initializeLifecycleManager() {
     // Only create LifecycleManager singleton in Driver. When register shuffle multiple times, we
     // need to ensure that LifecycleManager will only be created once. Parallelism needs to be
     // considered in this place, because if there is one RDD that depends on multiple RDDs
@@ -98,10 +98,10 @@ public class RssShuffleManager implements ShuffleManager {
     if (isDriver() && lifecycleManager == null) {
       synchronized (this) {
         if (lifecycleManager == null) {
-          lifecycleManager = new LifecycleManager(appId, celebornConf);
+          lifecycleManager = new LifecycleManager(appUniqueId, celebornConf);
           rssShuffleClient =
               ShuffleClient.get(
-                  appId,
+                  appUniqueId,
                   lifecycleManager.getRssMetaServiceHost(),
                   lifecycleManager.getRssMetaServicePort(),
                   celebornConf,
@@ -118,7 +118,7 @@ public class RssShuffleManager implements ShuffleManager {
     // is the same SparkContext among different shuffleIds.
     // This method may be called many times.
     appUniqueId = SparkUtils.appUniqueId(dependency.rdd().context());
-    initializeLifecycleManager(appUniqueId);
+    initializeLifecycleManager();
 
     if (fallbackPolicyRunner.applyAllFallbackPolicy(
         lifecycleManager, dependency.partitioner().numPartitions())) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/RssShuffleManager.java
@@ -101,6 +101,7 @@ public class RssShuffleManager implements ShuffleManager {
           lifecycleManager = new LifecycleManager(appId, celebornConf);
           rssShuffleClient =
               ShuffleClient.get(
+                appId,
                   lifecycleManager.getRssMetaServiceHost(),
                   lifecycleManager.getRssMetaServicePort(),
                   celebornConf,
@@ -147,7 +148,7 @@ public class RssShuffleManager implements ShuffleManager {
     if (rssShuffleClient == null) {
       return false;
     }
-    return rssShuffleClient.unregisterShuffle(appUniqueId, shuffleId, isDriver());
+    return rssShuffleClient.unregisterShuffle(shuffleId, isDriver());
   }
 
   @Override
@@ -180,7 +181,7 @@ public class RssShuffleManager implements ShuffleManager {
         @SuppressWarnings("unchecked")
         RssShuffleHandle<K, V, ?> h = ((RssShuffleHandle<K, V, ?>) handle);
         ShuffleClient client =
-            ShuffleClient.get(
+            ShuffleClient.get(h.appUniqueId(),
                 h.rssMetaServiceHost(), h.rssMetaServicePort(), celebornConf, h.userIdentifier());
         if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())) {
           ExecutorService pushThread =

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -61,7 +61,6 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private final ShuffleDependency<K, V, C> dep;
   private final Partitioner partitioner;
   private final ShuffleWriteMetricsReporter writeMetrics;
-  private final String appId;
   private final int shuffleId;
   private final int mapId;
   private final TaskContext taskContext;
@@ -107,7 +106,6 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException {
     this.mapId = taskContext.partitionId();
     this.dep = dep;
-    this.appId = appId;
     this.shuffleId = dep.shuffleId();
     SerializerInstance serializer = dep.serializer().newInstance();
     this.partitioner = dep.partitioner();
@@ -327,7 +325,6 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     logger.debug("Push giant record, size {}.", Utils.bytesToString(numBytes));
     int bytesWritten =
         rssShuffleClient.pushData(
-            appId,
             shuffleId,
             mapId,
             taskContext.attemptNumber(),
@@ -360,13 +357,13 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       currentPusher.close();
     }
 
-    rssShuffleClient.pushMergedData(appId, shuffleId, mapId, taskContext.attemptNumber());
+    rssShuffleClient.pushMergedData(shuffleId, mapId, taskContext.attemptNumber());
     writeMetrics.incWriteTime(System.nanoTime() - pushStartTime);
 
     updateMapStatus();
 
     long waitStartTime = System.nanoTime();
-    rssShuffleClient.mapperEnd(appId, shuffleId, mapId, taskContext.attemptNumber(), numMappers);
+    rssShuffleClient.mapperEnd(shuffleId, mapId, taskContext.attemptNumber(), numMappers);
     writeMetrics.incWriteTime(System.nanoTime() - waitStartTime);
   }
 
@@ -400,7 +397,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         }
       }
     } finally {
-      rssShuffleClient.cleanup(appId, shuffleId, mapId, taskContext.attemptNumber());
+      rssShuffleClient.cleanup(shuffleId, mapId, taskContext.attemptNumber());
     }
   }
 

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/RssShuffleReader.scala
@@ -42,6 +42,7 @@ class RssShuffleReader[K, C](
 
   private val dep = handle.dependency
   private val rssShuffleClient = ShuffleClient.get(
+    handle.appUniqueId,
     handle.rssMetaServiceHost,
     handle.rssMetaServicePort,
     conf,
@@ -80,7 +81,6 @@ class RssShuffleReader[K, C](
       if (handle.numMappers > 0) {
         val start = System.currentTimeMillis()
         val inputStream = rssShuffleClient.readPartition(
-          handle.appUniqueId,
           handle.shuffleId,
           partitionId,
           context.attemptNumber(),

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -52,7 +52,7 @@ public abstract class ShuffleClient {
   protected ShuffleClient() {}
 
   public static ShuffleClient get(
-      String driverHost, int port, CelebornConf conf, UserIdentifier userIdentifier) {
+      String appUniqueId, String driverHost, int port, CelebornConf conf, UserIdentifier userIdentifier) {
     if (null == _instance || !initialized) {
       synchronized (ShuffleClient.class) {
         if (null == _instance) {
@@ -61,12 +61,12 @@ public abstract class ShuffleClient {
           // ShuffleClient is building a singleton, it may cause the MetaServiceEndpoint to not be
           // assigned. An Executor will only construct a ShuffleClient singleton once. At this time,
           // when communicating with MetaService, it will cause a NullPointerException.
-          _instance = new ShuffleClientImpl(conf, userIdentifier);
+          _instance = new ShuffleClientImpl(appUniqueId, conf, userIdentifier);
           _instance.setupMetaServiceRef(driverHost, port);
           initialized = true;
         } else if (!initialized) {
           _instance.shutdown();
-          _instance = new ShuffleClientImpl(conf, userIdentifier);
+          _instance = new ShuffleClientImpl(appUniqueId, conf, userIdentifier);
           _instance.setupMetaServiceRef(driverHost, port);
           initialized = true;
         }
@@ -104,7 +104,6 @@ public abstract class ShuffleClient {
 
   // Write data to a specific reduce partition
   public abstract int pushData(
-      String applicationId,
       int shuffleId,
       int mapId,
       int attemptId,
@@ -120,7 +119,6 @@ public abstract class ShuffleClient {
       throws IOException;
 
   public abstract int mergeData(
-      String applicationId,
       int shuffleId,
       int mapId,
       int attemptId,
@@ -132,17 +130,16 @@ public abstract class ShuffleClient {
       int numPartitions)
       throws IOException;
 
-  public abstract void pushMergedData(String applicationId, int shuffleId, int mapId, int attemptId)
+  public abstract void pushMergedData(int shuffleId, int mapId, int attemptId)
       throws IOException;
 
   // Report partition locations written by the completed map task of ReducePartition Shuffle Type
   public abstract void mapperEnd(
-      String applicationId, int shuffleId, int mapId, int attemptId, int numMappers)
+      int shuffleId, int mapId, int attemptId, int numMappers)
       throws IOException;
 
   // Report partition locations written by the completed map task of MapPartition Shuffle Type
   public abstract void mapPartitionMapperEnd(
-      String applicationId,
       int shuffleId,
       int mapId,
       int attemptId,
@@ -151,12 +148,11 @@ public abstract class ShuffleClient {
       throws IOException;
 
   // Cleanup states of the map task
-  public abstract void cleanup(String applicationId, int shuffleId, int mapId, int attemptId);
+  public abstract void cleanup(int shuffleId, int mapId, int attemptId);
 
   // Reduce side read partition which is deduplicated by mapperId+mapperAttemptNum+batchId, batchId
   // is a self-incrementing variable hidden in the implementation when sending data.
   public abstract RssInputStream readPartition(
-      String applicationId,
       int shuffleId,
       int partitionId,
       int attemptNumber,
@@ -165,18 +161,18 @@ public abstract class ShuffleClient {
       throws IOException;
 
   public abstract RssInputStream readPartition(
-      String applicationId, int shuffleId, int partitionId, int attemptNumber) throws IOException;
+      int shuffleId, int partitionId, int attemptNumber) throws IOException;
 
-  public abstract boolean unregisterShuffle(String applicationId, int shuffleId, boolean isDriver);
+  public abstract boolean unregisterShuffle(int shuffleId, boolean isDriver);
 
   public abstract void shutdown();
 
   public abstract PartitionLocation registerMapPartitionTask(
-      String appId, int shuffleId, int numMappers, int mapId, int attemptId, int partitionId)
+      int shuffleId, int numMappers, int mapId, int attemptId, int partitionId)
       throws IOException;
 
   public abstract ConcurrentHashMap<Integer, PartitionLocation> getPartitionLocation(
-      String applicationId, int shuffleId, int numMappers, int numPartitions);
+      int shuffleId, int numMappers, int numPartitions);
 
   public abstract PushState getPushState(String mapKey);
 }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -52,7 +52,11 @@ public abstract class ShuffleClient {
   protected ShuffleClient() {}
 
   public static ShuffleClient get(
-      String appUniqueId, String driverHost, int port, CelebornConf conf, UserIdentifier userIdentifier) {
+      String appUniqueId,
+      String driverHost,
+      int port,
+      CelebornConf conf,
+      UserIdentifier userIdentifier) {
     if (null == _instance || !initialized) {
       synchronized (ShuffleClient.class) {
         if (null == _instance) {
@@ -130,22 +134,15 @@ public abstract class ShuffleClient {
       int numPartitions)
       throws IOException;
 
-  public abstract void pushMergedData(int shuffleId, int mapId, int attemptId)
-      throws IOException;
+  public abstract void pushMergedData(int shuffleId, int mapId, int attemptId) throws IOException;
 
   // Report partition locations written by the completed map task of ReducePartition Shuffle Type
-  public abstract void mapperEnd(
-      int shuffleId, int mapId, int attemptId, int numMappers)
+  public abstract void mapperEnd(int shuffleId, int mapId, int attemptId, int numMappers)
       throws IOException;
 
   // Report partition locations written by the completed map task of MapPartition Shuffle Type
   public abstract void mapPartitionMapperEnd(
-      int shuffleId,
-      int mapId,
-      int attemptId,
-      int numMappers,
-      int partitionId)
-      throws IOException;
+      int shuffleId, int mapId, int attemptId, int numMappers, int partitionId) throws IOException;
 
   // Cleanup states of the map task
   public abstract void cleanup(int shuffleId, int mapId, int attemptId);
@@ -153,23 +150,18 @@ public abstract class ShuffleClient {
   // Reduce side read partition which is deduplicated by mapperId+mapperAttemptNum+batchId, batchId
   // is a self-incrementing variable hidden in the implementation when sending data.
   public abstract RssInputStream readPartition(
-      int shuffleId,
-      int partitionId,
-      int attemptNumber,
-      int startMapIndex,
-      int endMapIndex)
+      int shuffleId, int partitionId, int attemptNumber, int startMapIndex, int endMapIndex)
       throws IOException;
 
-  public abstract RssInputStream readPartition(
-      int shuffleId, int partitionId, int attemptNumber) throws IOException;
+  public abstract RssInputStream readPartition(int shuffleId, int partitionId, int attemptNumber)
+      throws IOException;
 
   public abstract boolean unregisterShuffle(int shuffleId, boolean isDriver);
 
   public abstract void shutdown();
 
   public abstract PartitionLocation registerMapPartitionTask(
-      int shuffleId, int numMappers, int mapId, int attemptId, int partitionId)
-      throws IOException;
+      int shuffleId, int numMappers, int mapId, int attemptId, int partitionId) throws IOException;
 
   public abstract ConcurrentHashMap<Integer, PartitionLocation> getPartitionLocation(
       int shuffleId, int numMappers, int numPartitions);

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -109,7 +109,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   private final ExecutorService partitionSplitPool;
   private final Map<Integer, Set<Integer>> splitting = JavaUtils.newConcurrentHashMap();
 
-  private final String appUniqueId;
+  protected final String appUniqueId;
 
   ThreadLocal<Compressor> compressorThreadLocal =
       new ThreadLocal<Compressor>() {
@@ -186,6 +186,8 @@ public class ShuffleClientImpl extends ShuffleClient {
     partitionSplitPool =
         ThreadUtils.newDaemonCachedThreadPool(
             "celeborn-shuffle-split", pushSplitPartitionThreads, 60);
+
+    logger.info("Created ShuffleClientImpl, appUniqueId: {}", appUniqueId);
   }
 
   private boolean checkPushBlacklisted(

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1426,7 +1426,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   }
 
   protected ReduceFileGroups updateFileGroup(
-      int shuffleId) throws IOException {
+      int shuffleId, int partitionId) throws IOException {
     return reduceFileGroupsMap.computeIfAbsent(
         shuffleId, (id) -> loadFileGroupInternal(shuffleId));
   }
@@ -1434,7 +1434,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   protected ReduceFileGroups loadFileGroup(
       int shuffleId, int partitionId) throws IOException {
     ReduceFileGroups reduceFileGroups =
-        updateFileGroup(shuffleId);
+        updateFileGroup(shuffleId, partitionId);
     if (reduceFileGroups == null) {
       String msg =
           "Shuffle data lost for shuffle " + shuffleId + " partitionId " + partitionId + "!";

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPushQueue.java
@@ -48,7 +48,6 @@ public class DataPushQueue {
   private final DataPusher dataPusher;
   private final int maxInFlight;
 
-  private final String appId;
   private final int shuffleId;
   private final int numMappers;
   private final int numPartitions;
@@ -60,13 +59,11 @@ public class DataPushQueue {
       CelebornConf conf,
       DataPusher dataPusher,
       ShuffleClient client,
-      String appId,
       int shuffleId,
       int mapId,
       int attemptId,
       int numMappers,
       int numPartitions) {
-    this.appId = appId;
     this.shuffleId = shuffleId;
     this.numMappers = numMappers;
     this.numPartitions = numPartitions;
@@ -99,7 +96,7 @@ public class DataPushQueue {
         PushTask task = iterator.next();
         int partitionId = task.getPartitionId();
         Map<Integer, PartitionLocation> partitionLocationMap =
-            client.getPartitionLocation(appId, shuffleId, numMappers, numPartitions);
+            client.getPartitionLocation(shuffleId, numMappers, numPartitions);
         if (partitionLocationMap != null) {
           PartitionLocation loc = partitionLocationMap.get(partitionId);
           // According to CELEBORN-560, call rerun task and speculative task after LifecycleManager

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -48,7 +48,6 @@ public class DataPusher {
 
   private final AtomicReference<IOException> exceptionRef = new AtomicReference<>();
 
-  private final String appId;
   private final int shuffleId;
   private final int mapId;
   private final int attemptId;
@@ -62,7 +61,6 @@ public class DataPusher {
   private Thread pushThread;
 
   public DataPusher(
-      String appId,
       int shuffleId,
       int mapId,
       int attemptId,
@@ -80,13 +78,12 @@ public class DataPusher {
     idleQueue = new LinkedBlockingQueue<>(pushQueueCapacity);
     dataPushQueue =
         new DataPushQueue(
-            conf, this, client, appId, shuffleId, mapId, attemptId, numMappers, numPartitions);
+            conf, this, client, shuffleId, mapId, attemptId, numMappers, numPartitions);
 
     for (int i = 0; i < pushQueueCapacity; i++) {
       idleQueue.put(new PushTask(pushBufferMaxSize));
     }
 
-    this.appId = appId;
     this.shuffleId = shuffleId;
     this.mapId = mapId;
     this.attemptId = attemptId;
@@ -195,7 +192,6 @@ public class DataPusher {
   private void pushData(PushTask task) throws IOException {
     int bytesWritten =
         client.pushData(
-            appId,
             shuffleId,
             mapId,
             attemptId,

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -69,7 +69,7 @@ object CommitManager {
   type CommittedPartitionInfo = ConcurrentHashMap[Int, ShuffleCommittedInfo]
 }
 
-class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: LifecycleManager)
+class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManager: LifecycleManager)
   extends Logging {
 
   // shuffle id -> ShuffleCommittedInfo
@@ -142,7 +142,7 @@ class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: Lif
                                 .asJava
 
                             commitHandler.commitFiles(
-                              appId,
+                              appUniqueId,
                               shuffleId,
                               shuffleCommittedInfo,
                               workerInfo,
@@ -272,13 +272,13 @@ class CommitManager(appId: String, val conf: CelebornConf, lifecycleManager: Lif
         (partitionType: PartitionType) => {
           partitionType match {
             case PartitionType.REDUCE => new ReducePartitionCommitHandler(
-                appId,
+                appUniqueId,
                 conf,
                 lifecycleManager.shuffleAllocatedWorkers,
                 committedPartitionInfo,
                 lifecycleManager.workerStatusTracker)
             case PartitionType.MAP => new MapPartitionCommitHandler(
-                appId,
+                appUniqueId,
                 conf,
                 lifecycleManager.shuffleAllocatedWorkers,
                 committedPartitionInfo,

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -52,7 +52,8 @@ object LifecycleManager {
   type ShuffleFailedWorkers = ConcurrentHashMap[WorkerInfo, (StatusCode, Long)]
 }
 
-class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends RpcEndpoint with Logging {
+class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends RpcEndpoint
+  with Logging {
 
   private val lifecycleHost = Utils.localHostName
 

--- a/client/src/main/scala/org/apache/celeborn/client/ReleasePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ReleasePartitionManager.scala
@@ -30,7 +30,6 @@ import org.apache.celeborn.common.protocol.message.ControlMessages.WorkerResourc
 import org.apache.celeborn.common.util.{JavaUtils, ThreadUtils}
 
 class ReleasePartitionManager(
-    appId: String,
     val conf: CelebornConf,
     lifecycleManager: LifecycleManager)
   extends Logging {
@@ -84,7 +83,6 @@ class ReleasePartitionManager(
 
                             if (!destroyResource.isEmpty) {
                               lifecycleManager.destroySlotsWithRetry(
-                                appId,
                                 shuffleId,
                                 destroyResource)
                               logTrace(s"Destroyed partition resource for shuffle $shuffleId $destroyResource")
@@ -127,7 +125,7 @@ class ReleasePartitionManager(
       }
 
       if (!destroyResource.isEmpty) {
-        lifecycleManager.destroySlotsWithRetry(appId, shuffleId, destroyResource)
+        lifecycleManager.destroySlotsWithRetry(shuffleId, destroyResource)
         logTrace(
           s"Destroyed partition resource for partition $shuffleId-$partitionId, $destroyResource")
       }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -44,10 +44,10 @@ case class CommitResult(
     commitFilesFailedWorkers: ShuffleFailedWorkers)
 
 abstract class CommitHandler(
-    appId: String,
-    conf: CelebornConf,
-    committedPartitionInfo: CommittedPartitionInfo,
-    workerStatusTracker: WorkerStatusTracker) extends Logging {
+                              appUniqueId: String,
+                              conf: CelebornConf,
+                              committedPartitionInfo: CommittedPartitionInfo,
+                              workerStatusTracker: WorkerStatusTracker) extends Logging {
 
   private val pushReplicateEnabled = conf.clientPushReplicateEnabled
   private val testRetryCommitFiles = conf.testRetryCommitFiles
@@ -227,7 +227,7 @@ abstract class CommitHandler(
       }
 
       commitFiles(
-        appId,
+        appUniqueId,
         shuffleId,
         shuffleCommittedInfo,
         worker,
@@ -437,7 +437,7 @@ abstract class CommitHandler(
       shuffleId: Int,
       failedMasters: util.Map[String, WorkerInfo],
       failedSlaves: util.Map[String, WorkerInfo]): Boolean = {
-    val shuffleKey = Utils.makeShuffleKey(appId, shuffleId)
+    val shuffleKey = Utils.makeShuffleKey(appUniqueId, shuffleId)
     if (!pushReplicateEnabled && failedMasters.size() != 0) {
       val msg =
         failedMasters.asScala.map {

--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -44,10 +44,10 @@ case class CommitResult(
     commitFilesFailedWorkers: ShuffleFailedWorkers)
 
 abstract class CommitHandler(
-                              appUniqueId: String,
-                              conf: CelebornConf,
-                              committedPartitionInfo: CommittedPartitionInfo,
-                              workerStatusTracker: WorkerStatusTracker) extends Logging {
+    appUniqueId: String,
+    conf: CelebornConf,
+    committedPartitionInfo: CommittedPartitionInfo,
+    workerStatusTracker: WorkerStatusTracker) extends Logging {
 
   private val pushReplicateEnabled = conf.clientPushReplicateEnabled
   private val testRetryCommitFiles = conf.testRetryCommitFiles

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -47,11 +47,11 @@ import org.apache.celeborn.common.util.JavaUtils
  * @see [[org.apache.celeborn.common.protocol.PartitionType.REDUCE]]
  */
 class ReducePartitionCommitHandler(
-                                    appUniqueId: String,
-                                    conf: CelebornConf,
-                                    shuffleAllocatedWorkers: ShuffleAllocatedWorkers,
-                                    committedPartitionInfo: CommittedPartitionInfo,
-                                    workerStatusTracker: WorkerStatusTracker)
+    appUniqueId: String,
+    conf: CelebornConf,
+    shuffleAllocatedWorkers: ShuffleAllocatedWorkers,
+    committedPartitionInfo: CommittedPartitionInfo,
+    workerStatusTracker: WorkerStatusTracker)
   extends CommitHandler(appUniqueId, conf, committedPartitionInfo, workerStatusTracker)
   with Logging {
 

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -47,12 +47,12 @@ import org.apache.celeborn.common.util.JavaUtils
  * @see [[org.apache.celeborn.common.protocol.PartitionType.REDUCE]]
  */
 class ReducePartitionCommitHandler(
-    appId: String,
-    conf: CelebornConf,
-    shuffleAllocatedWorkers: ShuffleAllocatedWorkers,
-    committedPartitionInfo: CommittedPartitionInfo,
-    workerStatusTracker: WorkerStatusTracker)
-  extends CommitHandler(appId, conf, committedPartitionInfo, workerStatusTracker)
+                                    appUniqueId: String,
+                                    conf: CelebornConf,
+                                    shuffleAllocatedWorkers: ShuffleAllocatedWorkers,
+                                    committedPartitionInfo: CommittedPartitionInfo,
+                                    workerStatusTracker: WorkerStatusTracker)
+  extends CommitHandler(appUniqueId, conf, committedPartitionInfo, workerStatusTracker)
   with Logging {
 
   private val getReducerFileGroupRequest =

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -100,16 +100,11 @@ public class DummyShuffleClient extends ShuffleClient {
   public void pushMergedData(int shuffleId, int mapId, int attemptId) {}
 
   @Override
-  public void mapperEnd(
-      int shuffleId, int mapId, int attemptId, int numMappers) {}
+  public void mapperEnd(int shuffleId, int mapId, int attemptId, int numMappers) {}
 
   @Override
   public void mapPartitionMapperEnd(
-      int shuffleId,
-      int mapId,
-      int attemptId,
-      int numMappers,
-      int partitionId)
+      int shuffleId, int mapId, int attemptId, int numMappers, int partitionId)
       throws IOException {}
 
   @Override
@@ -117,17 +112,12 @@ public class DummyShuffleClient extends ShuffleClient {
 
   @Override
   public RssInputStream readPartition(
-      int shuffleId,
-      int partitionId,
-      int attemptNumber,
-      int startMapIndex,
-      int endMapIndex) {
+      int shuffleId, int partitionId, int attemptNumber, int startMapIndex, int endMapIndex) {
     return null;
   }
 
   @Override
-  public RssInputStream readPartition(
-      int shuffleId, int partitionId, int attemptNumber) {
+  public RssInputStream readPartition(int shuffleId, int partitionId, int attemptNumber) {
     return null;
   }
 

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -63,7 +63,6 @@ public class DummyShuffleClient extends ShuffleClient {
 
   @Override
   public int pushData(
-      String applicationId,
       int shuffleId,
       int mapId,
       int attemptId,
@@ -83,7 +82,6 @@ public class DummyShuffleClient extends ShuffleClient {
 
   @Override
   public int mergeData(
-      String applicationId,
       int shuffleId,
       int mapId,
       int attemptId,
@@ -99,15 +97,14 @@ public class DummyShuffleClient extends ShuffleClient {
   }
 
   @Override
-  public void pushMergedData(String applicationId, int shuffleId, int mapId, int attemptId) {}
+  public void pushMergedData(int shuffleId, int mapId, int attemptId) {}
 
   @Override
   public void mapperEnd(
-      String applicationId, int shuffleId, int mapId, int attemptId, int numMappers) {}
+      int shuffleId, int mapId, int attemptId, int numMappers) {}
 
   @Override
   public void mapPartitionMapperEnd(
-      String applicationId,
       int shuffleId,
       int mapId,
       int attemptId,
@@ -116,11 +113,10 @@ public class DummyShuffleClient extends ShuffleClient {
       throws IOException {}
 
   @Override
-  public void cleanup(String applicationId, int shuffleId, int mapId, int attemptId) {}
+  public void cleanup(int shuffleId, int mapId, int attemptId) {}
 
   @Override
   public RssInputStream readPartition(
-      String applicationId,
       int shuffleId,
       int partitionId,
       int attemptNumber,
@@ -131,12 +127,12 @@ public class DummyShuffleClient extends ShuffleClient {
 
   @Override
   public RssInputStream readPartition(
-      String applicationId, int shuffleId, int partitionId, int attemptNumber) {
+      int shuffleId, int partitionId, int attemptNumber) {
     return null;
   }
 
   @Override
-  public boolean unregisterShuffle(String applicationId, int shuffleId, boolean isDriver) {
+  public boolean unregisterShuffle(int shuffleId, boolean isDriver) {
     return false;
   }
 
@@ -151,13 +147,13 @@ public class DummyShuffleClient extends ShuffleClient {
 
   @Override
   public PartitionLocation registerMapPartitionTask(
-      String appId, int shuffleId, int numMappers, int mapId, int attemptId, int partitionId) {
+      int shuffleId, int numMappers, int mapId, int attemptId, int partitionId) {
     return null;
   }
 
   @Override
   public ConcurrentHashMap<Integer, PartitionLocation> getPartitionLocation(
-      String applicationId, int shuffleId, int numMappers, int numPartitions) {
+      int shuffleId, int numMappers, int numPartitions) {
     return reducePartitionMap.get(shuffleId);
   }
 

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
@@ -85,7 +85,7 @@ public abstract class ShuffleClientBaseSuiteJ {
     conf.set(CelebornConf.SHUFFLE_COMPRESSION_CODEC().key(), codec.name());
     conf.set(CelebornConf.CLIENT_PUSH_RETRY_THREADS().key(), "1");
     conf.set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE().key(), "1K");
-    shuffleClient = new ShuffleClientImpl(conf, new UserIdentifier("mock", "mock"));
+    shuffleClient = new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
     masterLocation.setPeer(slaveLocation);
 
     when(endpointRef.askSync(

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
@@ -90,7 +90,7 @@ public abstract class ShuffleClientBaseSuiteJ {
 
     when(endpointRef.askSync(
             ControlMessages.RegisterShuffle$.MODULE$.apply(
-                TEST_APPLICATION_ID, TEST_SHUFFLE_ID, 1, 1),
+                TEST_SHUFFLE_ID, 1, 1),
             ClassTag$.MODULE$.apply(PbRegisterShuffleResponse.class)))
         .thenAnswer(
             t ->

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
@@ -85,12 +85,12 @@ public abstract class ShuffleClientBaseSuiteJ {
     conf.set(CelebornConf.SHUFFLE_COMPRESSION_CODEC().key(), codec.name());
     conf.set(CelebornConf.CLIENT_PUSH_RETRY_THREADS().key(), "1");
     conf.set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE().key(), "1K");
-    shuffleClient = new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
+    shuffleClient =
+        new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
     masterLocation.setPeer(slaveLocation);
 
     when(endpointRef.askSync(
-            ControlMessages.RegisterShuffle$.MODULE$.apply(
-                TEST_SHUFFLE_ID, 1, 1),
+            ControlMessages.RegisterShuffle$.MODULE$.apply(TEST_SHUFFLE_ID, 1, 1),
             ClassTag$.MODULE$.apply(PbRegisterShuffleResponse.class)))
         .thenAnswer(
             t ->

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -173,7 +173,8 @@ public class ShuffleClientSuiteJ {
     conf.set(CelebornConf.SHUFFLE_COMPRESSION_CODEC().key(), codec.name());
     conf.set(CelebornConf.CLIENT_PUSH_RETRY_THREADS().key(), "1");
     conf.set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE().key(), "1K");
-    shuffleClient = new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
+    shuffleClient =
+        new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
 
     masterLocation.setPeer(slaveLocation);
     when(endpointRef.askSync(any(), any(), any()))

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -95,7 +95,6 @@ public class ShuffleClientSuiteJ {
 
       int pushDataLen =
           shuffleClient.pushData(
-              TEST_APPLICATION_ID,
               TEST_SHUFFLE_ID,
               TEST_ATTEMPT_ID,
               TEST_ATTEMPT_ID,
@@ -121,7 +120,6 @@ public class ShuffleClientSuiteJ {
 
       int mergeSize =
           shuffleClient.mergeData(
-              TEST_APPLICATION_ID,
               TEST_SHUFFLE_ID,
               TEST_ATTEMPT_ID,
               TEST_ATTEMPT_ID,
@@ -137,7 +135,6 @@ public class ShuffleClientSuiteJ {
       final int compressedTotalSize = compressor.getCompressedTotalSize();
 
       shuffleClient.mergeData(
-          TEST_APPLICATION_ID,
           TEST_SHUFFLE_ID,
           TEST_ATTEMPT_ID,
           TEST_ATTEMPT_ID,
@@ -153,7 +150,6 @@ public class ShuffleClientSuiteJ {
       byte[] buf1k = RandomStringUtils.random(4000).getBytes(StandardCharsets.UTF_8);
       int largeMergeSize =
           shuffleClient.mergeData(
-              TEST_APPLICATION_ID,
               TEST_SHUFFLE_ID,
               TEST_ATTEMPT_ID,
               TEST_ATTEMPT_ID,
@@ -177,7 +173,7 @@ public class ShuffleClientSuiteJ {
     conf.set(CelebornConf.SHUFFLE_COMPRESSION_CODEC().key(), codec.name());
     conf.set(CelebornConf.CLIENT_PUSH_RETRY_THREADS().key(), "1");
     conf.set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE().key(), "1K");
-    shuffleClient = new ShuffleClientImpl(conf, new UserIdentifier("mock", "mock"));
+    shuffleClient = new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
 
     masterLocation.setPeer(slaveLocation);
     when(endpointRef.askSync(any(), any(), any()))

--- a/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuitJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuitJ.java
@@ -82,7 +82,6 @@ public class DataPushQueueSuitJ {
     CelebornConf conf = new CelebornConf();
     conf.set(CelebornConf.CLIENT_PUSH_MAX_REQS_IN_FLIGHT().key(), "2");
 
-    String app = "APP-1";
     int shuffleId = 0;
     int mapId = 0;
     int attemptId = 0;
@@ -98,7 +97,6 @@ public class DataPushQueueSuitJ {
     }
     DataPusher dataPusher =
         new DataPusher(
-            app,
             shuffleId,
             mapId,
             attemptId,

--- a/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
@@ -57,12 +57,12 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
     prepareService()
     shuffleId = 1
     var location =
-      shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId, 1)
+      shuffleClient.registerMapPartitionTask(shuffleId, numMappers, mapId, attemptId, 1)
     Assert.assertEquals(location.getId, 1)
 
     // retry register
     location =
-      shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId, 1)
+      shuffleClient.registerMapPartitionTask(shuffleId, numMappers, mapId, attemptId, 1)
     Assert.assertEquals(location.getId, 1)
 
     // check all allocated slots
@@ -73,13 +73,12 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
 
     // another mapId
     location =
-      shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId + 1, attemptId, 2)
+      shuffleClient.registerMapPartitionTask(shuffleId, numMappers, mapId + 1, attemptId, 2)
     Assert.assertEquals(location.getId, 2)
 
     // another mapId with another attemptId
     location =
       shuffleClient.registerMapPartitionTask(
-        APP,
         shuffleId,
         numMappers,
         mapId + 1,
@@ -142,39 +141,38 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
     Assert.assertEquals(shuffleClient.getReduceFileGroupsMap.size(), 0)
 
     // reduce normal empty RssInputStream
-    var stream = shuffleClient.readPartition(APP, shuffleId, 1, 1)
+    var stream = shuffleClient.readPartition(shuffleId, 1, 1)
     Assert.assertEquals(stream.read(), -1)
 
     // reduce normal null partition for RssInputStream
-    stream = shuffleClient.readPartition(APP, shuffleId, 3, 1)
+    stream = shuffleClient.readPartition(shuffleId, 3, 1)
     Assert.assertEquals(stream.read(), -1)
   }
 
   private def prepareService(): Unit = {
     lifecycleManager = new LifecycleManager(APP, celebornConf)
-    shuffleClient = new ShuffleClientImpl(celebornConf, userIdentifier)
+    shuffleClient = new ShuffleClientImpl(APP, celebornConf, userIdentifier)
     shuffleClient.setupMetaServiceRef(lifecycleManager.self)
   }
 
   private def registerAndFinishPartition(): Unit = {
-    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId, 1)
-    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId + 1, attemptId, 2)
-    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId + 2, attemptId, 3)
+    shuffleClient.registerMapPartitionTask(shuffleId, numMappers, mapId, attemptId, 1)
+    shuffleClient.registerMapPartitionTask(shuffleId, numMappers, mapId + 1, attemptId, 2)
+    shuffleClient.registerMapPartitionTask(shuffleId, numMappers, mapId + 2, attemptId, 3)
 
     // task number incr to numMappers + 1
-    shuffleClient.registerMapPartitionTask(APP, shuffleId, numMappers, mapId, attemptId + 1, 9)
-    shuffleClient.mapPartitionMapperEnd(APP, shuffleId, mapId, attemptId, numMappers, 1)
+    shuffleClient.registerMapPartitionTask(shuffleId, numMappers, mapId, attemptId + 1, 9)
+    shuffleClient.mapPartitionMapperEnd(shuffleId, mapId, attemptId, numMappers, 1)
     // retry
-    shuffleClient.mapPartitionMapperEnd(APP, shuffleId, mapId, attemptId, numMappers, 1)
+    shuffleClient.mapPartitionMapperEnd(shuffleId, mapId, attemptId, numMappers, 1)
     // another attempt
     shuffleClient.mapPartitionMapperEnd(
-      APP,
       shuffleId,
       mapId,
       attemptId + 1,
       numMappers,
       9)
     // another mapper
-    shuffleClient.mapPartitionMapperEnd(APP, shuffleId, mapId + 1, attemptId, numMappers, mapId + 1)
+    shuffleClient.mapPartitionMapperEnd(shuffleId, mapId + 1, attemptId, numMappers, mapId + 1)
   }
 }

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -154,19 +154,17 @@ message PbHeartbeatResponse {
 }
 
 message PbRegisterShuffle {
-  string applicationId = 1;
-  int32 shuffleId = 2;
-  int32 numMapppers = 3;
-  int32 numPartitions = 4;
+  int32 shuffleId = 1;
+  int32 numMapppers = 2;
+  int32 numPartitions = 3;
 }
 
 message PbRegisterMapPartitionTask {
-  string applicationId = 1;
-  int32 shuffleId = 2;
-  int32 numMappers = 3;
-  int32 mapId = 4;
-  int32 attemptId = 5;
-  int32 partitionId = 6;
+  int32 shuffleId = 1;
+  int32 numMappers = 2;
+  int32 mapId = 3;
+  int32 attemptId = 4;
+  int32 partitionId = 5;
 }
 
 message PbRegisterShuffleResponse {
@@ -208,14 +206,13 @@ message PbRequestSlotsResponse {
 }
 
 message PbRevive {
-  string applicationId = 1;
-  int32 shuffleId = 2;
-  int32 mapId = 3;
-  int32 attemptId = 4;
-  int32 partitionId = 5;
-  int32 epoch = 6;
-  PbPartitionLocation oldPartition = 7;
-  int32 status = 8;
+  int32 shuffleId = 1;
+  int32 mapId = 2;
+  int32 attemptId = 3;
+  int32 partitionId = 4;
+  int32 epoch = 5;
+  PbPartitionLocation oldPartition = 6;
+  int32 status = 7;
 }
 
 message PbChangeLocationResponse {
@@ -225,20 +222,18 @@ message PbChangeLocationResponse {
 }
 
 message PbPartitionSplit {
-  string applicationId = 1;
-  int32 shuffleId = 2;
-  int32 partitionId = 3;
-  int32 epoch = 4;
-  PbPartitionLocation oldPartition = 5;
+  int32 shuffleId = 1;
+  int32 partitionId = 2;
+  int32 epoch = 3;
+  PbPartitionLocation oldPartition = 4;
 }
 
 message PbMapperEnd {
-  string applicationId = 1;
-  int32 shuffleId = 2;
-  int32 mapId = 3;
-  int32 attemptId = 4;
-  int32 numMappers = 5;
-  int32 partitionId = 6;
+  int32 shuffleId = 1;
+  int32 mapId = 2;
+  int32 attemptId = 3;
+  int32 numMappers = 4;
+  int32 partitionId = 5;
 }
 
 message PbMapperEndResponse {
@@ -246,8 +241,7 @@ message PbMapperEndResponse {
 }
 
 message PbGetReducerFileGroup {
-  string applicationId = 1;
-  int32 shuffleId = 2;
+  int32 shuffleId = 1;
 }
 
 message PbGetReducerFileGroupResponse {
@@ -412,8 +406,7 @@ message PbWorkerLostResponse {
 }
 
 message PbStageEnd {
-  string applicationId = 1;
-  int32 shuffleId = 2;
+  int32 shuffleId = 1;
 }
 
 message PbStageEndResponse {

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -552,6 +552,7 @@ object ControlMessages extends Logging {
 
     case GetReducerFileGroup(shuffleId) =>
       val payload = PbGetReducerFileGroup.newBuilder()
+        .setShuffleId(shuffleId)
         .build().toByteArray
       new TransportMessage(MessageType.GET_REDUCER_FILE_GROUP, payload)
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -613,8 +613,8 @@ object Utils extends Logging {
     (partitionId, epoch)
   }
 
-  def makeReducerKey(applicationId: String, shuffleId: Int, partitionId: Int): String = {
-    s"$applicationId-$shuffleId-$partitionId"
+  def makeReducerKey(shuffleId: Int, partitionId: Int): String = {
+    s"shuffleId-$partitionId"
   }
 
   def makeMapKey(applicationId: String, shuffleId: Int, mapId: Int, attemptId: Int): String = {

--- a/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/UtilsSuite.scala
@@ -99,7 +99,7 @@ class UtilsSuite extends CelebornFunSuite {
   }
 
   test("MapperEnd class convert with pb") {
-    val mapperEnd = MapperEnd("application1", 1, 1, 1, 2, 1)
+    val mapperEnd = MapperEnd(1, 1, 1, 2, 1)
     val mapperEndTrans =
       Utils.fromTransportMessage(Utils.toTransportMessage(mapperEnd)).asInstanceOf[MapperEnd]
     assert(mapperEnd == mapperEndTrans)

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/HeartbeatTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/HeartbeatTest.scala
@@ -34,6 +34,7 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
     val flinkShuffleClientImpl =
       new FlinkShuffleClientImpl(
         "",
+        "",
         0,
         System.currentTimeMillis(),
         clientConf,
@@ -48,6 +49,7 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
     val flinkShuffleClientImpl =
       new FlinkShuffleClientImpl(
         "",
+        "",
         0,
         System.currentTimeMillis(),
         clientConf,
@@ -61,6 +63,7 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
     val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithCloseChannelConf()
     val flinkShuffleClientImpl =
       new FlinkShuffleClientImpl(
+        "",
         "",
         0,
         System.currentTimeMillis(),

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
@@ -47,13 +47,13 @@ class ShuffleClientSuite extends WithShuffleClientSuite with MiniClusterFeature 
 
     val lifecycleManager: LifecycleManager = new LifecycleManager(APP, celebornConf)
     val shuffleClient: ShuffleClientImpl = {
-      val client = new ShuffleClientImpl(celebornConf, userIdentifier)
+      val client = new ShuffleClientImpl(APP, celebornConf, userIdentifier)
       client.setupMetaServiceRef(lifecycleManager.self)
       client
     }
 
     assertThrows[IOException] {
-      shuffleClient.registerMapPartitionTask(APP, 1, 1, 0, 0, 1)
+      shuffleClient.registerMapPartitionTask(1, 1, 0, 0, 1)
     }
 
     lifecycleManager.stop()

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HeartbeatTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HeartbeatTest.scala
@@ -39,21 +39,21 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
   test("celeborn spark heartbeat test - client <- worker") {
     val (_, clientConf) = getTestHeartbeatFromWorker2ClientConf()
     val shuffleClientImpl =
-      new ShuffleClientImpl(clientConf, new UserIdentifier("1", "1"))
+      new ShuffleClientImpl("APP", clientConf, new UserIdentifier("1", "1"))
     testHeartbeatFromWorker2Client(shuffleClientImpl.getDataClientFactory)
   }
 
   test("celeborn spark heartbeat test - client <- worker on heartbeat") {
     val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithNoHeartbeatConf()
     val shuffleClientImpl =
-      new ShuffleClientImpl(clientConf, new UserIdentifier("1", "1"))
+      new ShuffleClientImpl("APP", clientConf, new UserIdentifier("1", "1"))
     testHeartbeatFromWorker2ClientWithNoHeartbeat(shuffleClientImpl.getDataClientFactory)
   }
 
   test("celeborn spark heartbeat test - client <- worker timeout") {
     val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithCloseChannelConf()
     val shuffleClientImpl =
-      new ShuffleClientImpl(clientConf, new UserIdentifier("1", "1"))
+      new ShuffleClientImpl("APP", clientConf, new UserIdentifier("1", "1"))
     testHeartbeatFromWorker2ClientWithCloseChannel(shuffleClientImpl.getDataClientFactory)
   }
 }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
@@ -61,7 +61,7 @@ trait ReadWriteTestBase extends AnyFunSuite
       .set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
       .set("celeborn.data.io.numConnectionsPerPeer", "1")
     val lifecycleManager = new LifecycleManager(APP, clientConf)
-    val shuffleClient = new ShuffleClientImpl(clientConf, UserIdentifier("mock", "mock"))
+    val shuffleClient = new ShuffleClientImpl(APP, clientConf, UserIdentifier("mock", "mock"))
     shuffleClient.setupMetaServiceRef(lifecycleManager.self)
 
     val STR1 = RandomStringUtils.random(1024)
@@ -69,31 +69,31 @@ trait ReadWriteTestBase extends AnyFunSuite
     val OFFSET1 = 0
     val LENGTH1 = DATA1.length
 
-    val dataSize1 = shuffleClient.pushData(APP, 1, 0, 0, 0, DATA1, OFFSET1, LENGTH1, 1, 1)
+    val dataSize1 = shuffleClient.pushData(1, 0, 0, 0, DATA1, OFFSET1, LENGTH1, 1, 1)
     logInfo(s"push data data size $dataSize1")
 
     val STR2 = RandomStringUtils.random(32 * 1024)
     val DATA2 = STR2.getBytes(StandardCharsets.UTF_8)
     val OFFSET2 = 0
     val LENGTH2 = DATA2.length
-    val dataSize2 = shuffleClient.pushData(APP, 1, 0, 0, 0, DATA2, OFFSET2, LENGTH2, 1, 1)
+    val dataSize2 = shuffleClient.pushData(1, 0, 0, 0, DATA2, OFFSET2, LENGTH2, 1, 1)
     logInfo("push data data size " + dataSize2)
 
     val STR3 = RandomStringUtils.random(32 * 1024)
     val DATA3 = STR3.getBytes(StandardCharsets.UTF_8)
     val LENGTH3 = DATA3.length
-    shuffleClient.mergeData(APP, 1, 0, 0, 0, DATA3, 0, LENGTH3, 1, 1)
+    shuffleClient.mergeData(1, 0, 0, 0, DATA3, 0, LENGTH3, 1, 1)
 
     val STR4 = RandomStringUtils.random(16 * 1024)
     val DATA4 = STR4.getBytes(StandardCharsets.UTF_8)
     val LENGTH4 = DATA4.length
-    shuffleClient.mergeData(APP, 1, 0, 0, 0, DATA4, 0, LENGTH4, 1, 1)
-    shuffleClient.pushMergedData(APP, 1, 0, 0)
+    shuffleClient.mergeData( 1, 0, 0, 0, DATA4, 0, LENGTH4, 1, 1)
+    shuffleClient.pushMergedData(1, 0, 0)
     Thread.sleep(1000)
 
-    shuffleClient.mapperEnd(APP, 1, 0, 0, 1)
+    shuffleClient.mapperEnd(1, 0, 0, 1)
 
-    val inputStream = shuffleClient.readPartition(APP, 1, 0, 0)
+    val inputStream = shuffleClient.readPartition(1, 0, 0)
     val outputStream = new ByteArrayOutputStream()
 
     var b = inputStream.read()

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
@@ -87,7 +87,7 @@ trait ReadWriteTestBase extends AnyFunSuite
     val STR4 = RandomStringUtils.random(16 * 1024)
     val DATA4 = STR4.getBytes(StandardCharsets.UTF_8)
     val LENGTH4 = DATA4.length
-    shuffleClient.mergeData( 1, 0, 0, 0, DATA4, 0, LENGTH4, 1, 1)
+    shuffleClient.mergeData(1, 0, 0, 0, DATA4, 0, LENGTH4, 1, 1)
     shuffleClient.pushMergedData(1, 0, 0)
     Thread.sleep(1000)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Make appUniqueId a member of ShuffleClientImpl and remove applicationId from RPC messages across client side, so it won't cause compatibility issues.


### Why are the changes needed?
Currently Celeborn Client is bound to a single application id, so there's no need to pass applicationId around in many RPC messages in client side.


### Does this PR introduce _any_ user-facing change?
In some logs the application id will not be printed, which should not be a problem.

### How was this patch tested?
UTs.
