### PR TITLE
[CELEBORN-927][DOC] Correct celeborn.metrics.conf.*.sink.csv.class configuration example for a CSV sink

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -57,7 +57,7 @@ details, i.e. the parameters take the following form:
 `celeborn.metrics.conf.[instance|*].sink.[sink_name].[parameter_name]`.
 This example shows a list of Celeborn configuration parameters for a CSV sink:
 ```
-"celeborn.metrics.conf.*.sink.csv.class"="org.apache.celeborn.common.metrics.sink.GraphiteSink"
+"celeborn.metrics.conf.*.sink.csv.class"="org.apache.celeborn.common.metrics.sink.CsvSink"
 "celeborn.metrics.conf.*.sink.csv.period"="1"
 "celeborn.metrics.conf.*.sink.csv.unit"=minutes
 "celeborn.metrics.conf.*.sink.csv.directory"=/tmp/


### PR DESCRIPTION
### What changes were proposed in this pull request?

Correct `celeborn.metrics.conf.*.sink.csv.class` configuration example for a CSV sink.

### Why are the changes needed?

`celeborn.metrics.conf.*.sink.csv.class` configuration example for a CSV sink is wrong, which value should be `org.apache.celeborn.common.metrics.sink.CsvSink`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

None.