### PR TITLE
[CELEBORN-777][BUG] CongestionControl getPotentialConsumeSpeed throw /zero error

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
@@ -17,7 +17,6 @@
 
 package org.apache.celeborn.service.deploy.worker.congestcontrol;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -76,7 +75,7 @@ public class BufferStatusHub extends TimeSlidingHub<BufferStatusHub.BufferStatus
   }
 
   public long avgBytesPerSec() {
-    Pair<BufferStatusNode, Integer> sumInfo = sumInfo();
+    Pair<BufferStatusNode, Integer> sumInfo = sum();
     long currentNumBytes = sumInfo.getKey().numBytes();
     if (currentNumBytes > 0) {
       return currentNumBytes * 1000 / (long) sumInfo.getValue();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
@@ -78,7 +78,7 @@ public class BufferStatusHub extends TimeSlidingHub<BufferStatusHub.BufferStatus
     Pair<BufferStatusNode, Integer> sumInfo = sum();
     long currentNumBytes = sumInfo.getKey().numBytes();
     if (currentNumBytes > 0) {
-      return currentNumBytes * 1000 / (long) sumInfo.getValue();
+      return currentNumBytes * 1000 / (long) sumInfo.getRight() * intervalPerBucketInMills;
     }
     return 0L;
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
@@ -17,7 +17,10 @@
 
 package org.apache.celeborn.service.deploy.worker.congestcontrol;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 public class BufferStatusHub extends TimeSlidingHub<BufferStatusHub.BufferStatusNode> {
 
@@ -73,9 +76,10 @@ public class BufferStatusHub extends TimeSlidingHub<BufferStatusHub.BufferStatus
   }
 
   public long avgBytesPerSec() {
-    long currentNumBytes = sum().numBytes();
+    Pair<BufferStatusNode, AtomicInteger> sumInfo = sumInfo();
+    long currentNumBytes = sumInfo.getKey().numBytes();
     if (currentNumBytes > 0) {
-      return currentNumBytes * 1000 / (long) getCurrentTimeWindowsInMills();
+      return currentNumBytes * 1000 / (long) sumInfo.getValue().get();
     }
     return 0L;
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/BufferStatusHub.java
@@ -76,10 +76,10 @@ public class BufferStatusHub extends TimeSlidingHub<BufferStatusHub.BufferStatus
   }
 
   public long avgBytesPerSec() {
-    Pair<BufferStatusNode, AtomicInteger> sumInfo = sumInfo();
+    Pair<BufferStatusNode, Integer> sumInfo = sumInfo();
     long currentNumBytes = sumInfo.getKey().numBytes();
     if (currentNumBytes > 0) {
-      return currentNumBytes * 1000 / (long) sumInfo.getValue().get();
+      return currentNumBytes * 1000 / (long) sumInfo.getValue();
     }
     return 0L;
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -102,18 +102,17 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
       for (long i = 1; i < nodesToAdd; i++) {
         N toAdd = newEmptyNode();
         lastNode = Pair.of(lastNode.getLeft() + intervalPerBucketInMills, toAdd);
-        sumInfo.getValue().incrementAndGet();
         _deque.add(lastNode);
       }
 
       _deque.add(Pair.of(lastNode.getLeft() + intervalPerBucketInMills, (N) newNode.clone()));
-      sumInfo.getValue().incrementAndGet();
+      sumInfo.getValue().addAndGet(((int) nodesToAdd + 1));
       sumInfo.getKey().combineNode(newNode);
 
       while (_deque.size() > maxQueueSize) {
         Pair<Long, N> removed = _deque.removeFirst();
-        sumInfo.getValue().decrementAndGet();
         sumInfo.getKey().separateNode(removed.getRight());
+        sumInfo.getValue().decrementAndGet();
       }
       return;
     }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -151,7 +151,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
     if (dequeSize == 0) {
       return intervalPerBucketInMills;
     } else {
-      return _deque.size() * intervalPerBucketInMills;
+      return dequeSize * intervalPerBucketInMills;
     }
   }
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -151,7 +151,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
     if (dequeSize == 0) {
       return intervalPerBucketInMills;
     } else {
-      return dequeSize * intervalPerBucketInMills;
+      return _deque.size() * intervalPerBucketInMills;
     }
   }
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -87,7 +87,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
       // The node doesn't belong to the lastNode, there might be 2 different scenarios
       // 1. All existing nodes are out of date, should be removed
       // 2. some nodes are out of date, should be removed
