### PR TITLE
[CELEBORN-898][INFRA] Fix java.lang.NoClassDefFoundError: org/hamcrest/SelfDescribing for SBT CI

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -45,7 +45,6 @@ jobs:
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
-        cache: maven
         check-latest: false
     - name: Test Service with SBT
       run: |
@@ -74,7 +73,6 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
-          cache: maven
           check-latest: false
       - name: Test with SBT
         run: |
@@ -117,7 +115,6 @@ jobs:
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
-        cache: maven
         check-latest: false
     - name: Test with SBT
       run: |
@@ -149,7 +146,6 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
-          cache: maven
           check-latest: false
       - name: Test with SBT
         run: |

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -40,6 +40,23 @@ jobs:
           - 17
     steps:
     - uses: actions/checkout@v2
+    # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
+    - name: Cache SBT
+      uses: actions/cache@v3
+      with:
+        path: |
+          build/*.jar
+          ~/.sbt
+        key: build-${{ hashFiles('project/build.properties', 'build/sbt-launch-lib.bash') }}
+        restore-keys: |
+          build-
+    - name: Cache Coursier local repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/coursier
+        key: ${{ matrix.java }}-coursier-${{ hashFiles('project/**', '**/plugins.sbt') }}
+        restore-keys: |
+          ${{ matrix.java }}-coursier-
     - name: Setup JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
@@ -68,6 +85,23 @@ jobs:
           - '2.4'
     steps:
       - uses: actions/checkout@v2
+      # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
+      - name: Cache SBT
+        uses: actions/cache@v3
+        with:
+          path: |
+            build/*.jar
+            ~/.sbt
+          key: build-${{ hashFiles('project/build.properties', 'build/sbt-launch-lib.bash') }}
+          restore-keys: |
+            build-
+      - name: Cache Coursier local repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/coursier
+          key: ${{ matrix.java }}-coursier-${{ hashFiles('project/**', '**/plugins.sbt') }}
+          restore-keys: |
+            ${{ matrix.java }}-coursier-
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
@@ -110,6 +144,23 @@ jobs:
             spark: '3.2'
     steps:
     - uses: actions/checkout@v2
+    # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
+    - name: Cache SBT
+      uses: actions/cache@v3
+      with:
+        path: |
+          build/*.jar
+          ~/.sbt
+        key: build-${{ hashFiles('project/build.properties', 'build/sbt-launch-lib.bash') }}
+        restore-keys: |
+          build-
+    - name: Cache Coursier local repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/coursier
+        key: ${{ matrix.java }}-coursier-${{ hashFiles('project/**', '**/plugins.sbt') }}
+        restore-keys: |
+          ${{ matrix.java }}-coursier-
     - name: Setup JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
@@ -141,6 +192,23 @@ jobs:
           - '1.17'
     steps:
       - uses: actions/checkout@v2
+      # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
+      - name: Cache SBT
+        uses: actions/cache@v3
+        with:
+          path: |
+            build/*.jar
+            ~/.sbt
+          key: build-${{ hashFiles('project/build.properties', 'build/sbt-launch-lib.bash') }}
+          restore-keys: |
+            build-
+      - name: Cache Coursier local repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/coursier
+          key: ${{ matrix.java }}-coursier-${{ hashFiles('project/**', '**/plugins.sbt') }}
+          restore-keys: |
+            ${{ matrix.java }}-coursier-
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -40,23 +40,6 @@ jobs:
           - 17
     steps:
     - uses: actions/checkout@v2
-    # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
-    - name: Cache SBT
-      uses: actions/cache@v3
-      with:
-        path: |
-          build/*.jar
-          ~/.sbt
-        key: build-${{ hashFiles('project/build.properties', 'build/sbt-launch-lib.bash') }}
-        restore-keys: |
-          build-
-    - name: Cache Coursier local repository
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/coursier
-        key: ${{ matrix.java }}-coursier-${{ hashFiles('project/**', '**/plugins.sbt') }}
-        restore-keys: |
-          ${{ matrix.java }}-coursier-
     - name: Setup JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
@@ -85,23 +68,6 @@ jobs:
           - '2.4'
     steps:
       - uses: actions/checkout@v2
