### PR TITLE
[CELEBORN-750] Simplify get Netty used direct memory logic

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.celeborn.service.deploy.worker.memory;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -65,7 +64,6 @@ public class MemoryManager {
 
   private AtomicBoolean trimInProcess = new AtomicBoolean(false);
 
-  private AtomicLong nettyMemoryCounter = null;
   private final AtomicLong sortMemoryCounter = new AtomicLong(0);
   private final AtomicLong diskBufferCounter = new AtomicLong(0);
   private final LongAdder pausePushDataCounter = new LongAdder();
@@ -154,8 +152,6 @@ public class MemoryManager {
     readBufferTarget = (long) (readBufferThreshold * readBufferTargetRatio);
     memoryShuffleStorageThreshold = (long) (maxDirectorMemory * shuffleStorageRatio);
 
-    initDirectMemoryIndicator();
-
     checkService.scheduleWithFixedDelay(
         () -> {
           try {
@@ -207,7 +203,7 @@ public class MemoryManager {
         () ->
             logger.info(
                 "Direct memory usage: {}/{}, disk buffer size: {}, sort memory size: {}, read buffer size: {}",
-                Utils.bytesToString(nettyMemoryCounter.get()),
+                Utils.bytesToString(PlatformDependent.usedDirectMemory()),
                 Utils.bytesToString(maxDirectorMemory),
                 Utils.bytesToString(diskBufferCounter.get()),
                 Utils.bytesToString(sortMemoryCounter.get()),
@@ -266,23 +262,6 @@ public class MemoryManager {
         Utils.bytesToString(readBufferThreshold),
         Utils.bytesToString(readBufferTarget),
         Utils.bytesToString(memoryShuffleStorageThreshold));
-  }
-
-  private void initDirectMemoryIndicator() {
-    try {
-      Field field = null;
-      Field[] result = PlatformDependent.class.getDeclaredFields();
-      for (Field tf : result) {
-        if ("DIRECT_MEMORY_COUNTER".equals(tf.getName())) {
-          field = tf;
-        }
-      }
-      field.setAccessible(true);
-      nettyMemoryCounter = ((AtomicLong) field.get(PlatformDependent.class));
-    } catch (Exception e) {
-      logger.error("Fatal error, get netty_direct_memory failed, worker should stop", e);
-      System.exit(-1);
-    }
   }
 
   public MemoryManagerStat currentMemoryAction() {
@@ -350,12 +329,12 @@ public class MemoryManager {
     diskBufferCounter.addAndGet(size * -1);
   }
 
-  public AtomicLong getNettyMemoryCounter() {
-    return nettyMemoryCounter;
+  public long getNettyUsedDirectMemory() {
+    return PlatformDependent.usedDirectMemory();
   }
 
   public long getMemoryUsage() {
-    return nettyMemoryCounter.get() + sortMemoryCounter.get();
+    return PlatformDependent.usedDirectMemory() + sortMemoryCounter.get();
   }
 
   public AtomicLong getSortMemoryCounter() {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -203,7 +203,7 @@ public class MemoryManager {
         () ->
             logger.info(
                 "Direct memory usage: {}/{}, disk buffer size: {}, sort memory size: {}, read buffer size: {}",
-                Utils.bytesToString(PlatformDependent.usedDirectMemory()),
+                Utils.bytesToString(getNettyUsedDirectMemory()),
                 Utils.bytesToString(maxDirectorMemory),
                 Utils.bytesToString(diskBufferCounter.get()),
                 Utils.bytesToString(sortMemoryCounter.get()),
@@ -330,11 +330,13 @@ public class MemoryManager {
   }
 
   public long getNettyUsedDirectMemory() {
-    return PlatformDependent.usedDirectMemory();
+    long usedDirectMemory = PlatformDependent.usedDirectMemory();
+    assert usedDirectMemory != -1;
+    return usedDirectMemory;
   }
 
   public long getMemoryUsage() {
-    return PlatformDependent.usedDirectMemory() + sortMemoryCounter.get();
+    return getNettyUsedDirectMemory() + sortMemoryCounter.get();
   }
 
   public AtomicLong getSortMemoryCounter() {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -254,7 +254,7 @@ private[celeborn] class Worker(
   workerSource.addGauge(WorkerSource.SortedFiles, _ => partitionsSorter.getSortedCount)
   workerSource.addGauge(WorkerSource.SortedFileSize, _ => partitionsSorter.getSortedSize)
   workerSource.addGauge(WorkerSource.DiskBuffer, _ => memoryManager.getDiskBufferCounter.get())
-  workerSource.addGauge(WorkerSource.NettyMemory, _ => memoryManager.getNettyMemoryCounter.get())
+  workerSource.addGauge(WorkerSource.NettyMemory, _ => memoryManager.getNettyUsedDirectMemory())
   workerSource.addGauge(WorkerSource.PausePushDataCount, _ => memoryManager.getPausePushDataCounter)
   workerSource.addGauge(
     WorkerSource.PausePushDataAndReplicateCount,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

netty has exposed the public API `PlatformDependent.usedDirectMemory()` to get netty used direct memory since [netty-4.1.35.Final](https://github.com/netty/netty/pull/8945), simplifies the logic


### Why are the changes needed?

simplifies the get netty used direct memory logic

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass GA