### PR TITLE
[CELEBORN-943][PERF] Pre-create CelebornInputStreams in CelebornShuffleReader

### DIFF
--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -17,9 +17,14 @@
 
 package org.apache.spark.shuffle.celeborn
 
+import java.io.IOException
+import java.util.concurrent.{ConcurrentHashMap, ThreadPoolExecutor}
+import java.util.concurrent.atomic.AtomicReference
+
 import org.apache.spark.{InterruptibleIterator, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle.ShuffleReader
+import org.apache.spark.shuffle.celeborn.CelebornShuffleReader.streamCreatorPool
 import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection.ExternalSorter
 
@@ -27,6 +32,7 @@ import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.client.read.CelebornInputStream
 import org.apache.celeborn.client.read.MetricsCallback
 import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.util.ThreadUtils
 
 class CelebornShuffleReader[K, C](
     handle: CelebornShuffleHandle[K, _, C],
@@ -39,12 +45,14 @@ class CelebornShuffleReader[K, C](
   extends ShuffleReader[K, C] with Logging {
 
   private val dep = handle.dependency
-  private val essShuffleClient = ShuffleClient.get(
+  private val shuffleClient = ShuffleClient.get(
     handle.appUniqueId,
     handle.lifecycleManagerHost,
     handle.lifecycleManagerPort,
     conf,
     handle.userIdentifier)
+
+  private val exceptionRef = new AtomicReference[IOException]
 
   override def read(): Iterator[Product2[K, C]] = {
 
@@ -60,15 +68,51 @@ class CelebornShuffleReader[K, C](
         readMetrics.incFetchWaitTime(time)
     }
 
+    if (streamCreatorPool == null) {
+      CelebornShuffleReader.synchronized {
+        if (streamCreatorPool == null) {
+          streamCreatorPool = ThreadUtils.newDaemonCachedThreadPool(
+            "create-stream-thread",
+            conf.readStreamCreatorPoolThreads,
+            60);
+        }
+      }
+    }
+
+    val streams = new ConcurrentHashMap[Integer, CelebornInputStream]()
+    (startPartition until endPartition).map(partitionId => {
+      streamCreatorPool.submit(new Runnable {
+        override def run(): Unit = {
+          if (exceptionRef.get() == null) {
+            try {
+              val inputStream = shuffleClient.readPartition(
+                handle.shuffleId,
+                partitionId,
+                context.attemptNumber(),
+                startMapIndex,
+                endMapIndex)
+              streams.put(partitionId, inputStream)
+            } catch {
+              case e: IOException =>
+                logInfo("Exception caught when readPartition!")
+                exceptionRef.compareAndSet(null, e)
+            }
+          }
+        }
+      })
+    })
+
     val recordIter = (startPartition until endPartition).iterator.map(partitionId => {
       if (handle.numMaps > 0) {
         val start = System.currentTimeMillis()
-        val inputStream = essShuffleClient.readPartition(
-          handle.shuffleId,
-          partitionId,
-          context.attemptNumber(),
-          startMapIndex,
-          endMapIndex)
+        var inputStream: CelebornInputStream = streams.get(partitionId)
+        while (inputStream == null) {
+          if (exceptionRef.get() != null) {
+            throw exceptionRef.get()
+          }
+          Thread.sleep(50)
+          inputStream = streams.get(partitionId)
+        }
         metricsCallback.incReadTime(System.currentTimeMillis() - start)
         inputStream.setCallback(metricsCallback)
         // ensure inputStream is closed when task completes
@@ -134,4 +178,8 @@ class CelebornShuffleReader[K, C](
         new InterruptibleIterator[Product2[K, C]](context, resultIter)
     }
   }
+}
+
+object CelebornShuffleReader {
+  var streamCreatorPool: ThreadPoolExecutor = null
 }

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -17,16 +17,22 @@
 
 package org.apache.spark.shuffle.celeborn
 
+import java.io.IOException
+import java.util.concurrent.{ConcurrentHashMap, ThreadPoolExecutor}
+import java.util.concurrent.atomic.AtomicReference
+
 import org.apache.spark.{InterruptibleIterator, ShuffleDependency, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.shuffle.{ShuffleReader, ShuffleReadMetricsReporter}
+import org.apache.spark.shuffle.celeborn.CelebornShuffleReader.streamCreatorPool
 import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection.ExternalSorter
 
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.client.read.{CelebornInputStream, MetricsCallback}
 import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.util.ThreadUtils
 
 class CelebornShuffleReader[K, C](
     handle: CelebornShuffleHandle[K, _, C],
@@ -47,6 +53,8 @@ class CelebornShuffleReader[K, C](
     conf,
     handle.userIdentifier)
 
+  private val exceptionRef = new AtomicReference[IOException]
+
   override def read(): Iterator[Product2[K, C]] = {
 
     val serializerInstance = newSerializerInstance(dep)
@@ -62,15 +70,51 @@ class CelebornShuffleReader[K, C](
         metrics.incFetchWaitTime(time)
     }
 
+    if (streamCreatorPool == null) {
+      CelebornShuffleReader.synchronized {
+        if (streamCreatorPool == null) {
+          streamCreatorPool = ThreadUtils.newDaemonCachedThreadPool(
+            "create-stream-thread",
+            conf.readStreamCreatorPoolThreads,
+            60);
+        }
+      }
+    }
+
+    val streams = new ConcurrentHashMap[Integer, CelebornInputStream]()
+    (startPartition until endPartition).map(partitionId => {
+      streamCreatorPool.submit(new Runnable {
+        override def run(): Unit = {
+          if (exceptionRef.get() == null) {
+            try {
+              val inputStream = shuffleClient.readPartition(
+                handle.shuffleId,
+                partitionId,
+                context.attemptNumber(),
+                startMapIndex,
+                endMapIndex)
+              streams.put(partitionId, inputStream)
+            } catch {
+              case e: IOException =>
+                logInfo("Exception caught when readPartition!")
+                exceptionRef.compareAndSet(null, e)
+            }
+          }
+        }
+      })
+    })
+
     val recordIter = (startPartition until endPartition).iterator.map(partitionId => {
       if (handle.numMappers > 0) {
         val start = System.currentTimeMillis()
-        val inputStream = shuffleClient.readPartition(
-          handle.shuffleId,
-          partitionId,
-          context.attemptNumber(),
-          startMapIndex,
-          endMapIndex)
+        var inputStream: CelebornInputStream = streams.get(partitionId)
+        while (inputStream == null) {
+          if (exceptionRef.get() != null) {
+            throw exceptionRef.get()
+          }
+          Thread.sleep(50)
+          inputStream = streams.get(partitionId)
+        }
         metricsCallback.incReadTime(System.currentTimeMillis() - start)
         inputStream.setCallback(metricsCallback)
         // ensure inputStream is closed when task completes
@@ -147,4 +191,8 @@ class CelebornShuffleReader[K, C](
     dep.serializer.newInstance()
   }
 
+}
+
+object CelebornShuffleReader {
+  var streamCreatorPool: ThreadPoolExecutor = null
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -825,6 +825,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(CLIENT_BATCH_HANDLED_RELEASE_PARTITION_INTERVAL)
   def enableReadLocalShuffleFile: Boolean = get(READ_LOCAL_SHUFFLE_FILE)
   def readLocalShuffleThreads: Int = get(READ_LOCAL_SHUFFLE_THREADS)
+  def readStreamCreatorPoolThreads: Int = get(READ_STREAM_CREATOR_POOL_THREADS)
 
   // //////////////////////////////////////////////////////
   //                       Worker                        //
@@ -3817,6 +3818,14 @@ object CelebornConf extends Logging {
       .doc("Threads count for read local shuffle file.")
       .intConf
       .createWithDefault(4)
+
+  val READ_STREAM_CREATOR_POOL_THREADS: ConfigEntry[Int] =
+    buildConf("celeborn.client.streamCreatorPool.threads")
+      .categories("client")
+      .version("0.3.1")
+      .doc("Threads count for streamCreatorPool in CelebornShuffleReader.")
+      .intConf
+      .createWithDefault(32)
 
   val CLIENT_SHUFFLE_MAPPARTITION_SPLIT_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.client.shuffle.mapPartition.split.enabled")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -100,6 +100,7 @@ license: |
 | celeborn.client.spark.shuffle.forceFallback.enabled | false | Whether force fallback shuffle to Spark's default. | 0.3.0 | 
 | celeborn.client.spark.shuffle.forceFallback.numPartitionsThreshold | 2147483647 | Celeborn will only accept shuffle of partition number lower than this configuration value. | 0.3.0 | 
 | celeborn.client.spark.shuffle.writer | HASH | Celeborn supports the following kind of shuffle writers. 1. hash: hash-based shuffle writer works fine when shuffle partition count is normal; 2. sort: sort-based shuffle writer works fine when memory pressure is high or shuffle partition count is huge. | 0.3.0 | 
+| celeborn.client.streamCreatorPool.threads | 32 | Threads count for streamCreatorPool in CelebornShuffleReader. | 0.3.1 | 
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
 | celeborn.storage.hdfs.dir | &lt;undefined&gt; | HDFS base directory for Celeborn to store shuffle data. | 0.2.0 | 
 <!--end-include-->


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR fixes performance degradation when Spark's coalescePartitions takes effect caused
by RPC latency. 


### Why are the changes needed?
I encountered a performance degradation when testing  tpcds 10T q10:
||Time|
|---|---|
|ESS|14s|
|Celeborn| 24s|
After digging into it I found out that q10 triggers partition coalescence:

As I configured `spark.sql.adaptive.coalescePartitions.minPartitionNum` to 1000, `CelebornShuffleReader`
will call `shuffleClient.readPartition` sequentially 1000 times, causing the delay.

This PR optimizes by calling `shuffleClient.readPartition` in parallel.

### Does this PR introduce _any_ user-facing change?
No, but introduced a new client side configuration `celeborn.client.streamCreatorPool.threads`
which defaults to 32.


### How was this patch tested?
TPCDS 1T and passes GA.
