### PR TITLE
[CELEBORN-913] Implement method ShuffleDriverComponents#supportsRelia

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -95,6 +95,9 @@ jobs:
           - '3.3'
           - '3.4'
           - '3.5'
+        shuffle-plugin-class:
+          - 'org.apache.spark.shuffle.sort.io.LocalDiskShuffleDataIO'
+          - 'org.apache.spark.shuffle.celeborn.CelebornShuffleDataIO'
         exclude:
           # SPARK-33772: Spark supports JDK 17 since 3.3.0
           - java: 17
@@ -119,7 +122,7 @@ jobs:
         PROFILES="-Pgoogle-mirror,spark-${{ matrix.spark }}"
         TEST_MODULES="client-spark/common,client-spark/spark-${SPARK_MAJOR_VERSION},client-spark/spark-${SPARK_MAJOR_VERSION}-shaded,tests/spark-it"
         build/mvn $PROFILES -pl $TEST_MODULES -am clean install -DskipTests
-        build/mvn $PROFILES -pl $TEST_MODULES test
+        build/mvn $PROFILES -pl $TEST_MODULES -Dspark.shuffle.sort.io.plugin.class=${{ matrix.shuffle-plugin-class }} test
     - name: Upload test log
       if: failure()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -93,6 +93,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        shuffle-plugin-class:
+          - 'org.apache.spark.shuffle.sort.io.LocalDiskShuffleDataIO'
+          - 'org.apache.spark.shuffle.celeborn.CelebornShuffleDataIO'
         include:
           # Spark 3.0
           - spark: '3.0'
@@ -190,7 +193,7 @@ jobs:
         check-latest: false
     - name: Test with SBT
       run: |
-        build/sbt -Pspark-${{ matrix.spark }} ++${{ matrix.scala }} "clean; celeborn-spark-group/test"
+        build/sbt -Dspark.shuffle.plugin.class=${{ matrix.shuffle-plugin-class }} -Pspark-${{ matrix.spark }} ++${{ matrix.scala }} "clean; celeborn-spark-group/test"
     - name: Upload test log
       if: failure()
       uses: actions/upload-artifact@v3

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/CelebornShuffleDataIO.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/CelebornShuffleDataIO.java
@@ -1,0 +1,51 @@
+package org.apache.spark.shuffle.celeborn;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.api.ShuffleDataIO;
+import org.apache.spark.shuffle.api.ShuffleDriverComponents;
+import org.apache.spark.shuffle.api.ShuffleExecutorComponents;
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleDriverComponents;
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleExecutorComponents;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.CelebornConf;
+
+public class CelebornShuffleDataIO implements ShuffleDataIO {
+
+  private static final Logger logger = LoggerFactory.getLogger(CelebornShuffleDataIO.class);
+
+  private final SparkConf sparkConf;
+  private final CelebornConf celebornConf;
+
+  public CelebornShuffleDataIO(SparkConf sparkConf) {
+    logger.info("Loading CelebornShuffleDataIO");
+    this.sparkConf = sparkConf;
+    this.celebornConf = SparkUtils.fromSparkConf(sparkConf);
+  }
+
+  @Override
+  public ShuffleExecutorComponents executor() {
+    // Used when fallback to Spark SortShuffleManager
+    return new LocalDiskShuffleExecutorComponents(sparkConf);
+  }
+
+  @Override
+  public ShuffleDriverComponents driver() {
+    return new CelebornShuffleDriverComponents(celebornConf);
+  }
+}
+
+class CelebornShuffleDriverComponents extends LocalDiskShuffleDriverComponents {
+
+  private final boolean support;
+
+  public CelebornShuffleDriverComponents(CelebornConf celebornConf) {
+    this.support = !celebornConf.shuffleForceFallbackEnabled();
+  }
+
+  // Omitting @Override annotation to avoid compile error before Spark 3.5.0
+  public boolean supportsReliableStorage() {
+    return support;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,8 @@
       --add-opens=java.base/sun.security.action=ALL-UNNAMED
       --add-opens=java.base/sun.util.calendar=ALL-UNNAMED</extraJavaTestArgs>
 
+    <spark.shuffle.plugin.class>org.apache.spark.shuffle.sort.io.LocalDiskShuffleDataIO</spark.shuffle.plugin.class>
+
     <mavenCentralId>central</mavenCentralId>
     <mavenCentralName>Maven Central</mavenCentralName>
     <mavenCentralUrl>https://repo.maven.apache.org/maven2</mavenCentralUrl>
@@ -563,6 +565,7 @@
               <log4j2.configurationFile>src/test/resources/log4j2-test.xml</log4j2.configurationFile>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
               <spark.driver.memory>1g</spark.driver.memory>
+              <spark.shuffle.sort.io.plugin.class>${spark.shuffle.plugin.class}</spark.shuffle.sort.io.plugin.class>
             </systemProperties>
             <environmentVariables>
               <CELEBORN_LOCAL_HOSTNAME>localhost</CELEBORN_LOCAL_HOSTNAME>
@@ -600,6 +603,7 @@
               <log4j2.configurationFile>src/test/resources/log4j2-test.xml</log4j2.configurationFile>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
               <spark.driver.memory>1g</spark.driver.memory>
+              <spark.shuffle.sort.io.plugin.class>${spark.shuffle.plugin.class}</spark.shuffle.sort.io.plugin.class>
             </systemProperties>
             <environmentVariables>
               <CELEBORN_LOCAL_HOSTNAME>localhost</CELEBORN_LOCAL_HOSTNAME>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -178,6 +178,11 @@ object CelebornCommonSettings {
       "-Xmx4g"
     ),
 
+    Test / javaOptions ++= Seq(
+      "-Dspark.shuffle.sort.io.plugin.class="
+        + sys.props.getOrElse("spark.shuffle.plugin.class", "org.apache.spark.shuffle.sort.io.LocalDiskShuffleDataIO"),
+    ),
+
     Test / envVars += ("IS_TESTING", "1")
   )
 


### PR DESCRIPTION
…bleStorage

### What changes were proposed in this pull request?
As title


### Why are the changes needed?
See https://issues.apache.org/jira/browse/SPARK-42689


### Does this PR introduce _any_ user-facing change?
Yes. User need to set `spark.shuffle.sort.io.plugin.class` to `org.apache.spark.shuffle.celeborn.CelebornShuffleDataIO` to enable this feature.


### How was this patch tested?
Add a new matrix dimension, shuffle-plugin-class, in github ci.
