### PR TITLE
[CELEBORN-928][BUG] Don't stop LocalFlusher when notify error

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/Flusher.scala
@@ -169,9 +169,7 @@ private[worker] class LocalFlusher(
   }
 
   override def notifyError(mountPoint: String, diskStatus: DiskStatus): Unit = {
-    logError(s"$this is notified Disk $mountPoint $diskStatus! Stop LocalFlusher.")
-    stopAndCleanFlusher()
-    deviceMonitor.unregisterFlusher(this)
+    logError(s"$this is notified Disk $mountPoint $diskStatus! Won't stop LocalFlusher.")
   }
 
   override def hashCode(): Int = {
@@ -199,7 +197,6 @@ final private[worker] class HdfsFlusher(
   override def toString: String = s"HdfsFlusher@$flusherId"
 
   override def processIOException(e: IOException, deviceErrorType: DiskStatus): Unit = {
-    stopAndCleanFlusher()
     logError(s"$this write failed, reason $deviceErrorType ,exception: $e")
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Don't stop LocalFlusher when notify error.

### Why are the changes needed?

If LocalDeviceMonitor find non-critical error(e.g. disk full usage) count exceeds threshold and notify error to observed device. LocalFlusher will do stopAndCleanFlusher, which will interrupt flush threads. Then if the disk recover from the error, new disk buffer pushed into the flush queue cannot be flushed. It  always causes high memory usage, which would cause pausePushDataAndReplicate, and can't recover from it .


### Does this PR introduce _any_ user-facing change?
no 


### How was this patch tested?
Manual.

1. Run a spark job with shuffle.
2. Copy data in a worker to trigger full disk error.
3. See logs as below
![image](https://github.com/apache/incubator-celeborn/assets/16849112/a4da0bfd-418d-4062-9426-95ef775a9dea)
5. Confirm flush threads are still running.
6. Submit another spark job with shuffle, and found disk buffer increase and decrease while flushing disk.
![image](https://github.com/apache/incubator-celeborn/assets/16849112/7722ebb7-c110-4d39-a87f-d4ab86a25f86)


