### PR TITLE
[CELEBORN-918][INFRA] Auto Assign First-time contributor with Contributors role

### DIFF
--- a/dev/merge_pr.py
+++ b/dev/merge_pr.py
@@ -393,13 +393,33 @@ def choose_jira_assignee(issue, asf_jira):
                 except BaseException:
                     # assume it's a user id, and try to assign (might fail, we just prompt again)
                     assignee = asf_jira.user(raw_assignee)
-                assign_issue(asf_jira, issue.key, assignee.name)
+                try:
+                    assign_issue(asf_jira, issue.key, assignee.name)
+                except Exception as e:
+                    if (
+                        e.__class__.__name__ == "JIRAError"
+                        and ("'%s' cannot be assigned" % assignee.name)
+                        in getattr(e, "response").text
+                    ):
+                        continue_maybe(
+                            "User '%s' cannot be assigned, add to contributors role and try again?"
+                            % assignee.name
+                        )
+                        grant_contributor_role(assignee.name, asf_jira)
+                        assign_issue(asf_jira, issue.key, assignee.name)
+                    else:
+                        raise e
                 return assignee
         except KeyboardInterrupt:
             raise
         except BaseException:
             traceback.print_exc()
             print("Error assigning JIRA, try again (or leave blank and fix manually)")
+
+def grant_contributor_role(user: str, asf_jira):
+    role = asf_jira.project_role("CELEBORN", 10010)
+    role.add_user(user)
+    print("Successfully added user '%s' to contributors role" % user)
 
 def assign_issue(client, issue: int, assignee: str) -> bool:
     """


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As an incubating project, first-time contributors‘ welcome is routine. This PR adds automation for granting Contributors role to them to make them a assignable for issues

### Why are the changes needed?

GitHub - JIRA integration 

### Does this PR introduce _any_ user-facing change?

no


### How was this patch tested?

tested at apache/spark project, and

```python
>>> asf_jira.project_roles("CELEBORN")
{'Developers': {'id': '10050', 'url': 'https://issues.apache.org/jira/rest/api/2/project/12324920/role/10050'}, 'Contributors': {'id': '10010', 'url': 'https://issues.apache.org/jira/rest/api/2/project/12324920/role/10010'}, 'PMC': {'id': '10011', 'url': 'https://issues.apache.org/jira/rest/api/2/project/12324920/role/10011'}, 'Committers': {'id': '10001', 'url': 'https://issues.apache.org/jira/rest/api/2/project/12324920/role/10001'}, 'Administrators': {'id': '10002', 'url': 'https://issues.apache.org/jira/rest/api/2/project/12324920/role/10002'}, 'ASF Members': {'id': '10150', 'url': 'https://issues.apache.org/jira/rest/api/2/project/12324920/role/10150'}, 'Users': {'id': '10040', 'url': 'https://issues.apache.org/jira/rest/api/2/project/12324920/role/10040'}, 'Contributors 1': {'id': '10350', 'url': 'https://issues.apache.org/jira/rest/api/2/project/12324920/role/10350'}}

```
