### PR TITLE
[CELEBORN-878][Flink] Convert all IOException to PartitionUnRetryAbleException when openStream/read file

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
@@ -27,6 +27,7 @@ import org.apache.celeborn.common.network.protocol.BacklogAnnouncement;
 import org.apache.celeborn.common.network.protocol.ReadAddCredit;
 import org.apache.celeborn.common.network.protocol.RequestMessage;
 import org.apache.celeborn.common.network.protocol.TransportableError;
+import org.apache.celeborn.common.network.util.NettyUtils;
 import org.apache.celeborn.plugin.flink.buffer.CreditListener;
 import org.apache.celeborn.plugin.flink.buffer.TransferBufferPool;
 import org.apache.celeborn.plugin.flink.protocol.ReadData;
@@ -128,6 +129,12 @@ public class RemoteBufferStreamReader extends CreditListener {
   public void errorReceived(String errorMsg) {
     if (!closed) {
       closed = true;
+      if (bufferStream != null && bufferStream.getClient() != null) {
+        logger.error(
+            "Received error from {} message {}",
+            NettyUtils.getRemoteAddress(bufferStream.getClient().getChannel()),
+            errorMsg);
+      }
       failureListener.accept(new IOException(errorMsg));
     }
   }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/CelebornBufferStream.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/CelebornBufferStream.java
@@ -30,6 +30,7 @@ import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.network.client.RpcResponseCallback;
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.protocol.*;
+import org.apache.celeborn.common.network.util.NettyUtils;
 import org.apache.celeborn.common.protocol.PartitionLocation;
 import org.apache.celeborn.plugin.flink.network.FlinkTransportClientFactory;
 
@@ -112,6 +113,11 @@ public class CelebornBufferStream {
 
           @Override
           public void onFailure(Throwable e) {
+            logger.error(
+                "Open file {} stream for {} error from {}",
+                fileName,
+                shuffleKey,
+                NettyUtils.getRemoteAddress(client.getChannel()));
             messageConsumer.accept(new TransportableError(streamId, e));
           }
         });
@@ -176,5 +182,9 @@ public class CelebornBufferStream {
       }
       isClosed = true;
     }
+  }
+
+  public TransportClient getClient() {
+    return client;
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionUtils.java
@@ -17,13 +17,11 @@
 
 package org.apache.celeborn.common.util;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import org.apache.celeborn.common.exception.CelebornIOException;
-import org.apache.celeborn.common.exception.FileCorruptedException;
 import org.apache.celeborn.common.exception.PartitionUnRetryAbleException;
 
 public class ExceptionUtils {
@@ -38,11 +36,8 @@ public class ExceptionUtils {
     }
   }
 
-  public static Throwable wrapIOExceptionToUnRetryable(
-      Throwable throwable, boolean convertAllIOException2UnRetryable) {
-    if (throwable instanceof FileNotFoundException || throwable instanceof FileCorruptedException) {
-      return new PartitionUnRetryAbleException(throwable.getMessage(), throwable);
-    } else if (throwable instanceof IOException && convertAllIOException2UnRetryable) {
+  public static Throwable wrapIOExceptionToUnRetryable(Throwable throwable) {
+    if (throwable instanceof IOException) {
       return new PartitionUnRetryAbleException(throwable.getMessage(), throwable);
     } else {
       return throwable;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
1. Wrap IOException to PartitionUnRetryAbleException when fetch
2. Improve message logging when open stream/read data error


### Why are the changes needed?
When open stream, there would be encounter many different IOExceptions such as NoSuchFileException, FileNotFoundException,FileCorruptedException etc, for these checked exception should wrap to PartitionUnRetryAbleException to let client choose to regenerate the data.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT & Manual test
