### PR TITLE
[CELEBORN-888][WORKER]Tweak the logic and add unit tests for the MemoryManager#currentServingState method

### DIFF
--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -375,8 +375,8 @@ object CelebornMaster {
 
 object CelebornWorker {
   lazy val worker = Project("celeborn-worker", file("worker"))
-    .dependsOn(CelebornCommon.common % "test->test;compile->compile")
     .dependsOn(CelebornService.service)
+    .dependsOn(CelebornCommon.common % "test->test;compile->compile")
     .dependsOn(CelebornClient.client % "test->test;compile->compile")
     .dependsOn(CelebornMaster.master % "test->test;compile->compile")
     .settings (

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -375,7 +375,8 @@ object CelebornMaster {
 
 object CelebornWorker {
   lazy val worker = Project("celeborn-worker", file("worker"))
-    .dependsOn(CelebornCommon.common, CelebornService.service)
+    .dependsOn(CelebornCommon.common % "test->test;compile->compile")
+    .dependsOn(CelebornService.service)
     .dependsOn(CelebornClient.client % "test->test;compile->compile")
     .dependsOn(CelebornMaster.master % "test->test;compile->compile")
     .settings (

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -79,6 +79,13 @@
 
     <dependency>
       <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
       <artifactId>celeborn-client_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -256,10 +256,6 @@ public class MemoryManager {
         Utils.bytesToString(memoryShuffleStorageThreshold));
   }
 
-  /**
-   * Get current worker serving state. isPaused should be set true when trigger pause, and set false
-   * when trigger resume.
-   */
   public ServingState currentServingState() {
     long memoryUsage = getMemoryUsage();
     // trigger pause both push and replicate

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -257,8 +257,8 @@ public class MemoryManager {
   }
 
   /**
-   * Get current worker serving state.
-   * isPaused should be set true when trigger pause, and set false when trigger resume.
+   * Get current worker serving state. isPaused should be set true when trigger pause, and set false
+   * when trigger resume.
    */
   public ServingState currentServingState() {
     long memoryUsage = getMemoryUsage();

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
@@ -71,7 +71,7 @@ class MemoryManagerSuite extends CelebornFunSuite {
       memoryCounter.set(resumeThreshold + 2);
       assert(MemoryManager.ServingState.PUSH_PAUSED == memoryManager.currentServingState());
       // touch resume data threshold
-      memoryCounter.set(resumeThreshold - 1);
+      memoryCounter.set(0);
       assert(MemoryManager.ServingState.NONE_PAUSED == memoryManager.currentServingState());
     } catch {
       case e: Exception => throw e


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Tweak the logic of `MemoryManager#currentServingState`

Add Unit Test for this function

```mermaid
graph TB

A(Check Used Memory) --> B{Reach Pause Replicate Threshold}
B --> | N | C{Reach Pause Push Threshold}
B --> | Y | Z(Trigger Pause Push and Replicate)
C --> | N | D{Reach Resume Threshold}
C --> | Y | Y(Trigger Pause Push but Resume Replicate)
D --> | N | E{In Pause Mode}
D --> | Y | X(Trigger Resume Push and Replicate)
E --> | N | U(Do Nothing)
E --> | Y | Y
```
### Why are the changes needed?
Make this method logical, and add unit test to ensure logic won't be accidental modification



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add Unit Test 
