### PR TITLE
[CELEBORN-922] Improve celeborn shuffle maanger fallback log message

### DIFF
--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -129,7 +129,13 @@ public class SparkShuffleManager implements ShuffleManager {
 
     if (fallbackPolicyRunner.applyAllFallbackPolicy(
         lifecycleManager, dependency.partitioner().numPartitions())) {
-      logger.warn("Fallback to SortShuffleManager!");
+      if (conf.getBoolean("spark.dynamicAllocation.enabled", false)) {
+        logger.error("DRA is enabled but we fallback to vanilla Spark SortShuffleManager for " +
+            "shuffle: {} due to fallback policy. It may cause block can not found when reducer " +
+                "task fetch data.", shuffleId);
+      } else {
+        logger.warn("Fallback to vanilla Spark SortShuffleManager for shuffle: {}", shuffleId);
+      }
       sortShuffleIds.add(shuffleId);
       return sortShuffleManager().registerShuffle(shuffleId, dependency);
     } else {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -130,9 +130,11 @@ public class SparkShuffleManager implements ShuffleManager {
     if (fallbackPolicyRunner.applyAllFallbackPolicy(
         lifecycleManager, dependency.partitioner().numPartitions())) {
       if (conf.getBoolean("spark.dynamicAllocation.enabled", false)) {
-        logger.error("DRA is enabled but we fallback to vanilla Spark SortShuffleManager for " +
-            "shuffle: {} due to fallback policy. It may cause block can not found when reducer " +
-                "task fetch data.", shuffleId);
+        logger.error(
+            "DRA is enabled but we fallback to vanilla Spark SortShuffleManager for "
+                + "shuffle: {} due to fallback policy. It may cause block can not found when reducer "
+                + "task fetch data.",
+            shuffleId);
       } else {
         logger.warn("Fallback to vanilla Spark SortShuffleManager for shuffle: {}", shuffleId);
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

When celeborn shuffle maanger fallback to vanilla Spark shuffle manager, we should make sure the DRA is disabled, otherwise the reduer task may fail when fetching block.

This pr improves the log to use error level to print fallback message if DRA is enabled.

### Why are the changes needed?

Improve the log message.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

PASS CI