### PR TITLE
[CELEBORN-789] Increase default value of flushBuffer's max components

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2600,7 +2600,7 @@ object CelebornConf extends Logging {
         "When set to 1, Netty's direct memory is close to disk buffer, but performance " +
         "might decrease due to frequent memory copy during compaction.")
       .intConf
-      .createWithDefault(128)
+      .createWithDefault(64)
 
   val WORKER_FETCH_HEARTBEAT_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.worker.fetch.heartbeat.enabled")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2600,7 +2600,7 @@ object CelebornConf extends Logging {
         "When set to 1, Netty's direct memory is close to disk buffer, but performance " +
         "might decrease due to frequent memory copy during compaction.")
       .intConf
-      .createWithDefault(64)
+      .createWithDefault(128)
 
   val WORKER_FETCH_HEARTBEAT_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.worker.fetch.heartbeat.enabled")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2600,7 +2600,7 @@ object CelebornConf extends Logging {
         "When set to 1, Netty's direct memory is close to disk buffer, but performance " +
         "might decrease due to frequent memory copy during compaction.")
       .intConf
-      .createWithDefault(256)
+      .createWithDefault(128)
 
   val WORKER_FETCH_HEARTBEAT_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.worker.fetch.heartbeat.enabled")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2600,7 +2600,7 @@ object CelebornConf extends Logging {
         "When set to 1, Netty's direct memory is close to disk buffer, but performance " +
         "might decrease due to frequent memory copy during compaction.")
       .intConf
-      .createWithDefault(16)
+      .createWithDefault(256)
 
   val WORKER_FETCH_HEARTBEAT_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.worker.fetch.heartbeat.enabled")

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -66,6 +66,7 @@ import org.apache.celeborn.common.network.protocol.Message;
 import org.apache.celeborn.common.network.protocol.OpenStream;
 import org.apache.celeborn.common.network.protocol.StreamHandle;
 import org.apache.celeborn.common.network.server.TransportServer;
+import org.apache.celeborn.common.network.util.NettyUtils;
 import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.protocol.PartitionSplitMode;
 import org.apache.celeborn.common.protocol.PartitionType;
@@ -119,6 +120,7 @@ public class FileWriterSuiteJ {
             source,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             1,
+            NettyUtils.getPooledByteBufAllocator(new TransportConf("test", CONF), null, true),
             256,
             "disk1",
             StorageInfo.Type.HDD,
@@ -389,6 +391,7 @@ public class FileWriterSuiteJ {
             source,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             1,
+            NettyUtils.getPooledByteBufAllocator(new TransportConf("test", CONF), null, true),
             256,
             "disk2",
             StorageInfo.Type.HDD,

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriterSuiteJ.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.network.util.NettyUtils;
+import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.protocol.PartitionSplitMode;
 import org.apache.celeborn.common.protocol.StorageInfo;
 import org.apache.celeborn.common.util.JavaUtils;
@@ -84,6 +86,7 @@ public class MapPartitionFileWriterSuiteJ {
             source,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             1,
+            NettyUtils.getPooledByteBufAllocator(new TransportConf("test", CONF), null, true),
             256,
             "disk1",
             StorageInfo.Type.HDD,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Set default value of ```celeborn.worker.push.compositeBuffer.maxComponents``` to 256, to be aligned with 0.2.1-incubating version.


### Why are the changes needed?

Default 16 is too small, and causes ~~severe GC~~ and CPU high load.

<img width="1719" alt="image" src="https://github.com/apache/incubator-celeborn/assets/26535726/9ab9675e-c19e-44f1-af46-90c29dc4df75">

### Does this PR introduce _any_ user-facing change?
No, it's internal config.


### How was this patch tested?
Passes GA.
