### PR TITLE
[CELEBORN-790] Use pooled direct allocator for flusher's CompositeByteBuf

### DIFF
--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -66,6 +66,7 @@ import org.apache.celeborn.common.network.protocol.Message;
 import org.apache.celeborn.common.network.protocol.OpenStream;
 import org.apache.celeborn.common.network.protocol.StreamHandle;
 import org.apache.celeborn.common.network.server.TransportServer;
+import org.apache.celeborn.common.network.util.NettyUtils;
 import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.protocol.PartitionSplitMode;
 import org.apache.celeborn.common.protocol.PartitionType;
@@ -119,6 +120,7 @@ public class FileWriterSuiteJ {
             source,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             1,
+            NettyUtils.getPooledByteBufAllocator(new TransportConf("test", CONF), null, true),
             256,
             "disk1",
             StorageInfo.Type.HDD,
@@ -389,6 +391,7 @@ public class FileWriterSuiteJ {
             source,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             1,
+            NettyUtils.getPooledByteBufAllocator(new TransportConf("test", CONF), null, true),
             256,
             "disk2",
             StorageInfo.Type.HDD,

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionFileWriterSuiteJ.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.network.util.NettyUtils;
+import org.apache.celeborn.common.network.util.TransportConf;
 import org.apache.celeborn.common.protocol.PartitionSplitMode;
 import org.apache.celeborn.common.protocol.StorageInfo;
 import org.apache.celeborn.common.util.JavaUtils;
@@ -84,6 +86,7 @@ public class MapPartitionFileWriterSuiteJ {
             source,
             DeviceMonitor$.MODULE$.EmptyMonitor(),
             1,
+            NettyUtils.getPooledByteBufAllocator(new TransportConf("test", CONF), null, true),
             256,
             "disk1",
             StorageInfo.Type.HDD,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title.


### Why are the changes needed?
Before this PR, ```Flusher#takeBuffer``` returns a ```CompositeByteBuf``` which is unpooled and on heap:
```
      buffer = Unpooled.compositeBuffer(maxComponents)
```
```
    public static CompositeByteBuf compositeBuffer(int maxNumComponents) {
        return new CompositeByteBuf(ALLOC, /*direct*/ false, maxNumComponents);
    }
```
When consolidation happens, the data will be copied from direct memory to heap memory, causing OOM and
perf degration.
With this PR, in my test cases of shuffling 14G for three 1G/1G workers, I don't see disk buffer larger than direct memory,
nor do I encounter high GC.


### Does this PR introduce _any_ user-facing change?

This patch fixes some OOM issues.

### How was this patch tested?
Passes GA and manual test.
