### PR TITLE
[CELEBORN-845][BUG] Sort memory counter won't decrease after sort failed

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2173,6 +2173,7 @@ object CelebornConf extends Logging {
       .doc("Reserved memory when sorting a shuffle file off-heap.")
       .version("0.3.0")
       .bytesConf(ByteUnit.BYTE)
+      .checkValue(v => v < Int.MaxValue, "Reserved memory per partition must be less than 2GB.")
       .createWithDefaultString("1mb")
 
   val WORKER_FLUSHER_BUFFER_SIZE: ConfigEntry[Long] =

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -133,6 +133,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
                       () -> {
                         try {
                           task.sort();
+                          memoryManager.releaseSortMemory(reservedMemoryPerPartition);
                         } catch (InterruptedException e) {
                           logger.warn(
                               "File sorter thread was interrupted when expanding padding buffer.");
@@ -585,8 +586,6 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
           }
           sortedBlockInfoMap.put(mapId, sortedShuffleBlocks);
         }
-
-        memoryManager.releaseSortMemory(reserveMemory);
 
         writeIndex(sortedBlockInfoMap, indexFilePath, isHdfs);
         updateSortedShuffleFiles(shuffleKey, fileId, originFileLen);

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -133,10 +133,10 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
                       () -> {
                         try {
                           task.sort();
-                          memoryManager.releaseSortMemory(reservedMemoryPerPartition);
                         } catch (InterruptedException e) {
-                          logger.warn(
-                              "File sorter thread was interrupted when expanding padding buffer.");
+                          logger.warn("File sorter thread was interrupted.");
+                        } finally {
+                          memoryManager.releaseSortMemory(reservedMemoryPerPartition);
                         }
                       });
                 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Decrease sort memory counter after sorting procedure is complete.


### Why are the changes needed?
Fix incorrect sort memory counter.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
UT.
