### PR TITLE
[CELEBORN-790][FOLLOWUP] Use allocator.compositeDirectBuffer to track memory leak

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -105,7 +105,7 @@ abstract private[worker] class Flusher(
   def takeBuffer(): CompositeByteBuf = {
     var buffer = bufferQueue.poll()
     if (buffer == null) {
-      buffer = new CompositeByteBuf(allocator, true, maxComponents)
+      buffer = allocator.compositeDirectBuffer(maxComponents)
     }
     buffer
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
According to https://github.com/apache/incubator-celeborn/pull/1709#discussion_r1260133078 


### Why are the changes needed?
ditto


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Passes GA.
