### PR TITLE
[CELEBORN-756][WORKER] Refactor `PushDataHandler` class to utilize `while` loop

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
@@ -62,8 +62,34 @@ class WorkerPartitionLocationInfo extends Logging {
     getLocation(shuffleKey, uniqueId, primaryPartitionLocations)
   }
 
+  def getPrimaryLocations(
+      shuffleKey: String,
+      uniqueIds: Array[String]): Array[(String, PartitionLocation)] = {
+    val locations = new Array[(String, PartitionLocation)](uniqueIds.length)
+    var i = 0
+    while (i < uniqueIds.length) {
+      val uniqueId = uniqueIds(i)
+      locations(i) = uniqueId -> getPrimaryLocation(shuffleKey, uniqueId)
+      i += 1
+    }
+    locations
+  }
+
   def getReplicaLocation(shuffleKey: String, uniqueId: String): PartitionLocation = {
     getLocation(shuffleKey, uniqueId, replicaPartitionLocations)
+  }
+
+  def getReplicaLocations(
+      shuffleKey: String,
+      uniqueIds: Array[String]): Array[(String, PartitionLocation)] = {
+    val locations = new Array[(String, PartitionLocation)](uniqueIds.length)
+    var i = 0
+    while (i < uniqueIds.length) {
+      val uniqueId = uniqueIds(i)
+      locations(i) = uniqueId -> getReplicaLocation(shuffleKey, uniqueId)
+      i += 1
+    }
+    locations
   }
 
   def removeShuffle(shuffleKey: String): Unit = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -667,8 +667,8 @@ class PushDataHandler extends BaseMessageHandler with Logging {
     var i = 0
     var exceptionFileWriterIndex: Option[Int] = None
     while (i < partitionIdToLocations.length) {
-      val workingPartition = partitionIdToLocations(i)._2.asInstanceOf[WorkingPartition]
-      val fileWriter = workingPartition.getFileWriter
+      val (_, workingPartition) = partitionIdToLocations(i)
+      val fileWriter = workingPartition.asInstanceOf[WorkingPartition].getFileWriter
       if (fileWriter.getException != null) {
         exceptionFileWriterIndex = Some(i)
       }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/FlushTask.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/FlushTask.scala
@@ -34,10 +34,13 @@ private[worker] class LocalFlushTask(
     notifier: FlushNotifier) extends FlushTask(buffer, notifier) {
   override def flush(): Unit = {
     val buffers = buffer.nioBuffers()
-    for (buffer <- buffers) {
+    var i = 0
+    while (i < buffers.length) {
+      val buffer = buffers(i)
       while (buffer.hasRemaining) {
         fileChannel.write(buffer)
       }
+      i += 1
     }
   }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/FlushTask.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/FlushTask.scala
@@ -34,13 +34,10 @@ private[worker] class LocalFlushTask(
     notifier: FlushNotifier) extends FlushTask(buffer, notifier) {
   override def flush(): Unit = {
     val buffers = buffer.nioBuffers()
-    var i = 0
-    while (i < buffers.length) {
-      val buffer = buffers(i)
+    for (buffer <- buffers) {
       while (buffer.hasRemaining) {
         fileChannel.write(buffer)
       }
-      i += 1
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

as title

### Why are the changes needed?

per https://github.com/databricks/scala-style-guide#traversal-and-zipwithindex, use `while` loop for performance-sensitive code

worker's flame graph before:

![截屏2023-06-30 下午5 58 02](https://github.com/apache/incubator-celeborn/assets/8537877/28c199b6-a29b-4501-8064-e0f2ddb2a8b9)

after:

![截屏2023-06-30 下午5 58 18](https://github.com/apache/incubator-celeborn/assets/8537877/c6134959-5f78-436b-aa29-a78882b09e84)


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass GA