### PR TITLE
[CELEBORN-886][HELM] Support multiple celeborn clusters in the same K8s namespace

### DIFF
--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: celeborn-conf
+  name: {{ .Values.celebornClusterPrefix }}-conf
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
@@ -29,9 +29,9 @@ metadata:
 data:
   celeborn-defaults.conf: |-
     {{- $namespace := .Release.Namespace }}
-    celeborn.master.endpoints={{ range until (.Values.masterReplicas |int) }}celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local,{{ end }}
+    celeborn.master.endpoints={{ range until (.Values.masterReplicas |int) }}{{ $.Values.celebornClusterPrefix }}-master-{{ . }}.{{ $.Values.celebornClusterPrefix }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local,{{ end }}
     {{- range until (.Values.masterReplicas |int) }}
-    celeborn.master.ha.node.{{ . }}.host=celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local
+    celeborn.master.ha.node.{{ . }}.host={{ $.Values.celebornClusterPrefix }}-master-{{ . }}.{{ $.Values.celebornClusterPrefix }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local
     {{- end }}
     {{- $dirs := .Values.volumes.master }}
     celeborn.master.ha.ratis.raft.server.storage.dir={{ (index $dirs 0).mountPath }}

--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.celebornClusterPrefix }}-conf
+  name: {{ .Release.Name }}-conf
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
@@ -29,9 +29,9 @@ metadata:
 data:
   celeborn-defaults.conf: |-
     {{- $namespace := .Release.Namespace }}
-    celeborn.master.endpoints={{ range until (.Values.masterReplicas |int) }}{{ $.Values.celebornClusterPrefix }}-master-{{ . }}.{{ $.Values.celebornClusterPrefix }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local,{{ end }}
+    celeborn.master.endpoints={{ range until (.Values.masterReplicas |int) }}{{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local,{{ end }}
     {{- range until (.Values.masterReplicas |int) }}
-    celeborn.master.ha.node.{{ . }}.host={{ $.Values.celebornClusterPrefix }}-master-{{ . }}.{{ $.Values.celebornClusterPrefix }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local
+    celeborn.master.ha.node.{{ . }}.host={{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local
     {{- end }}
     {{- $dirs := .Values.volumes.master }}
     celeborn.master.ha.ratis.raft.server.storage.dir={{ (index $dirs 0).mountPath }}

--- a/charts/celeborn/templates/master-service.yaml
+++ b/charts/celeborn/templates/master-service.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: celeborn-master-svc
+  name: {{ .Values.celebornClusterPrefix }}-master-svc
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}

--- a/charts/celeborn/templates/master-service.yaml
+++ b/charts/celeborn/templates/master-service.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.celebornClusterPrefix }}-master-svc
+  name: {{ .Release.Name }}-master-svc
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -18,7 +18,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.celebornClusterPrefix }}-master
+  name: {{ .Release.Name }}-master
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
@@ -35,7 +35,7 @@ spec:
       app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       app.kubernetes.io/role: master
       {{- include "celeborn.selectorLabels" . | nindent 6 }}
-  serviceName: {{ .Values.celebornClusterPrefix }}-master-svc
+  serviceName: {{ .Release.Name }}-master-svc
   replicas: {{ .Values.masterReplicas }}
   template:
     metadata:
@@ -99,7 +99,7 @@ spec:
           - "/bin/sh"
           - '-c'
           {{- $namespace := .Release.Namespace }}
-          - "until {{ range until (.Values.masterReplicas |int) }}nslookup {{ $.Values.celebornClusterPrefix }}-master-{{ . }}.{{ $.Values.celebornClusterPrefix }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-master.sh"
+          - "until {{ range until (.Values.masterReplicas |int) }}nslookup {{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-master.sh"
         resources:
           {{- toYaml .Values.resources.master | nindent 12 }}
         ports:
@@ -123,7 +123,7 @@ spec:
       terminationGracePeriodSeconds: 30 
       volumes:
         - configMap:
-            name: {{ .Values.celebornClusterPrefix }}-conf
+            name: {{ .Release.Name }}-conf
           name: {{ include "celeborn.fullname" . }}-volume
         {{- range $index, $volume := .Values.volumes.master }}
         - name: celeborn-master-vol-{{ $index }}

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -18,7 +18,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: celeborn-master
+  name: {{ .Values.celebornClusterPrefix }}-master
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
@@ -35,7 +35,7 @@ spec:
       app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       app.kubernetes.io/role: master
       {{- include "celeborn.selectorLabels" . | nindent 6 }}
-  serviceName: celeborn-master-svc
+  serviceName: {{ .Values.celebornClusterPrefix }}-master-svc
   replicas: {{ .Values.masterReplicas }}
   template:
     metadata:
@@ -99,7 +99,7 @@ spec:
           - "/bin/sh"
           - '-c'
           {{- $namespace := .Release.Namespace }}
-          - "until {{ range until (.Values.masterReplicas |int) }}nslookup celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-master.sh"
+          - "until {{ range until (.Values.masterReplicas |int) }}nslookup {{ $.Values.celebornClusterPrefix }}-master-{{ . }}.{{ $.Values.celebornClusterPrefix }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-master.sh"
         resources:
           {{- toYaml .Values.resources.master | nindent 12 }}
         ports:
@@ -123,7 +123,7 @@ spec:
       terminationGracePeriodSeconds: 30 
       volumes:
         - configMap:
-            name: {{ .Values.configmap }}
+            name: {{ .Values.celebornClusterPrefix }}-conf
           name: {{ include "celeborn.fullname" . }}-volume
         {{- range $index, $volume := .Values.volumes.master }}
         - name: celeborn-master-vol-{{ $index }}

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -112,7 +112,7 @@ spec:
             name: {{ include "celeborn.fullname" . }}-volume
             readOnly: true
           {{- range $index, $volume := .Values.volumes.master }}
-          - name: celeborn-master-vol-{{ $index }}
+          - name: {{ $.Release.Name }}-master-vol-{{ $index }}
             mountPath: {{ .mountPath }}
           {{- end }}
         env:
@@ -126,7 +126,7 @@ spec:
             name: {{ .Release.Name }}-conf
           name: {{ include "celeborn.fullname" . }}-volume
         {{- range $index, $volume := .Values.volumes.master }}
-        - name: celeborn-master-vol-{{ $index }}
+        - name: {{ $.Release.Name }}-master-vol-{{ $index }}
         {{- if eq "emptyDir" $volume.type }}
           emptyDir:
             sizeLimit: {{ $volume.size }}

--- a/charts/celeborn/templates/prometheus-podmonitor.yaml
+++ b/charts/celeborn/templates/prometheus-podmonitor.yaml
@@ -20,7 +20,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Values.celebornClusterPrefix }}-master-podmonitor
+  name: {{ .Release.Name }}-master-podmonitor
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
@@ -48,7 +48,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Values.celebornClusterPrefix }}-worker-podmonitor
+  name: {{ .Release.Name }}-worker-podmonitor
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}

