### PR TITLE
[CELEBORN-909][DOC] Mention `celeborn.worker.directMemoryRatioToResume` default value changed in main/0.4

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -21,16 +21,18 @@ license: |
 
 # Migration Guide
 
-## Upgrading from 0.3 to 0.4
+## Upgrading from 0.3.1 to 0.4
 
 - Since 0.4.0, Celeborn won't be compatible with Celeborn client that versions below 0.3.0.
   Note that: It's strongly recommended to use the same version of Client and Celeborn Master/Worker in production.
 
 - Since 0.4.0, Celeborn won't support `org.apache.spark.shuffle.celeborn.RssShuffleManager`.
 
-- Since 0.4.0, Celeborn changed the default value of `celeborn.worker.directMemoryRatioToResume` from `0.5` to `0.7`.
+## Upgrading from 0.3.0 to 0.3.1
 
-## Upgrading from 0.2 to 0.3
+- Since 0.3.1, Celeborn changed the default value of `celeborn.worker.directMemoryRatioToResume` from `0.5` to `0.7`.
+
+## Upgrading from 0.2 to 0.3.0
 
  - Celeborn 0.2 Client is compatible with 0.3 Master/Server, it allows to upgrade Master/Worker first then Client.
    Note that: It's strongly recommended to use the same version of Client and Celeborn Master/Worker in production.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -28,6 +28,8 @@ license: |
 
 - Since 0.4.0, Celeborn won't support `org.apache.spark.shuffle.celeborn.RssShuffleManager`.
 
+- Since 0.4.0, Celeborn changed the default value of `celeborn.worker.directMemoryRatioToResume` from `0.5` to `0.7`.
+
 ## Upgrading from 0.2 to 0.3
 
  - Celeborn 0.2 Client is compatible with 0.3 Master/Server, it allows to upgrade Master/Worker first then Client.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title


### Why are the changes needed?
After #1829 we set `celeborn.worker.directMemoryRatioToResume` default value from `0.5` to `0.7`.


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
No