-      long nodesToAdd = timeDiff / intervalPerBucketInMills;
+      int nodesToAdd = (int) timeDiff / intervalPerBucketInMills;
       if (nodesToAdd >= maxQueueSize) {
         // The new node exceed existing sliding list, need to clear all old nodes
         // and create a new sliding list
@@ -107,7 +107,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
       _deque.add(Pair.of(lastNode.getLeft() + intervalPerBucketInMills, (N) newNode.clone()));
       N nodeToCombine = sumInfo.getLeft();
       nodeToCombine.combineNode(newNode);
-      sumInfo = Pair.of(nodeToCombine, sumInfo.getRight() + (int) nodesToAdd);
+      sumInfo = Pair.of(nodeToCombine, sumInfo.getRight() + nodesToAdd);
 
       while (_deque.size() > maxQueueSize) {
         Pair<Long, N> removed = _deque.removeFirst();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -98,7 +98,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
       }
 
       // Add new node at the end of the list, and deprecate nodes out of timeInterval
-      for (long i = 1; i < nodesToAdd; i++) {
+      for (int i = 1; i < nodesToAdd; i++) {
         N toAdd = newEmptyNode();
         lastNode = Pair.of(lastNode.getLeft() + intervalPerBucketInMills, toAdd);
         _deque.add(lastNode);

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -76,7 +76,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
   public synchronized void add(long currentTimestamp, N newNode) {
     if (_deque.size() == 0) {
       _deque.add(Pair.of(currentTimestamp, (N) newNode.clone()));
-      sumInfo = Pair.of((N) newNode.clone(), _deque.size());
+      sumInfo = Pair.of((N) newNode.clone(), 1);
       return;
     }
 
@@ -94,7 +94,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
         // and create a new sliding list
         _deque.clear();
         _deque.add(Pair.of(currentTimestamp, (N) newNode.clone()));
-        sumInfo = Pair.of((N) newNode.clone(), _deque.size());
+        sumInfo = Pair.of((N) newNode.clone(), 1);
         return;
       }
 
@@ -106,15 +106,15 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
       }
 
       _deque.add(Pair.of(lastNode.getLeft() + intervalPerBucketInMills, (N) newNode.clone()));
-      N node = sumInfo.getKey();
-      node.combineNode(newNode);
-      sumInfo = Pair.of(node, sumInfo.getValue() + (int) nodesToAdd + 1);
+      N nodeToCombine = sumInfo.getKey();
+      nodeToCombine.combineNode(newNode);
+      sumInfo = Pair.of(nodeToCombine, sumInfo.getValue() + (int) nodesToAdd);
 
       while (_deque.size() > maxQueueSize) {
         Pair<Long, N> removed = _deque.removeFirst();
-        N node2 = sumInfo.getKey();
-        node2.separateNode(removed.getRight());
-        sumInfo = Pair.of(node2, sumInfo.getValue().intValue() - 1);
+        N nodeToSeparate = sumInfo.getKey();
+        nodeToSeparate.separateNode(removed.getRight());
+        sumInfo = Pair.of(nodeToSeparate, sumInfo.getValue() - 1);
       }
       return;
     }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -145,14 +145,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
   protected abstract N newEmptyNode();
 
   protected int getCurrentTimeWindowsInMills() {
-    // _deque size could be 0 after clear, after clear will add one pair,
-    // to avoid such case, we return _deque size as 1.
-    int dequeSize = _deque.size();
-    if (dequeSize == 0) {
-      return intervalPerBucketInMills;
-    } else {
-      return _deque.size() * intervalPerBucketInMills;
-    }
+    return _deque.size() * intervalPerBucketInMills;
   }
 
   @VisibleForTesting

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -74,8 +74,8 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
 
   public synchronized void add(long currentTimestamp, N newNode) {
     if (_deque.size() == 0) {
-      sumNode = (N) newNode.clone();
       _deque.add(Pair.of(currentTimestamp, (N) newNode.clone()));
+      sumNode = (N) newNode.clone();
       return;
     }
 
@@ -104,8 +104,8 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
         _deque.add(lastNode);
       }
 
-      sumNode.combineNode(newNode);
       _deque.add(Pair.of(lastNode.getLeft() + intervalPerBucketInMills, (N) newNode.clone()));
+      sumNode.combineNode(newNode);
 
       while (_deque.size() > maxQueueSize) {
         Pair<Long, N> removed = _deque.removeFirst();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -64,7 +64,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
     this.sumInfo = Pair.of(newEmptyNode(), 0);
   }
 
-  public Pair<N, Integer> sumInfo() {
+  public Pair<N, Integer> sum() {
     return sumInfo;
   }
 
@@ -108,7 +108,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
       _deque.add(Pair.of(lastNode.getLeft() + intervalPerBucketInMills, (N) newNode.clone()));
       N node = sumInfo.getKey();
       node.combineNode(newNode);
-      sumInfo = Pair.of(node, sumInfo.getValue() + (int)nodesToAdd + 1);
+      sumInfo = Pair.of(node, sumInfo.getValue() + (int) nodesToAdd + 1);
 
       while (_deque.size() > maxQueueSize) {
         Pair<Long, N> removed = _deque.removeFirst();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -19,7 +19,6 @@ package org.apache.celeborn.service.deploy.worker.congestcontrol;
 
 import java.util.Iterator;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.tuple.Pair;

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -91,9 +91,9 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
       if (nodesToAdd >= maxQueueSize) {
         // The new node exceed existing sliding list, need to clear all old nodes
         // and create a new sliding list
+        sumNode = (N) newNode.clone();
         _deque.clear();
         _deque.add(Pair.of(currentTimestamp, (N) newNode.clone()));
-        sumNode = (N) newNode.clone();
         return;
       }
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -91,9 +91,9 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
       if (nodesToAdd >= maxQueueSize) {
         // The new node exceed existing sliding list, need to clear all old nodes
         // and create a new sliding list
-        sumNode = (N) newNode.clone();
         _deque.clear();
         _deque.add(Pair.of(currentTimestamp, (N) newNode.clone()));
+        sumNode = (N) newNode.clone();
         return;
       }
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -145,7 +145,14 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
   protected abstract N newEmptyNode();
 
   protected int getCurrentTimeWindowsInMills() {
-    return _deque.size() * intervalPerBucketInMills;
+    // _deque size could be 0 after clear, after clear will add one pair,
+    // to avoid such case, we return _deque size as 1.
+    int dequeSize = _deque.size();
+    if (dequeSize == 0) {
+      return intervalPerBucketInMills;
+    } else {
+      return _deque.size() * intervalPerBucketInMills;
+    }
   }
 
   @VisibleForTesting

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -74,8 +74,8 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
 
   public synchronized void add(long currentTimestamp, N newNode) {
     if (_deque.size() == 0) {
-      _deque.add(Pair.of(currentTimestamp, (N) newNode.clone()));
       sumNode = (N) newNode.clone();
+      _deque.add(Pair.of(currentTimestamp, (N) newNode.clone()));
       return;
     }
 
@@ -104,8 +104,8 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
         _deque.add(lastNode);
       }
 
-      _deque.add(Pair.of(lastNode.getLeft() + intervalPerBucketInMills, (N) newNode.clone()));
       sumNode.combineNode(newNode);
+      _deque.add(Pair.of(lastNode.getLeft() + intervalPerBucketInMills, (N) newNode.clone()));
 
       while (_deque.size() > maxQueueSize) {
         Pair<Long, N> removed = _deque.removeFirst();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TimeSlidingHub.java
@@ -106,15 +106,15 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
       }
 
       _deque.add(Pair.of(lastNode.getLeft() + intervalPerBucketInMills, (N) newNode.clone()));
-      N nodeToCombine = sumInfo.getKey();
+      N nodeToCombine = sumInfo.getLeft();
       nodeToCombine.combineNode(newNode);
-      sumInfo = Pair.of(nodeToCombine, sumInfo.getValue() + (int) nodesToAdd);
+      sumInfo = Pair.of(nodeToCombine, sumInfo.getRight() + (int) nodesToAdd);
 
       while (_deque.size() > maxQueueSize) {
         Pair<Long, N> removed = _deque.removeFirst();
-        N nodeToSeparate = sumInfo.getKey();
+        N nodeToSeparate = sumInfo.getLeft();
         nodeToSeparate.separateNode(removed.getRight());
-        sumInfo = Pair.of(nodeToSeparate, sumInfo.getValue() - 1);
+        sumInfo = Pair.of(nodeToSeparate, sumInfo.getRight() - 1);
       }
       return;
     }
@@ -126,7 +126,7 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
         Pair<Long, N> curNode = iter.next();
         if (currentTimestamp - curNode.getLeft() >= 0) {
           curNode.getRight().combineNode(newNode);
-          sumInfo.getKey().combineNode(newNode);
+          sumInfo.getLeft().combineNode(newNode);
           return;
         }
       }
@@ -137,13 +137,13 @@ public abstract class TimeSlidingHub<N extends TimeSlidingHub.TimeSlidingNode> {
 
     // Belong to last node
     lastNode.getRight().combineNode(newNode);
-    sumInfo.getKey().combineNode(newNode);
+    sumInfo.getLeft().combineNode(newNode);
   }
 
   public void clear() {
     synchronized (_deque) {
       _deque.clear();
-      sumInfo = Pair.of(newEmptyNode(), new AtomicInteger());
+      sumInfo = Pair.of(newEmptyNode(), 0);
     }
   }
 

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestTimeSlidingHub.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestTimeSlidingHub.java
@@ -84,34 +84,34 @@ public class TestTimeSlidingHub {
 
     hub.setDummyTimestamp(0L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(1));
-    Assert.assertEquals(1, hub.sumInfo().getKey().getValue());
+    Assert.assertEquals(1, hub.sum().getKey().getValue());
 
     hub.setDummyTimestamp(1000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(2));
-    Assert.assertEquals(3, hub.sumInfo().getKey().getValue());
+    Assert.assertEquals(3, hub.sum().getKey().getValue());
 
     hub.setDummyTimestamp(2200L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(3));
-    Assert.assertEquals(6, hub.sumInfo().getKey().getValue());
+    Assert.assertEquals(6, hub.sum().getKey().getValue());
 
     hub.setDummyTimestamp(2400L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(4));
-    Assert.assertEquals(10, hub.sumInfo().getKey().getValue());
+    Assert.assertEquals(10, hub.sum().getKey().getValue());
 
     // Should remove the value 1
     hub.setDummyTimestamp(3000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(5));
-    Assert.assertEquals(14, hub.sumInfo().getKey().getValue());
+    Assert.assertEquals(14, hub.sum().getKey().getValue());
 
     // Should remove the value 2
     hub.setDummyTimestamp(4000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(6));
-    Assert.assertEquals(18, hub.sumInfo().getKey().getValue());
+    Assert.assertEquals(18, hub.sum().getKey().getValue());
 
     // Should remove the value 3 and 4
     hub.setDummyTimestamp(5000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(7));
-    Assert.assertEquals(18, hub.sumInfo().getKey().getValue());
+    Assert.assertEquals(18, hub.sum().getKey().getValue());
   }
 
   @Test
@@ -120,10 +120,10 @@ public class TestTimeSlidingHub {
 
     hub.setDummyTimestamp(0L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(1));
-    Assert.assertEquals(1, hub.sumInfo().getKey().getValue());
+    Assert.assertEquals(1, hub.sum().getKey().getValue());
 
     hub.setDummyTimestamp(10000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(2));
-    Assert.assertEquals(2, hub.sumInfo().getKey().getValue());
+    Assert.assertEquals(2, hub.sum().getKey().getValue());
   }
 }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestTimeSlidingHub.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestTimeSlidingHub.java
