### PR TITLE
[CELEBORN-778] Rename MemoryManagerStat to ServingState

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
@@ -40,8 +40,8 @@ public class ChannelsLimiter extends ChannelDuplexHandler
   private final Set<Channel> channels = ConcurrentHashMap.newKeySet();
   private final String moduleName;
   private final AtomicBoolean isPaused = new AtomicBoolean(false);
-  private AtomicInteger needTrimChannels = new AtomicInteger(0);
-  private long waitTrimInterval;
+  private final AtomicInteger needTrimChannels = new AtomicInteger(0);
+  private final long waitTrimInterval;
 
   public ChannelsLimiter(String moduleName, CelebornConf conf) {
     this.moduleName = moduleName;
@@ -128,7 +128,7 @@ public class ChannelsLimiter extends ChannelDuplexHandler
   @Override
   public void onPause(String moduleName) {
     if (this.moduleName.equals(moduleName)) {
-      logger.info(this.moduleName + " channels pause read.");
+      logger.info("{} channels pause read.", this.moduleName);
       pauseAllChannels();
     }
   }
@@ -136,11 +136,11 @@ public class ChannelsLimiter extends ChannelDuplexHandler
   @Override
   public void onResume(String moduleName) {
     if (moduleName.equalsIgnoreCase("all")) {
-      logger.info(this.moduleName + " channels resume read.");
+      logger.info("{} channels resume read.", this.moduleName);
       resumeAllChannels();
     }
     if (this.moduleName.equals(moduleName)) {
-      logger.info(this.moduleName + " channels resume read.");
+      logger.info("{} channels resume read.", this.moduleName);
       resumeAllChannels();
     }
   }
@@ -150,5 +150,5 @@ public class ChannelsLimiter extends ChannelDuplexHandler
     trimCache();
   }
 
-  class TrimCache {}
+  static class TrimCache {}
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -66,7 +66,7 @@ public abstract class FileWriter implements DeviceObserver {
   @GuardedBy("flushLock")
   private CompositeByteBuf flushBuffer;
 
-  private Object flushLock = new Object();
+  private final Object flushLock = new Object();
   private final long writerCloseTimeoutMs;
 
   protected final long flusherBufferSize;
@@ -170,11 +170,7 @@ public abstract class FileWriter implements DeviceObserver {
     }
   }
 
-  /**
-   * assume data size is less than chunk capacity
-   *
-   * @param data
-   */
+  /** assume data size is less than chunk capacity */
   public void write(ByteBuf data) throws IOException {
     if (closed) {
       String msg = "FileWriter has already closed!, fileName " + fileInfo.getFilePath();
@@ -244,14 +240,14 @@ public abstract class FileWriter implements DeviceObserver {
   public abstract long close() throws IOException;
 
   @FunctionalInterface
-  public interface RunnableWithException<R extends IOException> {
-    void run() throws R;
+  public interface RunnableWithIOException {
+    void run() throws IOException;
   }
 
   protected synchronized long close(
-      RunnableWithException tryClose,
-      RunnableWithException streamClose,
-      RunnableWithException finalClose)
+      RunnableWithIOException tryClose,
+      RunnableWithIOException streamClose,
+      RunnableWithIOException finalClose)
       throws IOException {
     if (closed) {
       String msg = "FileWriter has already closed! fileName " + fileInfo.getFilePath();
@@ -279,14 +275,14 @@ public abstract class FileWriter implements DeviceObserver {
           streamClose.run();
         }
       } catch (IOException e) {
-        logger.warn("close file writer" + this + "failed", e);
+        logger.warn("close file writer {} failed", this, e);
       }
 
       finalClose.run();
 
       // unregister from DeviceMonitor
       if (!fileInfo.isHdfs()) {
-        logger.debug("file info {} register from device monitor");
+        logger.debug("file info {} register from device monitor", fileInfo);
         deviceMonitor.unregisterFileWriter(this);
       }
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -39,7 +39,7 @@ abstract private[worker] class Flusher(
     val workerSource: AbstractSource,
     val threadCount: Int,
     flushTimeMetric: TimeWindow) extends Logging {
-  protected lazy val flusherId = System.identityHashCode(this)
+  protected lazy val flusherId: Int = System.identityHashCode(this)
   protected val workingQueues = new Array[LinkedBlockingQueue[FlushTask]](threadCount)
   protected val bufferQueue = new LinkedBlockingQueue[CompositeByteBuf]()
   protected val workers = new Array[Thread](threadCount)
@@ -47,7 +47,6 @@ abstract private[worker] class Flusher(
 
   val lastBeginFlushTime: AtomicLongArray = new AtomicLongArray(threadCount)
   val stopFlag = new AtomicBoolean(false)
-  val rand = new Random()
 
   init()
 
@@ -61,7 +60,7 @@ abstract private[worker] class Flusher(
         override def run(): Unit = {
           while (!stopFlag.get()) {
             val task = workingQueues(index).take()
-            val key = s"Flusher-$this-${rand.nextInt()}"
+            val key = s"Flusher-$this-${Random.nextInt()}"
             workerSource.sample(WorkerSource.FLUSH_DATA_TIME, key) {
               if (!task.notifier.hasException) {
                 try {
@@ -178,9 +177,7 @@ private[worker] class LocalFlusher(
     obj.asInstanceOf[LocalFlusher].mountPoint.equals(mountPoint)
   }
 
-  override def toString(): String = {
-    s"LocalFlusher@$flusherId-$mountPoint"
-  }
+  override def toString: String = s"LocalFlusher@$flusherId-$mountPoint"
 }
 
 final private[worker] class HdfsFlusher(

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -188,7 +188,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   if (!checkIfWorkingDirCleaned) {
     logWarning(
       "Worker still has residual files in the working directory before registering with Master, " +
-        "please refer to the configuration document to increase celeborn.worker.disk.checkFileClean.maxRetries or " +
+        "please refer to the configuration document to increase " +
         s"${CelebornConf.WORKER_CHECK_FILE_CLEAN_TIMEOUT.key}.")
   } else {
     logInfo("Successfully remove all files under working directory.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Rename

```
enum MemoryManagerStat { resumeAll, pausePushDataAndReplicate, pausePushDataAndResumeReplicate }
```

to

```
enum ServingState { NONE_PAUSED, PUSH_AND_REPLICATE_PAUSED, PUSH_PAUSED }
```

### Why are the changes needed?

`MemoryManagerStat` indicates the worker serving functionalities, and it's weird to represent the state using verbs.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass GA.