### PR TITLE
[CELEBORN-819][FOLLOWUP] Fix worker graceful shutdown exitKind set

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -84,7 +84,7 @@ private[celeborn] class Worker(
       conf.workerPushPort > 0 && conf.workerReplicatePort > 0),
     "If enable graceful shutdown, the worker should use stable server port.")
   if (gracefulShutdown) {
-    exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN
+    exitKind = CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN
     try {
       val recoverRoot = new File(conf.workerGracefulShutdownRecoverPath)
       if (!recoverRoot.exists()) {
@@ -678,10 +678,13 @@ private[celeborn] class Worker(
         logInfo("Shutdown hook called.")
         exitKind match {
           case CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN =>
+            logInfo("Worker start to shutdown gracefully")
             shutdownGracefully()
           case CelebornExitKind.WORKER_DECOMMISSION =>
+            logInfo("Worker start to decommission")
             decommissionWorker()
           case _ =>
+            logInfo("Worker start to exit immediately")
             exitImmediately()
         }
         stop(exitKind)


### PR DESCRIPTION
### What changes were proposed in this pull request?
When worker enabled graceful shutdown, `exitKind` is not set correctly


### Why are the changes needed?
Ditto


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually test