@@ -84,34 +84,34 @@ public class TestTimeSlidingHub {
 
     hub.setDummyTimestamp(0L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(1));
-    Assert.assertEquals(1, hub.sum().getValue());
+    Assert.assertEquals(1, hub.sumInfo().getKey().getValue());
 
     hub.setDummyTimestamp(1000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(2));
-    Assert.assertEquals(3, hub.sum().getValue());
+    Assert.assertEquals(3, hub.sumInfo().getKey().getValue());
 
     hub.setDummyTimestamp(2200L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(3));
-    Assert.assertEquals(6, hub.sum().getValue());
+    Assert.assertEquals(6, hub.sumInfo().getKey().getValue());
 
     hub.setDummyTimestamp(2400L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(4));
-    Assert.assertEquals(10, hub.sum().getValue());
+    Assert.assertEquals(10, hub.sumInfo().getKey().getValue());
 
     // Should remove the value 1
     hub.setDummyTimestamp(3000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(5));
-    Assert.assertEquals(14, hub.sum().getValue());
+    Assert.assertEquals(14, hub.sumInfo().getKey().getValue());
 
     // Should remove the value 2
     hub.setDummyTimestamp(4000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(6));
-    Assert.assertEquals(18, hub.sum().getValue());
+    Assert.assertEquals(18, hub.sumInfo().getKey().getValue());
 
     // Should remove the value 3 and 4
     hub.setDummyTimestamp(5000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(7));
-    Assert.assertEquals(18, hub.sum().getValue());
+    Assert.assertEquals(18, hub.sumInfo().getKey().getValue());
   }
 
   @Test
