### PR TITLE
[CELEBORN-919][FOLLOWUP] Put map index args after partition index args in CelebornShuffleReader constructor

### DIFF
--- a/client-spark/spark-3-columnar-shuffle/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReader.scala
+++ b/client-spark/spark-3-columnar-shuffle/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReader.scala
@@ -27,19 +27,19 @@ import org.apache.celeborn.common.CelebornConf
 
 class CelebornColumnarShuffleReader[K, C](
     handle: CelebornShuffleHandle[K, _, C],
-    startMapIndex: Int = 0,
-    endMapIndex: Int = Int.MaxValue,
     startPartition: Int,
     endPartition: Int,
+    startMapIndex: Int = 0,
+    endMapIndex: Int = Int.MaxValue,
     context: TaskContext,
     conf: CelebornConf,
     metrics: ShuffleReadMetricsReporter)
   extends CelebornShuffleReader[K, C](
     handle,
-    startMapIndex,
-    endMapIndex,
     startPartition,
     endPartition,
+    startMapIndex,
+    endMapIndex,
     context,
     conf,
     metrics) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -269,10 +269,10 @@ public class SparkShuffleManager implements ShuffleManager {
     return SparkUtils.getReader(
         sortShuffleManager(),
         handle,
-        startMapIndex,
-        endMapIndex,
         startPartition,
         endPartition,
+        startMapIndex,
+        endMapIndex,
         context,
         metrics);
   }
@@ -286,15 +286,15 @@ public class SparkShuffleManager implements ShuffleManager {
       ShuffleReadMetricsReporter metrics) {
     if (handle instanceof CelebornShuffleHandle) {
       return getCelebornShuffleReader(
-          handle, 0, Integer.MAX_VALUE, startPartition, endPartition, context, metrics);
+          handle, startPartition, endPartition, 0, Integer.MAX_VALUE, context, metrics);
     }
     return SparkUtils.getReader(
         sortShuffleManager(),
         handle,
-        0,
-        Integer.MAX_VALUE,
         startPartition,
         endPartition,
+        0,
+        Integer.MAX_VALUE,
         context,
         metrics);
   }
@@ -325,10 +325,10 @@ public class SparkShuffleManager implements ShuffleManager {
 
   public <K, C> ShuffleReader<K, C> getCelebornShuffleReader(
       ShuffleHandle handle,
-      int startMapIndex,
-      int endMapIndex,
       int startPartition,
       int endPartition,
+      int startMapIndex,
+      int endMapIndex,
       TaskContext context,
       ShuffleReadMetricsReporter metrics) {
     CelebornShuffleHandle<K, ?, C> h = (CelebornShuffleHandle<K, ?, C>) handle;

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -264,7 +264,7 @@ public class SparkShuffleManager implements ShuffleManager {
       ShuffleReadMetricsReporter metrics) {
     if (handle instanceof CelebornShuffleHandle) {
       return getCelebornShuffleReader(
-          handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics);
+          handle, startPartition, endPartition, startMapIndex, endMapIndex, context, metrics);
     }
     return SparkUtils.getReader(
         sortShuffleManager(),
@@ -310,15 +310,15 @@ public class SparkShuffleManager implements ShuffleManager {
       ShuffleReadMetricsReporter metrics) {
     if (handle instanceof CelebornShuffleHandle) {
       return getCelebornShuffleReader(
-          handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics);
+          handle, startPartition, endPartition, startMapIndex, endMapIndex, context, metrics);
     }
     return SparkUtils.getReader(
         sortShuffleManager(),
         handle,
-        startMapIndex,
-        endMapIndex,
         startPartition,
         endPartition,
+        startMapIndex,
+        endMapIndex,
         context,
         metrics);
   }
@@ -335,20 +335,20 @@ public class SparkShuffleManager implements ShuffleManager {
     if (COLUMNAR_SHUFFLE_CLASSES_PRESENT && celebornConf.columnarShuffleEnabled()) {
       return SparkUtils.createColumnarShuffleReader(
           h,
-          startMapIndex,
-          endMapIndex,
           startPartition,
           endPartition,
+          startMapIndex,
+          endMapIndex,
           context,
           celebornConf,
           metrics);
     } else {
       return new CelebornShuffleReader<>(
           h,
-          startMapIndex,
-          endMapIndex,
           startPartition,
           endPartition,
+          startMapIndex,
+          endMapIndex,
           context,
           celebornConf,
           metrics);

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -135,10 +135,10 @@ public class SparkUtils {
   public static <K, C> ShuffleReader<K, C> getReader(
       SortShuffleManager sortShuffleManager,
       ShuffleHandle handle,
-      Integer startMapIndex,
-      Integer endMapIndex,
       Integer startPartition,
       Integer endPartition,
+      Integer startMapIndex,
+      Integer endMapIndex,
       TaskContext context,
       ShuffleReadMetricsReporter metrics) {
     ShuffleReader<K, C> shuffleReader =
@@ -200,10 +200,10 @@ public class SparkUtils {
 
   public static <K, C> CelebornShuffleReader<K, C> createColumnarShuffleReader(
       CelebornShuffleHandle<K, ?, C> handle,
-      int startMapIndex,
-      int endMapIndex,
       int startPartition,
       int endPartition,
+      int startMapIndex,
+      int endMapIndex,
       TaskContext context,
       CelebornConf conf,
       ShuffleReadMetricsReporter metrics) {
@@ -212,10 +212,10 @@ public class SparkUtils {
         .invoke(
             null,
             handle,
-            startMapIndex,
-            endMapIndex,
             startPartition,
             endPartition,
+            startMapIndex,
+            endMapIndex,
             context,
             conf,
             metrics);

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -30,10 +30,10 @@ import org.apache.celeborn.common.CelebornConf
 
 class CelebornShuffleReader[K, C](
     handle: CelebornShuffleHandle[K, _, C],
-    startMapIndex: Int = 0,
-    endMapIndex: Int = Int.MaxValue,
     startPartition: Int,
     endPartition: Int,
+    startMapIndex: Int = 0,
+    endMapIndex: Int = Int.MaxValue,
     context: TaskContext,
     conf: CelebornConf,
     metrics: ShuffleReadMetricsReporter)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Put map index args after partition index args in CelebornShuffleReader constructor

### Why are the changes needed?

#1853 changed the args order in CelebornShuffleReader constructor. It will break gluten celeborn shuffle manager.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Run test locally.