### PR TITLE
[CELEBORN-666][FOLLOWUP] Rename all RPC blacklist fields

### DIFF
--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -295,18 +295,18 @@ message PbHeartbeatFromApplication {
 
 message PbHeartbeatFromApplicationResponse {
   int32 status = 1;
-  repeated PbWorkerInfo blacklist = 2;
+  repeated PbWorkerInfo excludedWorkers = 2;
   repeated PbWorkerInfo unknownWorkers = 3;
   repeated PbWorkerInfo shuttingWorkers = 4;
 }
 
 message PbGetBlacklist {
-  repeated PbWorkerInfo localBlackList = 1;
+  repeated PbWorkerInfo localExcludedWorkers = 1;
 }
 
 message PbGetBlacklistResponse {
   int32 status = 1;
-  repeated PbWorkerInfo blacklist = 2;
+  repeated PbWorkerInfo excludedWorkers = 2;
   repeated PbWorkerInfo unknownWorkers = 3;
 }
 
@@ -474,7 +474,7 @@ message PbSnapshotMetaInfo {
   int64 estimatedPartitionSize = 1;
   repeated string registeredShuffle = 2;
   repeated string hostnameSet = 3;
-  repeated PbWorkerInfo blacklist = 4;
+  repeated PbWorkerInfo excludedWorkers = 4;
   repeated PbWorkerInfo workerLostEvents = 5;
   map<string, int64> appHeartbeatTime = 6;
   repeated PbWorkerInfo workers = 7;

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -633,11 +633,15 @@ object ControlMessages extends Logging {
         .build().toByteArray
       new TransportMessage(MessageType.HEARTBEAT_FROM_APPLICATION, payload)
 
-    case HeartbeatFromApplicationResponse(statusCode, blacklist, unknownWorkers, shuttingWorkers) =>
+    case HeartbeatFromApplicationResponse(
+          statusCode,
+          excludedWorkers,
+          unknownWorkers,
+          shuttingWorkers) =>
       val payload = PbHeartbeatFromApplicationResponse.newBuilder()
         .setStatus(statusCode.getValue)
-        .addAllBlacklist(
-          blacklist.asScala.map(PbSerDeUtils.toPbWorkerInfo(_, true)).toList.asJava)
+        .addAllExcludedWorkers(
+          excludedWorkers.asScala.map(PbSerDeUtils.toPbWorkerInfo(_, true)).toList.asJava)
         .addAllUnknownWorkers(
           unknownWorkers.asScala.map(PbSerDeUtils.toPbWorkerInfo(_, true)).toList.asJava)
         .addAllShuttingWorkers(
@@ -647,7 +651,7 @@ object ControlMessages extends Logging {
 
     case GetBlacklist(localExcludedWorkers) =>
       val payload = PbGetBlacklist.newBuilder()
-        .addAllLocalBlackList(localExcludedWorkers.asScala.map { workerInfo =>
+        .addAllLocalExcludedWorkers(localExcludedWorkers.asScala.map { workerInfo =>
           PbSerDeUtils.toPbWorkerInfo(workerInfo, true)
         }.toList.asJava)
         .build().toByteArray
@@ -656,7 +660,7 @@ object ControlMessages extends Logging {
     case GetBlacklistResponse(statusCode, excludedWorkers, unknownWorkers) =>
       val builder = PbGetBlacklistResponse.newBuilder()
         .setStatus(statusCode.getValue)
-      builder.addAllBlacklist(
+      builder.addAllExcludedWorkers(
         excludedWorkers.asScala.map(PbSerDeUtils.toPbWorkerInfo(_, true)).toList.asJava)
       builder.addAllUnknownWorkers(
         unknownWorkers.asScala.map(PbSerDeUtils.toPbWorkerInfo(_, true)).toList.asJava)
@@ -982,7 +986,7 @@ object ControlMessages extends Logging {
           PbHeartbeatFromApplicationResponse.parseFrom(message.getPayload)
         HeartbeatFromApplicationResponse(
           Utils.toStatusCode(pbHeartbeatFromApplicationResponse.getStatus),
-          pbHeartbeatFromApplicationResponse.getBlacklistList.asScala
+          pbHeartbeatFromApplicationResponse.getExcludedWorkersList.asScala
             .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava,
           pbHeartbeatFromApplicationResponse.getUnknownWorkersList.asScala
             .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava,
@@ -991,14 +995,15 @@ object ControlMessages extends Logging {
 
       case GET_BLACKLIST =>
         val pbGetBlacklist = PbGetBlacklist.parseFrom(message.getPayload)
-        GetBlacklist(new util.ArrayList[WorkerInfo](pbGetBlacklist.getLocalBlackListList.asScala
-          .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava))
+        GetBlacklist(
+          new util.ArrayList[WorkerInfo](pbGetBlacklist.getLocalExcludedWorkersList.asScala
+            .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava))
 
       case GET_BLACKLIST_RESPONSE =>
         val pbGetBlacklistResponse = PbGetBlacklistResponse.parseFrom(message.getPayload)
         GetBlacklistResponse(
           Utils.toStatusCode(pbGetBlacklistResponse.getStatus),
-          pbGetBlacklistResponse.getBlacklistList.asScala
+          pbGetBlacklistResponse.getExcludedWorkersList.asScala
             .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava,
           pbGetBlacklistResponse.getUnknownWorkersList.asScala
             .map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava)

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -378,7 +378,7 @@ object PbSerDeUtils {
       .setEstimatedPartitionSize(estimatedPartitionSize)
       .addAllRegisteredShuffle(registeredShuffle)
       .addAllHostnameSet(hostnameSet)
-      .addAllBlacklist(excludedWorkers.asScala.map(toPbWorkerInfo(_, true)).asJava)
+      .addAllExcludedWorkers(excludedWorkers.asScala.map(toPbWorkerInfo(_, true)).asJava)
       .addAllWorkerLostEvents(workerLostEvent.asScala.map(toPbWorkerInfo(_, true)).asJava)
       .putAllAppHeartbeatTime(appHeartbeatTime)
       .addAllWorkers(workers.asScala.map(toPbWorkerInfo(_, true)).asJava)

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -270,7 +270,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
       registeredShuffle.addAll(snapshotMetaInfo.getRegisteredShuffleList());
       hostnameSet.addAll(snapshotMetaInfo.getHostnameSetList());
       excludedWorkers.addAll(
-          snapshotMetaInfo.getBlacklistList().stream()
+          snapshotMetaInfo.getExcludedWorkersList().stream()
               .map(PbSerDeUtils::fromPbWorkerInfo)
               .collect(Collectors.toSet()));
       workerLostEvents.addAll(


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this pr, we rename all RPC blacklist fields,  it won't have have compatibility issues.

For RPC `GetBlacklist` and `GetBlacklistResponse` we won't change it, since it won't be used in next release, so we can remove these two RPC in next release.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

