### PR TITLE
[CELEBORN-975] Refactor the check logic to stop the celeborn master and worker

### DIFF
--- a/sbin/celeborn-daemon.sh
+++ b/sbin/celeborn-daemon.sh
@@ -188,21 +188,8 @@ stop_celeborn() {
         if [[ $(ps -p "$TARGET_ID" -o comm=) == "" ]]; then
           rm -f "$pid"
         else
-          echo "Failed to stop server after ${wait_timeout}s, try 'kill -9 ${TARGET_ID}' forcefully"
-          kill -9 "${TARGET_ID}"
-          for i in {1..20}
-          do
-            sleep 0.5
-            if [[ $(ps -p "$TARGET_ID" -o comm=) == "" ]]; then
-              rm -f "$pid"
-              break
-            fi
-          done
-
-          if [ -f ${pid} ]; then
-            echo "Failed to stop server forcefully after 10 seconds"
-            exit 1
-          fi
+          echo "Failed to stop server(pid=$TARGET_ID) after ${wait_timeout}s"
+          exit 1
         fi
       else
         echo "no $command to stop"


### PR DESCRIPTION
### What changes were proposed in this pull request?

`stop-master.sh` and `stop-worker.sh` support the stop command to wait up to 600s after starting `kill -15`.

Delete the pid file only when the stop succeeds, to avoid failing to retry the stop command to find the pid file.


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

