### PR TITLE
[CELEBORN-728] Celeborn won't clean remnant application directory on HDFS if worker is restarted

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -531,7 +531,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     if (hadoopFs != null) {
       val hdfsWorkPath = new Path(hdfsDir, conf.workerWorkingDir)
       if (hadoopFs.exists(hdfsWorkPath)) {
-        val iter = hadoopFs.listFiles(hdfsWorkPath, false)
+        val iter = hadoopFs.listStatusIterator(hdfsWorkPath)
         while (iter.hasNext) {
           val fileStatus = iter.next()
           if (!appIds.contains(fileStatus.getPath.getName)) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
To clean the remnant application directory after Celeborn Worker is restarted.


### Why are the changes needed?
Remnant application directories will not be deleted, because `hadoopFs.listFiles(path,false)` will not list directories.


### Does this PR introduce _any_ user-facing change?
No.

