### PR TITLE
[CELEBORN-931][INFRA] Fix merged pull requests resolution

### DIFF
--- a/dev/merge_pr.py
+++ b/dev/merge_pr.py
@@ -582,9 +582,9 @@ def main():
     pr_repo_desc = "%s/%s" % (user_login, base_ref)
 
     # Merged pull requests don't appear as merged in the GitHub API;
-    # Instead, they're closed by asfgit.
+    # Instead, they're closed by committers.
     merge_commits = [
-        e for e in pr_events if e["actor"]["login"] == "asfgit" and e["event"] == "closed"
+        e for e in pr_events if e["event"] == "closed" and e["commit_id"] is not None
     ]
 
     if merge_commits:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?


This PR fixes the resolution for merged pull requests. It appears that the user "asfgit" is no longer closing pull requests, but rather the committers are.


### Why are the changes needed?

Bugfix, make the merge script re-runnable again if you accidentally abort cherry-pick or change you mind later for backporting


### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

tested locally