### PR TITLE
[CELEBORN-626][FOLLOWUP] Fix wrong update chunkOffsets when final flush with empty buffer

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -260,7 +260,9 @@ public abstract class FileWriter implements DeviceObserver {
       closed = true;
 
       synchronized (flushLock) {
-        flush(true);
+        if (flushBuffer.readableBytes() > 0) {
+          flush(true);
+        }
       }
 
       tryClose.run();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Final flush with none empty buffer.


### Why are the changes needed?
This bug was introduced by [CELEBORN-626](https://github.com/apache/incubator-celeborn/pull/1534/files)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass UT
