### PR TITLE
[CELEBORN-755] Support disable shuffle compression

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -101,6 +101,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   protected final Map<String, PushState> pushStates = JavaUtils.newConcurrentHashMap();
 
   private final boolean pushExcludeWorkerOnFailureEnabled;
+  private final boolean shuffleCompressionEnabled;
   private final Set<String> pushExcludedWorkers = ConcurrentHashMap.newKeySet();
   private final ConcurrentHashMap<String, Long> fetchExcludedWorkers =
       JavaUtils.newConcurrentHashMap();
@@ -164,6 +165,7 @@ public class ShuffleClientImpl extends ShuffleClient {
     testRetryRevive = conf.testRetryRevive();
     pushBufferMaxSize = conf.clientPushBufferMaxSize();
     pushExcludeWorkerOnFailureEnabled = conf.clientPushExcludeWorkerOnFailureEnabled();
+    shuffleCompressionEnabled = !conf.shuffleCompressionCodec().equals(CompressionCodec.NONE);
     if (conf.clientPushReplicateEnabled()) {
       pushDataTimeout = conf.pushDataTimeoutMs() * 2;
     } else {
@@ -834,19 +836,26 @@ public class ShuffleClientImpl extends ShuffleClient {
     // increment batchId
     final int nextBatchId = pushState.nextBatchId();
 
-    // compress data
-    final Compressor compressor = compressorThreadLocal.get();
-    compressor.compress(data, offset, length);
+    int totalSize = length;
+    byte[] shuffleDataBuf = new byte[length];
 
-    final int compressedTotalSize = compressor.getCompressedTotalSize();
+    if (shuffleCompressionEnabled) {
+      // compress data
+      final Compressor compressor = compressorThreadLocal.get();
+      compressor.compress(data, offset, length);
 
-    final byte[] body = new byte[BATCH_HEADER_SIZE + compressedTotalSize];
+      totalSize = compressor.getCompressedTotalSize();
+      shuffleDataBuf = compressor.getCompressedBuffer();
+    } else {
+      System.arraycopy(data, offset, shuffleDataBuf, 0, length);
+    }
+
+    final byte[] body = new byte[BATCH_HEADER_SIZE + totalSize];
     Platform.putInt(body, Platform.BYTE_ARRAY_OFFSET, mapId);
     Platform.putInt(body, Platform.BYTE_ARRAY_OFFSET + 4, attemptId);
     Platform.putInt(body, Platform.BYTE_ARRAY_OFFSET + 8, nextBatchId);
-    Platform.putInt(body, Platform.BYTE_ARRAY_OFFSET + 12, compressedTotalSize);
-    System.arraycopy(
-        compressor.getCompressedBuffer(), 0, body, BATCH_HEADER_SIZE, compressedTotalSize);
+    Platform.putInt(body, Platform.BYTE_ARRAY_OFFSET + 12, totalSize);
+    System.arraycopy(shuffleDataBuf, 0, body, BATCH_HEADER_SIZE, totalSize);
 
     if (doPush) {
       // check limit

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -105,11 +105,14 @@ public class ShuffleClientSuiteJ {
               1,
               1);
 
-      Compressor compressor = Compressor.getCompressor(conf);
-      compressor.compress(TEST_BUF1, 0, TEST_BUF1.length);
-      final int compressedTotalSize = compressor.getCompressedTotalSize();
-
-      assert (pushDataLen == compressedTotalSize + BATCH_HEADER_SIZE);
+      if (codec.equals(CompressionCodec.NONE)) {
+        assert (pushDataLen == TEST_BUF1.length + BATCH_HEADER_SIZE);
+      } else {
+        Compressor compressor = Compressor.getCompressor(conf);
+        compressor.compress(TEST_BUF1, 0, TEST_BUF1.length);
+        final int compressedTotalSize = compressor.getCompressedTotalSize();
+        assert (pushDataLen == compressedTotalSize + BATCH_HEADER_SIZE);
+      }
     }
   }
 
@@ -130,22 +133,14 @@ public class ShuffleClientSuiteJ {
               1,
               1);
 
-      Compressor compressor = Compressor.getCompressor(conf);
-      compressor.compress(TEST_BUF1, 0, TEST_BUF1.length);
-      final int compressedTotalSize = compressor.getCompressedTotalSize();
-
-      shuffleClient.mergeData(
-          TEST_SHUFFLE_ID,
-          TEST_ATTEMPT_ID,
-          TEST_ATTEMPT_ID,
-          TEST_REDUCRE_ID,
-          TEST_BUF1,
-          0,
-          TEST_BUF1.length,
-          1,
-          1);
-
-      assert (mergeSize == compressedTotalSize + BATCH_HEADER_SIZE);
+      if (codec.equals(CompressionCodec.NONE)) {
+        assert (mergeSize == TEST_BUF1.length + BATCH_HEADER_SIZE);
+      } else {
+        Compressor compressor = Compressor.getCompressor(conf);
+        compressor.compress(TEST_BUF1, 0, TEST_BUF1.length);
+        final int compressedTotalSize = compressor.getCompressedTotalSize();
+        assert (mergeSize == compressedTotalSize + BATCH_HEADER_SIZE);
+      }
 
       byte[] buf1k = RandomStringUtils.random(4000).getBytes(StandardCharsets.UTF_8);
       int largeMergeSize =
@@ -160,11 +155,14 @@ public class ShuffleClientSuiteJ {
               1,
               1);
 
-      compressor = Compressor.getCompressor(conf);
-      compressor.compress(buf1k, 0, buf1k.length);
-      int compressedTotalSize1 = compressor.getCompressedTotalSize();
-
-      assert (largeMergeSize == compressedTotalSize1 + BATCH_HEADER_SIZE);
+      if (codec.equals(CompressionCodec.NONE)) {
+        assert (largeMergeSize == buf1k.length + BATCH_HEADER_SIZE);
+      } else {
+        Compressor compressor = Compressor.getCompressor(conf);
+        compressor.compress(buf1k, 0, buf1k.length);
+        final int compressedTotalSize = compressor.getCompressedTotalSize();
+        assert (largeMergeSize == compressedTotalSize + BATCH_HEADER_SIZE);
+      }
     }
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2939,11 +2939,14 @@ object CelebornConf extends Logging {
       .withAlternative("celeborn.shuffle.compression.codec")
       .withAlternative("remote-shuffle.job.compression.codec")
       .categories("client")
-      .doc("The codec used to compress shuffle data. By default, Celeborn provides two codecs: `lz4` and `zstd`.")
+      .doc("The codec used to compress shuffle data. By default, Celeborn provides three codecs: `lz4`, `zstd`, `none`.")
       .version("0.3.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
-      .checkValues(Set(CompressionCodec.LZ4.name, CompressionCodec.ZSTD.name))
+      .checkValues(Set(
+        CompressionCodec.LZ4.name,
+        CompressionCodec.ZSTD.name,
+        CompressionCodec.NONE.name))
       .createWithDefault(CompressionCodec.LZ4.name)
 
   val SHUFFLE_COMPRESSION_ZSTD_LEVEL: ConfigEntry[Int] =

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -81,7 +81,7 @@ license: |
 | celeborn.client.shuffle.batchHandleReleasePartition.enabled | true | When true, LifecycleManager will handle release partition request in batch. Otherwise, LifecycleManager will process release partition request immediately | 0.3.0 | 
 | celeborn.client.shuffle.batchHandleReleasePartition.interval | 5s | Interval for LifecycleManager to schedule handling release partition requests in batch. | 0.3.0 | 
 | celeborn.client.shuffle.batchHandleReleasePartition.threads | 8 | Threads number for LifecycleManager to handle release partition request in batch. | 0.3.0 | 
-| celeborn.client.shuffle.compression.codec | LZ4 | The codec used to compress shuffle data. By default, Celeborn provides two codecs: `lz4` and `zstd`. | 0.3.0 | 
+| celeborn.client.shuffle.compression.codec | LZ4 | The codec used to compress shuffle data. By default, Celeborn provides three codecs: `lz4`, `zstd`, `none`. | 0.3.0 | 
 | celeborn.client.shuffle.compression.zstd.level | 1 | Compression level for Zstd compression codec, its value should be an integer between -5 and 22. Increasing the compression level will result in better compression at the expense of more CPU and memory. | 0.3.0 | 
 | celeborn.client.shuffle.expired.checkInterval | 60s | Interval for client to check expired shuffles. | 0.3.0 | 
 | celeborn.client.shuffle.manager.port | 0 | Port used by the LifecycleManager on the Driver. | 0.3.0 | 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ClusterReadWriteTestWithNONE.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ClusterReadWriteTestWithNONE.scala
@@ -15,10 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.common.protocol;
+package org.apache.celeborn.service.deploy.cluster
 
-public enum CompressionCodec {
-  LZ4,
-  ZSTD,
-  NONE;
+import org.apache.celeborn.common.protocol.CompressionCodec
+
+class ClusterReadWriteTestWithNONE extends ReadWriteTestBase {
+
+  test(s"test MiniCluster With NONE") {
+    testReadWriteByCode(CompressionCodec.NONE)
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support to decide whether to compress shuffle data through configuration.


### Why are the changes needed?
Currently, Celeborn compresses all shuffle data, but for example, the shuffle data of Gluten has already been compressed. In this case, no additional compression is required. Therefore, configuration needs to be provided for users to decide whether to use Celeborn’s compression according to the actual situation.


### Does this PR introduce _any_ user-facing change?
no.

