### PR TITLE
[CELEBORN-717][Flink] Fix ResultPartition lost numBytesOut/numBuffersOut metrics

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionDelegation.java
@@ -332,4 +332,9 @@ public class RemoteShuffleResultPartitionDelegation {
   public void setEndOfDataNotified(boolean endOfDataNotified) {
     this.endOfDataNotified = endOfDataNotified;
   }
+
+  public void setMetricCounters(Counter numBytesOut, Counter numBuffersOut) {
+    this.numBytesOut = numBytesOut;
+    this.numBuffersOut = numBuffersOut;
+  }
 }

--- a/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.partition.*;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.util.function.SupplierWithException;
 
 import org.apache.celeborn.plugin.flink.buffer.SortBuffer;
@@ -194,5 +195,11 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   @VisibleForTesting
   public RemoteShuffleResultPartitionDelegation getDelegation() {
     return delegation;
+  }
+
+  @Override
+  public void setMetricGroup(TaskIOMetricGroup metrics) {
+    super.setMetricGroup(metrics);
+    this.delegation.setMetricCounters(numBytesOut, numBuffersOut);
   }
 }

--- a/client-flink/flink-1.17/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.17/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.partition.*;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.util.function.SupplierWithException;
 
 import org.apache.celeborn.plugin.flink.buffer.SortBuffer;
@@ -206,5 +207,11 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   @VisibleForTesting
   public RemoteShuffleResultPartitionDelegation getDelegation() {
     return delegation;
+  }
+
+  @Override
+  public void setMetricGroup(TaskIOMetricGroup metrics) {
+    super.setMetricGroup(metrics);
+    this.delegation.setMetricCounters(numBytesOut, numBuffersOut);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reset  numBytesOut/numBuffersOut metrics for RemoteShuffleResultPartition


### Why are the changes needed?
Currently ResultPartition lost numBytesOut/numBuffersOut metrics, this will cause Flink AdaptiveScheduler can not dynamically adjust the task parallelism based on the input amount of data


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test.
