### PR TITLE
[CELEBORN-729] Fix typo PbRegisterShuffle#numMappers

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -207,7 +207,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
     case pb: PbRegisterShuffle =>
       val shuffleId = pb.getShuffleId
-      val numMappers = pb.getNumMapppers
+      val numMappers = pb.getNumMappers
       val numPartitions = pb.getNumPartitions
       logDebug(s"Received RegisterShuffle request, " +
         s"$shuffleId, $numMappers, $numPartitions.")

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -155,7 +155,7 @@ message PbHeartbeatResponse {
 
 message PbRegisterShuffle {
   int32 shuffleId = 1;
-  int32 numMapppers = 2;
+  int32 numMappers = 2;
   int32 numPartitions = 3;
 }
 

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -125,7 +125,7 @@ object ControlMessages extends Logging {
         numPartitions: Int): PbRegisterShuffle =
       PbRegisterShuffle.newBuilder()
         .setShuffleId(shuffleId)
-        .setNumMapppers(numMappers)
+        .setNumMappers(numMappers)
         .setNumPartitions(numPartitions)
         .build()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Fix typo `numMapppers`, should be `numMappers`

### Why are the changes needed?

Fix typo

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Protobuf serde depends on message field seq no, not name.