### PR TITLE
[CELEBORN-976] Introduce script to check master and worker status

### DIFF
--- a/sbin/status-master.sh
+++ b/sbin/status-master.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-# Stops the celeborn master on the machine this script is executed on.
+# Get the celeborn master status on the machine this script is executed on.
 
 if [ -z "${CELEBORN_HOME}" ]; then
   export CELEBORN_HOME="$(cd "`dirname "$0"`"/..; pwd)"

--- a/sbin/status-master.sh
+++ b/sbin/status-master.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Stops the celeborn master on the machine this script is executed on.
+
+if [ -z "${CELEBORN_HOME}" ]; then
+  export CELEBORN_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+fi
+
+"${CELEBORN_HOME}/sbin/celeborn-daemon.sh" status org.apache.celeborn.service.deploy.master.Master 1

--- a/sbin/status-worker.sh
+++ b/sbin/status-worker.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Stops the celeborn worker on the machine this script is executed on.
+
+if [ -z "${CELEBORN_HOME}" ]; then
+  export CELEBORN_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+fi
+
+if [ "$WORKER_INSTANCE" = "" ]; then
+  WORKER_INSTANCE=1
+fi
+
+"${CELEBORN_HOME}/sbin/celeborn-daemon.sh" status org.apache.celeborn.service.deploy.worker.Worker "$WORKER_INSTANCE"

--- a/sbin/status-worker.sh
+++ b/sbin/status-worker.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-# Stops the celeborn worker on the machine this script is executed on.
+# Get the celeborn worker status on the machine this script is executed on.
 
 if [ -z "${CELEBORN_HOME}" ]; then
   export CELEBORN_HOME="$(cd "`dirname "$0"`"/..; pwd)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `status-master.sh` and `status-worker.sh` to check the pid status corresponding to the master and worker.

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

