### PR TITLE
[CELEBORN-887] Option --config should take effect in celeborn-daemon.sh script

### DIFF
--- a/sbin/celeborn-daemon.sh
+++ b/sbin/celeborn-daemon.sh
@@ -31,7 +31,7 @@
 usage() {
   echo "Usage: celeborn-daemon.sh [--config <conf-dir>] (start|stop|restart|status) <celeborn-class-name> <celeborn-instance-number> [args]"
   echo ""
-  echo "OPTIONS"
+  echo "Options:"
   echo "  <conf-dir>                  Override CELEBORN_CONF_DIR"
   echo "  <celeborn-class-name>       The main class name of the celeborn command to run"
   echo "                              Example: org.apache.celeborn.service.deploy.master.Master for celeborn master"

--- a/sbin/celeborn-daemon.sh
+++ b/sbin/celeborn-daemon.sh
@@ -30,7 +30,8 @@
 
 usage() {
   echo "Usage: celeborn-daemon.sh [--config <conf-dir>] (start|stop|restart|status) <celeborn-class-name> <celeborn-instance-number> [args]"
-  echo "Definitions:"
+  echo ""
+  echo "OPTIONS"
   echo "  <conf-dir>                  Override CELEBORN_CONF_DIR"
   echo "  <celeborn-class-name>       The main class name of the celeborn command to run"
   echo "                              Example: org.apache.celeborn.service.deploy.master.Master for celeborn master"

--- a/sbin/celeborn-daemon.sh
+++ b/sbin/celeborn-daemon.sh
@@ -32,7 +32,7 @@ usage() {
   echo "Usage: celeborn-daemon.sh [--config <conf-dir>] (start|stop|restart|status) <celeborn-class-name> <celeborn-instance-number> [args]"
   echo "Definitions:"
   echo "  <conf-dir>                  Override CELEBORN_CONF_DIR"
-  echo "  <celeborn-class-name>       The java class name of the celeborn command to run"
+  echo "  <celeborn-class-name>       The class name of the celeborn command to run"
   echo "                              Example: org.apache.celeborn.service.deploy.master.Master for celeborn master"
   echo "                                       org.apache.celeborn.service.deploy.worker.Worker for celeborn worker"
   echo "  <celeborn-instance-number>  The instance number of the celeborn command to run"

--- a/sbin/celeborn-daemon.sh
+++ b/sbin/celeborn-daemon.sh
@@ -32,7 +32,7 @@ usage() {
   echo "Usage: celeborn-daemon.sh [--config <conf-dir>] (start|stop|restart|status) <celeborn-class-name> <celeborn-instance-number> [args]"
   echo "Definitions:"
   echo "  <conf-dir>                  Override CELEBORN_CONF_DIR"
-  echo "  <celeborn-class-name>       The class name of the celeborn command to run"
+  echo "  <celeborn-class-name>       The main class name of the celeborn command to run"
   echo "                              Example: org.apache.celeborn.service.deploy.master.Master for celeborn master"
   echo "                                       org.apache.celeborn.service.deploy.worker.Worker for celeborn worker"
   echo "  <celeborn-instance-number>  The instance number of the celeborn command to run"


### PR DESCRIPTION
### What changes were proposed in this pull request?
I find a little difficult to use `celeborn-daemon.sh` to get instance status, so I polish the usage and fix --config load.


### Why are the changes needed?
Ditto


### Does this PR introduce _any_ user-facing change?
Polish the `celeborn-daemon.sh` usage 


### How was this patch tested?
Manually test.
