### PR TITLE
[CELEBORN-822][DOC] Introduce a quick start guide for running Apache Flink with Apache Celeborn

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
@@ -391,8 +391,7 @@ public class PartitionSortedBuffer implements SortBuffer {
 
   @Override
   public void finish() {
-    checkState(
-        !isFinished, "com.alibaba.flink.shuffle.plugin.transfer.SortBuffer is already finished.");
+    checkState(!isFinished, SortBuffer.class.getCanonicalName() + " is already finished.");
 
     isFinished = true;
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -190,7 +190,7 @@ spark.sql.adaptive.skewJoin.enabled true
 Copy $CELEBORN_HOME/flink/*.jar to $FLINK_HOME/lib/
 
 ### Flink Configuration
-TO use Celeborn, following flink configurations should be added.
+To use Celeborn, following flink configurations should be added.
 ```properties
 shuffle-service-factory.class: org.apache.celeborn.plugin.flink.RemoteShuffleServiceFactory
 celeborn.master.endpoints: clb-1:9097,clb-2:9097,clb-3:9097


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce a quick start guide for running Apache Flink with Apache Celeborn to help Flink users to run with Celeborn.

### Why are the changes needed?

There is no quick start guide for running Apache Flink with Apache Celeborn.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

None.