### PR TITLE
[CELEBORN-958] Log DNS resolution result

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -163,10 +163,13 @@ public class TransportClientFactory implements Closeable {
     final InetSocketAddress resolvedAddress = new InetSocketAddress(remoteHost, remotePort);
     final long hostResolveTimeMs =
         TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - preResolveHost);
+    final String resolveMsg = resolvedAddress.isUnresolved() ? "failed" : "succeed";
     if (hostResolveTimeMs > 2000) {
-      logger.warn("DNS resolution for {} took {} ms", resolvedAddress, hostResolveTimeMs);
+      logger.warn(
+          "DNS resolution {} for {} took {} ms", resolveMsg, resolvedAddress, hostResolveTimeMs);
     } else {
-      logger.trace("DNS resolution for {} took {} ms", resolvedAddress, hostResolveTimeMs);
+      logger.trace(
+          "DNS resolution {} for {} took {} ms", resolveMsg, resolvedAddress, hostResolveTimeMs);
     }
 
     synchronized (clientPool.locks[clientIndex]) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

In some scenarios, DNS resolution may fail. We can record the DNS resolution results like Spark.

https://github.com/apache/spark/blob/fd424caf6c46e7030ac2deb2afbe3f4a5fc1095c/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java#L185-L192

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

