### PR TITLE
[CELEBORN-727][TEST] Fix flaky test RssHashCheckDiskSuite

### DIFF
--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
@@ -44,7 +44,7 @@ class PushDataTimeoutTest extends AnyFunSuite
     // enabled, there is a possibility that two workers might be added to the excluded list due to
     // master/slave timeout issues, then there are not enough workers to do replication if available
     // workers number = 1
-    setUpMiniCluster(masterConfs = null, workerConfs = workerConf, workerNum = 4)
+    setUpMiniCluster(masterConf = null, workerConf = workerConf, workerNum = 4)
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryCommitFilesTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryCommitFilesTest.scala
@@ -34,7 +34,7 @@ class RetryCommitFilesTest extends AnyFunSuite
     logInfo("test initialized , setup Celeborn mini cluster")
     val workerConf = Map(
       "celeborn.test.retryCommitFiles" -> s"true")
-    setUpMiniCluster(masterConfs = null, workerConfs = workerConf)
+    setUpMiniCluster(masterConf = null, workerConf = workerConf)
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala
@@ -32,7 +32,7 @@ class RetryReviveTest extends AnyFunSuite
 
   override def beforeAll(): Unit = {
     logInfo("test initialized , setup celeborn mini cluster")
-    setUpMiniCluster(masterConfs = null)
+    setUpMiniCluster(masterConf = null)
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RssHashCheckDiskSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RssHashCheckDiskSuite.scala
@@ -22,7 +22,6 @@ import scala.collection.JavaConverters._
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.concurrent.Futures._
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
 import org.apache.celeborn.client.ShuffleClient
@@ -87,18 +86,15 @@ class RssHashCheckDiskSuite extends SparkTestBase {
 
     logInfo("after shuffle key expired")
     eventually(timeout(60.seconds), interval(2.seconds)) {
-      // after shuffle key expired, storageManager.workingDirWriters will be empty
       workers.foreach { worker =>
+        // after shuffle key expired, storageManager.workingDirWriters will be empty
         worker.storageManager.workingDirWriters.values().asScala.foreach { t =>
           assert(t.size() === 0)
         }
-      }
-    }
-
-    // after shuffle key expired, diskInfo.actualUsableSpace will equal capacity=1000
-    workers.foreach { worker =>
-      worker.storageManager.disksSnapshot().foreach { diskInfo =>
-        assert(diskInfo.actualUsableSpace === 1000)
+        // after shuffle key expired, diskInfo.actualUsableSpace will equal capacity=1000
+        worker.storageManager.disksSnapshot().foreach { diskInfo =>
+          assert(diskInfo.actualUsableSpace === 1000)
+        }
       }
     }
   }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RssHashCheckDiskSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RssHashCheckDiskSuite.scala
@@ -54,15 +54,13 @@ class RssHashCheckDiskSuite extends SparkTestBase {
   test("celeborn spark integration test - hash-checkDiskFull") {
     val sparkConf = new SparkConf().setAppName("rss-demo")
       .setMaster("local[2]")
-      .set(s"spark.${CelebornConf.SHUFFLE_EXPIRED_CHECK_INTERVAL.key}", "10s")
+      .set(s"spark.${CelebornConf.SHUFFLE_EXPIRED_CHECK_INTERVAL.key}", "20s")
 
     val sparkSession = SparkSession.builder().config(sparkConf).getOrCreate()
     val combineResult = combine(sparkSession)
     val groupByResult = groupBy(sparkSession)
     val repartitionResult = repartition(sparkSession)
     val sqlResult = runsql(sparkSession)
-
-    Thread.sleep(3000L)
     sparkSession.stop()
 
     val rssSparkSession = SparkSession.builder()
@@ -92,7 +90,7 @@ class RssHashCheckDiskSuite extends SparkTestBase {
       // after shuffle key expired, storageManager.workingDirWriters will be empty
       workers.foreach { worker =>
         worker.storageManager.workingDirWriters.values().asScala.foreach { t =>
-          assert(t.size() == 0)
+          assert(t.size() === 0)
         }
       }
     }
@@ -100,7 +98,7 @@ class RssHashCheckDiskSuite extends SparkTestBase {
     // after shuffle key expired, diskInfo.actualUsableSpace will equal capacity=1000
     workers.foreach { worker =>
       worker.storageManager.disksSnapshot().foreach { diskInfo =>
-        assert(diskInfo.actualUsableSpace == 1000)
+        assert(diskInfo.actualUsableSpace === 1000)
       }
     }
   }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SparkTestBase.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SparkTestBase.scala
@@ -21,7 +21,7 @@ import scala.util.Random
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.celeborn.common.CelebornConf._
@@ -30,7 +30,7 @@ import org.apache.celeborn.common.protocol.ShuffleMode
 import org.apache.celeborn.service.deploy.MiniClusterFeature
 
 trait SparkTestBase extends AnyFunSuite
-  with Logging with MiniClusterFeature with BeforeAndAfterAll {
+  with Logging with MiniClusterFeature with BeforeAndAfterAll with BeforeAndAfterEach {
   private val sampleSeq = (1 to 78)
     .map(Random.alphanumeric)
     .toList

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -95,25 +95,23 @@ trait MiniClusterFeature extends Logging {
   }
 
   def setUpMiniCluster(
-      masterConfs: Map[String, String] = null,
-      workerConfs: Map[String, String] = null,
+      masterConf: Map[String, String] = null,
+      workerConf: Map[String, String] = null,
       workerNum: Int = 3): (Master, collection.Set[Worker]) = {
-    val master = createMaster(masterConfs)
+    val master = createMaster(masterConf)
     val masterThread = runnerWrap(master.rpcEnv.awaitTermination())
     masterThread.start()
     masterInfo = (master, masterThread)
     Thread.sleep(5000L)
-    for (_ <- 1 to workerNum) {
-      val worker = createWorker(workerConfs)
+    (1 to workerNum).foreach { _ =>
+      val worker = createWorker(workerConf)
       val workerThread = runnerWrap(worker.initialize())
       workerThread.start()
       workerInfos.put(worker, workerThread)
     }
     Thread.sleep(5000L)
 
-    workerInfos.foreach {
-      case (worker, _) => assert(worker.registered.get())
-    }
+    workerInfos.foreach { case (worker, _) => assert(worker.registered.get()) }
     (master, workerInfos.keySet)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Fix the flaky test by enlarging `celeborn.client.shuffle.expired.checkInterval`

### Why are the changes needed?

```
RssHashCheckDiskSuite:
- celeborn spark integration test - hash-checkDiskFull *** FAILED ***
  868 was not less than 0 (RssHashCheckDiskSuite.scala:83)
```

https://github.com/apache/incubator-celeborn/actions/runs/5396767745/jobs/9800766633

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass GA, and should observe CI,