### PR TITLE
[CELEBORN-867][BUILD] Add maven local repository to sbt respositories

### DIFF
--- a/build/sbt-config/repositories
+++ b/build/sbt-config/repositories
@@ -1,5 +1,6 @@
 [repositories]
   local
+  mavenLocal: file://${user.home}/.m2/repository/
   local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
   # The system property value of `celeborn.sbt.default.artifact.repository` is

--- a/build/sbt-config/repositories-cn.template
+++ b/build/sbt-config/repositories-cn.template
@@ -8,6 +8,7 @@
 
 [repositories]
   local
+  mavenLocal: file://${user.home}/.m2/repository/
   # The system property value of `celeborn.sbt.default.artifact.repository` is
   # fetched from the environment variable `DEFAULT_ARTIFACT_REPOSITORY` and
   # assigned within the build/sbt-launch-lib.bash script.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?

https://github.com/apache/incubator-celeborn/pull/1764#issuecomment-1659463340

before this PR
```shell
> ./build/sbt -Pspark-3.3 "clean; show celeborn-common/csrResolvers"
[info] * FileRepository(local, Patterns(ivyPatterns=Vector(/Users/fchen/.ivy2/local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(/Users/fchen/.ivy2/local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), FileConfiguration(true, None))
[info] * private: file:/dev/null
[info] * aliyun-maven: https://maven.aliyun.com/nexus/content/groups/public/
[info] * huawei-central: https://mirrors.huaweicloud.com/repository/maven/
[success] Total time: 0 s, completed 2023-8-1 11:40:25
```

```shell
> ./build/sbt -Pspark-3.3 "clean; show celeborn-client-spark-3/managedClasspath" | grep spark
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/apache/spark/spark-core_2.12/3.3.2/spark-core_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/apache/spark/spark-sql_2.12/3.3.2/spark-sql_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/apache/spark/spark-launcher_2.12/3.3.2/spark-launcher_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/apache/spark/spark-kvstore_2.12/3.3.2/spark-kvstore_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/apache/spark/spark-network-common_2.12/3.3.2/spark-network-common_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/apache/spark/spark-network-shuffle_2.12/3.3.2/spark-network-shuffle_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/apache/spark/spark-unsafe_2.12/3.3.2/spark-unsafe_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/apache/spark/spark-tags_2.12/3.3.2/spark-tags_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar)
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/apache/spark/spark-sketch_2.12/3.3.2/spark-sketch_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/Library/Caches/Coursier/v1/https/mirrors.huaweicloud.com/repository/maven/org/apache/spark/spark-catalyst_2.12/3.3.2/spark-catalyst_2.12-3.3.2.jar)
```

after this PR

```shell
> ./build/sbt -Pspark-3.3 "clean; show celeborn-common/csrResolvers"
[success] Total time: 0 s, completed 2023-8-1 11:45:02
[info] * FileRepository(local, Patterns(ivyPatterns=Vector(/Users/fchen/.ivy2/local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(/Users/fchen/.ivy2/local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), FileConfiguration(true, None))
[info] * mavenLocal: file:/Users/fchen/.m2/repository/
[info] * private: file:/dev/null
[info] * aliyun-maven: https://maven.aliyun.com/nexus/content/groups/public/
[info] * huawei-central: https://mirrors.huaweicloud.com/repository/maven/
[success] Total time: 0 s, completed 2023-8-1 11:45:02
```

```shell
> ./build/sbt -Pspark-3.3 "clean; show celeborn-client-spark-3/managedClasspath" | grep spark
[info] * Attributed(/Users/fchen/.m2/repository/org/apache/spark/spark-core_2.12/3.3.2/spark-core_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/.m2/repository/org/apache/spark/spark-sql_2.12/3.3.2/spark-sql_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/.m2/repository/org/apache/spark/spark-launcher_2.12/3.3.2/spark-launcher_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/.m2/repository/org/apache/spark/spark-kvstore_2.12/3.3.2/spark-kvstore_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/.m2/repository/org/apache/spark/spark-network-common_2.12/3.3.2/spark-network-common_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/.m2/repository/org/apache/spark/spark-network-shuffle_2.12/3.3.2/spark-network-shuffle_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/.m2/repository/org/apache/spark/spark-unsafe_2.12/3.3.2/spark-unsafe_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/.m2/repository/org/apache/spark/spark-tags_2.12/3.3.2/spark-tags_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/.m2/repository/org/spark-project/spark/unused/1.0.0/unused-1.0.0.jar)
[info] * Attributed(/Users/fchen/.m2/repository/org/apache/spark/spark-sketch_2.12/3.3.2/spark-sketch_2.12-3.3.2.jar)
[info] * Attributed(/Users/fchen/.m2/repository/org/apache/spark/spark-catalyst_2.12/3.3.2/spark-catalyst_2.12-3.3.2.jar)
```


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass GA