### PR TITLE
[CELEBORN-779] Fix sorted file size summary overflow.

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -154,8 +154,8 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
     return sortedFileCount.get();
   }
 
-  public int getSortedSize() {
-    return (int) sortedFilesSize.get();
+  public long getSortedSize() {
+    return sortedFilesSize.get();
   }
 
   public FileInfo getSortedFileInfo(


### PR DESCRIPTION
### What changes were proposed in this pull request?
To fix sorted file size summary counter overflow. Sorted file size summary can be larger than the integer's max value. It should be applied to branch-0.3, branch-0.2, and main branch.


### Why are the changes needed?
This graph is incorrect.
<img width="1500" alt="lQLPJx4a6A76xo7NBOHNC7iwLBx50tXnv5IEoQTQxMAMAA_3000_1249" src="https://github.com/apache/incubator-celeborn/assets/4150993/8d288087-64d7-4569-ba04-05bb1915118a">



### Does this PR introduce _any_ user-facing change?
It will cause user-facing changes.  Celeborn worker's metric for sorted file summary is incorrect and this patch will correct it.


### How was this patch tested?
UT.
