### PR TITLE
[CELEBORN-830] Check available workers in CelebornShuffleFallbackPolicyRunner

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1090,6 +1090,19 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     }
   }
 
+  def checkWorkersAvailable(): PbCheckWorkersAvailableResponse = {
+    try {
+      masterClient.askSync[PbCheckWorkersAvailableResponse](
+        CheckWorkersAvailable(),
+        classOf[PbCheckWorkersAvailableResponse])
+    } catch {
+      case e: Exception =>
+        val msg = s"AskSync Cluster check workers available for $userIdentifier failed."
+        logError(msg, e)
+        CheckWorkersAvailableResponse(false)
+    }
+  }
+
   // Once a partition is released, it will be never needed anymore
   def releasePartition(shuffleId: Int, partitionId: Int): Unit = {
     commitManager.releasePartitionResource(shuffleId, partitionId)

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -73,6 +73,8 @@ enum MessageType {
   CHECK_FOR_HDFS_EXPIRED_DIRS_TIMEOUT = 50;
   OPEN_STREAM = 51;
   STREAM_HANDLER = 52;
+  CHECK_WORKERS_AVAILABLE = 53;
+  CHECK_WORKERS_AVAILABLE_RESPONSE = 54;
 }
 
 message PbStorageInfo {
@@ -317,6 +319,13 @@ message PbCheckQuota {
 message PbCheckQuotaResponse {
   bool available = 1;
   string reason = 2;
+}
+
+message PbCheckWorkersAvailable {
+}
+
+message PbCheckWorkersAvailableResponse {
+  bool available = 1;
 }
 
 message PbReportWorkerUnavailable {

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -347,6 +347,19 @@ object ControlMessages extends Logging {
       unavailable: util.List[WorkerInfo],
       override var requestId: String = ZERO_UUID) extends MasterRequestMessage
 
+  object CheckWorkersAvailable {
+    def apply(): PbCheckWorkersAvailable = {
+      PbCheckWorkersAvailable.newBuilder().build()
+    }
+  }
+
+  object CheckWorkersAvailableResponse {
+    def apply(isAvailable: Boolean): PbCheckWorkersAvailableResponse =
+      PbCheckWorkersAvailableResponse.newBuilder()
+        .setAvailable(isAvailable)
+        .build()
+  }
+
   /**
    * ==========================================
    *         handled by worker
@@ -765,6 +778,12 @@ object ControlMessages extends Logging {
 
     case OneWayMessageResponse =>
       new TransportMessage(MessageType.ONE_WAY_MESSAGE_RESPONSE, null)
+
+    case pb: PbCheckWorkersAvailable =>
+      new TransportMessage(MessageType.CHECK_WORKERS_AVAILABLE, pb.toByteArray)
+
+    case pb: PbCheckWorkersAvailableResponse =>
+      new TransportMessage(MessageType.CHECK_WORKERS_AVAILABLE_RESPONSE, pb.toByteArray)
   }
 
   // TODO change return type to GeneratedMessageV3
@@ -1070,6 +1089,12 @@ object ControlMessages extends Logging {
       case STAGE_END_RESPONSE_VALUE =>
         val pbStageEndResponse = PbStageEndResponse.parseFrom(message.getPayload)
         StageEndResponse(Utils.toStatusCode(pbStageEndResponse.getStatus))
+
+      case CHECK_WORKERS_AVAILABLE_VALUE =>
+        PbCheckWorkersAvailable.parseFrom(message.getPayload)
+
+      case CHECK_WORKERS_AVAILABLE_RESPONSE_VALUE =>
+        PbCheckWorkersAvailableResponse.parseFrom(message.getPayload)
     }
   }
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -373,6 +373,9 @@ private[celeborn] class Master(
 
     case CheckQuota(userIdentifier) =>
       executeWithLeaderChecker(context, handleCheckQuota(userIdentifier, context))
+
+    case _: PbCheckWorkersAvailable =>
+      executeWithLeaderChecker(context, handleCheckWorkersAvailable(context))
   }
 
   private def timeoutDeadWorkers() {
@@ -766,6 +769,10 @@ private[celeborn] class Master(
     val (isAvailable, reason) =
       quota.checkQuotaSpaceAvailable(userIdentifier, userResourceConsumption)
     context.reply(CheckQuotaResponse(isAvailable, reason))
+  }
+
+  private def handleCheckWorkersAvailable(context: RpcCallContext): Unit = {
+    context.reply(CheckWorkersAvailableResponse(!workersAvailable().isEmpty))
   }
 
   private def workersAvailable(


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CelebornShuffleFallbackPolicyRunner` could not only check quota, but also check whether cluster has available workers. If there is no available workers, fallback to external shuffle.

### Why are the changes needed?

`CelebornShuffleFallbackPolicyRunner` adds a check for available workers.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `SparkShuffleManagerSuite#testClusterNotAvailableWithAvailableWorkers`