### PR TITLE
[CELEBORN-721] Fix concurrent bug in ChangePartitionManager

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -75,10 +75,10 @@ class ChangePartitionManager(
           override def run(): Unit = {
             try {
               changePartitionRequests.asScala.foreach { case (shuffleId, requests) =>
-                requests.synchronized {
-                  batchHandleChangePartitionExecutors.submit {
-                    new Runnable {
-                      override def run(): Unit = {
+                batchHandleChangePartitionExecutors.submit {
+                  new Runnable {
+                    override def run(): Unit = {
+                      requests.synchronized {
                         // For each partition only need handle one request
                         val distinctPartitions = requests.asScala.filter { case (partitionId, _) =>
                           !inBatchPartitions.get(shuffleId).contains(partitionId)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Fixes concurrent bug in ChangePartitionManager.


### Why are the changes needed?
Before this PR, ```ChangePartitionManager.start``` tries to synchronize on ```requests``` in the body
of ```run()```, but the synchronized keyword was put outside of the ```batchHandleChangePartitionExecutors.submit```,
which has no effect.

When I was testing https://github.com/apache/incubator-celeborn/pull/1588 , I encountered unexpected situations that
when all ```rss-lifecycle-manager-change-partition-executor``` threads are idle, the ```inBatchPartitions``` is still not
empty:
```
23/06/27 20:35:55 INFO ChangePartitionManager: Inside run, shuffleId 0 inBatchPartitions size 834
```


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual test.
