### PR TITLE
[CELEBORN-908][WORKER] Tweak pause and resume logic & add unit test MemoryManager memory check thread

### DIFF
--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
@@ -87,7 +87,7 @@ class MemoryManagerSuite extends CelebornFunSuite {
     }
   }
 
-  test("[CELEBORN-882]") {
+  test("[CELEBORN-882] Test MemoryManager check memory thread logic") {
     val conf = new CelebornConf()
     val memoryManager = MemoryManager.initialize(conf)
     val maxDirectorMemory = memoryManager.maxDirectorMemory

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
@@ -17,10 +17,17 @@
 
 package org.apache.celeborn.service.deploy.memory
 
+import scala.concurrent.duration.DurationInt
+
+import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.concurrent.Futures.{interval, timeout}
+
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.CelebornConf.{WORKER_DIRECT_MEMORY_RATIO_PAUSE_RECEIVE, WORKER_DIRECT_MEMORY_RATIO_PAUSE_REPLICATE}
+import org.apache.celeborn.common.protocol.TransportModuleConstants
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
+import org.apache.celeborn.service.deploy.worker.memory.MemoryManager.MemoryPressureListener
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager.ServingState
 class MemoryManagerSuite extends CelebornFunSuite {
 
@@ -77,6 +84,86 @@ class MemoryManagerSuite extends CelebornFunSuite {
       case e: Exception => throw e
     } finally {
       MemoryManager.reset()
+    }
+  }
+
+  test("[CELEBORN-882]") {
+    val conf = new CelebornConf()
+    val memoryManager = MemoryManager.initialize(conf)
+    val maxDirectorMemory = memoryManager.maxDirectorMemory
+    val pushThreshold =
+      (conf.workerDirectMemoryRatioToPauseReceive * maxDirectorMemory).longValue()
+    val replicateThreshold =
+      (conf.workerDirectMemoryRatioToPauseReplicate * maxDirectorMemory).longValue()
+    val memoryCounter = memoryManager.getSortMemoryCounter
+
+    val pushListener = new MockMemoryPressureListener(TransportModuleConstants.PUSH_MODULE)
+    val replicateListener =
+      new MockMemoryPressureListener(TransportModuleConstants.REPLICATE_MODULE)
+    memoryManager.registerMemoryListener(pushListener)
+    memoryManager.registerMemoryListener(replicateListener)
+
+    // Non PAUSED -> PAUSE PUSH
+    memoryCounter.set(pushThreshold + 1)
+    // default check interval is 10ms and we need wait 30ms to make sure the listener is triggered
+    eventually(timeout(30.second), interval(10.milliseconds)) {
+      assert(pushListener.isPause)
+      assert(!replicateListener.isPause)
+    }
+
+    // PAUSE PUSH -> PAUSE PUSH AND REPLICATE
+    memoryCounter.set(replicateThreshold + 1);
+    eventually(timeout(30.second), interval(10.milliseconds)) {
+      assert(pushListener.isPause)
+      assert(replicateListener.isPause)
+    }
+
+    // PAUSE PUSH AND REPLICATE -> PAUSE PUSH
+    memoryCounter.set(pushThreshold + 1);
+    eventually(timeout(30.second), interval(10.milliseconds)) {
+      assert(pushListener.isPause)
+      assert(!replicateListener.isPause)
+    }
+
+    // PAUSE PUSH -> NONE PAUSED
+    memoryCounter.set(0);
+    eventually(timeout(30.second), interval(10.milliseconds)) {
+      assert(!pushListener.isPause)
+      assert(!replicateListener.isPause)
+    }
+
+    // NONE PAUSED -> PAUSE PUSH AND REPLICATE
+    memoryCounter.set(replicateThreshold + 1);
+    eventually(timeout(30.second), interval(10.milliseconds)) {
+      assert(pushListener.isPause)
+      assert(replicateListener.isPause)
+    }
+
+    // PAUSE PUSH AND REPLICATE -> NONE PAUSED
+    memoryCounter.set(0);
+    eventually(timeout(30.second), interval(10.milliseconds)) {
+      assert(!pushListener.isPause)
+      assert(!replicateListener.isPause)
+    }
+  }
+
+  class MockMemoryPressureListener(
+      val belongModuleName: String,
+      var isPause: Boolean = false) extends MemoryPressureListener {
+    override def onPause(moduleName: String): Unit = {
+      if (belongModuleName == moduleName) {
+        isPause = true
+      }
+    }
+
+    override def onResume(moduleName: String): Unit = {
+      if (belongModuleName == moduleName) {
+        isPause = false
+      }
+    }
+
+    override def onTrim(): Unit = {
+      // do nothing
     }
   }
 }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/memory/MemoryManagerSuite.scala
@@ -103,7 +103,7 @@ class MemoryManagerSuite extends CelebornFunSuite {
     memoryManager.registerMemoryListener(pushListener)
     memoryManager.registerMemoryListener(replicateListener)
 
-    // Non PAUSED -> PAUSE PUSH
+    // NONE PAUSED -> PAUSE PUSH
     memoryCounter.set(pushThreshold + 1)
     // default check interval is 10ms and we need wait 30ms to make sure the listener is triggered
     eventually(timeout(30.second), interval(10.milliseconds)) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
- Tweak pause and resume logic
- Add unit test

```mermaid
graph TB
A(NON_PAUSE)
B(PAUSE_PUSH)
C(PAUSE_PUSH_AND_REPLICATE)
A --> | pause push listener | B
B --> | resume push listener | A
A --> | pause push and replicate listeners | C
C --> | resume push and replicate listeners | A
B --> | pause replicate listener | C
C --> | resume replicate listener | B
```


### Why are the changes needed?
Add unit test for those pause and resume logic.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add unit test.
