### PR TITLE
[CELEBORN-968] Make volume name dynamic in StatefulSet in Helm chart

### DIFF
--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       {{- $dirs := .Values.volumes.master }}
       {{- if eq "hostPath" (index $dirs 0).type }}
-      - name: chown-celeborn-master-volume
+      - name: chown-{{ $.Release.Name }}-master-volume
         image: alpine:3.18
         imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
         securityContext:
@@ -86,7 +86,7 @@ spec:
         - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
         - {{ (index $dirs 0).mountPath }}
         volumeMounts:
-          - name: celeborn-master-vol-0
+          - name: {{ $.Release.Name }}-master-vol-0
             mountPath: {{ (index $dirs 0).mountPath }}
       {{- end }}
       containers:

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
       {{- $dirs := .Values.volumes.worker }}
       {{- if eq "hostPath" (index $dirs 0).type }}
-      - name: chown-celeborn-worker-volume
+      - name: chown-{{ $.Release.Name }}-worker-volume
         image: alpine:3.18
         imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
         securityContext:
@@ -89,7 +89,7 @@ spec:
         {{- end}}
         volumeMounts:
         {{- range $index, $dir := $dirs }}
-        - name: celeborn-worker-vol-{{ $index }}
+        - name: {{ $.Release.Name }}-worker-vol-{{ $index }}
           mountPath: {{ $dir.mountPath }}
         {{- end}}
       {{- end }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Update volumeMounts's name by a dynamic {{ $.Release.Name }} prefix  in `master-stateful.yaml` and `worker-stateful.yaml`

### Why are the changes needed?

When running multiple Celeborn clusters with different release names and Celeborn versions, helm install was failed until making the initContainers' volume name dynamic. See the error from master's statefulset :

>> kubectl describe statefulset.apps/clbv3-master  -n celeborn

Events:
  Type     Reason        Age                From                    Message
  ----     ------        ----               ----                    -------
  Warning  FailedCreate  5s (x14 over 46s)  statefulset-controller  create Pod clbv3-master-0 in StatefulSet clbv3-master failed error: Pod "clbv3-master-0" is invalid: spec.initContainers[0].volumeMounts[0].name: Not found: "celeborn-master-vol-0"


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
Helm install Celeborn cluster twice in the same namespace but different release names. It shouldn't fail.
For example:
```
helm install celeborn charts/celeborn-shuffle-service  -n celeborn
helm install clbv3 charts/celeborn-shuffle-service  -n celeborn
```