### PR TITLE
[CELEBORN-945] Change ShutdownHook's timeout for decommission

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/util/ShutdownHookManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ShutdownHookManager.java
@@ -169,7 +169,7 @@ public final class ShutdownHookManager {
     private final Runnable hook;
     private final int priority;
     private long timeout;
-    private final TimeUnit unit;
+    private TimeUnit unit;
 
     HookEntry(Runnable hook, int priority) {
       this(hook, priority, getShutdownTimeout(new CelebornConf()), TIME_UNIT_DEFAULT);
@@ -210,8 +210,9 @@ public final class ShutdownHookManager {
       return timeout;
     }
 
-    public void setTimeout(long timeout) {
+    public void setTimeout(long timeout, TimeUnit unit) {
       this.timeout = timeout;
+      this.unit = unit;
     }
 
     TimeUnit getTimeUnit() {
@@ -286,8 +287,8 @@ public final class ShutdownHookManager {
     hooks.add(new HookEntry(shutdownHook, priority, timeout, unit));
   }
 
-  public void updateTimeout(long timeout) {
-    hooks.forEach(hook -> hook.setTimeout(timeout));
+  public void updateTimeout(long timeout, TimeUnit unit) {
+    hooks.forEach(hook -> hook.setTimeout(timeout, unit));
   }
 
   /**

--- a/common/src/main/java/org/apache/celeborn/common/util/ShutdownHookManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ShutdownHookManager.java
@@ -287,7 +287,7 @@ public final class ShutdownHookManager {
   }
 
   public void updateTimeout(long timeout) {
-    hooks.forEach((hook) -> hook.setTimeout(timeout));
+    hooks.forEach(hook -> hook.setTimeout(timeout));
   }
 
   /**

--- a/common/src/main/java/org/apache/celeborn/common/util/ShutdownHookManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ShutdownHookManager.java
@@ -107,7 +107,10 @@ public final class ShutdownHookManager {
     for (HookEntry entry : MGR.getShutdownHooksInOrder()) {
       Future<?> future = EXECUTOR.submit(entry.getHook());
       try {
-        logger.info("timeout {}, time unit {}", entry.getTimeout(), entry.getTimeUnit());
+        logger.info(
+            "timeout {}",
+            Utils.msDurationToString(
+                entry.getTimeUnit().convert(entry.getTimeout(), TimeUnit.MILLISECONDS)));
         future.get(entry.getTimeout(), entry.getTimeUnit());
       } catch (TimeoutException ex) {
         timeouts++;

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -581,7 +581,9 @@ private[celeborn] class Worker(
     exitType match {
       case "DECOMMISSION" =>
         exitKind = CelebornExitKind.WORKER_DECOMMISSION
-        ShutdownHookManager.get().updateTimeout(conf.workerDecommissionForceExitTimeout)
+        ShutdownHookManager.get().updateTimeout(
+          conf.workerDecommissionForceExitTimeout,
+          TimeUnit.MILLISECONDS)
       case "GRACEFUL" =>
         exitKind = CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN
       case "IMMEDIATELY" =>

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -581,6 +581,7 @@ private[celeborn] class Worker(
     exitType match {
       case "DECOMMISSION" =>
         exitKind = CelebornExitKind.WORKER_DECOMMISSION
+        ShutdownHookManager.get().updateTimeout(conf.workerDecommissionForceExitTimeout)
       case "GRACEFUL" =>
         exitKind = CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN
       case "IMMEDIATELY" =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
When shutdown type is decommission, we should change the `ShutdownHookManager#HookEntry`'s
timeout to `celeborn.worker.decommission.forceExitTimeout`.


### Why are the changes needed?
ditto


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test
