### PR TITLE
[CELEBORN-863] Persist committed file infos to support worker recovery

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2261,7 +2261,8 @@ object CelebornConf extends Logging {
   val WORKER_GRACEFUL_SHUTDOWN_SAVE_COMMITTED_FILEINFO_SYNC: ConfigEntry[Boolean] =
     buildConf("celeborn.worker.graceful.shutdown.saveCommittedFileInfo.sync")
       .categories("worker")
-      .doc("Whether to call sync method to save committed file infos into Level DB to handle OS crash.")
+      .doc(
+        "Whether to call sync method to save committed file infos into Level DB to handle OS crash.")
       .version("0.3.1")
       .booleanConf
       .createWithDefault(false)

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2261,7 +2261,7 @@ object CelebornConf extends Logging {
   val WORKER_GRACEFUL_SHUTDOWN_SAVE_COMMITTED_FILEINFO_SYNC: ConfigEntry[Boolean] =
     buildConf("celeborn.worker.graceful.shutdown.saveCommittedFileInfo.sync")
       .categories("worker")
-      .doc("Whether to call sync method to save committed fileinfo intos into Level DB to handle OS crash.")
+      .doc("Whether to call sync method to save committed file infos into Level DB to handle OS crash.")
       .version("0.3.1")
       .booleanConf
       .createWithDefault(false)

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -920,6 +920,10 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerGracefulShutdownPartitionSorterCloseAwaitTimeMs: Long =
     get(WORKER_PARTITION_SORTER_SHUTDOWN_TIMEOUT)
   def workerGracefulShutdownFlusherShutdownTimeoutMs: Long = get(WORKER_FLUSHER_SHUTDOWN_TIMEOUT)
+  def workerGracefulShutdownSaveCommittedFileInfoInterval: Long =
+    get(WORKER_GRACEFUL_SHUTDOWN_SAVE_COMMITTED_FILEINFO_INTERVAL)
+  def workerGracefulShutdownSaveCommittedFileInfoSync: Boolean =
+    get(WORKER_GRACEFUL_SHUTDOWN_SAVE_COMMITTED_FILEINFO_SYNC)
 
   // //////////////////////////////////////////////////////
   //                      Flusher                        //
@@ -2245,6 +2249,22 @@ object CelebornConf extends Logging {
       .version("0.2.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("3s")
+
+  val WORKER_GRACEFUL_SHUTDOWN_SAVE_COMMITTED_FILEINFO_INTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.worker.graceful.shutdown.saveCommittedFileInfo.interval")
+      .categories("worker")
+      .doc("Interval for a Celeborn worker to flush committed file infos into Level DB.")
+      .version("0.3.1")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("5s")
+
+  val WORKER_GRACEFUL_SHUTDOWN_SAVE_COMMITTED_FILEINFO_SYNC: ConfigEntry[Boolean] =
+    buildConf("celeborn.worker.graceful.shutdown.saveCommittedFileInfo.sync")
+      .categories("worker")
+      .doc("Whether to call sync method to save committed fileinfo intos into Level DB to handle OS crash.")
+      .version("0.3.1")
+      .booleanConf
+      .createWithDefault(false)
 
   val WORKER_DISKTIME_SLIDINGWINDOW_SIZE: ConfigEntry[Int] =
     buildConf("celeborn.worker.flusher.diskTime.slidingWindow.size")

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -56,6 +56,8 @@ license: |
 | celeborn.worker.graceful.shutdown.enabled | false | When true, during worker shutdown, the worker will wait for all released slots to be committed or destroyed. | 0.2.0 | 
 | celeborn.worker.graceful.shutdown.partitionSorter.shutdownTimeout | 120s | The wait time of waiting for sorting partition files during worker graceful shutdown. | 0.2.0 | 
 | celeborn.worker.graceful.shutdown.recoverPath | &lt;tmp&gt;/recover | The path to store levelDB. | 0.2.0 | 
+| celeborn.worker.graceful.shutdown.saveCommittedFileInfo.interval | 5s | Interval for a Celeborn worker to flush committed file infos into Level DB. | 0.3.1 | 
+| celeborn.worker.graceful.shutdown.saveCommittedFileInfo.sync | false | Whether to call sync method to save committed fileinfo intos into Level DB to handle OS crash. | 0.3.1 | 
 | celeborn.worker.graceful.shutdown.timeout | 600s | The worker's graceful shutdown timeout time. | 0.2.0 | 
 | celeborn.worker.monitor.disk.check.interval | 60s | Intervals between device monitor to check disk. | 0.3.0 | 
 | celeborn.worker.monitor.disk.check.timeout | 30s | Timeout time for worker check device status. | 0.3.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -57,7 +57,7 @@ license: |
 | celeborn.worker.graceful.shutdown.partitionSorter.shutdownTimeout | 120s | The wait time of waiting for sorting partition files during worker graceful shutdown. | 0.2.0 | 
 | celeborn.worker.graceful.shutdown.recoverPath | &lt;tmp&gt;/recover | The path to store levelDB. | 0.2.0 | 
 | celeborn.worker.graceful.shutdown.saveCommittedFileInfo.interval | 5s | Interval for a Celeborn worker to flush committed file infos into Level DB. | 0.3.1 | 
-| celeborn.worker.graceful.shutdown.saveCommittedFileInfo.sync | false | Whether to call sync method to save committed fileinfo intos into Level DB to handle OS crash. | 0.3.1 | 
+| celeborn.worker.graceful.shutdown.saveCommittedFileInfo.sync | false | Whether to call sync method to save committed file infos into Level DB to handle OS crash. | 0.3.1 | 
 | celeborn.worker.graceful.shutdown.timeout | 600s | The worker's graceful shutdown timeout time. | 0.2.0 | 
 | celeborn.worker.monitor.disk.check.interval | 60s | Intervals between device monitor to check disk. | 0.3.0 | 
 | celeborn.worker.monitor.disk.check.timeout | 30s | Timeout time for worker check device status. | 0.3.0 | 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -81,6 +81,8 @@ public abstract class FileWriter implements DeviceObserver {
   protected boolean deleted = false;
   private RoaringBitmap mapIdBitMap = null;
   protected final FlushNotifier notifier = new FlushNotifier();
+  private String shuffleKey;
+  private StorageManager storageManager;
 
   public FileWriter(
       FileInfo fileInfo,
@@ -288,6 +290,7 @@ public abstract class FileWriter implements DeviceObserver {
         deviceMonitor.unregisterFileWriter(this);
       }
     }
+    storageManager.notifyFileInfoCommitted(shuffleKey, getFile().getName(), fileInfo);
     return fileInfo.getFileLength();
   }
 
@@ -439,5 +442,13 @@ public abstract class FileWriter implements DeviceObserver {
 
   public PartitionType getPartitionType() {
     return partitionType;
+  }
+
+  public void setShuffleKey(String shuffleKey) {
+    this.shuffleKey = shuffleKey;
+  }
+
+  public void setStorageManager(StorageManager storageManager) {
+    this.storageManager = storageManager;
   }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -81,7 +81,7 @@ public abstract class FileWriter implements DeviceObserver {
   protected boolean deleted = false;
   private RoaringBitmap mapIdBitMap = null;
   protected final FlushNotifier notifier = new FlushNotifier();
-  // It's only needed when graceful shutdown is enabled, no need to add it into constructor
+  // It's only needed when graceful shutdown is enabled
   private String shuffleKey;
   private StorageManager storageManager;
   private boolean workerGracefulShutdown;
@@ -294,8 +294,7 @@ public abstract class FileWriter implements DeviceObserver {
       }
     }
     if (workerGracefulShutdown) {
-      storageManager.notifyFileInfoCommittedWhenGracefulShutdownIsEnabled(
-          shuffleKey, getFile().getName(), fileInfo);
+      storageManager.notifyFileInfoCommitted(shuffleKey, getFile().getName(), fileInfo);
     }
     return fileInfo.getFileLength();
   }
@@ -450,9 +449,11 @@ public abstract class FileWriter implements DeviceObserver {
     return partitionType;
   }
 
-  public void setShuffleKeyAndStorageManagerWhenGracefulShutdownIsEnabled(
-      String shuffleKey, StorageManager storageManager) {
+  public void setShuffleKey(String shuffleKey) {
     this.shuffleKey = shuffleKey;
+  }
+
+  public void setStorageManager(StorageManager storageManager) {
     this.storageManager = storageManager;
   }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -290,7 +290,10 @@ public abstract class FileWriter implements DeviceObserver {
         deviceMonitor.unregisterFileWriter(this);
       }
     }
-    storageManager.notifyFileInfoCommitted(shuffleKey, getFile().getName(), fileInfo);
+    // For UT
+    if (storageManager != null) {
+      storageManager.notifyFileInfoCommitted(shuffleKey, getFile().getName(), fileInfo);
+    }
     return fileInfo.getFileLength();
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -485,6 +485,7 @@ private[deploy] class Controller(
               s"${committedReplicaIds.size()} committed replica partitions, " +
               s"${emptyFileReplicaIds.size()} empty replica partitions, " +
               s"${failedReplicaIds.size()} failed replica partitions.")
+          storageManager.persistShuffle(shuffleKey)
           CommitFilesResponse(
             StatusCode.SUCCESS,
             committedPrimaryIdList,

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -485,7 +485,6 @@ private[deploy] class Controller(
               s"${committedReplicaIds.size()} committed replica partitions, " +
               s"${emptyFileReplicaIds.size()} empty replica partitions, " +
               s"${failedReplicaIds.size()} failed replica partitions.")
-          storageManager.persistShuffle(shuffleKey, true)
           CommitFilesResponse(
             StatusCode.SUCCESS,
             committedPrimaryIdList,

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -485,7 +485,7 @@ private[deploy] class Controller(
               s"${committedReplicaIds.size()} committed replica partitions, " +
               s"${emptyFileReplicaIds.size()} empty replica partitions, " +
               s"${failedReplicaIds.size()} failed replica partitions.")
-          storageManager.persistShuffle(shuffleKey)
+          storageManager.persistShuffle(shuffleKey, true)
           CommitFilesResponse(
             StatusCode.SUCCESS,
             committedPrimaryIdList,

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -531,7 +531,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         if (db != null) {
           committedFileInfos.remove(shuffleKey)
           // if delete a shuffle key failed, heartbeat from worker will clean it again.
-          if (onClose) {
+          if (!onClose) {
             // worker shutdown don't clean expired shuffle because db is closed.
             db.delete(dbShuffleKey(shuffleKey))
           }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -352,7 +352,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           case _ => throw new UnsupportedOperationException(s"Not support $partitionType yet")
         }
         if (workerGracefulShutdown) {
-          hdfsWriter.setShuffleKeyAndStorageManagerWhenGracefulShutdownIsEnabled(shuffleKey, this)
+          hdfsWriter.setStorageManager(this)
+          hdfsWriter.setShuffleKey(shuffleKey)
         }
         fileInfos.computeIfAbsent(shuffleKey, newMapFunc).put(fileName, fileInfo)
         hdfsWriters.put(fileInfo.getFilePath, hdfsWriter)
@@ -398,7 +399,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
             case _ => throw new UnsupportedOperationException(s"Not support $partitionType yet")
           }
           if (workerGracefulShutdown) {
-            fileWriter.setShuffleKeyAndStorageManagerWhenGracefulShutdownIsEnabled(shuffleKey, this)
+            fileWriter.setStorageManager(this)
+            fileWriter.setShuffleKey(shuffleKey)
           }
           deviceMonitor.registerFileWriter(fileWriter)
           val map = workingDirWriters.computeIfAbsent(dir, workingDirWriterListFunc)
@@ -789,7 +791,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     }
   }
 
-  def notifyFileInfoCommittedWhenGracefulShutdownIsEnabled(
+  def notifyFileInfoCommitted(
       shuffleKey: String,
       fileName: String,
       fileInfo: FileInfo): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support worker recovery if the worker has crashed when workers has enabled graceful shutdown..

1. Persist committed file info to LevelDB.
2. Load levelDB when worker started.
3. Clean expired file infos in LevelDB.


### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA and cluster. After testing on a cluster I found that 8k file infos will consume about 2MB of disk space, disk space can be reclaimed if shuffle is expired shortly.
