### PR TITLE
[CELEBORN-717][Flink][FOLLOWUP] Fix ResultPartition lost numBytesOut/numBuffersOut metrics

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGateDelegation.java
@@ -442,7 +442,9 @@ public class RemoteShuffleInputGateDelegation {
       numUnconsumedSubpartitions--;
       // not the real end.
       if (numSubPartitionsNotConsumed[channelInfo.getInputChannelIdx()] != 0) {
-        return Optional.empty();
+        LOG.debug(
+            "numSubPartitionsNotConsumed: {}",
+            numSubPartitionsNotConsumed[channelInfo.getInputChannelIdx()]);
       } else {
         // the real end.
         bufferReaders.get(channelIndexToReaderIndex[channelInfo.getInputChannelIdx()]).close();

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionDelegation.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartitionDelegation.java
@@ -20,11 +20,11 @@ package org.apache.celeborn.plugin.flink;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
@@ -58,25 +58,22 @@ public class RemoteShuffleResultPartitionDelegation {
   /** Whether notifyEndOfData has been called or not. */
   private boolean endOfDataNotified;
 
-  private Counter numBuffersOut;
-  private Counter numBytesOut;
   private int numSubpartitions;
   private BufferPool bufferPool;
   private BufferCompressor bufferCompressor;
   private Function<Buffer, Boolean> canBeCompressed;
   private Runnable checkProducerState;
+  private BiConsumer<SortBuffer.BufferWithChannel, Boolean> statisticsConsumer;
 
   public RemoteShuffleResultPartitionDelegation(
       int networkBufferSize,
       RemoteShuffleOutputGate outputGate,
-      Counter numBuffersOut,
-      Counter numBytesOut,
+      BiConsumer<SortBuffer.BufferWithChannel, Boolean> statisticsConsumer,
       int numSubpartitions) {
     this.networkBufferSize = networkBufferSize;
     this.outputGate = outputGate;
-    this.numBuffersOut = numBuffersOut;
-    this.numBytesOut = numBytesOut;
     this.numSubpartitions = numSubpartitions;
+    this.statisticsConsumer = statisticsConsumer;
   }
 
   public void setup(
@@ -185,7 +182,7 @@ public class RemoteShuffleResultPartitionDelegation {
 
           Buffer buffer = bufferWithChannel.getBuffer();
           int subpartitionIndex = bufferWithChannel.getChannelIndex();
-          updateStatistics(bufferWithChannel.getBuffer());
+          statisticsConsumer.accept(bufferWithChannel, isBroadcast);
           writeCompressedBufferIfPossible(buffer, subpartitionIndex);
         }
         outputGate.regionFinish();
@@ -220,11 +217,6 @@ public class RemoteShuffleResultPartitionDelegation {
     outputGate.write(buffer, targetSubpartition);
   }
 
-  public void updateStatistics(Buffer buffer) {
-    numBuffersOut.inc();
-    numBytesOut.inc(buffer.readableBytes() - BufferUtils.HEADER_LENGTH);
-  }
-
   /** Spills the large record into {@link RemoteShuffleOutputGate}. */
   public void writeLargeRecord(
       ByteBuffer record, int targetSubpartition, Buffer.DataType dataType, boolean isBroadcast)
@@ -242,7 +234,9 @@ public class RemoteShuffleResultPartitionDelegation {
               dataType,
               toCopy + BufferUtils.HEADER_LENGTH);
 
-      updateStatistics(buffer);
+      SortBuffer.BufferWithChannel bufferWithChannel =
+          new SortBuffer.BufferWithChannel(buffer, targetSubpartition);
+      statisticsConsumer.accept(bufferWithChannel, isBroadcast);
       writeCompressedBufferIfPossible(buffer, targetSubpartition);
     }
     outputGate.regionFinish();
@@ -331,10 +325,5 @@ public class RemoteShuffleResultPartitionDelegation {
 
   public void setEndOfDataNotified(boolean endOfDataNotified) {
     this.endOfDataNotified = endOfDataNotified;
-  }
-
-  public void setMetricCounters(Counter numBytesOut, Counter numBuffersOut) {
-    this.numBytesOut = numBytesOut;
-    this.numBuffersOut = numBuffersOut;
   }
 }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/SortBuffer.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/SortBuffer.java
@@ -74,7 +74,7 @@ public interface SortBuffer {
 
     private final int channelIndex;
 
-    BufferWithChannel(Buffer buffer, int channelIndex) {
+    public BufferWithChannel(Buffer buffer, int channelIndex) {
       this.buffer = checkNotNull(buffer);
       this.channelIndex = channelIndex;
     }

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -81,7 +81,10 @@ public class RemoteShuffleResultPartition extends ResultPartition {
 
     delegation =
         new RemoteShuffleResultPartitionDelegation(
-            networkBufferSize, outputGate, numBuffersOut, numBytesOut, numSubpartitions);
+            networkBufferSize,
+            outputGate,
+            (bufferWithChannel, isBroadcast) -> updateStatistics(bufferWithChannel, isBroadcast),
+            numSubpartitions);
   }
 
   @Override
@@ -194,5 +197,12 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   @VisibleForTesting
   public RemoteShuffleResultPartitionDelegation getDelegation() {
     return delegation;
+  }
+
+  public void updateStatistics(
+      SortBuffer.BufferWithChannel bufferWithChannel, boolean isBroadcast) {
+    numBuffersOut.inc(isBroadcast ? numSubpartitions : 1);
+    long readableBytes = bufferWithChannel.getBuffer().readableBytes() - BufferUtils.HEADER_LENGTH;
+    numBytesOut.inc(isBroadcast ? readableBytes * numSubpartitions : readableBytes);
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Metics update logic need align with Flink 1.17/1.15


### Why are the changes needed?
See [1626](https://github.com/apache/incubator-celeborn/pull/1626) And metics update logic need align with Flink 1.17/1.15

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tpcds Manual
