### PR TITLE
[CELEBORN-770][FLINK] Convert BacklogAnnouncement, BufferStreamEnd, ReadAddCredit to PB

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteBufferStreamReader.java
@@ -25,10 +25,10 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.network.protocol.BacklogAnnouncement;
 import org.apache.celeborn.common.network.protocol.BufferStreamEnd;
-import org.apache.celeborn.common.network.protocol.ReadAddCredit;
 import org.apache.celeborn.common.network.protocol.RequestMessage;
 import org.apache.celeborn.common.network.protocol.TransportableError;
 import org.apache.celeborn.common.network.util.NettyUtils;
+import org.apache.celeborn.common.protocol.PbReadAddCredit;
 import org.apache.celeborn.plugin.flink.buffer.CreditListener;
 import org.apache.celeborn.plugin.flink.buffer.TransferBufferPool;
 import org.apache.celeborn.plugin.flink.protocol.ReadData;
@@ -115,8 +115,11 @@ public class RemoteBufferStreamReader extends CreditListener {
 
   public void notifyAvailableCredits(int numCredits) {
     if (!closed) {
-      ReadAddCredit addCredit = new ReadAddCredit(bufferStream.getStreamId(), numCredits);
-      bufferStream.addCredit(addCredit);
+      bufferStream.addCredit(
+          PbReadAddCredit.newBuilder()
+              .setStreamId(bufferStream.getStreamId())
+              .setCredit(numCredits)
+              .build());
     }
   }
 

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/CelebornBufferStream.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/readclient/CelebornBufferStream.java
@@ -29,11 +29,15 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.network.client.RpcResponseCallback;
 import org.apache.celeborn.common.network.client.TransportClient;
-import org.apache.celeborn.common.network.protocol.*;
+import org.apache.celeborn.common.network.protocol.RequestMessage;
+import org.apache.celeborn.common.network.protocol.TransportMessage;
+import org.apache.celeborn.common.network.protocol.TransportableError;
 import org.apache.celeborn.common.network.util.NettyUtils;
 import org.apache.celeborn.common.protocol.MessageType;
 import org.apache.celeborn.common.protocol.PartitionLocation;
+import org.apache.celeborn.common.protocol.PbBufferStreamEnd;
 import org.apache.celeborn.common.protocol.PbOpenStream;
+import org.apache.celeborn.common.protocol.PbReadAddCredit;
 import org.apache.celeborn.common.protocol.PbStreamHandler;
 import org.apache.celeborn.plugin.flink.network.FlinkTransportClientFactory;
 
@@ -82,21 +86,25 @@ public class CelebornBufferStream {
     moveToNextPartitionIfPossible(0);
   }
 
-  public void addCredit(ReadAddCredit addCredit) {
-    this.client
-        .getChannel()
-        .writeAndFlush(addCredit)
-        .addListener(
-            future -> {
-              if (future.isSuccess()) {
-                // Send ReadAddCredit do not expect response.
-              } else {
-                logger.warn(
-                    "Send ReadAddCredit to {} failed, detail {}",
-                    this.client.getSocketAddress().toString(),
-                    future.cause());
-              }
-            });
+  public void addCredit(PbReadAddCredit pbReadAddCredit) {
+    this.client.sendRpc(
+        new TransportMessage(MessageType.READ_ADD_CREDIT, pbReadAddCredit.toByteArray())
+            .toByteBuffer(),
+        new RpcResponseCallback() {
+
+          @Override
+          public void onSuccess(ByteBuffer response) {
+            // Send PbReadAddCredit do not expect response.
+          }
+
+          @Override
+          public void onFailure(Throwable e) {
+            logger.warn(
+                "Send PbReadAddCredit to {} failed, detail {}",
+                NettyUtils.getRemoteAddress(client.getChannel()),
+                e.getCause());
+          }
+        });
   }
 
   public static CelebornBufferStream empty() {
@@ -127,7 +135,11 @@ public class CelebornBufferStream {
 
   private void closeStream(long streamId) {
     if (client != null && client.isActive()) {
-      client.getChannel().writeAndFlush(new BufferStreamEnd(streamId));
+      client.sendRpc(
+          new TransportMessage(
+                  MessageType.BUFFER_STREAM_END,
+                  PbBufferStreamEnd.newBuilder().setStreamId(streamId).build().toByteArray())
+              .toByteBuffer());
     }
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -170,6 +170,22 @@ public class TransportClient implements Closeable {
     return requestId;
   }
 
+  /**
+   * Sends an opaque message to the RpcHandler on the server-side.
+   *
+   * @param message The message to send.
+   * @return The RPC's id.
+   */
+  public long sendRpc(ByteBuffer message) {
+    if (logger.isTraceEnabled()) {
+      logger.trace("Sending RPC to {}", NettyUtils.getRemoteAddress(channel));
+    }
+
+    long requestId = requestId();
+    channel.writeAndFlush(new RpcRequest(requestId, new NioManagedBuffer(message)));
+    return requestId;
+  }
+
   public ChannelFuture pushData(
       PushData pushData, long pushDataTimeout, RpcResponseCallback callback) {
     return pushData(pushData, pushDataTimeout, callback, null);

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/BacklogAnnouncement.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/BacklogAnnouncement.java
@@ -21,6 +21,8 @@ import static org.apache.celeborn.common.network.protocol.Message.Type.BACKLOG_A
 
 import io.netty.buffer.ByteBuf;
 
+import org.apache.celeborn.common.protocol.PbBacklogAnnouncement;
+
 // This RPC is sent to flink plugin to tell flink client to be ready for buffers.
 public class BacklogAnnouncement extends RequestMessage {
   private long streamId;
@@ -59,5 +61,9 @@ public class BacklogAnnouncement extends RequestMessage {
 
   public int getBacklog() {
     return backlog;
+  }
+
+  public static BacklogAnnouncement fromProto(PbBacklogAnnouncement pb) {
+    return new BacklogAnnouncement(pb.getStreamId(), pb.getBacklog());
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/BufferStreamEnd.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/BufferStreamEnd.java
@@ -19,6 +19,8 @@ package org.apache.celeborn.common.network.protocol;
 
 import io.netty.buffer.ByteBuf;
 
+import org.apache.celeborn.common.protocol.PbBufferStreamEnd;
+
 public class BufferStreamEnd extends RequestMessage {
   private long streamId;
 
@@ -48,5 +50,9 @@ public class BufferStreamEnd extends RequestMessage {
 
   public long getStreamId() {
     return streamId;
+  }
+
+  public static BufferStreamEnd fromProto(PbBufferStreamEnd pb) {
+    return new BufferStreamEnd(pb.getStreamId());
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ReadAddCredit.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ReadAddCredit.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
 
+@Deprecated
 public class ReadAddCredit extends RequestMessage {
   private long streamId;
   private int credit;

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
@@ -17,8 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import static org.apache.celeborn.common.protocol.MessageType.BACKLOG_ANNOUNCEMENT_VALUE;
+import static org.apache.celeborn.common.protocol.MessageType.BUFFER_STREAM_END_VALUE;
 import static org.apache.celeborn.common.protocol.MessageType.OPEN_STREAM_VALUE;
 import static org.apache.celeborn.common.protocol.MessageType.PUSH_DATA_HAND_SHAKE_VALUE;
+import static org.apache.celeborn.common.protocol.MessageType.READ_ADD_CREDIT_VALUE;
 import static org.apache.celeborn.common.protocol.MessageType.REGION_FINISH_VALUE;
 import static org.apache.celeborn.common.protocol.MessageType.REGION_START_VALUE;
 import static org.apache.celeborn.common.protocol.MessageType.STREAM_HANDLER_VALUE;
@@ -33,8 +36,11 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.protocol.MessageType;
+import org.apache.celeborn.common.protocol.PbBacklogAnnouncement;
+import org.apache.celeborn.common.protocol.PbBufferStreamEnd;
 import org.apache.celeborn.common.protocol.PbOpenStream;
 import org.apache.celeborn.common.protocol.PbPushDataHandShake;
+import org.apache.celeborn.common.protocol.PbReadAddCredit;
 import org.apache.celeborn.common.protocol.PbRegionFinish;
 import org.apache.celeborn.common.protocol.PbRegionStart;
 import org.apache.celeborn.common.protocol.PbStreamHandler;
@@ -76,6 +82,12 @@ public class TransportMessage implements Serializable {
         return (T) PbRegionStart.parseFrom(payload);
       case REGION_FINISH_VALUE:
         return (T) PbRegionFinish.parseFrom(payload);
+      case BACKLOG_ANNOUNCEMENT_VALUE:
+        return (T) PbBacklogAnnouncement.parseFrom(payload);
+      case BUFFER_STREAM_END_VALUE:
+        return (T) PbBufferStreamEnd.parseFrom(payload);
+      case READ_ADD_CREDIT_VALUE:
+        return (T) PbReadAddCredit.parseFrom(payload);
       default:
         logger.error("Unexpected type {}", type);
     }

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -79,6 +79,9 @@ enum MessageType {
   PUSH_DATA_HAND_SHAKE = 56;
   REGION_START = 57;
   REGION_FINISH = 58;
+  BACKLOG_ANNOUNCEMENT = 59;
+  BUFFER_STREAM_END = 60;
+  READ_ADD_CREDIT = 61;
 }
 
 message PbStorageInfo {
@@ -498,9 +501,9 @@ message PbOpenStream {
 }
 
 message PbStreamHandler {
-  int64 streamId = 1 ;
+  int64 streamId = 1;
   int32 numChunks = 2;
-  repeated int64 chunkOffsets = 3 ;
+  repeated int64 chunkOffsets = 3;
   string fullPath = 4;
 }
 
@@ -527,4 +530,18 @@ message PbRegionFinish {
   string shuffleKey = 2;
   string partitionUniqueId = 3;
   int32 attemptId = 4;
+}
+
+message PbBacklogAnnouncement {
+  int64 streamId = 1;
+  int32 backlog = 2;
+}
+
+message PbBufferStreamEnd {
+  int64 streamId = 1;
+}
+
+message PbReadAddCredit {
+  int64 streamId = 1;
+  int32 credit = 2;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`BacklogAnnouncement`, `BufferStreamEnd`, and `ReadAddCredit` should merge to transport messages to enhance celeborn's compatibility.

### Why are the changes needed?

1. Improves celeborn's transport flexibility to change RPC.
2. Makes Compatible with 0.2 client.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `TransportFrameDecoderWithBufferSupplierSuiteJ`