### PR TITLE
[CELEBORN-902][HELM]Associate Celeborn.storage.dir[capacity] with volumes[capacity] in Helm values.yml

### DIFF
--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
     celeborn.master.ha.ratis.raft.server.storage.dir={{ (index $dirs 0).mountPath }}
     {{- $path := "" }}
     {{- range $worker := .Values.volumes.worker }}
-    {{- $info := (cat $worker.mountPath ":disktype=" (get $worker "diskType" | default "HDD") | nospace) }}
+    {{- $info := (cat $worker.mountPath ":disktype=" (get $worker "diskType" | default "HDD") ":capacity=" (get $worker "capacity" | default "1PB") | nospace) }}
     {{- if eq $path "" }}
     {{- $path = $info }}
     {{- else }}

--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -129,7 +129,7 @@ spec:
         - name: {{ $.Release.Name }}-master-vol-{{ $index }}
         {{- if eq "emptyDir" $volume.type }}
           emptyDir:
-            sizeLimit: {{ $volume.size }}
+            sizeLimit: {{ $volume.capacity }}
         {{- else if eq "hostPath" $volume.type }}
           hostPath:
             path: {{ $volume.hostPath | default $volume.mountPath }}/master

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -134,7 +134,7 @@ spec:
         - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
         {{- if eq "emptyDir" $volume.type }}
           emptyDir:
-            sizeLimit: {{ $volume.size }}
+            sizeLimit: {{ $volume.capacity }}
         {{- else if eq "hostPath" $volume.type }}
           hostPath:
             path: {{ $volume.hostPath | default $volume.mountPath }}/worker

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -53,28 +53,28 @@ volumes:
     - mountPath: /mnt/celeborn_ratis
       hostPath: /mnt/celeborn_ratis
       type: hostPath
-      capacity: 1Gi
+      capacity: 100Gi
   worker:
     - mountPath: /mnt/disk1
       hostPath: /mnt/disk1
       type: hostPath
-      diskType: HDD
-      capacity: 1Gi
+      diskType: SSD
+      capacity: 100Gi
     - mountPath: /mnt/disk2
       hostPath: /mnt/disk2
       type: hostPath
-      diskType: HDD
-      capacity: 1Gi
+      diskType: SSD
+      capacity: 100Gi
     - mountPath: /mnt/disk3
       hostPath: /mnt/disk3
       type: hostPath
-      diskType: HDD
-      capacity: 1Gi
+      diskType: SSD
+      capacity: 100Gi
     - mountPath: /mnt/disk4
       hostPath: /mnt/disk4
       type: hostPath
-      diskType: HDD
-      capacity: 1Gi
+      diskType: SSD
+      capacity: 100Gi
 
 # celeborn configurations
 celeborn:

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -44,7 +44,7 @@ securityContext:
 # Current Celeborn support followings volume type:
 # - emptyDir
 # - hostPath
-# Note: size only works in emptyDir type
+# Note:
 # hostPath only works in hostPath type using to set `volumes hostPath path`
 # Celeborn Master will pick first volumes for store raft log
 # diskType only works in Celeborn Worker with hostPath type to manifest local disk type
@@ -53,28 +53,28 @@ volumes:
     - mountPath: /mnt/celeborn_ratis
       hostPath: /mnt/celeborn_ratis
       type: hostPath
-      size: 1Gi
+      capacity: 1Gi
   worker:
     - mountPath: /mnt/disk1
       hostPath: /mnt/disk1
       type: hostPath
       diskType: HDD
-      size: 1Gi
+      capacity: 1Gi
     - mountPath: /mnt/disk2
       hostPath: /mnt/disk2
       type: hostPath
       diskType: HDD
-      size: 1Gi
+      capacity: 1Gi
     - mountPath: /mnt/disk3
       hostPath: /mnt/disk3
       type: hostPath
       diskType: HDD
-      size: 1Gi
+      capacity: 1Gi
     - mountPath: /mnt/disk4
       hostPath: /mnt/disk4
       type: hostPath
       diskType: HDD
-      size: 1Gi
+      capacity: 1Gi
 
 # celeborn configurations
 celeborn:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Build `celeborn.worker.storage.dirs` with volumes capacity in values.yml.


### Why are the changes needed?
Associate the volumes size in the` values.yml` file with the capacity attribute in the `celeborn.worker.storage.dirs` to avoid user doubt.


### Does this PR introduce _any_ user-facing change?
No, but users will find  volumes capacity can affect `celeborn.worker.storage.dirs`.


### How was this patch tested?
Helm install in local dry-run

Default helm will build following config:
```yaml 

celeborn.worker.storage.dirs=/mnt/disk1:disktype=HDD:capacity=1Gi,/mnt/disk2:disktype=HDD:capacity=1Gi,/mnt/disk3:disktype=HDD:capacity=1Gi,/mnt/disk4:disktype=HDD:capacity=1Gi
```
