### PR TITLE
[CELEBORN-761] Change from pooled scheduler to single thread scheduler for push/fetch timeout checker

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -82,13 +82,11 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
     synchronized (TransportResponseHandler.class) {
       if (pushTimeoutChecker == null) {
         pushTimeoutChecker =
-            ThreadUtils.newDaemonThreadPoolScheduledExecutor(
-                "push-timeout-checker", conf.pushDataTimeoutCheckerThreads());
+            ThreadUtils.newDaemonSingleThreadScheduledExecutor("push-timeout-checker");
       }
       if (fetchTimeoutChecker == null) {
         fetchTimeoutChecker =
-            ThreadUtils.newDaemonThreadPoolScheduledExecutor(
-                "fetch-timeout-checker", conf.fetchDataTimeoutCheckerThreads());
+            ThreadUtils.newDaemonSingleThreadScheduledExecutor("fetch-timeout-checker");
       }
     }
     pushCheckerScheduleFuture =

--- a/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
@@ -134,16 +134,8 @@ public class TransportConf {
     return celebornConf;
   }
 
-  public int pushDataTimeoutCheckerThreads() {
-    return celebornConf.pushDataTimeoutCheckerThreads(module);
-  }
-
   public long pushDataTimeoutCheckIntervalMs() {
     return celebornConf.pushDataTimeoutCheckInterval(module);
-  }
-
-  public int fetchDataTimeoutCheckerThreads() {
-    return celebornConf.fetchDataTimeoutCheckerThreads(module);
   }
 
   public long fetchDataTimeoutCheckIntervalMs() {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -473,19 +473,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     getTimeAsMs(key, CHANNEL_HEARTBEAT_INTERVAL.defaultValueString)
   }
 
-  def pushDataTimeoutCheckerThreads(module: String): Int = {
-    val key = PUSH_TIMEOUT_CHECK_THREADS.key.replace("<module>", module)
-    getInt(key, PUSH_TIMEOUT_CHECK_THREADS.defaultValue.get)
-  }
-
   def pushDataTimeoutCheckInterval(module: String): Long = {
     val key = PUSH_TIMEOUT_CHECK_INTERVAL.key.replace("<module>", module)
     getTimeAsMs(key, PUSH_TIMEOUT_CHECK_INTERVAL.defaultValueString)
-  }
-
-  def fetchDataTimeoutCheckerThreads(module: String): Int = {
-    val key = FETCH_TIMEOUT_CHECK_THREADS.key.replace("<module>", module)
-    getInt(key, FETCH_TIMEOUT_CHECK_THREADS.defaultValue.get)
   }
 
   def fetchDataTimeoutCheckInterval(module: String): Long = {
@@ -1422,18 +1412,6 @@ object CelebornConf extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("5s")
 
-  val PUSH_TIMEOUT_CHECK_THREADS: ConfigEntry[Int] =
-    buildConf("celeborn.<module>.push.timeoutCheck.threads")
-      .categories("network")
-      .doc("Threads num for checking push data timeout. " +
-        s"If setting <module> to `${TransportModuleConstants.DATA_MODULE}`, " +
-        s"it works for shuffle client push data and should be configured on client side. " +
-        s"If setting <module> to `${TransportModuleConstants.REPLICATE_MODULE}`, " +
-        s"it works for worker replicate data to peer worker and should be configured on worker side.")
-      .version("0.3.0")
-      .intConf
-      .createWithDefault(16)
-
   val FETCH_TIMEOUT_CHECK_INTERVAL: ConfigEntry[Long] =
     buildConf("celeborn.<module>.fetch.timeoutCheck.interval")
       .categories("network")
@@ -1443,16 +1421,6 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("5s")
-
-  val FETCH_TIMEOUT_CHECK_THREADS: ConfigEntry[Int] =
-    buildConf("celeborn.<module>.fetch.timeoutCheck.threads")
-      .categories("network")
-      .doc("Threads num for checking fetch data timeout. " +
-        s"It only support setting <module> to `${TransportModuleConstants.DATA_MODULE}` " +
-        s"since it works for shuffle client fetch data and should be configured on client side.")
-      .version("0.3.0")
-      .intConf
-      .createWithDefault(16)
 
   val CHANNEL_HEARTBEAT_INTERVAL: ConfigEntry[Long] =
     buildConf("celeborn.<module>.heartbeat.interval")

--- a/docs/configuration/network.md
+++ b/docs/configuration/network.md
@@ -20,7 +20,6 @@ license: |
 | Key | Default | Description | Since |
 | --- | ------- | ----------- | ----- |
 | celeborn.&lt;module&gt;.fetch.timeoutCheck.interval | 5s | Interval for checking fetch data timeout. It only support setting <module> to `data` since it works for shuffle client fetch data and should be configured on client side. | 0.3.0 | 
-| celeborn.&lt;module&gt;.fetch.timeoutCheck.threads | 16 | Threads num for checking fetch data timeout. It only support setting <module> to `data` since it works for shuffle client fetch data and should be configured on client side. | 0.3.0 | 
 | celeborn.&lt;module&gt;.heartbeat.interval | 60s | The heartbeat interval between worker and client. If setting <module> to `data`, it works for shuffle client push and fetch data and should be configured on client side. If setting <module> to `replicate`, it works for worker replicate data to peer worker and should be configured on worker side. | 0.3.0 | 
 | celeborn.&lt;module&gt;.io.backLog | 0 | Requested maximum length of the queue of incoming connections. Default 0 for no backlog. |  | 
 | celeborn.&lt;module&gt;.io.clientThreads | 0 | Number of threads used in the client thread pool. Default to 0, which is 2x#cores. |  | 
@@ -37,7 +36,6 @@ license: |
 | celeborn.&lt;module&gt;.io.sendBuffer | 0b | Send buffer size (SO_SNDBUF). | 0.2.0 | 
 | celeborn.&lt;module&gt;.io.serverThreads | 0 | Number of threads used in the server thread pool. Default to 0, which is 2x#cores. |  | 
 | celeborn.&lt;module&gt;.push.timeoutCheck.interval | 5s | Interval for checking push data timeout. If setting <module> to `data`, it works for shuffle client push data and should be configured on client side. If setting <module> to `replicate`, it works for worker replicate data to peer worker and should be configured on worker side. | 0.3.0 | 
-| celeborn.&lt;module&gt;.push.timeoutCheck.threads | 16 | Threads num for checking push data timeout. If setting <module> to `data`, it works for shuffle client push data and should be configured on client side. If setting <module> to `replicate`, it works for worker replicate data to peer worker and should be configured on worker side. | 0.3.0 | 
 | celeborn.network.bind.preferIpAddress | true | When `ture`, prefer to use IP address, otherwise FQDN. This configuration only takes effects when the bind hostname is not set explicitly, in such case, Celeborn will find the first non-loopback address to bind. | 0.3.0 | 
 | celeborn.network.connect.timeout | 10s | Default socket connect timeout. | 0.2.0 | 
 | celeborn.network.memory.allocator.numArenas | &lt;undefined&gt; | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 | 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change from pooled scheduler to single thread scheduler for push/fetch timeout checker.

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.