@@ -120,10 +120,10 @@ public class TestTimeSlidingHub {
 
     hub.setDummyTimestamp(0L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(1));
-    Assert.assertEquals(1, hub.sum().getValue());
+    Assert.assertEquals(1, hub.sumInfo().getKey().getValue());
 
     hub.setDummyTimestamp(10000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(2));
-    Assert.assertEquals(2, hub.sum().getValue());
+    Assert.assertEquals(2, hub.sumInfo().getKey().getValue());
   }
 }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestTimeSlidingHub.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/congestcontrol/TestTimeSlidingHub.java
@@ -84,34 +84,34 @@ public class TestTimeSlidingHub {
 
     hub.setDummyTimestamp(0L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(1));
-    Assert.assertEquals(1, hub.sum().getKey().getValue());
+    Assert.assertEquals(1, hub.sum().getLeft().getValue());
 
     hub.setDummyTimestamp(1000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(2));
-    Assert.assertEquals(3, hub.sum().getKey().getValue());
+    Assert.assertEquals(3, hub.sum().getLeft().getValue());
 
     hub.setDummyTimestamp(2200L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(3));
-    Assert.assertEquals(6, hub.sum().getKey().getValue());
+    Assert.assertEquals(6, hub.sum().getLeft().getValue());
 
     hub.setDummyTimestamp(2400L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(4));
-    Assert.assertEquals(10, hub.sum().getKey().getValue());
+    Assert.assertEquals(10, hub.sum().getLeft().getValue());
 
     // Should remove the value 1
     hub.setDummyTimestamp(3000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(5));
-    Assert.assertEquals(14, hub.sum().getKey().getValue());
+    Assert.assertEquals(14, hub.sum().getLeft().getValue());
 
     // Should remove the value 2
     hub.setDummyTimestamp(4000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(6));
-    Assert.assertEquals(18, hub.sum().getKey().getValue());
+    Assert.assertEquals(18, hub.sum().getLeft().getValue());
 
     // Should remove the value 3 and 4
     hub.setDummyTimestamp(5000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(7));
-    Assert.assertEquals(18, hub.sum().getKey().getValue());
+    Assert.assertEquals(18, hub.sum().getLeft().getValue());
   }
 
   @Test
