### PR TITLE
[CELEBORN-907][INFRA] The Jira Python misses our assignee when it searches users again

### DIFF
--- a/dev/merge_pr.py
+++ b/dev/merge_pr.py
@@ -385,13 +385,26 @@ def choose_jira_assignee(issue, asf_jira):
                 except BaseException:
                     # assume it's a user id, and try to assign (might fail, we just prompt again)
                     assignee = asf_jira.user(raw_assignee)
-                asf_jira.assign_issue(issue.key, assignee.name)
+                assign_issue(asf_jira, issue.key, assignee.name)
                 return assignee
         except KeyboardInterrupt:
             raise
         except BaseException:
             traceback.print_exc()
             print("Error assigning JIRA, try again (or leave blank and fix manually)")
+
+def assign_issue(client, issue: int, assignee: str) -> bool:
+    """
+    Assign an issue to a user, which is a shorthand for jira.client.JIRA.assign_issue.
+    The original one has an issue that it will search users again and only choose the assignee
+    from 20 candidates. If it's unmatched, it picks the head blindly. In our case, the assignee
+    is already resolved.
+    """
+    url = getattr(client, "_get_latest_url")(f"issue/{issue}/assignee")
+    payload = {"name": assignee}
+    getattr(client, "_session").put(url, data=json.dumps(payload))
+    return True
+
 
 
 def resolve_jira_issues(title, merge_branches, comment):


### PR DESCRIPTION
…

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

detailed desc can be found https://github.com/apache/spark/commit/8fb799d47bbd5d5ce9db35283d08ab1a31dc37b9

### Why are the changes needed?

bypass upstream bug

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

I guess @pan3793 has already hit the issue when resolving CELEBORN-903 at jira side