### PR TITLE
[CELEBORN-782] Make max components configurable for FileWriter#flushBuffer

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2585,10 +2585,11 @@ object CelebornConf extends Logging {
       .internal
       .categories("worker")
       .version("0.3.0")
-      .doc("Max components in FileWriter's flushBuffer. When this value is too big, i.e. 16, " +
-        "there will be many memory fragments in netty's memory pool, and total direct memory can by several " +
-        "times larger than disk buffer. When set to 1, netty's direct memory is close to disk buffer, but performance" +
-        "might decrease.")
+      .doc("Max components of Netty `CompositeByteBuf` in `FileWriter`'s `flushBuffer`. " +
+           "When this value is too big, i.e. 256, there will be many memory fragments in Netty's memory pool, "
+           "and total direct memory can be significantly larger than the disk buffer. " +
+           "When set to 1, Netty's direct memory is close to disk buffer, but performance " +
+           "might decrease due to frequent memory copy during compaction.")
       .intConf
       .createWithDefault(16)
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2586,10 +2586,10 @@ object CelebornConf extends Logging {
       .categories("worker")
       .version("0.3.0")
       .doc("Max components of Netty `CompositeByteBuf` in `FileWriter`'s `flushBuffer`. " +
-           "When this value is too big, i.e. 256, there will be many memory fragments in Netty's memory pool, "
-           "and total direct memory can be significantly larger than the disk buffer. " +
-           "When set to 1, Netty's direct memory is close to disk buffer, but performance " +
-           "might decrease due to frequent memory copy during compaction.")
+        "When this value is too big, i.e. 256, there will be many memory fragments in Netty's memory pool, " +
+        "and total direct memory can be significantly larger than the disk buffer. " +
+        "When set to 1, Netty's direct memory is close to disk buffer, but performance " +
+        "might decrease due to frequent memory copy during compaction.")
       .intConf
       .createWithDefault(16)
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -647,6 +647,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def partitionSorterThreads: Int =
     get(PARTITION_SORTER_THREADS).getOrElse(Runtime.getRuntime.availableProcessors)
   def workerPushHeartbeatEnabled: Boolean = get(WORKER_PUSH_HEARTBEAT_ENABLED)
+  def workerPushMaxComponents: Int = get(WORKER_PUSH_COMPOSITEBUFFER_MAXCOMPONENTS)
   def workerFetchHeartbeatEnabled: Boolean = get(WORKER_FETCH_HEARTBEAT_ENABLED)
   def workerPartitionSplitEnabled: Boolean = get(WORKER_PARTITION_SPLIT_ENABLED)
 
@@ -2578,6 +2579,15 @@ object CelebornConf extends Logging {
       .doc("enable the heartbeat from worker to client when pushing data")
       .booleanConf
       .createWithDefault(false)
+
+  val WORKER_PUSH_COMPOSITEBUFFER_MAXCOMPONENTS: ConfigEntry[Int] =
+    buildConf("celeborn.worker.push.compositeBuffer.maxComponents")
+      .internal
+      .categories("worker")
+      .version("0.3.0")
+      .doc("Max components in CompositeByteBuf for FileWriter's flushBuffer.")
+      .intConf
+      .createWithDefault(32)
 
   val WORKER_FETCH_HEARTBEAT_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.worker.fetch.heartbeat.enabled")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2585,9 +2585,12 @@ object CelebornConf extends Logging {
       .internal
       .categories("worker")
       .version("0.3.0")
-      .doc("Max components in CompositeByteBuf for FileWriter's flushBuffer.")
+      .doc("Max components in FileWriter's flushBuffer. When this value is too big, i.e. 16, " +
+        "there will be many memory fragments in netty's memory pool, and total direct memory can by several " +
+        "times larger than disk buffer. When set to 1, netty's direct memory is close to disk buffer, but performance" +
+        "might decrease.")
       .intConf
-      .createWithDefault(32)
+      .createWithDefault(16)
 
   val WORKER_FETCH_HEARTBEAT_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.worker.fetch.heartbeat.enabled")

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -108,6 +108,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           workerSource,
           deviceMonitor,
           diskInfo.threadCount,
+          conf.workerPushMaxComponents,
           diskInfo.mountPoint,
           diskInfo.storageType,
           diskInfo.flushTimeMetrics)
@@ -130,7 +131,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       (
         Some(new HdfsFlusher(
           workerSource,
-          conf.workerHdfsFlusherThreads)),
+          conf.workerHdfsFlusherThreads,
+          conf.workerPushMaxComponents)),
         conf.workerHdfsFlusherThreads)
     } else {
       (None, 0)

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -116,7 +116,13 @@ public class FileWriterSuiteJ {
     dirs.$plus$eq(tempDir);
     localFlusher =
         new LocalFlusher(
-            source, DeviceMonitor$.MODULE$.EmptyMonitor(), 1, "disk1", StorageInfo.Type.HDD, null);
+            source,
+            DeviceMonitor$.MODULE$.EmptyMonitor(),
+            1,
+            256,
+            "disk1",
+            StorageInfo.Type.HDD,
+            null);
 
     CelebornConf conf = new CelebornConf();
     conf.set(CelebornConf.WORKER_DIRECT_MEMORY_RATIO_PAUSE_RECEIVE().key(), "0.8");
@@ -380,7 +386,13 @@ public class FileWriterSuiteJ {
     dirs.$plus$eq(file);
     localFlusher =
         new LocalFlusher(
-            source, DeviceMonitor$.MODULE$.EmptyMonitor(), 1, "disk2", StorageInfo.Type.HDD, null);
+            source,
+            DeviceMonitor$.MODULE$.EmptyMonitor(),
+            1,
+            256,
+            "disk2",
+            StorageInfo.Type.HDD,
+            null);
   }
 
   @Test

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriterSuiteJ.java
@@ -81,7 +81,13 @@ public class MapPartitionFileWriterSuiteJ {
     dirs.$plus$eq(tempDir);
     localFlusher =
         new LocalFlusher(
-            source, DeviceMonitor$.MODULE$.EmptyMonitor(), 1, "disk1", StorageInfo.Type.HDD, null);
+            source,
+            DeviceMonitor$.MODULE$.EmptyMonitor(),
+            1,
+            256,
+            "disk1",
+            StorageInfo.Type.HDD,
+            null);
 
     CelebornConf conf = new CelebornConf();
     conf.set(CelebornConf.WORKER_DIRECT_MEMORY_RATIO_PAUSE_RECEIVE().key(), "0.8");


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Make max components configurable for FileWriter#flushBuffer.


### Why are the changes needed?
When max components of ```CompositeByteBuf``` is too big (hard coded 256 before this PR), netty's offheap memory
usage will be several times bigger than true usage:
```
 Direct memory usage: 1044.0 MiB/4.0 GiB, disk buffer size: 255.9 MiB
``` 
When set to 1, netty's memory usage will be very close to disk buffer:
```
Direct memory usage: 376.0 MiB/4.0 GiB, disk buffer size: 353.0 MiB
```
but when it set too low, for example 1, performance might decrease, especially for sort pusher:
```
max components:   1 vs. 16
shuffle write time:   34s vs. 30s
```
For hash pusher, difference is not so big:
```
max components:   1 vs. 8
shuffle write time:   25s vs. 23s
```
This PR makes the parameter configurable.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Passes GA, and manual test.
