### PR TITLE
[CELEBORN-819] Worker close should pass close status to support handle graceful shutdown and decommission

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.common.network.TransportContext;
 import org.apache.celeborn.common.network.util.*;
+import org.apache.celeborn.common.util.CelebornExitStatus;
 import org.apache.celeborn.common.util.JavaUtils;
 
 /** Server for the efficient, low-level streaming service. */
@@ -130,24 +131,24 @@ public class TransportServer implements Closeable {
 
   @Override
   public void close() {
-    shutdown(true);
+    shutdown(CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN());
   }
 
-  public void shutdown(boolean graceful) {
+  public void shutdown(int exitCode) {
     if (channelFuture != null) {
       // close is a local operation and should finish within milliseconds; timeout just to be safe
       channelFuture.channel().close().awaitUninterruptibly(10, TimeUnit.SECONDS);
       channelFuture = null;
     }
     if (bootstrap != null && bootstrap.config().group() != null) {
-      if (graceful) {
+      if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN()) {
         bootstrap.config().group().shutdownGracefully();
       } else {
         bootstrap.config().group().shutdownGracefully(0, 0, TimeUnit.SECONDS);
       }
     }
     if (bootstrap != null && bootstrap.config().childGroup() != null) {
-      if (graceful) {
+      if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN()) {
         bootstrap.config().childGroup().shutdownGracefully();
       } else {
         bootstrap.config().childGroup().shutdownGracefully(0, 0, TimeUnit.SECONDS);

--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.common.network.TransportContext;
 import org.apache.celeborn.common.network.util.*;
-import org.apache.celeborn.common.util.CelebornExitStatus;
+import org.apache.celeborn.common.util.CelebornExitKind;
 import org.apache.celeborn.common.util.JavaUtils;
 
 /** Server for the efficient, low-level streaming service. */
@@ -131,24 +131,24 @@ public class TransportServer implements Closeable {
 
   @Override
   public void close() {
-    shutdown(CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN());
+    shutdown(CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN());
   }
 
-  public void shutdown(int exitCode) {
+  public void shutdown(int exitKind) {
     if (channelFuture != null) {
       // close is a local operation and should finish within milliseconds; timeout just to be safe
       channelFuture.channel().close().awaitUninterruptibly(10, TimeUnit.SECONDS);
       channelFuture = null;
     }
     if (bootstrap != null && bootstrap.config().group() != null) {
-      if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN()) {
+      if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN()) {
         bootstrap.config().group().shutdownGracefully();
       } else {
         bootstrap.config().group().shutdownGracefully(0, 0, TimeUnit.SECONDS);
       }
     }
     if (bootstrap != null && bootstrap.config().childGroup() != null) {
-      if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN()) {
+      if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN()) {
         bootstrap.config().childGroup().shutdownGracefully();
       } else {
         bootstrap.config().childGroup().shutdownGracefully(0, 0, TimeUnit.SECONDS);

--- a/common/src/main/scala/org/apache/celeborn/common/util/CelebornExitKind.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/CelebornExitKind.scala
@@ -17,8 +17,8 @@
 
 package org.apache.celeborn.common.util
 
-private[celeborn] object CelebornExitStatus {
-  val EXIT = 0
+private[celeborn] object CelebornExitKind {
+  val EXIT_IMMEDIATELY = 0
   val WORKER_GRACEFUL_SHUTDOWN = 1
   val WORKER_DECOMMISSION = 2
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/CelebornExitStatus.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/CelebornExitStatus.scala
@@ -15,30 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.server.common
+package org.apache.celeborn.common.util
 
-import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.metrics.MetricsSystem
-
-abstract class Service extends Logging {
-  def serviceName: String
-
-  def conf: CelebornConf
-
-  def metricsSystem: MetricsSystem
-
-  def initialize(): Unit = {
-    if (conf.metricsSystemEnable) {
-      logInfo(s"Metrics system enabled.")
-      metricsSystem.start()
-    }
-  }
-
-  def stop(exitCode: Int): Unit = {}
-}
-
-object Service {
-  val MASTER = "master"
-  val WORKER = "worker"
+private[celeborn] object CelebornExitStatus {
+  val EXIT = 0
+  val WORKER_GRACEFUL_SHUTDOWN = 1
+  val WORKER_DECOMMISSION = 2
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -882,11 +882,11 @@ private[celeborn] class Master(
     rpcEnv.awaitTermination()
   }
 
-  override def stop(graceful: Boolean): Unit = synchronized {
+  override def stop(exitCode: Int): Unit = synchronized {
     if (!stopped) {
       logInfo("Stopping Master")
       rpcEnv.stop(self)
-      super.stop(false)
+      super.stop(exitCode)
       logInfo("Master stopped.")
       stopped = true
     }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -882,11 +882,11 @@ private[celeborn] class Master(
     rpcEnv.awaitTermination()
   }
 
-  override def stop(exitCode: Int): Unit = synchronized {
+  override def stop(exitKind: Int): Unit = synchronized {
     if (!stopped) {
       logInfo("Stopping Master")
       rpcEnv.stop(self)
-      super.stop(exitCode)
+      super.stop(exitKind)
       logInfo("Master stopped.")
       stopped = true
     }

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -22,7 +22,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.util.CelebornExitStatus
+import org.apache.celeborn.common.util.CelebornExitKind
 
 class MasterSuite extends AnyFunSuite
   with BeforeAndAfterAll
@@ -54,7 +54,7 @@ class MasterSuite extends AnyFunSuite
       }
     }.start()
     Thread.sleep(5000L)
-    master.stop(CelebornExitStatus.EXIT)
+    master.stop(CelebornExitKind.EXIT_IMMEDIATELY)
     master.rpcEnv.shutdown()
   }
 }

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -22,6 +22,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
+import org.apache.celeborn.common.util.CelebornExitStatus
 
 class MasterSuite extends AnyFunSuite
   with BeforeAndAfterAll
@@ -53,7 +54,7 @@ class MasterSuite extends AnyFunSuite
       }
     }.start()
     Thread.sleep(5000L)
-    master.stop(false)
+    master.stop(CelebornExitStatus.EXIT)
     master.rpcEnv.shutdown()
   }
 }

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -105,11 +105,11 @@ abstract class HttpService extends Service with Logging {
     startHttpServer()
   }
 
-  override def stop(exitCode: Int): Unit = {
+  override def stop(exitKind: Int): Unit = {
     // may be null when running the unit test
     if (null != httpServer) {
-      httpServer.stop(exitCode)
+      httpServer.stop(exitKind)
     }
-    super.stop(exitCode)
+    super.stop(exitKind)
   }
 }

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -105,11 +105,11 @@ abstract class HttpService extends Service with Logging {
     startHttpServer()
   }
 
-  override def stop(graceful: Boolean): Unit = {
+  override def stop(exitCode: Int): Unit = {
     // may be null when running the unit test
     if (null != httpServer) {
-      httpServer.stop(graceful)
+      httpServer.stop(exitCode)
     }
-    super.stop(graceful)
+    super.stop(exitCode)
   }
 }

--- a/service/src/main/scala/org/apache/celeborn/server/common/Service.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/Service.scala
@@ -35,7 +35,7 @@ abstract class Service extends Logging {
     }
   }
 
-  def stop(exitCode: Int): Unit = {}
+  def stop(exitKind: Int): Unit = {}
 }
 
 object Service {

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
@@ -27,7 +27,7 @@ import io.netty.handler.logging.{LoggingHandler, LogLevel}
 
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.network.util.{IOMode, NettyUtils}
-import org.apache.celeborn.common.util.{CelebornExitStatus, Utils}
+import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
 
 class HttpServer(
     role: String,
@@ -66,7 +66,7 @@ class HttpServer(
       }
       if (bootstrap != null && bootstrap.config.group != null) {
         Utils.tryLogNonFatalError {
-          if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN) {
+          if (exitCode == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
             bootstrap.config.group.shutdownGracefully(3, 5, TimeUnit.SECONDS)
           } else {
             bootstrap.config.group.shutdownGracefully(0, 0, TimeUnit.SECONDS)
@@ -75,7 +75,7 @@ class HttpServer(
       }
       if (bootstrap != null && bootstrap.config.childGroup != null) {
         Utils.tryLogNonFatalError {
-          if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN) {
+          if (exitCode == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
             bootstrap.config.childGroup.shutdownGracefully(3, 5, TimeUnit.SECONDS)
           } else {
             bootstrap.config.childGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS)

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
@@ -27,7 +27,7 @@ import io.netty.handler.logging.{LoggingHandler, LogLevel}
 
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.network.util.{IOMode, NettyUtils}
-import org.apache.celeborn.common.util.Utils
+import org.apache.celeborn.common.util.{CelebornExitStatus, Utils}
 
 class HttpServer(
     role: String,
@@ -56,7 +56,7 @@ class HttpServer(
     isStarted = true
   }
 
-  def stop(graceful: Boolean): Unit = synchronized {
+  def stop(exitCode: Int): Unit = synchronized {
     if (isStarted) {
       logInfo(s"$role: Stopping HttpServer")
       if (bindFuture != null) {
@@ -66,7 +66,7 @@ class HttpServer(
       }
       if (bootstrap != null && bootstrap.config.group != null) {
         Utils.tryLogNonFatalError {
-          if (graceful) {
+          if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN) {
             bootstrap.config.group.shutdownGracefully(3, 5, TimeUnit.SECONDS)
           } else {
             bootstrap.config.group.shutdownGracefully(0, 0, TimeUnit.SECONDS)
@@ -75,7 +75,7 @@ class HttpServer(
       }
       if (bootstrap != null && bootstrap.config.childGroup != null) {
         Utils.tryLogNonFatalError {
-          if (graceful) {
+          if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN) {
             bootstrap.config.childGroup.shutdownGracefully(3, 5, TimeUnit.SECONDS)
           } else {
             bootstrap.config.childGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS)

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -267,7 +267,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
     } else {
       fileSorterSchedulerThread.interrupt();
       fileSorterExecutors.shutdownNow();
-      if(sortedFilesDb != null) {
+      if (sortedFilesDb != null) {
         try {
           sortedFilesDb.close();
           recoverFile.delete();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -242,7 +242,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
   public void close(int exitCode) {
     logger.info("Closing {}", this.getClass().getSimpleName());
     shutdown = true;
-    if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN()) {
+    if (exitCode == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN()) {
       long start = System.currentTimeMillis();
       try {
         fileSorterExecutors.shutdown();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -239,10 +239,10 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
     }
   }
 
-  public void close() {
+  public void close(int exitCode) {
     logger.info("Closing {}", this.getClass().getSimpleName());
     shutdown = true;
-    if (gracefulShutdown) {
+    if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN()) {
       long start = System.currentTimeMillis();
       try {
         fileSorterExecutors.shutdown();
@@ -254,6 +254,14 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
       } catch (InterruptedException e) {
         logger.error("Await partition sorter executor shutdown catch exception: ", e);
       }
+      if (sortedFilesDb != null) {
+        try {
+          updateSortedShuffleFilesInDB();
+          sortedFilesDb.close();
+        } catch (IOException e) {
+          logger.error("Store recover data to LevelDB failed.", e);
+        }
+      }
       long end = System.currentTimeMillis();
       logger.info("Await partition sorter executor complete cost " + (end - start) + "ms");
     } else {
@@ -261,14 +269,6 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
       fileSorterExecutors.shutdownNow();
     }
     cachedIndexMaps.clear();
-    if (sortedFilesDb != null) {
-      try {
-        updateSortedShuffleFilesInDB();
-        sortedFilesDb.close();
-      } catch (IOException e) {
-        logger.error("Store recover data to LevelDB failed.", e);
-      }
-    }
   }
 
   private void reloadAndCleanSortedShuffleFiles(DB db) {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -239,10 +239,10 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
     }
   }
 
-  public void close(int exitCode) {
+  public void close(int exitKind) {
     logger.info("Closing {}", this.getClass().getSimpleName());
     shutdown = true;
-    if (exitCode == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN()) {
+    if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN()) {
       long start = System.currentTimeMillis();
       try {
         fileSorterExecutors.shutdown();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -267,6 +267,14 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
     } else {
       fileSorterSchedulerThread.interrupt();
       fileSorterExecutors.shutdownNow();
+      if(sortedFilesDb != null) {
+        try {
+          sortedFilesDb.close();
+          recoverFile.delete();
+        } catch (IOException e) {
+          logger.error("Clean LevelDB failed.", e);
+        }
+      }
     }
     cachedIndexMaps.clear();
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -427,7 +427,7 @@ private[celeborn] class Worker(
       }
 
       if (null != storageManager) {
-        storageManager.close()
+        storageManager.close(exitKind)
       }
       memoryManager.close()
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -42,7 +42,7 @@ import org.apache.celeborn.common.protocol.{PartitionType, PbRegisterWorkerRespo
 import org.apache.celeborn.common.protocol.message.ControlMessages._
 import org.apache.celeborn.common.quota.ResourceConsumption
 import org.apache.celeborn.common.rpc._
-import org.apache.celeborn.common.util.{CelebornExitStatus, JavaUtils, ShutdownHookManager, ThreadUtils, Utils}
+import org.apache.celeborn.common.util.{CelebornExitKind, JavaUtils, ShutdownHookManager, ThreadUtils, Utils}
 // Can Remove this if celeborn don't support scala211 in future
 import org.apache.celeborn.common.util.FunctionConverter._
 import org.apache.celeborn.server.common.{HttpService, Service}
@@ -397,7 +397,7 @@ private[celeborn] class Worker(
       logInfo("Stopping Worker.")
 
       if (sendHeartbeatTask != null) {
-        if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN) {
+        if (exitCode == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
           sendHeartbeatTask.cancel(false)
         } else {
           sendHeartbeatTask.cancel(true)
@@ -405,14 +405,14 @@ private[celeborn] class Worker(
         sendHeartbeatTask = null
       }
       if (checkFastFailTask != null) {
-        if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN) {
+        if (exitCode == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
           checkFastFailTask.cancel(false)
         } else {
           checkFastFailTask.cancel(true)
         }
         checkFastFailTask = null
       }
-      if (exitCode == CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN) {
+      if (exitCode == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
         forwardMessageScheduler.shutdown()
         replicateThreadPool.shutdown()
         commitThreadPool.shutdown()
@@ -612,7 +612,7 @@ private[celeborn] class Worker(
               s"unreleased PartitionLocation: \n$partitionLocationInfo")
           }
         }
-        stop(CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN)
+        stop(CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN)
       }
     }),
     WORKER_SHUTDOWN_PRIORITY)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -392,12 +392,12 @@ private[celeborn] class Worker(
     rpcEnv.awaitTermination()
   }
 
-  override def stop(exitCode: Int): Unit = {
+  override def stop(exitKind: Int): Unit = {
     if (!stopped) {
       logInfo("Stopping Worker.")
 
       if (sendHeartbeatTask != null) {
-        if (exitCode == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
+        if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
           sendHeartbeatTask.cancel(false)
         } else {
           sendHeartbeatTask.cancel(true)
@@ -405,25 +405,25 @@ private[celeborn] class Worker(
         sendHeartbeatTask = null
       }
       if (checkFastFailTask != null) {
-        if (exitCode == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
+        if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
           checkFastFailTask.cancel(false)
         } else {
           checkFastFailTask.cancel(true)
         }
         checkFastFailTask = null
       }
-      if (exitCode == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
+      if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
         forwardMessageScheduler.shutdown()
         replicateThreadPool.shutdown()
         commitThreadPool.shutdown()
         asyncReplyPool.shutdown()
-        partitionsSorter.close(exitCode)
+        partitionsSorter.close(exitKind)
       } else {
         forwardMessageScheduler.shutdownNow()
         replicateThreadPool.shutdownNow()
         commitThreadPool.shutdownNow()
         asyncReplyPool.shutdownNow()
-        partitionsSorter.close(exitCode)
+        partitionsSorter.close(exitKind)
       }
 
       if (null != storageManager) {
@@ -432,11 +432,11 @@ private[celeborn] class Worker(
       memoryManager.close()
 
       masterClient.close()
-      replicateServer.shutdown(exitCode)
-      fetchServer.shutdown(exitCode)
-      pushServer.shutdown(exitCode)
+      replicateServer.shutdown(exitKind)
+      fetchServer.shutdown(exitKind)
+      pushServer.shutdown(exitKind)
 
-      super.stop(exitCode)
+      super.stop(exitKind)
 
       logInfo("Worker is stopped.")
       stopped = true

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -439,7 +439,6 @@ private[celeborn] class Worker(
       logInfo("Worker is stopped.")
       stopped = true
     }
-    shutdown.set(true)
   }
 
   private def registerWithMaster(): Unit = {
@@ -623,11 +622,15 @@ private[celeborn] class Worker(
   ShutdownHookManager.get().addShutdownHook(
     new Thread(new Runnable {
       override def run(): Unit = {
-        logInfo("Shutdown hook called.")
-        if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
-          shutdownGracefully()
+        if (stopped) {
+          logInfo("Worker already stopped before call ShutdownHook.")
         } else {
-          exitImmediately()
+          logInfo("Shutdown hook called.")
+          if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
+            shutdownGracefully()
+          } else {
+            exitImmediately()
+          }
         }
       }
     }),

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -604,14 +604,19 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   }
 
   def close(exitKind: Int): Unit = {
-    if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
-      if (db != null) {
+    if (db != null) {
+      if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
         try {
           updateFileInfosInDB()
           db.close()
         } catch {
           case exception: Exception =>
             logError("Store recover data to LevelDB failed.", exception)
+        }
+      } else {
+        if (db != null) {
+          db.close()
+          new File(conf.workerGracefulShutdownRecoverPath, RECOVERY_FILE_NAME).delete()
         }
       }
     }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
-import org.apache.celeborn.common.util.CelebornExitStatus;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -40,6 +39,7 @@ import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.unsafe.Platform;
+import org.apache.celeborn.common.util.CelebornExitStatus;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager;

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
@@ -39,7 +39,7 @@ import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.unsafe.Platform;
-import org.apache.celeborn.common.util.CelebornExitStatus;
+import org.apache.celeborn.common.util.CelebornExitKind;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager;
@@ -185,7 +185,7 @@ public class PartitionFilesSorterSuiteJ {
     partitionFilesSorter.initSortedShuffleFiles("application-3-1");
     partitionFilesSorter.updateSortedShuffleFiles("application-3-1", "0-0-1", 0);
     partitionFilesSorter.deleteSortedShuffleFiles("application-2-1");
-    partitionFilesSorter.close(CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN());
+    partitionFilesSorter.close(CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN());
     PartitionFilesSorter partitionFilesSorter2 =
         new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
     Assert.assertEquals(
@@ -194,7 +194,7 @@ public class PartitionFilesSorterSuiteJ {
     Assert.assertEquals(partitionFilesSorter2.getSortedShuffleFiles("application-2-1"), null);
     Assert.assertEquals(
         partitionFilesSorter2.getSortedShuffleFiles("application-3-1").toString(), "[0-0-1]");
-    partitionFilesSorter2.close(CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN());
+    partitionFilesSorter2.close(CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN());
     recoverPath.delete();
   }
 }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import org.apache.celeborn.common.util.CelebornExitStatus;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -184,7 +185,7 @@ public class PartitionFilesSorterSuiteJ {
     partitionFilesSorter.initSortedShuffleFiles("application-3-1");
     partitionFilesSorter.updateSortedShuffleFiles("application-3-1", "0-0-1", 0);
     partitionFilesSorter.deleteSortedShuffleFiles("application-2-1");
-    partitionFilesSorter.close();
+    partitionFilesSorter.close(CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN());
     PartitionFilesSorter partitionFilesSorter2 =
         new PartitionFilesSorter(MemoryManager.instance(), conf, new WorkerSource(conf));
     Assert.assertEquals(
@@ -193,7 +194,7 @@ public class PartitionFilesSorterSuiteJ {
     Assert.assertEquals(partitionFilesSorter2.getSortedShuffleFiles("application-2-1"), null);
     Assert.assertEquals(
         partitionFilesSorter2.getSortedShuffleFiles("application-3-1").toString(), "[0-0-1]");
-    partitionFilesSorter2.close();
+    partitionFilesSorter2.close(CelebornExitStatus.WORKER_GRACEFUL_SHUTDOWN());
     recoverPath.delete();
   }
 }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.util.Utils
+import org.apache.celeborn.common.util.{CelebornExitStatus, Utils}
 import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
 import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
@@ -119,19 +119,19 @@ trait MiniClusterFeature extends Logging {
     // shutdown workers
     workerInfos.foreach {
       case (worker, _) =>
-        worker.stop(false)
+        worker.stop(CelebornExitStatus.EXIT)
         worker.rpcEnv.shutdown()
     }
 
     // shutdown masters
-    masterInfo._1.stop(false)
+    masterInfo._1.stop(CelebornExitStatus.EXIT)
     masterInfo._1.rpcEnv.shutdown()
 
     // interrupt threads
     Thread.sleep(5000)
     workerInfos.foreach {
       case (worker, thread) =>
-        worker.stop(false)
+        worker.stop(CelebornExitStatus.EXIT)
         thread.interrupt()
     }
     workerInfos.clear()

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.util.{CelebornExitStatus, Utils}
+import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
 import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
 import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
@@ -119,19 +119,19 @@ trait MiniClusterFeature extends Logging {
     // shutdown workers
     workerInfos.foreach {
       case (worker, _) =>
-        worker.stop(CelebornExitStatus.EXIT)
+        worker.stop(CelebornExitKind.EXIT_IMMEDIATELY)
         worker.rpcEnv.shutdown()
     }
 
     // shutdown masters
-    masterInfo._1.stop(CelebornExitStatus.EXIT)
+    masterInfo._1.stop(CelebornExitKind.EXIT_IMMEDIATELY)
     masterInfo._1.rpcEnv.shutdown()
 
     // interrupt threads
     Thread.sleep(5000)
     workerInfos.foreach {
       case (worker, thread) =>
-        worker.stop(CelebornExitStatus.EXIT)
+        worker.stop(CelebornExitKind.EXIT_IMMEDIATELY)
         thread.interrupt()
     }
     workerInfos.clear()

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
@@ -31,7 +31,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType}
-import org.apache.celeborn.common.util.{CelebornExitStatus, JavaUtils}
+import org.apache.celeborn.common.util.{CelebornExitKind, JavaUtils}
 import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 
 class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach {
@@ -46,7 +46,7 @@ class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach {
   override def afterEach(): Unit = {
     if (null != worker) {
       worker.rpcEnv.shutdown()
-      worker.stop(CelebornExitStatus.EXIT)
+      worker.stop(CelebornExitKind.EXIT_IMMEDIATELY)
       worker = null
     }
   }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
@@ -31,7 +31,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType}
-import org.apache.celeborn.common.util.JavaUtils
+import org.apache.celeborn.common.util.{CelebornExitStatus, JavaUtils}
 import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 
 class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach {
@@ -46,7 +46,7 @@ class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach {
   override def afterEach(): Unit = {
     if (null != worker) {
       worker.rpcEnv.shutdown()
-      worker.stop(false)
+      worker.stop(CelebornExitStatus.EXIT)
       worker = null
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Pass exit kind to each component, if the exit kind match:

- GRACEFUL_SHUTDOWN: Behavior as origin code's graceful == true
- Others: will clean the level db file.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

