### PR TITLE
[CELEBORN-838] Add custom mvn flag to celeborn

### DIFF
--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -24,6 +24,7 @@ PROJECT_DIR="$(cd "`dirname "$0"`/.."; pwd)"
 DIST_DIR="$PROJECT_DIR/dist"
 NAME="bin"
 RELEASE="false"
+MVN="$PROJECT_DIR/build/mvn"
 
 function exit_with_usage {
   echo "make-distribution.sh - tool for making binary distributions of Celeborn"
@@ -40,6 +41,10 @@ while (( "$#" )); do
   case $1 in
     --name)
       NAME="bin-$2"
+      shift
+      ;;
+    --mvn)
+      MVN="$2"
       shift
       ;;
     --release)
@@ -86,7 +91,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit -1
 fi
 
-MVN="$PROJECT_DIR/build/mvn"
 export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=1g}"
 
 if [ ! "$(command -v "$MVN")" ] ; then

--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -30,7 +30,7 @@ function exit_with_usage {
   echo "make-distribution.sh - tool for making binary distributions of Celeborn"
   echo ""
   echo "usage:"
-  cl_options="[--name <custom_name>] [--release]"
+  cl_options="[--name <custom_name>] [--release] [--mvn <mvn-command>]"
   echo "make-distribution.sh $cl_options <maven build options>"
   echo ""
   exit 1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add an option to pass in a custom maven installation, similar to how [Spark does it](https://github.com/apache/spark/blob/master/dev/make-distribution.sh#L65). 



### Why are the changes needed?
We need this internally as some of our machines may not have access to external Maven. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
ran make-distribution.sh to make sure it worked. 