--- a/charts/celeborn/templates/prometheus-podmonitor.yaml
+++ b/charts/celeborn/templates/prometheus-podmonitor.yaml
@@ -20,7 +20,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: celeborn-master-podmonitor
+  name: {{ .Values.celebornClusterPrefix }}-master-podmonitor
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
@@ -40,12 +40,15 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       app.kubernetes.io/role: master
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: celeborn-worker-podmonitor
+  name: {{ .Values.celebornClusterPrefix }}-worker-podmonitor
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
@@ -65,6 +68,9 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       app.kubernetes.io/role: worker
 {{ end }}
 {{- end }}

--- a/charts/celeborn/templates/prometheus-podmonitor.yaml
+++ b/charts/celeborn/templates/prometheus-podmonitor.yaml
@@ -42,7 +42,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       app.kubernetes.io/role: master
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -70,7 +69,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       app.kubernetes.io/role: worker
 {{ end }}
 {{- end }}

--- a/charts/celeborn/templates/worker-service.yaml
+++ b/charts/celeborn/templates/worker-service.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: celeborn-worker-svc
+  name: {{ .Values.celebornClusterPrefix }}-worker-svc
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}

--- a/charts/celeborn/templates/worker-service.yaml
+++ b/charts/celeborn/templates/worker-service.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.celebornClusterPrefix }}-worker-svc
+  name: {{ .Release.Name }}-worker-svc
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -18,7 +18,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.celebornClusterPrefix }}-worker
+  name: {{ .Release.Name }}-worker
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
@@ -35,7 +35,7 @@ spec:
       app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       app.kubernetes.io/role: worker
       {{- include "celeborn.selectorLabels" . | nindent 6 }}
-  serviceName: {{ .Values.celebornClusterPrefix }}-worker
+  serviceName: {{ .Release.Name }}-worker
   replicas: {{ .Values.workerReplicas }}
   template:
     metadata:
@@ -103,7 +103,7 @@ spec:
           - "/bin/sh"
           - '-c'
           {{- $namespace := .Release.Namespace }}
