### PR TITLE
[CELEBORN-798] Add heartbeat from client to LifecycleManager to clean…

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/FlinkShuffleClientImpl.java
@@ -125,7 +125,7 @@ public class FlinkShuffleClientImpl extends ShuffleClientImpl {
       long driverTimestamp,
       CelebornConf conf,
       UserIdentifier userIdentifier) {
-    super(appUniqueId, conf, userIdentifier);
+    super(appUniqueId, conf, userIdentifier, false);
     String module = TransportModuleConstants.DATA_MODULE;
     TransportConf dataTransportConf =
         Utils.fromCelebornConf(conf, module, conf.getInt("celeborn." + module + ".io.threads", 8));

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -109,7 +109,8 @@ public class SparkShuffleManager implements ShuffleManager {
                   lifecycleManager.getHost(),
                   lifecycleManager.getPort(),
                   celebornConf,
-                  lifecycleManager.getUserIdentifier());
+                  lifecycleManager.getUserIdentifier(),
+                  true);
         }
       }
     }
@@ -186,7 +187,8 @@ public class SparkShuffleManager implements ShuffleManager {
                 h.lifecycleManagerHost(),
                 h.lifecycleManagerPort(),
                 celebornConf,
-                h.userIdentifier());
+                h.userIdentifier(),
+                false);
         if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())) {
           ExecutorService pushThread =
               celebornConf.clientPushSortPipelineEnabled() ? getPusherThread() : null;

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -44,7 +44,8 @@ class CelebornShuffleReader[K, C](
     handle.lifecycleManagerHost,
     handle.lifecycleManagerPort,
     conf,
-    handle.userIdentifier)
+    handle.userIdentifier,
+    false)
 
   override def read(): Iterator[Product2[K, C]] = {
 

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -107,7 +107,8 @@ public class SparkShuffleManager implements ShuffleManager {
                   lifecycleManager.getHost(),
                   lifecycleManager.getPort(),
                   celebornConf,
-                  lifecycleManager.getUserIdentifier());
+                  lifecycleManager.getUserIdentifier(),
+                  true);
         }
       }
     }
