### PR TITLE
[CELEBORN-776] Restore package name of MasterNotLeaderException

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
@@ -167,10 +167,12 @@ public class MasterClient {
   private boolean shouldRetry(@Nullable RpcEndpointRef oldRef, Throwable e) {
     // It will always throw celeborn exception , so we need to get the cause
     // 'CelebornException: Exception thrown in awaitResult'
-    if (e.getCause() instanceof MasterNotLeaderException) {
-      MasterNotLeaderException exception = (MasterNotLeaderException) e.getCause();
+    if (e.getCause() instanceof org.apache.celeborn.common.haclient.MasterNotLeaderException) {
+      org.apache.celeborn.common.haclient.MasterNotLeaderException exception =
+          (org.apache.celeborn.common.haclient.MasterNotLeaderException) e.getCause();
       String leaderAddr = exception.getSuggestedLeaderAddress();
-      if (!leaderAddr.equals(MasterNotLeaderException.LEADER_NOT_PRESENTED)) {
+      if (!leaderAddr.equals(
+          org.apache.celeborn.common.haclient.MasterNotLeaderException.LEADER_NOT_PRESENTED)) {
         setRpcEndpointRef(leaderAddr);
       } else {
         LOG.warn("Master leader is not present currently, please check masters' status!");

--- a/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
@@ -180,7 +180,6 @@ public class MasterClient {
     } else if (e.getCause()
         instanceof org.apache.celeborn.common.haclient.MasterNotLeaderException) {
       // 0.3 Master returns org.apache.celeborn.common.haclient.MasterNotLeaderException
-      // TODO remove it in 0.4.0
       org.apache.celeborn.common.haclient.MasterNotLeaderException exception =
           (org.apache.celeborn.common.haclient.MasterNotLeaderException) e.getCause();
       String leaderAddr = exception.getSuggestedLeaderAddress();

--- a/common/src/main/java/org/apache/celeborn/common/haclient/MasterNotLeaderException.java
+++ b/common/src/main/java/org/apache/celeborn/common/haclient/MasterNotLeaderException.java
@@ -20,7 +20,6 @@ package org.apache.celeborn.common.haclient;
 import java.io.IOException;
 
 // This class is reserved for compatible with 0.2 client
-// TODO remove it in 0.4.0
 public class MasterNotLeaderException extends IOException {
 
   private final String currentPeer;

--- a/common/src/main/java/org/apache/celeborn/common/haclient/MasterNotLeaderException.java
+++ b/common/src/main/java/org/apache/celeborn/common/haclient/MasterNotLeaderException.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.haclient;
+
+import java.io.IOException;
+
+// This class is reserved for compatible with 0.2 client
+// TODO remove it in 0.4.0
+public class MasterNotLeaderException extends IOException {
+
+  private final String currentPeer;
+  private final String leaderPeer;
+
+  public static final String LEADER_NOT_PRESENTED = "leader is not present";
+
+  public MasterNotLeaderException(String currentPeer, String suggestedLeaderPeer) {
+    super(
+        "Master:"
+            + currentPeer
+            + " is not the leader. Suggested leader is"
+            + " Master:"
+            + suggestedLeaderPeer
+            + ".");
+    this.currentPeer = currentPeer;
+    this.leaderPeer = suggestedLeaderPeer;
+  }
+
+  public String getSuggestedLeaderAddress() {
+    return leaderPeer;
+  }
+}

--- a/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
@@ -227,7 +227,9 @@ public class MasterClientSuiteJ {
 
     // master leader switch to host2
     Mockito.doReturn(
-            Future$.MODULE$.failed(new MasterNotLeaderException("host1:9097", "host2:9097")))
+            Future$.MODULE$.failed(
+                new org.apache.celeborn.common.haclient.MasterNotLeaderException(
+                    "host1:9097", "host2:9097")))
         .when(master1)
         .ask(Mockito.any(), Mockito.any(), Mockito.any());
 
@@ -275,7 +277,9 @@ public class MasterClientSuiteJ {
 
     // master leader switch to host2
     Mockito.doReturn(
-            Future$.MODULE$.failed(new MasterNotLeaderException("host1:9097", "host2:9097")))
+            Future$.MODULE$.failed(
+                new org.apache.celeborn.common.haclient.MasterNotLeaderException(
+                    "host1:9097", "host2:9097")))
         .when(ref1)
         .ask(Mockito.any(), Mockito.any(), Mockito.any());
     // Assume host2 down.

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAHelper.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAHelper.java
@@ -26,8 +26,8 @@ import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorageUtil;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
-import org.apache.celeborn.common.client.MasterNotLeaderException;
 import org.apache.celeborn.common.exception.CelebornIOException;
+import org.apache.celeborn.common.haclient.MasterNotLeaderException;
 import org.apache.celeborn.common.rpc.RpcCallContext;
 import org.apache.celeborn.service.deploy.master.clustermeta.AbstractMetaManager;
 import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Restore the package name of `MasterNotLeaderException`.

- 0.2
```
org.apache.celeborn.common.haclient.MasterNotLeaderException
```

- 0.3
```
org.apache.celeborn.common.client.MasterNotLeaderException
org.apache.celeborn.common.haclient.MasterNotLeaderException (server return this one)
```

- 0.4
```
org.apache.celeborn.common.client.MasterNotLeaderException (server return this one)
```

### Why are the changes needed?

```
2023-07-06 16:12:24 [WARN] [rpc-client-1-1] org.apache.celeborn.common.network.server.TransportChannelHandler#77 - Exception in connection from celeborn-master-0.celeborn-master-svc.spark/10.153.153.23:9097
java.lang.ClassNotFoundException: org.apache.celeborn.common.client.MasterNotLeaderException
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387) ~[?:1.8.0_352]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418) ~[?:1.8.0_352]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351) ~[?:1.8.0_352]
	at java.lang.Class.forName0(Native Method) ~[?:1.8.0_352]
	at java.lang.Class.forName(Class.java:348) ~[?:1.8.0_352]
	at org.apache.celeborn.common.serializer.JavaDeserializationStream$$anon$1.resolveClass(JavaSerializer.scala:68) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:1988) ~[?:1.8.0_352]
	at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1852) ~[?:1.8.0_352]
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2186) ~[?:1.8.0_352]
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1669) ~[?:1.8.0_352]
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2431) ~[?:1.8.0_352]
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2355) ~[?:1.8.0_352]
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2213) ~[?:1.8.0_352]
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1669) ~[?:1.8.0_352]
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:503) ~[?:1.8.0_352]
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:461) ~[?:1.8.0_352]
	at org.apache.celeborn.common.serializer.JavaDeserializationStream.readObject(JavaSerializer.scala:76) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.common.serializer.JavaSerializerInstance.deserialize(JavaSerializer.scala:110) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.common.rpc.netty.NettyRpcEnv.$anonfun$deserialize$2(NettyRpcEnv.scala:276) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:62) ~[scala-library-2.12.15.jar:?]
	at org.apache.celeborn.common.rpc.netty.NettyRpcEnv.deserialize(NettyRpcEnv.scala:323) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.common.rpc.netty.NettyRpcEnv.$anonfun$deserialize$1(NettyRpcEnv.scala:275) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:62) ~[scala-library-2.12.15.jar:?]
	at org.apache.celeborn.common.rpc.netty.NettyRpcEnv.deserialize(NettyRpcEnv.scala:275) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.common.rpc.netty.NettyRpcEnv.$anonfun$ask$6(NettyRpcEnv.scala:235) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.common.rpc.netty.NettyRpcEnv.$anonfun$ask$6$adapted(NettyRpcEnv.scala:235) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.common.rpc.netty.RpcOutboxMessage.onSuccess(Outbox.scala:82) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.common.network.client.TransportResponseHandler.handle(TransportResponseHandler.java:180) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.common.network.server.TransportChannelHandler.channelRead(TransportChannelHandler.java:119) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.common.network.util.TransportFrameDecoder.channelRead(TransportFrameDecoder.java:74) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at org.apache.celeborn.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[celeborn-client-spark-3-shaded_2.12-0.2.0.13.jar:?]
	at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_352]
```

### Does this PR introduce _any_ user-facing change?

Yes, bring back compatibility with 0.2.1 client

### How was this patch tested?

Use 0.2.1 client with branch-0.3 master/worker