### PR TITLE
[CELEBORN-807] Adjust shutdown worker logs in LifecycleManager

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -250,6 +250,10 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
     getCommitHandler(shuffleId).isStageEnd(shuffleId)
   }
 
+  def isStageEndOrInProcess(shuffleId: Int): Boolean = {
+    getCommitHandler(shuffleId).isStageEndOrInProcess(shuffleId)
+  }
+
   def setStageEnd(shuffleId: Int): Unit = {
     getCommitHandler(shuffleId).setStageEnd(shuffleId)
   }
@@ -300,27 +304,26 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
 
     override def notifyChangedWorkersStatus(workersStatus: WorkersStatus): Unit = {
       if (workersStatus.shutdownWorkers != null) {
-        workersStatus.shutdownWorkers.asScala.foreach { case shuttingWorker =>
-          logError(s"Worker ${shuttingWorker.toUniqueId()} shutdown, " +
-            "commit all it's partition location.")
-          lifecycleManager.shuffleAllocatedWorkers.asScala.foreach {
-            case (shuffleId, workerToPartitionLocationInfos) =>
+        lifecycleManager.shuffleAllocatedWorkers.asScala.foreach {
+          case (shuffleId, workerToPartitionLocationInfos) =>
+            if (!isStageEndOrInProcess(shuffleId)) {
               val shuffleCommittedInfo = committedPartitionInfo.get(shuffleId)
-              val partitionLocationInfo = workerToPartitionLocationInfos.get(shuttingWorker)
-              if (partitionLocationInfo != null) {
-                partitionLocationInfo.getPrimaryPartitions().asScala.foreach { partitionLocation =>
-                  shuffleCommittedInfo.synchronized {
-                    shuffleCommittedInfo.unhandledPartitionLocations.add(partitionLocation)
-                  }
-                }
+              val needCommitPartitionLocations = new util.HashSet[PartitionLocation]()
 
-                partitionLocationInfo.getReplicaPartitions().asScala.foreach { partitionLocation =>
-                  shuffleCommittedInfo.synchronized {
-                    shuffleCommittedInfo.unhandledPartitionLocations.add(partitionLocation)
-                  }
+              workersStatus.shutdownWorkers.asScala.foreach { worker =>
+                val partitionLocationInfos = workerToPartitionLocationInfos.get(worker)
+                if (partitionLocationInfos != null) {
+                  logWarning(s"Worker ${worker.toUniqueId()} shutdown, " +
+                    s"commit all it's partition locations for shuffle $shuffleId.")
+                  needCommitPartitionLocations.addAll(partitionLocationInfos.getPrimaryPartitions())
+                  needCommitPartitionLocations.addAll(partitionLocationInfos.getReplicaPartitions())
                 }
               }
-          }
+              shuffleCommittedInfo.synchronized {
+                shuffleCommittedInfo.unhandledPartitionLocations.addAll(
+                  needCommitPartitionLocations)
+              }
+            }
         }
       }
     }

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -152,7 +152,7 @@ class WorkerStatusTracker(
 
   def handleHeartbeatResponse(res: HeartbeatFromApplicationResponse): Unit = {
     if (res.statusCode == StatusCode.SUCCESS) {
-      logInfo(s"Received Worker status from Primary, excluded workers: ${res.excludedWorkers} " +
+      logDebug(s"Received Worker status from Primary, excluded workers: ${res.excludedWorkers} " +
         s"unknown workers: ${res.unknownWorkers}, shutdown workers: ${res.shuttingWorkers}")
       val current = System.currentTimeMillis()
 

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -209,8 +209,13 @@ class WorkerStatusTracker(
       }
       if (statusChanged) {
         logInfo(
-          s"Current excluded workers $excludedWorkers, " +
-            s"Current shutting down workers ${shuttingWorkers.asScala.map(_.readableAddress()).mkString("\n")}")
+          s"""
+             |Current excluded workers:
+             |${excludedWorkers.asScala.mkString("\n")}
+             |
+             |Current shutting down workers:
+             |${shuttingWorkers.asScala.map(_.readableAddress()).mkString("\n")}
+             |""".stripMargin)
       }
     }
   }

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -208,6 +208,7 @@ class WorkerStatusTracker(
         }
       }
       if (statusChanged) {
+        logWarning("Worker status changed from application heartbeat response")
         logInfo(
           s"""
              |Current excluded workers:


### PR DESCRIPTION
### What changes were proposed in this pull request?
In a long run celeborn cluster,  there are some shutdown workers. Whether it is a new task or an old task, even if the worker is not assigned , it will always log below, seems a little noisy.
ERROR CommitManager: Worker xx shutdown, commit all it's partition location.

### Why are the changes needed?
Ditto


### Does this PR introduce _any_ user-facing change?
shutdown worker logs in LifecycleManager changes


### How was this patch tested?
manually test
