### PR TITLE
[CELEBORN-802] Pool PushTask queues for reuse among DataPushers

### DIFF
--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedPusherSuiteJ.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedPusherSuiteJ.java
@@ -93,7 +93,8 @@ public class SortBasedPusherSuiteJ {
             /*mapStatusLengths=*/ null,
             /*pushSortMemoryThreshold=*/ Utils.byteStringAsBytes("1m"),
             /*sharedPushLock=*/ null,
-            /*executorService=*/ null);
+            /*executorService=*/ null,
+            SendBufferPool.get(4));
 
     // default page size == 2 MiB
     assertEquals(unifiedMemoryManager.pageSizeBytes(), Utils.byteStringAsBytes("2m"));

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -99,7 +99,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       TaskContext taskContext,
       CelebornConf conf,
       ShuffleClient client,
-      ExecutorService executorService)
+      ExecutorService executorService,
+      SendBufferPool sendBufferPool)
       throws IOException {
     this.mapId = taskContext.partitionId();
     this.dep = dep;
@@ -143,7 +144,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
                 mapStatusLengths,
                 conf.clientPushSortMemoryThreshold() / 2,
                 globalPushLock,
-                executorService);
+                executorService,
+                sendBufferPool);
       }
       currentPusher = pushers[0];
     } else {
@@ -162,7 +164,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
               mapStatusLengths,
               conf.clientPushSortMemoryThreshold(),
               globalPushLock,
-              null);
+              null,
+              sendBufferPool);
     }
   }
 

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -191,7 +191,13 @@ public class SparkShuffleManager implements ShuffleManager {
           ExecutorService pushThread =
               celebornConf.clientPushSortPipelineEnabled() ? getPusherThread() : null;
           return new SortBasedShuffleWriter<>(
-              h.dependency(), h.numMaps(), context, celebornConf, client, pushThread);
+              h.dependency(),
+              h.numMaps(),
+              context,
+              celebornConf,
+              client,
+              pushThread,
+              SendBufferPool.get(cores));
         } else if (ShuffleMode.HASH.equals(celebornConf.shuffleWriterMode())) {
           return new HashBasedShuffleWriter<>(
               h, mapId, context, celebornConf, client, SendBufferPool.get(cores));

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriterSuiteJ.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriterSuiteJ.java
@@ -34,6 +34,6 @@ public class SortBasedShuffleWriterSuiteJ extends CelebornShuffleWriterSuiteBase
       CelebornShuffleHandle handle, TaskContext context, CelebornConf conf, ShuffleClient client)
       throws IOException {
     return new SortBasedShuffleWriter<Integer, String, String>(
-        handle.dependency(), numPartitions, context, conf, client, null);
+        handle.dependency(), numPartitions, context, conf, client, null, SendBufferPool.get(4));
   }
 }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -100,7 +100,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       CelebornConf conf,
       ShuffleClient client,
       ShuffleWriteMetricsReporter metrics,
-      ExecutorService executorService)
+      ExecutorService executorService,
+      SendBufferPool sendBufferPool)
       throws IOException {
     this.mapId = taskContext.partitionId();
     this.dep = dep;
@@ -143,7 +144,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
                 mapStatusLengths,
                 conf.clientPushSortMemoryThreshold() / 2,
                 sharedPushLock,
-                executorService);
+                executorService,
+                sendBufferPool);
       }
       currentPusher = pushers[0];
     } else {
@@ -162,7 +164,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
               mapStatusLengths,
               conf.clientPushSortMemoryThreshold(),
               sharedPushLock,
-              null);
+              null,
+              sendBufferPool);
     }
   }
 
@@ -172,7 +175,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       CelebornConf conf,
       ShuffleClient client,
       ShuffleWriteMetricsReporter metrics,
-      ExecutorService executorService)
+      ExecutorService executorService,
+      SendBufferPool sendBufferPool)
       throws IOException {
     this(
         handle.dependency(),
@@ -181,7 +185,8 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         conf,
         client,
         metrics,
-        executorService);
+        executorService,
+        sendBufferPool);
   }
 
   private void updatePeakMemoryUsed() {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -193,7 +193,14 @@ public class SparkShuffleManager implements ShuffleManager {
           ExecutorService pushThread =
               celebornConf.clientPushSortPipelineEnabled() ? getPusherThread() : null;
           return new SortBasedShuffleWriter<>(
-              h.dependency(), h.numMappers(), context, celebornConf, client, metrics, pushThread);
+              h.dependency(),
+              h.numMappers(),
+              context,
+              celebornConf,
+              client,
+              metrics,
+              pushThread,
+              SendBufferPool.get(cores));
         } else if (ShuffleMode.HASH.equals(celebornConf.shuffleWriterMode())) {
           return new HashBasedShuffleWriter<>(
               h, context, celebornConf, client, metrics, SendBufferPool.get(cores));

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriterSuiteJ.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriterSuiteJ.java
@@ -36,6 +36,6 @@ public class SortBasedShuffleWriterSuiteJ extends CelebornShuffleWriterSuiteBase
       ShuffleWriteMetricsReporter metrics)
       throws IOException {
     return new SortBasedShuffleWriter<Integer, String, String>(
-        handle, context, conf, client, metrics, null);
+        handle, context, conf, client, metrics, null, SendBufferPool.get(4));
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -69,18 +69,23 @@ public class DataPusher {
       int numPartitions,
       CelebornConf conf,
       ShuffleClient client,
+      LinkedBlockingQueue<PushTask> pushTasks,
       Consumer<Integer> afterPush,
       LongAdder[] mapStatusLengths)
       throws InterruptedException {
     final int pushQueueCapacity = conf.clientPushQueueCapacity();
     final int pushBufferMaxSize = conf.clientPushBufferMaxSize();
 
-    idleQueue = new LinkedBlockingQueue<>(pushQueueCapacity);
+    if (pushTasks == null) {
+      idleQueue = new LinkedBlockingQueue<>(pushQueueCapacity);
+    } else {
+      idleQueue = pushTasks;
+    }
     dataPushQueue =
         new DataPushQueue(
             conf, this, client, shuffleId, mapId, attemptId, numMappers, numPartitions);
 
-    for (int i = 0; i < pushQueueCapacity; i++) {
+    for (int i = idleQueue.size(); i < pushQueueCapacity; i++) {
       idleQueue.put(new PushTask(pushBufferMaxSize));
     }
 
@@ -224,5 +229,9 @@ public class DataPusher {
 
   public DataPushQueue getDataPushQueue() {
     return dataPushQueue;
+  }
+
+  public LinkedBlockingQueue<PushTask> getIdleQueue() {
+    return idleQueue;
   }
 }

--- a/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuitJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuitJ.java
@@ -105,6 +105,7 @@ public class DataPushQueueSuitJ {
             numPartitions,
             conf,
             client,
+            null,
             integer -> {},
             mapStatusLengths);
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Reuse ```DataPusher#idleQueue``` by pooling in ```SendBufferPool``` to avoid too many ```byte[]```
objects in ```PushTask```.


### Why are the changes needed?
ditto



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Passes GA and Manual test.
