### PR TITLE
[CELEBORN-934] Make the log description in switchServingState more precise

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -255,12 +255,13 @@ public class MemoryManager {
     switch (servingState) {
       case PUSH_PAUSED:
         pausePushDataCounter.increment();
-        logger.info("Trigger action: PAUSE PUSH, RESUME REPLICATE");
         if (lastState == ServingState.PUSH_AND_REPLICATE_PAUSED) {
+          logger.info("Trigger action: RESUME REPLICATE");
           memoryPressureListeners.forEach(
               memoryPressureListener ->
                   memoryPressureListener.onResume(TransportModuleConstants.REPLICATE_MODULE));
         } else if (lastState == ServingState.NONE_PAUSED) {
+          logger.info("Trigger action: PAUSE PUSH");
           memoryPressureListeners.forEach(
               memoryPressureListener ->
                   memoryPressureListener.onPause(TransportModuleConstants.PUSH_MODULE));
@@ -269,24 +270,26 @@ public class MemoryManager {
         break;
       case PUSH_AND_REPLICATE_PAUSED:
         pausePushDataAndReplicateCounter.increment();
-        logger.info("Trigger action: PAUSE PUSH and REPLICATE");
         if (lastState == ServingState.NONE_PAUSED) {
+          logger.info("Trigger action: PAUSE PUSH");
           memoryPressureListeners.forEach(
               memoryPressureListener ->
                   memoryPressureListener.onPause(TransportModuleConstants.PUSH_MODULE));
         }
+        logger.info("Trigger action: PAUSE REPLICATE");
         memoryPressureListeners.forEach(
             memoryPressureListener ->
                 memoryPressureListener.onPause(TransportModuleConstants.REPLICATE_MODULE));
         trimAllListeners();
         break;
       case NONE_PAUSED:
-        logger.info("Trigger action: RESUME PUSH and REPLICATE");
         if (lastState == ServingState.PUSH_AND_REPLICATE_PAUSED) {
+          logger.info("Trigger action: RESUME REPLICATE");
           memoryPressureListeners.forEach(
               memoryPressureListener ->
                   memoryPressureListener.onResume(TransportModuleConstants.REPLICATE_MODULE));
         }
+        logger.info("Trigger action: RESUME PUSH");
         memoryPressureListeners.forEach(
             memoryPressureListener ->
                 memoryPressureListener.onResume(TransportModuleConstants.PUSH_MODULE));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Modify log content and location to accurately describe state changes

### Why are the changes needed?

In the previous implementation, when servingState was PUSH_PAUSED and lastState was PUSH_AND_REPLICATE_PAUSED, the code only triggered the Resume of REPLICATE_MODULE, but the log showed "Trigger action: PAUSE PUSH, RESUME REPLICATE"

The above log content is not accurate

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

PASS GA