### PR TITLE
[CELEBORN-714][Helm] Improved the local disk binding mechanism of Kubernetes HostPath

### DIFF
--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
     celeborn.master.ha.ratis.raft.server.storage.dir={{ (index $dirs 0).mountPath }}
     {{- $path := "" }}
     {{- range $worker := .Values.volumes.worker }}
-    {{- $info := (cat $worker.mountPath ":disktype=" (get $worker "disktype" | default "HDD") | nospace) }}
+    {{- $info := (cat $worker.mountPath ":disktype=" (get $worker "diskType" | default "HDD") | nospace) }}
     {{- if eq $path "" }}
     {{- $path = $info }}
     {{- else }}

--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -37,10 +37,11 @@ data:
     celeborn.master.ha.ratis.raft.server.storage.dir={{ (index $dirs 0).mountPath }}
     {{- $path := "" }}
     {{- range $worker := .Values.volumes.worker }}
+    {{- $info := (cat $worker.mountPath ":disktype=" (get $worker "disktype" | default "HDD") | nospace) }}
     {{- if eq $path "" }}
-    {{- $path = $worker.mountPath }}
+    {{- $path = $info }}
     {{- else }}
-    {{- $path = ( list $path $worker.mountPath | join ",") }}
+    {{- $path = ( list $path $info | join ",") }}
     {{- end }}
     {{- end }}
     celeborn.worker.storage.dirs={{ $path }}

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -57,18 +57,22 @@ volumes:
     - mountPath: /mnt/disk1
       hostPath: /mnt/disk1
       type: hostPath
+      disktype: HDD
       size: 1Gi
     - mountPath: /mnt/disk2
       hostPath: /mnt/disk2
       type: hostPath
+      disktype: HDD
       size: 1Gi
     - mountPath: /mnt/disk3
       hostPath: /mnt/disk3
       type: hostPath
+      disktype: HDD
       size: 1Gi
     - mountPath: /mnt/disk4
       hostPath: /mnt/disk4
       type: hostPath
+      disktype: HDD
       size: 1Gi
 
 # celeborn configurations

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -47,6 +47,7 @@ securityContext:
 # Note: size only works in emptyDir type
 # hostPath only works in hostPath type using to set `volumes hostPath path`
 # Celeborn Master will pick first volumes for store raft log
+# diskType only works in Celeborn Worker with hostPath type to manifest local disk type
 volumes:
   master:
     - mountPath: /mnt/rss_ratis
@@ -57,22 +58,22 @@ volumes:
     - mountPath: /mnt/disk1
       hostPath: /mnt/disk1
       type: hostPath
-      disktype: HDD
+      diskType: HDD
       size: 1Gi
     - mountPath: /mnt/disk2
       hostPath: /mnt/disk2
       type: hostPath
-      disktype: HDD
+      diskType: HDD
       size: 1Gi
     - mountPath: /mnt/disk3
       hostPath: /mnt/disk3
       type: hostPath
-      disktype: HDD
+      diskType: HDD
       size: 1Gi
     - mountPath: /mnt/disk4
       hostPath: /mnt/disk4
       type: hostPath
-      disktype: HDD
+      diskType: HDD
       size: 1Gi
 
 # celeborn configurations


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add `diskType` in `charts/celeborn/values.yml` to help configuration `celeborn.worker.storage.dirs`

Result like:
```properties
celeborn.worker.storage.dirs=/mnt/disk1:disktype=HDD,/mnt/disk2:disktype=HDD,/mnt/disk3:disktype=HDD,/mnt/disk4:disktype=SSD
```

### Why are the changes needed?
Help user specify local disk type.


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
Local dry-run
```shell
helm install celeborn charts/celeborn --dry-run 
```
