### PR TITLE
[CELEBORN-900][FOLLOWUP] Disable jemalloc in non-docker environment

### DIFF
--- a/conf/celeborn-env.sh.template
+++ b/conf/celeborn-env.sh.template
@@ -32,4 +32,4 @@
 # CELEBORN_MASTER_JAVA_OPTS="-XX:-PrintGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:gc-master.out -Dio.netty.leakDetectionLevel=advanced"
 # CELEBORN_PID_DIR="$CELEBORN_HOME/pids"
 # CELEBORN_LOG_DIR="$CELEBORN_HOME/logs"
-# DISABLE_JEMALLOC="false"
+# CELEBORN_PREFER_JEMALLOC="true"

--- a/conf/celeborn-env.sh.template
+++ b/conf/celeborn-env.sh.template
@@ -23,6 +23,9 @@
 # - CELEBORN_WORKER_JAVA_OPTS
 # - CELEBORN_PID_DIR
 # - CELEBORN_LOG_DIR
+# - CELEBORN_PREFER_JEMALLOC, to enable jemalloc memory allocator
+# - CELEBORN_JEMALLOC_PATH, to set jemalloc library path
+
 
 # Example:
 # CELEBORN_MASTER_MEMORY=2g
@@ -33,3 +36,4 @@
 # CELEBORN_PID_DIR="$CELEBORN_HOME/pids"
 # CELEBORN_LOG_DIR="$CELEBORN_HOME/logs"
 # CELEBORN_PREFER_JEMALLOC="true"
+# CELEBORN_JEMALLOC_PATH="/path/to/libjemalloc.so"

--- a/conf/celeborn-env.sh.template
+++ b/conf/celeborn-env.sh.template
@@ -26,7 +26,6 @@
 # - CELEBORN_PREFER_JEMALLOC, to enable jemalloc memory allocator
 # - CELEBORN_JEMALLOC_PATH, to set jemalloc library path
 
-
 # Example:
 # CELEBORN_MASTER_MEMORY=2g
 # CELEBORN_WORKER_MEMORY=2g

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ ARG celeborn_uid=10006
 ARG celeborn_gid=10006
 
 ENV CELEBORN_HOME=/opt/celeborn
+ENV CELEBORN_PREFER_JEMALLOC=true
 ENV PATH=/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/busybox:${CELEBORN_HOME}/sbin:${CELEBORN_HOME}/bin
 
 RUN set -ex && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ ARG celeborn_gid=10006
 
 ENV CELEBORN_HOME=/opt/celeborn
 ENV CELEBORN_PREFER_JEMALLOC=true
-ENV PATH=/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/busybox:${CELEBORN_HOME}/sbin:${CELEBORN_HOME}/bin
+ENV PATH=${PATH}:/opt/busybox:${CELEBORN_HOME}/sbin:${CELEBORN_HOME}/bin
 
 RUN set -ex && \
     apt-get update && \

--- a/sbin/load-celeborn-env.sh
+++ b/sbin/load-celeborn-env.sh
@@ -69,10 +69,11 @@ if [ "$CELEBORN_PID_DIR" = "" ]; then
   export CELEBORN_PID_DIR="${CELEBORN_HOME}/pids"
 fi
 
-# jemalloc memory allocator is enabled by default, you may set DISABLE_JEMALLOC to true in celeborn-env.sh if it's not as you wish.
+# The jemalloc memory allocator is disabled by default, but in the docker environment, jemalloc is enabled by default.
+# You can set CELEBORN_PREFER_JEMALLOC to true in celeborn-env.sh and configure the path to jemalloc via CELEBORN_JEMALLOC_PATH.
 maybe_enable_jemalloc() {
-  if [ "${DISABLE_JEMALLOC:-false}" == "false" ]; then
-    JEMALLOC_PATH="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so"
+  if [ "${CELEBORN_PREFER_JEMALLOC:-false}" == "true" ]; then
+    JEMALLOC_PATH="${CELEBORN_JEMALLOC_PATH:-/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so}"
     JEMALLOC_FALLBACK="/usr/lib/x86_64-linux-gnu/libjemalloc.so"
     if [ -f "$JEMALLOC_PATH" ]; then
       export LD_PRELOAD="$LD_PRELOAD:$JEMALLOC_PATH"


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Provide `CELEBORN_PREFER_JEMALLOC` configuration to determine whether to enable jemalloc
2. Provide `CELEBORN_JEMALLOC_PATH` to configure the jemalloc path, for example, Centos is `/usr/lib64/libjemalloc.so`
3. Enable jemalloc by default in the docker environment

### Why are the changes needed?
Prevent unnecessary WARNING.

https://github.com/apache/incubator-celeborn/pull/1824#discussion_r1319909938


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
local test
