### PR TITLE
[CELEBORN-857][TEST] Refine DataPushQueueSuiteJ

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -193,7 +193,7 @@ public class DataPusher {
     }
   }
 
-  private void pushData(PushTask task) throws IOException {
+  protected void pushData(PushTask task) throws IOException {
     int bytesWritten =
         client.pushData(
             shuffleId,

--- a/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuiteJ.java
@@ -41,8 +41,8 @@ import org.apache.celeborn.common.util.JavaUtils;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.common.write.PushState;
 
-public class DataPushQueueSuitJ {
-  private static final Logger LOG = LoggerFactory.getLogger(DataPushQueueSuitJ.class);
+public class DataPushQueueSuiteJ {
+  private static final Logger LOG = LoggerFactory.getLogger(DataPushQueueSuiteJ.class);
   private static File tempDir = null;
 
   private final int shuffleId = 0;

--- a/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuiteJ.java
+++ b/client/src/test/java/org/apache/celeborn/client/write/DataPushQueueSuiteJ.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.junit.AfterClass;
@@ -113,8 +112,10 @@ public class DataPushQueueSuiteJ {
             null,
             integer -> {},
             mapStatusLengths) {
-          @Override protected void pushData(PushTask task) throws IOException {
-            byte[] buffer = task.getBuffer(); int partitionId = task.getPartitionId();
+          @Override
+          protected void pushData(PushTask task) throws IOException {
+            byte[] buffer = task.getBuffer();
+            int partitionId = task.getPartitionId();
             tarWorkerData.get(partitionId % numWorker).add(bytesToInt(buffer));
             pushState.removeBatch(
                 partitionBatchIdMap.get(partitionId),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

1. This PR propose renaming the class `DataPushQueueSuitJ` to `DataPushQueueSuiteJ` in order to enable its integration with the test suite. This change is required to comply with our maven-surefire-plugin plugin rule

https://github.com/apache/incubator-celeborn/blob/5f0295e9f3f1f5781af124ae319e202a2594a103/pom.xml#L543-L551

2. To fix a potential logic bug in the test, tasks within `DataPushQueue` may inadvertently be consumed by the `DataPusher`s built-in thread `DataPusher-${taskId}`, leading to test suite failures.

![截屏2023-07-31 下午12 08 06](https://github.com/apache/incubator-celeborn/assets/8537877/b7a294a5-a12b-474a-b43d-233998bc7f31)


![截屏2023-07-31 下午12 07 49](https://github.com/apache/incubator-celeborn/assets/8537877/c585ed00-0111-4aab-863a-e7984ed8a298)


### Why are the changes needed?

fix DataPushQueueSuiteJ bug

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass GA