### PR TITLE
[CELEBORN-734] Remove unused RPC ReregisterWorkerResonse

### DIFF
--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -45,7 +45,7 @@ enum MessageType {
   CHECK_QUOTA_RESPONSE = 24;
   REPORT_WORKER_FAILURE = 25;
   REGISTER_WORKER_RESPONSE = 26;
-  REREGISTER_WORKER_RESPONSE = 27;
+  // TODO: REREGISTER_WORKER_RESPONSE = 27;
   RESERVE_SLOTS = 28;
   RESERVE_SLOTS_RESPONSE = 29;
   COMMIT_FILES = 30;
@@ -327,10 +327,6 @@ message PbReportWorkerUnavailable {
 message PbRegisterWorkerResponse {
   bool success = 1;
   string message = 2;
-}
-
-message PbReregisterWorkerResponse {
-  bool success = 1;
 }
 
 message PbReserveSlots {

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -360,8 +360,6 @@ object ControlMessages extends Logging {
         .build()
   }
 
-  case class ReregisterWorkerResponse(success: Boolean) extends WorkerMessage
-
   case class ReserveSlots(
       applicationId: String,
       shuffleId: Int,
@@ -690,12 +688,6 @@ object ControlMessages extends Logging {
     case pb: PbRegisterWorkerResponse =>
       new TransportMessage(MessageType.REGISTER_WORKER_RESPONSE, pb.toByteArray)
 
-    case ReregisterWorkerResponse(success) =>
-      val payload = PbReregisterWorkerResponse.newBuilder()
-        .setSuccess(success)
-        .build().toByteArray
-      new TransportMessage(MessageType.REREGISTER_WORKER_RESPONSE, payload)
-
     case ReserveSlots(
           applicationId,
           shuffleId,
@@ -1023,10 +1015,6 @@ object ControlMessages extends Logging {
 
       case REGISTER_WORKER_RESPONSE =>
         PbRegisterWorkerResponse.parseFrom(message.getPayload)
-
-      case REREGISTER_WORKER_RESPONSE =>
-        val pbReregisterWorkerResponse = PbReregisterWorkerResponse.parseFrom(message.getPayload)
-        ReregisterWorkerResponse(pbReregisterWorkerResponse.getSuccess)
 
       case RESERVE_SLOTS =>
         val pbReserveSlots = PbReserveSlots.parseFrom(message.getPayload)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove unused RPC ReregisterWorkerResonse


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

