### PR TITLE
[CELEBORN-906][FOLLOWUP] Removal of redundant dependency `log4j-slf4j2-impl` from SBT profile `spark-3.4`

### DIFF
--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -492,30 +492,6 @@ object Spark34 extends SparkClientProjects {
 
   val sparkVersion = "3.4.1"
   val zstdJniVersion = "1.5.2-5"
-
-  lazy val deps = Seq(
-    // Spark Use `log4j-slf4j2-impl` instead of `log4j-slf4j-impl` in SPARK-40511
-    // to fix the error:
-    // ```
-    //   java.lang.NoSuchMethodError: org.apache.logging.slf4j.Log4jLoggerFactory.<init>(Lorg/apache/logging/slf4j/Log4jMarkerFactory;)V
-    // ```
-    "org.apache.logging.log4j" % "log4j-slf4j2-impl" % "2.19.0" % "test"
-  )
-
-  override def sparkCommon: Project = {
-    super.sparkCommon
-      .settings(libraryDependencies ++= deps)
-  }
-
-  override def sparkClient: Project = {
-    super.sparkClient
-      .settings(libraryDependencies ++= deps)
-  }
-
-  override def sparkIt: Project = {
-    super.sparkIt
-      .settings(libraryDependencies ++= deps)
-  }
 }
 
 trait SparkClientProjects {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?

To address the CI failure introduced in https://github.com/apache/incubator-celeborn/pull/1831, this pull request resolves the issue by removing the `log4j-slf4j2-impl` dependency from SBT profile `spark-3.4`. This change is prompted by the pinning of `slf4j-api` to version 1.7.36, rendering `log4j-slf4j2-impl` unnecessary.


```
[error] Test org.apache.spark.shuffle.celeborn.SortBasedPusherSuiteJ failed: java.lang.NoSuchMethodError: org.apache.logging.slf4j.Log4jLoggerFactory: method <init>()V not found, took 0.0 sec
[error]     at org.slf4j.impl.StaticLoggerBinder.<init>(StaticLoggerBinder.java:53)
[error]     at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:41)
[error]     at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
[error]     at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
[error]     at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:417)
[error]     at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362)
[error]     at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:3[88](https://github.com/apache/incubator-celeborn/actions/runs/5974971986/job/16210071148#step:4:89))
[error]     at org.apache.spark.shuffle.celeborn.SortBasedPusherSuiteJ.<clinit>(SortBasedPusherSuiteJ.java:51)
[error]     ...
[error] Test org.apache.spark.shuffle.celeborn.SortBasedPusherSuiteJ failed: java.lang.NoClassDefFoundError: Could not initialize class org.apache.spark.shuffle.celeborn.SortBasedPusherSuiteJ, took 0.0 sec
[error]     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     ...
```

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass GA