### PR TITLE
[CELEBORN-963] Add WORKDIR in celeborn Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,5 +49,6 @@ RUN chown -R celeborn:celeborn ${CELEBORN_HOME} && \
     chmod a+x ${CELEBORN_HOME}/sbin/*
 
 USER celeborn
+WORKDIR /opt/celeborn
 
 ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION

### What changes were proposed in this pull request?
Introduce env `WORKDIR` into celeborn `docker/Dockerfile`.


### Why are the changes needed?
We should add `WORKDIR` in Dockerfile, this will lead us to `/opt/celeborn` when we get into Celeborn Containers.


According to https://docs.docker.com/engine/reference/builder/{}
> The WORKDIR instruction sets the working directory for any RUN, CMD, ENTRYPOINT, COPY and ADD instructions that follow it in the Dockerfile. If the WORKDIR doesn't exist, it will be created even if it's not used in any subsequent Dockerfile instruction.

And also we can find same `WORKDIR` in spark project
https://github.com/apache/spark/blob/3d119a52806029752b3807c63a1a41c30deec863/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile#L57
### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Local test

```log
hadoop@XXXX:~/yangbinjie/XXXXe$ docker run cd3d2a0ccab5e88c202ad56c98d4db6ca5d36b2f7d44b5aa2a9166f075d5f950 ls -l
total 269
drwxrwxr-x 2 celeborn celeborn   4 Sep 11 05:37 bin
drwxrwxr-x 2 celeborn celeborn   9 Sep 11 05:37 conf
drwxrwxr-x 2 celeborn celeborn  78 Sep 11 05:37 jars
drwxrwxr-x 2 celeborn celeborn  79 Sep 11 05:37 master-jars
-rw-rw-r-- 1 celeborn celeborn 138 Sep 11 03:33 RELEASE
drwxrwxr-x 2 celeborn celeborn  11 Sep 11 05:37 sbin
drwxrwxr-x 2 celeborn celeborn  66 Sep 11 05:37 worker-jars
```
