### PR TITLE
[CELEBORN-793] Trim the thread's local cache before the channel is removed

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/ChannelsLimiter.java
@@ -124,7 +124,7 @@ public class ChannelsLimiter extends ChannelDuplexHandler
   @Override
   public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
     if (evt instanceof TrimCache) {
-      logger.debug("trim thread local cache.");
+      logger.info("trim thread local cache.");
       ((PooledByteBufAllocator) ctx.alloc()).trimCurrentThreadCache();
       needTrimChannels.decrementAndGet();
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title.

### Why are the changes needed?

If the worker is under memory pressure and the channel exits unexpectedly, the worker doesn't have the chance to clean up the thread's local cache.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass GA.