@@ -120,10 +120,10 @@ public class TestTimeSlidingHub {
 
     hub.setDummyTimestamp(0L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(1));
-    Assert.assertEquals(1, hub.sum().getKey().getValue());
+    Assert.assertEquals(1, hub.sum().getLeft().getValue());
 
     hub.setDummyTimestamp(10000L);
     hub.add(new DummyTimeSlidingHub.DummyTimeSlidingNode(2));
-    Assert.assertEquals(2, hub.sum().getKey().getValue());
+    Assert.assertEquals(2, hub.sum().getLeft().getValue());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `TimeSlidingHub.add()` `_deque` will clear then add the pair.

```
      if (nodesToAdd >= maxQueueSize) {
        // The new node exceed existing sliding list, need to clear all old nodes
        // and create a new sliding list
        _deque.clear();
        _deque.add(Pair.of(currentTimestamp, (N) newNode.clone()));
        sumNode = (N) newNode.clone();
        return;
      }

```


Then when call `BufferStatusHub.avgBytesPerSec()`,  `currentNumBytes` can be `> 0` but `getCurrentTimeWindowsInMills` may return 0. Cause the error.

```
  public long avgBytesPerSec() {
    long currentNumBytes = sum().numBytes();
    if (currentNumBytes > 0) {
      return currentNumBytes * 1000 / (long) getCurrentTimeWindowsInMills();
    }
    return 0L;
  }
```

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

