### PR TITLE
[CELEBORN-961] Catch exception when constructing Worker

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -727,8 +727,8 @@ private[deploy] object Worker extends Logging {
       conf.set(MASTER_ENDPOINTS.key, RpcAddress.fromCelebornURL(master).hostPort)
     }
 
-    val worker = new Worker(conf, workerArgs)
     try {
+      val worker = new Worker(conf, workerArgs)
       worker.initialize()
     } catch {
       case e: Throwable =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Move the constructor of Worker into a try-catch block.


### Why are the changes needed?
There are some exceptions thrown from Worker's constructor instead of Worker.initialize(), so it is necessary to catch these exceptions.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Start a worker with conf
```
celeborn.worker.directMemoryRatioToPauseReceive=0.7
celeborn.worker.directMemoryRatioToResume=0.7 
```
an IllegalArgumentException will be caught