### PR TITLE
[CELEBORN-919][FOLLOWUP] Unify the order of map index args and partit…

### DIFF
--- a/client-spark/spark-3-columnar-shuffle/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReader.scala
+++ b/client-spark/spark-3-columnar-shuffle/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReader.scala
@@ -27,19 +27,19 @@ import org.apache.celeborn.common.CelebornConf
 
 class CelebornColumnarShuffleReader[K, C](
     handle: CelebornShuffleHandle[K, _, C],
-    startPartition: Int,
-    endPartition: Int,
     startMapIndex: Int = 0,
     endMapIndex: Int = Int.MaxValue,
+    startPartition: Int,
+    endPartition: Int,
     context: TaskContext,
     conf: CelebornConf,
     metrics: ShuffleReadMetricsReporter)
   extends CelebornShuffleReader[K, C](
     handle,
-    startPartition,
-    endPartition,
     startMapIndex,
     endMapIndex,
+    startPartition,
+    endPartition,
     context,
     conf,
     metrics) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -264,7 +264,7 @@ public class SparkShuffleManager implements ShuffleManager {
       ShuffleReadMetricsReporter metrics) {
     if (handle instanceof CelebornShuffleHandle) {
       return getCelebornShuffleReader(
-          handle, startPartition, endPartition, startMapIndex, endMapIndex, context, metrics);
+          handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics);
     }
     return SparkUtils.getReader(
         sortShuffleManager(),
@@ -310,7 +310,7 @@ public class SparkShuffleManager implements ShuffleManager {
       ShuffleReadMetricsReporter metrics) {
     if (handle instanceof CelebornShuffleHandle) {
       return getCelebornShuffleReader(
-          handle, startPartition, endPartition, startMapIndex, endMapIndex, context, metrics);
+          handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics);
     }
     return SparkUtils.getReader(
         sortShuffleManager(),
@@ -335,20 +335,20 @@ public class SparkShuffleManager implements ShuffleManager {
     if (COLUMNAR_SHUFFLE_CLASSES_PRESENT && celebornConf.columnarShuffleEnabled()) {
       return SparkUtils.createColumnarShuffleReader(
           h,
-          startPartition,
-          endPartition,
           startMapIndex,
           endMapIndex,
+          startPartition,
+          endPartition,
           context,
           celebornConf,
           metrics);
     } else {
       return new CelebornShuffleReader<>(
           h,
-          startPartition,
-          endPartition,
           startMapIndex,
           endMapIndex,
+          startPartition,
+          endPartition,
           context,
           celebornConf,
           metrics);

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -200,10 +200,10 @@ public class SparkUtils {
 
   public static <K, C> CelebornShuffleReader<K, C> createColumnarShuffleReader(
       CelebornShuffleHandle<K, ?, C> handle,
-      int startPartition,
-      int endPartition,
       int startMapIndex,
       int endMapIndex,
+      int startPartition,
+      int endPartition,
       TaskContext context,
       CelebornConf conf,
       ShuffleReadMetricsReporter metrics) {

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -30,10 +30,10 @@ import org.apache.celeborn.common.CelebornConf
 
 class CelebornShuffleReader[K, C](
     handle: CelebornShuffleHandle[K, _, C],
-    startPartition: Int,
-    endPartition: Int,
     startMapIndex: Int = 0,
     endMapIndex: Int = Int.MaxValue,
+    startPartition: Int,
+    endPartition: Int,
     context: TaskContext,
     conf: CelebornConf,
     metrics: ShuffleReadMetricsReporter)


### PR DESCRIPTION
…ion index args in ShuffleReader related methods

### What changes were proposed in this pull request?
Unify the order of map index args and partition index args in ShuffleReader related methods.


### Why are the changes needed?
The order of map index args and partition index args in CelebornShuffleReader constructor is different the order in `SparkShuffleManager#getReader`.
It can messed up easily.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Run tests locally.
