### PR TITLE
[CELEBORN-871] Init PartitionReader OpenStream failed won't show location info

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
@@ -101,14 +101,14 @@ public class WorkerPartitionReader implements PartitionReader {
     TransportClient client = null;
     try {
       client = clientFactory.createClient(location.getHost(), location.getFetchPort());
-    } catch (InterruptedException ie) {
-      logger.error("PartitionReader thread interrupted while creating client.");
-      throw ie;
+      OpenStream openBlocks =
+          new OpenStream(shuffleKey, location.getFileName(), startMapIndex, endMapIndex);
+      ByteBuffer response = client.sendRpcSync(openBlocks.toByteBuffer(), fetchTimeoutMs);
+      streamHandle = (StreamHandle) Message.decode(response);
+    } catch (IOException | InterruptedException e) {
+      logger.error("PartitionReader thread interrupted while creating client.", e);
+      throw e;
     }
-    OpenStream openBlocks =
-        new OpenStream(shuffleKey, location.getFileName(), startMapIndex, endMapIndex);
-    ByteBuffer response = client.sendRpcSync(openBlocks.toByteBuffer(), fetchTimeoutMs);
-    streamHandle = (StreamHandle) Message.decode(response);
 
     this.location = location;
     this.clientFactory = clientFactory;


### PR DESCRIPTION
### What changes were proposed in this pull request?
As title
```
23/08/01 20:37:49 WARN RssInputStream: CreatePartitionReader failed 1/6 times, change to peer
java.io.IOException: Exception in sendRpcSync
	at com.aliyun.emr.rss.common.network.client.TransportClient.sendRpcSync(TransportClient.java:243)
	at com.aliyun.emr.rss.client.read.PartitionReader.openStream(PartitionReader.java:116)
	at com.aliyun.emr.rss.client.read.PartitionReader.<init>(PartitionReader.java:94)
	at com.aliyun.emr.rss.client.read.RssInputStream$RssInputStreamImpl.createReader(RssInputStream.java:255)
	at com.aliyun.emr.rss.client.read.RssInputStream$RssInputStreamImpl.createReaderWithRetry(RssInputStream.java:195)
	at com.aliyun.emr.rss.client.read.RssInputStream$RssInputStreamImpl.moveToNextReader(RssInputStream.java:168)
	at com.aliyun.emr.rss.client.read.RssInputStream$RssInputStreamImpl.<init>(RssInputStream.java:158)
	at com.aliyun.emr.rss.client.read.RssInputStream.create(RssInputStream.java:62)
	at com.aliyun.emr.rss.client.ShuffleClientImpl.readPartition(ShuffleClientImpl.java:1124)
	at org.apache.spark.shuffle.rss.RssShuffleReader.$anonfun$read$1(RssShuffleReader.scala:64)
	at org.apache.spark.shuffle.rss.RssShuffleReader.$anonfun$read$1$adapted(RssShuffleReader.scala:60)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
	at scala.collection.immutable.Range.foreach(Range.scala:158)
	at scala.collection.TraversableLike.map(TraversableLike.scala:286)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
	at scala.collection.AbstractTraversable.map(Traversable.scala:108)
	at org.apache.spark.shuffle.rss.RssShuffleReader.read(RssShuffleReader.scala:60)
	at org.apache.spark.rdd.ShuffledRDD.compute(ShuffledRDD.scala:106)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.rdd.PipedRDD$$anon$2.run(PipedRDD.scala:145)
Caused by: java.util.concurrent.ExecutionException: java.lang.RuntimeException: java.io.FileNotFoundException
	at com.aliyun.emr.rss.service.deploy.worker.ChunkFetchRpcHandler.receive(ChunkFetchRpcHandler.java:102)
	at com.aliyun.emr.rss.common.network.server.TransportRequestHandler.processRpcRequest(TransportRequestHandler.java:196)
	at com.aliyun.emr.rss.common.network.server.TransportRequestHandler.handle(TransportRequestHandler.java:120)
	at com.aliyun.emr.rss.common.network.server.TransportChannelHandler.channelRead(TransportChannelHandler.java:118)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at com.aliyun.emr.rss.common.network.util.TransportFrameDecoder.channelRead(TransportFrameDecoder.java:85)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)

```


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

