### PR TITLE
[CELEBORN-812] Cleanup SendBufferPool if idle for long

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SendBufferPool.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/SendBufferPool.java
@@ -20,17 +20,20 @@ package org.apache.spark.shuffle.celeborn;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.celeborn.client.write.PushTask;
+import org.apache.celeborn.common.util.ThreadUtils;
 
 public class SendBufferPool {
   private static volatile SendBufferPool _instance;
 
-  public static SendBufferPool get(int capacity) {
+  public static SendBufferPool get(int capacity, long checkInterval, long timeout) {
     if (_instance == null) {
       synchronized (SendBufferPool.class) {
         if (_instance == null) {
-          _instance = new SendBufferPool(capacity);
+          _instance = new SendBufferPool(capacity, checkInterval, timeout);
         }
       }
     }
@@ -41,16 +44,35 @@ public class SendBufferPool {
 
   // numPartitions -> buffers
   private final LinkedList<byte[][]> buffers;
+  private long lastAquireTime;
   private final LinkedList<LinkedBlockingQueue<PushTask>> pushTaskQueues;
 
-  private SendBufferPool(int capacity) {
+  private ScheduledExecutorService cleaner =
+      ThreadUtils.newDaemonSingleThreadScheduledExecutor("celeborn-sendbufferpool-cleaner");
+
+  private SendBufferPool(int capacity, long checkInterval, long timeout) {
     assert capacity > 0;
     this.capacity = capacity;
     buffers = new LinkedList<>();
     pushTaskQueues = new LinkedList<>();
+
+    lastAquireTime = System.currentTimeMillis();
+    cleaner.scheduleAtFixedRate(
+        () -> {
+          if (System.currentTimeMillis() - lastAquireTime > timeout) {
+            synchronized (this) {
+              buffers.clear();
+              pushTaskQueues.clear();
+            }
+          }
+        },
+        checkInterval,
+        checkInterval,
+        TimeUnit.MILLISECONDS);
   }
 
   public synchronized byte[][] acquireBuffer(int numPartitions) {
+    lastAquireTime = System.currentTimeMillis();
     Iterator<byte[][]> iterator = buffers.iterator();
     while (iterator.hasNext()) {
       byte[][] candidate = iterator.next();
@@ -66,6 +88,7 @@ public class SendBufferPool {
   }
 
   public synchronized LinkedBlockingQueue<PushTask> acquirePushTaskQueue() {
+    lastAquireTime = System.currentTimeMillis();
     if (!pushTaskQueues.isEmpty()) {
       return pushTaskQueues.removeFirst();
     }

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedPusherSuiteJ.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedPusherSuiteJ.java
@@ -94,7 +94,7 @@ public class SortBasedPusherSuiteJ {
             /*pushSortMemoryThreshold=*/ Utils.byteStringAsBytes("1m"),
             /*sharedPushLock=*/ null,
             /*executorService=*/ null,
-            SendBufferPool.get(4));
+            SendBufferPool.get(4, 30, 60));
 
     // default page size == 2 MiB
     assertEquals(unifiedMemoryManager.pageSizeBytes(), Utils.byteStringAsBytes("2m"));

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -187,10 +187,21 @@ public class SparkShuffleManager implements ShuffleManager {
               celebornConf,
               client,
               pushThread,
-              SendBufferPool.get(cores));
+              SendBufferPool.get(
+                  cores,
+                  celebornConf.clientPushSendBufferPoolExpireCheckInterval(),
+                  celebornConf.clientPushSendBufferPoolExpireTimeout()));
         } else if (ShuffleMode.HASH.equals(celebornConf.shuffleWriterMode())) {
           return new HashBasedShuffleWriter<>(
-              h, mapId, context, celebornConf, client, SendBufferPool.get(cores));
+              h,
+              mapId,
+              context,
+              celebornConf,
+              client,
+              SendBufferPool.get(
+                  cores,
+                  celebornConf.clientPushSendBufferPoolExpireCheckInterval(),
+                  celebornConf.clientPushSendBufferPoolExpireTimeout()));
         } else {
           throw new UnsupportedOperationException(
               "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -198,10 +198,21 @@ public class SparkShuffleManager implements ShuffleManager {
               shuffleClient,
               metrics,
               pushThread,
-              SendBufferPool.get(cores));
+              SendBufferPool.get(
+                  cores,
+                  celebornConf.clientPushSendBufferPoolExpireCheckInterval(),
+                  celebornConf.clientPushSendBufferPoolExpireTimeout()));
         } else if (ShuffleMode.HASH.equals(celebornConf.shuffleWriterMode())) {
           return new HashBasedShuffleWriter<>(
-              h, context, celebornConf, shuffleClient, metrics, SendBufferPool.get(cores));
+              h,
+              context,
+              celebornConf,
+              shuffleClient,
+              metrics,
+              SendBufferPool.get(
+                  cores,
+                  celebornConf.clientPushSendBufferPoolExpireCheckInterval(),
+                  celebornConf.clientPushSendBufferPoolExpireTimeout()));
         } else {
           throw new UnsupportedOperationException(
               "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriterSuiteJ.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriterSuiteJ.java
@@ -37,6 +37,6 @@ public class HashBasedShuffleWriterSuiteJ extends CelebornShuffleWriterSuiteBase
       ShuffleWriteMetricsReporter metrics)
       throws IOException {
     return new HashBasedShuffleWriter<Integer, String, String>(
-        handle, context, conf, client, metrics, SendBufferPool.get(1));
+        handle, context, conf, client, metrics, SendBufferPool.get(1, 30, 60));
   }
 }

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriterSuiteJ.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriterSuiteJ.java
@@ -36,6 +36,6 @@ public class SortBasedShuffleWriterSuiteJ extends CelebornShuffleWriterSuiteBase
       ShuffleWriteMetricsReporter metrics)
       throws IOException {
     return new SortBasedShuffleWriter<Integer, String, String>(
-        handle, context, conf, client, metrics, null, SendBufferPool.get(4));
+        handle, context, conf, client, metrics, null, SendBufferPool.get(4, 30, 60));
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -783,6 +783,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def clientPushSplitPartitionThreads: Int = get(CLIENT_PUSH_SPLIT_PARTITION_THREADS)
   def clientPushTakeTaskWaitIntervalMs: Long = get(CLIENT_PUSH_TAKE_TASK_WAIT_INTERVAL)
   def clientPushTakeTaskMaxWaitAttempts: Int = get(CLIENT_PUSH_TAKE_TASK_MAX_WAIT_ATTEMPTS)