-          - "until {{ range until (.Values.masterReplicas |int) }}nslookup {{ $.Values.celebornClusterPrefix }}-master-{{ . }}.{{ $.Values.celebornClusterPrefix }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-worker.sh"
+          - "until {{ range until (.Values.masterReplicas |int) }}nslookup {{ $.Release.Name }}-master-{{ . }}.{{ $.Release.Name }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-worker.sh"
         resources:
           {{- toYaml .Values.resources.worker | nindent 12 }}
         ports:
@@ -128,7 +128,7 @@ spec:
       terminationGracePeriodSeconds: 30
       volumes:
         - configMap:
-            name: {{ .Values.celebornClusterPrefix }}-conf
+            name: {{ .Release.Name }}-conf
           name: {{ include "celeborn.fullname" . }}-volume
         {{- range $index, $volume := .Values.volumes.worker }}
         {{- if eq "emptyDir" $volume.type }}

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
             readOnly: true
           {{- end }}
           {{- range $index, $volume := .Values.volumes.worker }}
-          - name: celeborn-worker-vol-{{ $index }}
+          - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
             mountPath: {{ .mountPath }}
           {{- end }}
         env:
@@ -131,12 +131,11 @@ spec:
             name: {{ .Release.Name }}-conf
           name: {{ include "celeborn.fullname" . }}-volume
         {{- range $index, $volume := .Values.volumes.worker }}
+        - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
         {{- if eq "emptyDir" $volume.type }}
-        - name: celeborn-worker-vol-{{ $index }}
           emptyDir:
             sizeLimit: {{ $volume.size }}
         {{- else if eq "hostPath" $volume.type }}
-        - name: celeborn-worker-vol-{{ $index }}
           hostPath:
             path: {{ $volume.hostPath | default $volume.mountPath }}/worker
             type: DirectoryOrCreate

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -18,7 +18,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: celeborn-worker
+  name: {{ .Values.celebornClusterPrefix }}-worker
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
@@ -35,7 +35,7 @@ spec:
       app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
       app.kubernetes.io/role: worker
       {{- include "celeborn.selectorLabels" . | nindent 6 }}
-  serviceName: celeborn-worker
+  serviceName: {{ .Values.celebornClusterPrefix }}-worker
   replicas: {{ .Values.workerReplicas }}
   template:
     metadata:
@@ -103,7 +103,7 @@ spec:
           - "/bin/sh"
           - '-c'
           {{- $namespace := .Release.Namespace }}
-          - "until {{ range until (.Values.masterReplicas |int) }}nslookup celeborn-master-{{ . }}.celeborn-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-worker.sh"
+          - "until {{ range until (.Values.masterReplicas |int) }}nslookup {{ $.Values.celebornClusterPrefix }}-master-{{ . }}.{{ $.Values.celebornClusterPrefix }}-master-svc.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && {{ end }}true; do echo waiting for master; sleep 2; done && exec /opt/celeborn/sbin/start-worker.sh"
         resources:
           {{- toYaml .Values.resources.worker | nindent 12 }}
         ports:
@@ -128,7 +128,7 @@ spec:
       terminationGracePeriodSeconds: 30
       volumes:
         - configMap:
-            name: {{ .Values.configmap }}
+            name: {{ .Values.celebornClusterPrefix }}-conf
           name: {{ include "celeborn.fullname" . }}-volume
         {{- range $index, $volume := .Values.volumes.worker }}
         {{- if eq "emptyDir" $volume.type }}

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -32,8 +32,6 @@ imagePullSecrets: {}
 masterReplicas: 3
 # worker replicas set on demand, should less than node number
 workerReplicas: 5
-# celeborn resources' name prefix
-celebornClusterPrefix: celeborn
 
 hostNetwork: false
 dnsPolicy: ClusterFirst

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -120,8 +120,6 @@ service:
 cluster:
   name: cluster
 
-configmap: celeborn-conf
-
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -32,6 +32,8 @@ imagePullSecrets: {}
 masterReplicas: 3
 # worker replicas set on demand, should less than node number
 workerReplicas: 5
+# celeborn resources' name prefix
+celebornClusterPrefix: celeborn
 
 hostNetwork: false
 dnsPolicy: ClusterFirst


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use built-in helm var {{ .Release.Name }} to naming kubernetes resources, default with user input `celeborn`

close #1762
```
helm install celeborn charts/celeborn
// release name is celeborn
helm install celeborn-beta charts/celeborn
// release name is celeborn-beta
```

### Why are the changes needed?
Support multiple celeborn clusters in the same k8s namespace


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
GA and IT
