### PR TITLE
[CELEBORN-784][CLIENT] Push merged data revive should directly clean pushState or it will remain inflight count in pushState

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -887,7 +887,6 @@ public class ShuffleClientImpl extends ShuffleClient {
 
             @Override
             public void onFailure(Throwable e) {
-              pushState.removeBatch(nextBatchId, loc.hostAndPushPort());
               String errorMsg =
                   String.format(
                       "Push data to %s failed for shuffle %d map %d attempt %d partition %d batch %d.",
@@ -990,7 +989,6 @@ public class ShuffleClientImpl extends ShuffleClient {
               StatusCode cause = getPushDataFailCause(e.getMessage());
 
               if (pushState.exception.get() != null) {
-                pushState.removeBatch(nextBatchId, loc.hostAndPushPort());
                 return;
               }
 
@@ -1276,7 +1274,6 @@ public class ShuffleClientImpl extends ShuffleClient {
                     groupedBatchId,
                     Arrays.toString(batchIds),
                     remainReviveTimes);
-            pushState.removeBatch(groupedBatchId, hostPort);
             pushState.exception.compareAndSet(null, new CelebornIOException(errorMsg, e));
             if (logger.isDebugEnabled()) {
               for (int i = 0; i < numBatches; i++) {
@@ -1373,7 +1370,6 @@ public class ShuffleClientImpl extends ShuffleClient {
             StatusCode cause = getPushDataFailCause(e.getMessage());
 
             if (pushState.exception.get() != null) {
-              pushState.removeBatch(groupedBatchId, hostPort);
               return;
             }
             if (remainReviveTimes <= 0) {


### PR DESCRIPTION
### What changes were proposed in this pull request? 
Since when revive for PushMergedData,  we call `doPushMergedData` again, it will add a new infight count, then forgot to clean the old state. This pr fix this issue

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