+  def clientPushSendBufferPoolExpireCheckInterval: Long =
+    get(CLIENT_PUSH_SENDBUFFERPOOL_CHECKEXPIREINTERVAL)
+  def clientPushSendBufferPoolExpireTimeout: Long = get(CLIENT_PUSH_SENDBUFFERPOOL_EXPIRETIMEOUT)
 
   // //////////////////////////////////////////////////////
   //                   Client Shuffle                    //
@@ -2882,6 +2885,24 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .intConf
       .createWithDefault(1)
+
+  val CLIENT_PUSH_SENDBUFFERPOOL_CHECKEXPIREINTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.client.push.sendbufferpool.checkExpireInteval")
+      .categories("client")
+      .doc("Interval to check expire for send buffer pool. If the pool has been idle " +
+        "for more than `celeborn.client.push.sendbufferpool.expireTimeout`, the pooled send buffers and push tasks will be cleaned up.")
+      .version("0.3.1")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("30s")
+
+  val CLIENT_PUSH_SENDBUFFERPOOL_EXPIRETIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.client.push.sendbufferpool.expireTimeout")
+      .categories("client")
+      .doc("Timeout before clean up SendBufferPool. If SendBufferPool is idle for more than this time, " +
+        "the send buffers and push tasks will be cleaned up.")
+      .version("0.3.1")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("60s")
 
   val TEST_CLIENT_RETRY_REVIVE: ConfigEntry[Boolean] =
     buildConf("celeborn.test.client.retryRevive")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -51,6 +51,8 @@ license: |
 | celeborn.client.push.revive.batchSize | 2048 | Max number of partitions in one Revive request. | 0.3.0 | 
 | celeborn.client.push.revive.interval | 100ms | Interval for client to trigger Revive to LifecycleManager. The number of partitions in one Revive request is `celeborn.client.push.revive.batchSize`. | 0.3.0 | 
 | celeborn.client.push.revive.maxRetries | 5 | Max retry times for reviving when celeborn push data failed. | 0.3.0 | 
+| celeborn.client.push.sendbufferpool.checkExpireInteval | 30s | Interval to check expire for send buffer pool. If the pool has been idle for more than `celeborn.client.push.sendbufferpool.expireTimeout`, the pooled send buffers and push tasks will be cleaned up. | 0.3.1 | 
+| celeborn.client.push.sendbufferpool.expireTimeout | 60s | Timeout before clean up SendBufferPool. If SendBufferPool is idle for more than this time, the send buffers and push tasks will be cleaned up. | 0.3.1 | 
 | celeborn.client.push.slowStart.initialSleepTime | 500ms | The initial sleep time if the current max in flight requests is 0 | 0.3.0 | 
 | celeborn.client.push.slowStart.maxSleepTime | 2s | If celeborn.client.push.limit.strategy is set to SLOWSTART, push side will take a sleep strategy for each batch of requests, this controls the max sleep time if the max in flight requests limit is 1 for a long time | 0.3.0 | 
 | celeborn.client.push.sort.randomizePartitionId.enabled | false | Whether to randomize partitionId in push sorter. If true, partitionId will be randomized when sort data to avoid skew when push to worker | 0.3.0 | 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Cleans up the pooled send buffers and push tasks if the SendBufferPool has been idle for more than
`celeborn.client.push.sendbufferpool.expireTimeout`.


### Why are the changes needed?
Before this PR the SendBufferPool will cache the send buffers and push tasks forever. If they are large
and will not be reused in the future, it wastes memory.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Passes GA and manual tests.