@@ -188,7 +189,8 @@ public class SparkShuffleManager implements ShuffleManager {
                 h.lifecycleManagerHost(),
                 h.lifecycleManagerPort(),
                 celebornConf,
-                h.userIdentifier());
+                h.userIdentifier(),
+                false);
         if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())) {
           ExecutorService pushThread =
               celebornConf.clientPushSortPipelineEnabled() ? getPusherThread() : null;

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -46,7 +46,8 @@ class CelebornShuffleReader[K, C](
     handle.lifecycleManagerHost,
     handle.lifecycleManagerPort,
     conf,
-    handle.userIdentifier)
+    handle.userIdentifier,
+    false)
 
   override def read(): Iterator[Product2[K, C]] = {
 

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -56,7 +56,8 @@ public abstract class ShuffleClient {
       String driverHost,
       int port,
       CelebornConf conf,
-      UserIdentifier userIdentifier) {
+      UserIdentifier userIdentifier,
+      boolean isDriver) {
     if (null == _instance || !initialized) {
       synchronized (ShuffleClient.class) {
         if (null == _instance) {
@@ -66,12 +67,12 @@ public abstract class ShuffleClient {
           // be
           // assigned. An Executor will only construct a ShuffleClient singleton once. At this time,
           // when communicating with LifecycleManager, it will cause a NullPointerException.
-          _instance = new ShuffleClientImpl(appUniqueId, conf, userIdentifier);
+          _instance = new ShuffleClientImpl(appUniqueId, conf, userIdentifier, isDriver);
           _instance.setupLifecycleManagerRef(driverHost, port);
           initialized = true;
         } else if (!initialized) {
           _instance.shutdown();
-          _instance = new ShuffleClientImpl(appUniqueId, conf, userIdentifier);
+          _instance = new ShuffleClientImpl(appUniqueId, conf, userIdentifier, isDriver);
           _instance.setupLifecycleManagerRef(driverHost, port);
           initialized = true;
         }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -203,7 +203,7 @@ public class ShuffleClientImpl extends ShuffleClient {
                     HeartbeatFromClient$.MODULE$.apply(reducePartitionMap.keySet()),
                     ClassTag$.MODULE$.apply(PbHeartbeatFromClientResponse.class));
             List<Integer> unknownShuffleIds = resp.getUnknownShuffleIdList();
-            for (int i = 0; i < unkownShuffleIds.size(); i++) {
+            for (int i = 0; i < unknownShuffleIds.size(); i++) {
               unregisterShuffle(unknownShuffleIds.get(i), false);
             }
           },

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -202,9 +202,9 @@ public class ShuffleClientImpl extends ShuffleClient {
                 lifecycleManagerRef.askSync(
                     HeartbeatFromClient$.MODULE$.apply(reducePartitionMap.keySet()),
                     ClassTag$.MODULE$.apply(PbHeartbeatFromClientResponse.class));
-            List<Integer> unkownShuffleIds = resp.getUnkownShuffleIdList();
+            List<Integer> unknownShuffleIds = resp.getUnknownShuffleIdList();
             for (int i = 0; i < unkownShuffleIds.size(); i++) {
-              unregisterShuffle(unkownShuffleIds.get(i), false);
+              unregisterShuffle(unknownShuffleIds.get(i), false);
             }
           },
           60,

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1651,6 +1651,9 @@ public class ShuffleClientImpl extends ShuffleClient {
     if (null != lifecycleManagerRef) {
       lifecycleManagerRef = null;
     }
+    if (null != heartbeater) {
+      heartbeater.shutdown();
+    }
     pushExcludedWorkers.clear();
     fetchExcludedWorkers.clear();
     logger.warn("Shuffle client has been shutdown!");

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -195,7 +195,8 @@ public class ShuffleClientImpl extends ShuffleClient {
 
     if (!isDriver) {
       heartbeater =
-          ThreadUtils.newDaemonSingleThreadScheduledExecutor("lifecycleManager-heartbeater");
+          ThreadUtils.newDaemonSingleThreadScheduledExecutor(
+              "celeborn-lifecyclemanager-heartbeater");
       heartbeater.scheduleAtFixedRate(
           () -> {
             PbHeartbeatFromClientResponse resp =
@@ -207,9 +208,9 @@ public class ShuffleClientImpl extends ShuffleClient {
               unregisterShuffle(unknownShuffleIds.get(i), false);
             }
           },
-          60,
-          60,
-          TimeUnit.SECONDS);
+          conf.clientHeartbeatToLifecycleManagerInterval(),
+          conf.clientHeartbeatToLifecycleManagerInterval(),
+          TimeUnit.MILLISECONDS);
     }
     logger.info("Created ShuffleClientImpl, appUniqueId: {}", appUniqueId);
   }

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -20,6 +20,7 @@ package org.apache.celeborn.client
 import java.util
 import java.util.{function, List => JList}
 import java.util.concurrent.{ConcurrentHashMap, ScheduledFuture, TimeUnit}
+import java.util.function.Predicate
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -302,8 +303,11 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       handleGetReducerFileGroup(context, shuffleId)
 
     case pb: PbHeartbeatFromClient =>
-      val shuffleIds = new util.ArrayList(pb.getShuffleIdList)
-      shuffleIds.removeIf(id => registeredShuffle.contains(id))
+      val shuffleIds = new util.ArrayList[Integer](pb.getShuffleIdList)
+      val pred = new Predicate[Integer] {
+        override def test(id: Integer): Boolean = registeredShuffle.contains(id)
+      }
+      shuffleIds.removeIf(pred)
       context.reply(HeartbeatFromClientResponse(shuffleIds))
   }
 

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -303,12 +303,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       handleGetReducerFileGroup(context, shuffleId)
 
     case pb: PbHeartbeatFromClient =>
-      val shuffleIds = new util.ArrayList[Integer](pb.getShuffleIdList)
-      val pred = new Predicate[Integer] {
-        override def test(id: Integer): Boolean = registeredShuffle.contains(id)
-      }
-      shuffleIds.removeIf(pred)
-      context.reply(HeartbeatFromClientResponse(shuffleIds))
+      handleHeartbeatFromClient(context, pb)
   }
 
   private def offerAndReserveSlots(
@@ -571,6 +566,17 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       context: RpcCallContext,
       shuffleId: Int): Unit = {
     commitManager.handleGetReducerFileGroup(context, shuffleId)
+  }
+
+  private def handleHeartbeatFromClient(
+      context: RpcCallContext,
+      pb: PbHeartbeatFromClient): Unit = {
+    val shuffleIds = new util.ArrayList[Integer](pb.getShuffleIdList)
+    val pred = new Predicate[Integer] {
+      override def test(id: Integer): Boolean = registeredShuffle.contains(id)
+    }
+    shuffleIds.removeIf(pred)
+    context.reply(HeartbeatFromClientResponse(shuffleIds))
   }
 
   private def handleStageEnd(shuffleId: Int): Unit = {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -300,6 +300,11 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       logDebug(s"Received GetShuffleFileGroup request," +
         s"shuffleId $shuffleId.")
       handleGetReducerFileGroup(context, shuffleId)
+
+    case pb: PbHeartbeatFromClient =>
+      val shuffleIds = new util.ArrayList(pb.getShuffleIdList)
+      shuffleIds.removeIf(id => registeredShuffle.contains(id))
+      context.reply(HeartbeatFromClientResponse(shuffleIds))
   }
 
   private def offerAndReserveSlots(

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientBaseSuiteJ.java
@@ -86,7 +86,7 @@ public abstract class ShuffleClientBaseSuiteJ {
     conf.set(CelebornConf.CLIENT_PUSH_RETRY_THREADS().key(), "1");
     conf.set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE().key(), "1K");
     shuffleClient =
-        new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
+        new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"), false);
     primaryLocation.setPeer(replicaLocation);
 
     when(endpointRef.askSync(

--- a/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/ShuffleClientSuiteJ.java
@@ -172,7 +172,7 @@ public class ShuffleClientSuiteJ {
     conf.set(CelebornConf.CLIENT_PUSH_RETRY_THREADS().key(), "1");
     conf.set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE().key(), "1K");
     shuffleClient =
-        new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"));
+        new ShuffleClientImpl(TEST_APPLICATION_ID, conf, new UserIdentifier("mock", "mock"), false);
 
     primaryLocation.setPeer(replicaLocation);
     when(endpointRef.askSync(any(), any(), any()))

--- a/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WithShuffleClientSuite.scala
@@ -151,7 +151,7 @@ trait WithShuffleClientSuite extends CelebornFunSuite {
 
   private def prepareService(): Unit = {
     lifecycleManager = new LifecycleManager(APP, celebornConf)
-    shuffleClient = new ShuffleClientImpl(APP, celebornConf, userIdentifier)
+    shuffleClient = new ShuffleClientImpl(APP, celebornConf, userIdentifier, false)
     shuffleClient.setupLifecycleManagerRef(lifecycleManager.self)
   }
 

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -180,7 +180,7 @@ message PbHeartbeatFromClient {
 }
 
 message PbHeartbeatFromClientResponse {
-  repeated int32 unkownShuffleId = 1;
+  repeated int32 unknownShuffleId = 1;
 }
 
 message PbRequestSlots {

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -69,6 +69,8 @@ enum MessageType {
   REGISTER_MAP_PARTITION_TASK = 48;
   HEARTBEAT_FROM_APPLICATION_RESPONSE = 49;
   CHECK_FOR_HDFS_EXPIRED_DIRS_TIMEOUT = 50;
+  HEARTBEAT_FROM_CLIENT = 51;
+  HEARTBEAT_FROM_CLIENT_RESPONSE = 52;
 }
 
 message PbStorageInfo {
@@ -171,6 +173,14 @@ message PbRegisterMapPartitionTask {
 message PbRegisterShuffleResponse {
   int32 status = 1;
   repeated PbPartitionLocation partitionLocations = 2;
+}
+
+message PbHeartbeatFromClient {
+  repeated int32 shuffleId = 1;
+}
+
+message PbHeartbeatFromClientResponse {
+  repeated int32 unkownShuffleId = 1;
 }
 
 message PbRequestSlots {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -697,10 +697,12 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def appHeartbeatTimeoutMs: Long = get(APPLICATION_HEARTBEAT_TIMEOUT)
   def hdfsExpireDirsTimeoutMS: Long = get(HDFS_EXPIRE_DIRS_TIMEOUT)
   def appHeartbeatIntervalMs: Long = get(APPLICATION_HEARTBEAT_INTERVAL)
-  def clientCheckedUseAllocatedWorkers: Boolean = get(CLIENT_CHECKED_USE_ALLOCATED_WORKERS)
-  def clientExcludedWorkerExpireTimeout: Long = get(CLIENT_EXCLUDED_WORKER_EXPIRE_TIMEOUT)
   def clientExcludeReplicaOnFailureEnabled: Boolean =
     get(CLIENT_EXCLUDE_PEER_WORKER_ON_FAILURE_ENABLED)
+  def clientExcludedWorkerExpireTimeout: Long = get(CLIENT_EXCLUDED_WORKER_EXPIRE_TIMEOUT)
+  def clientCheckedUseAllocatedWorkers: Boolean = get(CLIENT_CHECKED_USE_ALLOCATED_WORKERS)
+  def clientHeartbeatToLifecycleManagerInterval: Long =
+    get(CLIENT_HEARTBEAT_TO_LIFECYCLEMANAGER_INTERVAL)
 
   // //////////////////////////////////////////////////////
   //               Shuffle Compression                   //
@@ -995,6 +997,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def testPushReplicaDataTimeout: Boolean = get(TEST_WORKER_PUSH_REPLICA_DATA_TIMEOUT)
   def testRetryRevive: Boolean = get(TEST_CLIENT_RETRY_REVIVE)
   def testAlternative: String = get(TEST_ALTERNATIVE.key, "celeborn")
+
+  // //////////////////////////////////////////////////////
+  //                      Flink                          //
+  // //////////////////////////////////////////////////////
   def clientFlinkMemoryPerResultPartitionMin: Long = get(CLIENT_MEMORY_PER_RESULT_PARTITION_MIN)
   def clientFlinkMemoryPerResultPartition: Long = get(CLIENT_MEMORY_PER_RESULT_PARTITION)
   def clientFlinkMemoryPerInputGateMin: Long = get(CLIENT_MEMORY_PER_INPUT_GATE_MIN)
@@ -2648,6 +2654,15 @@ object CelebornConf extends Logging {
         "otherwise use local black list as candidate being checked workers.")
       .booleanConf
       .createWithDefault(false)
+
+  val CLIENT_HEARTBEAT_TO_LIFECYCLEMANAGER_INTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.client.heartbeatToLifecycleManager.interval")
+      .categories("client")
+      .version("0.3.0")
+      .doc(
+        "Interval for client in Executor(for Spark) to send heartbeat message to lifecycle manager.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("30s")
 
   val TEST_CLIENT_RETRY_COMMIT_FILE: ConfigEntry[Boolean] =
     buildConf("celeborn.test.client.retryCommitFiles")

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -244,6 +244,23 @@ object ControlMessages extends Logging {
     }
   }
 
+  object HeartbeatFromClient {
+    def apply(
+        shuffleIds: util.Set[Integer]): PbHeartbeatFromClient = {
+      PbHeartbeatFromClient.newBuilder()
+        .addAllShuffleId(shuffleIds)
+        .build()
+    }
+  }
+
+  object HeartbeatFromClientResponse {
+    def apply(shuflfeIds: util.List[Integer]): PbHeartbeatFromClientResponse = {
+      PbHeartbeatFromClientResponse.newBuilder()
+        .addAllUnkownShuffleId(shuflfeIds)
+        .build()
+    }
+  }
+
   case class MapperEnd(
       shuffleId: Int,
       mapId: Int,
@@ -527,6 +544,12 @@ object ControlMessages extends Logging {
 
     case pb: PbChangeLocationResponse =>
       new TransportMessage(MessageType.CHANGE_LOCATION_RESPONSE, pb.toByteArray)
+
+    case pb: PbHeartbeatFromClient =>
+      new TransportMessage(MessageType.HEARTBEAT_FROM_CLIENT, pb.toByteArray)
+
+    case pb: PbHeartbeatFromClientResponse =>
+      new TransportMessage(MessageType.HEARTBEAT_FROM_CLIENT_RESPONSE, pb.toByteArray)
 
     case MapperEnd(shuffleId, mapId, attemptId, numMappers, partitionId) =>
       val payload = PbMapperEnd.newBuilder()
@@ -857,6 +880,12 @@ object ControlMessages extends Logging {
 
       case CHANGE_LOCATION_RESPONSE_VALUE =>
         PbChangeLocationResponse.parseFrom(message.getPayload)
+
+      case HEARTBEAT_FROM_CLIENT_VALUE =>
+        PbHeartbeatFromClient.parseFrom(message.getPayload)
+
+      case HEARTBEAT_FROM_CLIENT_RESPONSE_VALUE =>
+        PbHeartbeatFromClientResponse.parseFrom(message.getPayload)
 
       case MAPPER_END_VALUE =>
         val pbMapperEnd = PbMapperEnd.parseFrom(message.getPayload)

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -256,7 +256,7 @@ object ControlMessages extends Logging {
   object HeartbeatFromClientResponse {
     def apply(shuflfeIds: util.List[Integer]): PbHeartbeatFromClientResponse = {
       PbHeartbeatFromClientResponse.newBuilder()
-        .addAllUnkownShuffleId(shuflfeIds)
+        .addAllUnknownShuffleId(shuflfeIds)
         .build()
     }
   }

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -37,6 +37,7 @@ license: |
 | celeborn.client.flink.resultPartition.memory | 64m | Memory reserved for a result partition. | 0.3.0 | 
 | celeborn.client.flink.resultPartition.minMemory | 8m | Min memory reserved for a result partition. | 0.3.0 | 
 | celeborn.client.flink.resultPartition.supportFloatingBuffer | true | Whether to support floating buffer for result partitions. | 0.3.0 | 
+| celeborn.client.heartbeatToLifecycleManager.interval | 30s | Interval for client in Executor(for Spark) to send heartbeat message to lifecycle manager. | 0.3.0 | 
 | celeborn.client.push.buffer.initial.size | 8k |  | 0.3.0 | 
 | celeborn.client.push.buffer.max.size | 64k | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. | 0.3.0 | 
 | celeborn.client.push.excludeWorkerOnFailure.enabled | false | Whether to enable shuffle client-side push exclude workers on failures. | 0.3.0 | 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/ShuffleClientSuite.scala
@@ -47,7 +47,7 @@ class ShuffleClientSuite extends WithShuffleClientSuite with MiniClusterFeature 
 
     val lifecycleManager: LifecycleManager = new LifecycleManager(APP, celebornConf)
     val shuffleClient: ShuffleClientImpl = {
-      val client = new ShuffleClientImpl(APP, celebornConf, userIdentifier)
+      val client = new ShuffleClientImpl(APP, celebornConf, userIdentifier, false)
       client.setupLifecycleManagerRef(lifecycleManager.self)
       client
     }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HeartbeatTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/HeartbeatTest.scala
@@ -39,21 +39,21 @@ class HeartbeatTest extends AnyFunSuite with Logging with MiniClusterFeature wit
   test("celeborn spark heartbeat test - client <- worker") {
     val (_, clientConf) = getTestHeartbeatFromWorker2ClientConf
     val shuffleClientImpl =
-      new ShuffleClientImpl("APP", clientConf, new UserIdentifier("1", "1"))
+      new ShuffleClientImpl("APP", clientConf, new UserIdentifier("1", "1"), false)
     testHeartbeatFromWorker2Client(shuffleClientImpl.getDataClientFactory)
   }
 
   test("celeborn spark heartbeat test - client <- worker on heartbeat") {
     val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithNoHeartbeatConf
     val shuffleClientImpl =
-      new ShuffleClientImpl("APP", clientConf, new UserIdentifier("1", "1"))
+      new ShuffleClientImpl("APP", clientConf, new UserIdentifier("1", "1"), false)
     testHeartbeatFromWorker2ClientWithNoHeartbeat(shuffleClientImpl.getDataClientFactory)
   }
 
   test("celeborn spark heartbeat test - client <- worker timeout") {
     val (_, clientConf) = getTestHeartbeatFromWorker2ClientWithCloseChannelConf
     val shuffleClientImpl =
-      new ShuffleClientImpl("APP", clientConf, new UserIdentifier("1", "1"))
+      new ShuffleClientImpl("APP", clientConf, new UserIdentifier("1", "1"), false)
     testHeartbeatFromWorker2ClientWithCloseChannel(shuffleClientImpl.getDataClientFactory)
   }
 }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
@@ -61,7 +61,8 @@ trait ReadWriteTestBase extends AnyFunSuite
       .set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
       .set("celeborn.data.io.numConnectionsPerPeer", "1")
     val lifecycleManager = new LifecycleManager(APP, clientConf)
-    val shuffleClient = new ShuffleClientImpl(APP, clientConf, UserIdentifier("mock", "mock"))
+    val shuffleClient =
+      new ShuffleClientImpl(APP, clientConf, UserIdentifier("mock", "mock"), false)
     shuffleClient.setupLifecycleManagerRef(lifecycleManager.self)
 
     val STR1 = RandomStringUtils.random(1024)


### PR DESCRIPTION
…up client

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add heartbeat from client to lifecycle manager. In this PR heartbeat request contains local shuffle ids from
client, lifecycle manager checks with it's local set and returns ids it doesn't know. Upon receiving response,
client calls ```unregisterShuffle``` for cleanup.


### Why are the changes needed?
Before this PR, client side ```unregisterShuffle``` is never called. When running TPCDS 3T with spark thriftserver
without DRA, I found the Executor's heap contains 1.6 million PartitionLocation objects (and StorageInfo):
![image](https://github.com/apache/incubator-celeborn/assets/948245/43658369-7763-4511-a5b0-9b3fbdf02005)

After this PR, the number of PartitionLocation objects decreases to 275 thousands
![image](https://github.com/apache/incubator-celeborn/assets/948245/45f8f849-186d-4cad-83c8-64bd6d18debc)


This heartbeat can be extended in the future for other purposes, i.e. reporting client's metrics.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Passes GA and  manual test.