-      # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
-      - name: Cache SBT
-        uses: actions/cache@v3
-        with:
-          path: |
-            build/*.jar
-            ~/.sbt
-          key: build-${{ hashFiles('project/build.properties', 'build/sbt-launch-lib.bash') }}
-          restore-keys: |
-            build-
-      - name: Cache Coursier local repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/coursier
-          key: ${{ matrix.java }}-coursier-${{ hashFiles('project/**', '**/plugins.sbt') }}
-          restore-keys: |
-            ${{ matrix.java }}-coursier-
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
@@ -144,23 +110,6 @@ jobs:
             spark: '3.2'
     steps:
     - uses: actions/checkout@v2
-    # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
-    - name: Cache SBT
-      uses: actions/cache@v3
-      with:
-        path: |
-          build/*.jar
-          ~/.sbt
-        key: build-${{ hashFiles('project/build.properties', 'build/sbt-launch-lib.bash') }}
-        restore-keys: |
-          build-
-    - name: Cache Coursier local repository
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/coursier
-        key: ${{ matrix.java }}-coursier-${{ hashFiles('project/**', '**/plugins.sbt') }}
-        restore-keys: |
-          ${{ matrix.java }}-coursier-
     - name: Setup JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
@@ -192,23 +141,6 @@ jobs:
           - '1.17'
     steps:
       - uses: actions/checkout@v2
-      # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
-      - name: Cache SBT
-        uses: actions/cache@v3
-        with:
-          path: |
-            build/*.jar
-            ~/.sbt
-          key: build-${{ hashFiles('project/build.properties', 'build/sbt-launch-lib.bash') }}
-          restore-keys: |
-            build-
-      - name: Cache Coursier local repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/coursier
-          key: ${{ matrix.java }}-coursier-${{ hashFiles('project/**', '**/plugins.sbt') }}
-          restore-keys: |
-            ${{ matrix.java }}-coursier-
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?

Recently, I came across an issue in the SBT CI process that can result in failure due to the `NoClassDefFoundError` exception.

```
[error] Uncaught exception when running org.apache.celeborn.common.unsafe.PlatformUtilSuite: java.lang.NoClassDefFoundError: org/hamcrest/SelfDescribing
[error] sbt.ForkMain$ForkError: java.lang.NoClassDefFoundError: org/hamcrest/SelfDescribing
[error]    at java.lang.ClassLoader.defineClass1(Native Method)
[error]    at java.lang.ClassLoader.defineClass(ClassLoader.java:757)
[error]    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
[error]    at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
[error]    at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
[error]    at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
[error]    at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
[error]    at java.security.AccessController.doPrivileged(Native Method)
[error]    at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
[error]    at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
[error]    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
[error]    at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
[error]    at org.junit.runner.Computer.getSuite(Computer.java:28)
[error]    at org.junit.runner.Request.classes(Request.java:77)
[error]    at org.junit.runner.Request.classes(Request.java:92)
[error]    at com.novocode.junit.JUnitTask.execute(JUnitTask.java:52)
[error]    at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[error]    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error]    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error]    at java.lang.Thread.run(Thread.java:750)
[error] Caused by: sbt.ForkMain$ForkError: java.lang.ClassNotFoundException: org.hamcrest.SelfDescribing
[error]    at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
[error]    at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
[error]    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
[error]    at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
[error]    at java.lang.ClassLoader.defineClass1(Native Method)
[error]    at java.lang.ClassLoader.defineClass(ClassLoader.java:757)
[error]    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
[error]    at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
[error]    at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
[error]    at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
[error]    at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
[error]    at java.security.AccessController.doPrivileged(Native Method)
[error]    at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
```

Upon further investigation, I found that the root cause is SBT's sometimes inability to resolve Maven dependencies cached within GA.


```shell
./build/sbt "show celeborn-common/update"
```

```
[info] 		org.hamcrest:hamcrest-core:1.3:default: (MISSING) Artifact(hamcrest-core, jar, jar, None, Vector(), Some(file:/home/runner/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar), Map(), None, false)
```


This PR addresses the random issue by disabling the Maven cache for SBT CI.


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass GA

https://github.com/apache/incubator-celeborn/pull/1797 pass GA after disabled maven cache.