### PR TITLE
[CELEBORN-740] Remove usage of AccessController

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/serializer/SerializationDebugger.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/serializer/SerializationDebugger.scala
@@ -18,8 +18,8 @@
 package org.apache.celeborn.common.serializer
 
 import java.io._
+import java.lang.{Boolean => JBoolean}
 import java.lang.reflect.{Field, Method}
-import java.security.AccessController
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -68,8 +68,7 @@ private[celeborn] object SerializationDebugger extends Logging {
   }
 
   private[serializer] var enableDebugging: Boolean = {
-    !AccessController.doPrivileged(new sun.security.action.GetBooleanAction(
-      "sun.io.serialization.extendedDebugInfo")).booleanValue()
+    !JBoolean.getBoolean("sun.io.serialization.extendedDebugInfo")
   }
 
   private class SerializationDebugger {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Remove usage of deprecated `java.security.AccessController`

### Why are the changes needed?

`AccessController` is deprecated for removal since Java 17

https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/security/AccessController.html

Recover building for Java 17

```
[INFO] compiling 72 Scala sources and 209 Java sources to /home/runner/work/incubator-celeborn/incubator-celeborn/common/target/classes ...
Error:  /home/runner/work/incubator-celeborn/incubator-celeborn/common/src/main/scala/org/apache/celeborn/common/serializer/SerializationDebugger.scala:71: class AccessController in package security is deprecated
Error: [ERROR] one error found
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
scala> System.getProperty("java.version")
res0: String = 1.8.0_332

scala> System.getProperty("sun.io.serialization.extendedDebugInfo")
res1: String = null

scala> java.lang.Boolean.getBoolean("sun.io.serialization.extendedDebugInfo")
res2: Boolean = false
```