### PR TITLE
[CELEBORN-977] Support RocksDB as recover DB backend

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -211,4 +211,3 @@ Apache Software Foundation License 2.0
 --------------------------------------
 
 common/src/main/java/org/apache/celeborn/common/network/util/LimitedInputStream.java
-worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/*

--- a/LICENSE
+++ b/LICENSE
@@ -211,3 +211,4 @@ Apache Software Foundation License 2.0
 --------------------------------------
 
 common/src/main/java/org/apache/celeborn/common/network/util/LimitedInputStream.java
+worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/*

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -268,6 +268,7 @@ org.scala-lang:scala-library
 org.scala-lang:scala-reflect
 org.slf4j:jcl-over-slf4j
 org.yaml:snakeyaml
+org.rocksdb:rocksdbjni
 
 
 ------------------------------------------------------------------------------------

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -930,6 +930,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerGracefulShutdownCheckSlotsFinishedTimeoutMs: Long =
     get(WORKER_CHECK_SLOTS_FINISHED_TIMEOUT)
   def workerGracefulShutdownRecoverPath: String = get(WORKER_GRACEFUL_SHUTDOWN_RECOVER_PATH)
+  def workerGracefulShutdownRecoverDbBackend: String =
+    get(WORKER_GRACEFUL_SHUTDOWN_RECOVER_DB_BACKEND)
   def workerGracefulShutdownPartitionSorterCloseAwaitTimeMs: Long =
     get(WORKER_PARTITION_SORTER_SHUTDOWN_TIMEOUT)
   def workerGracefulShutdownFlusherShutdownTimeoutMs: Long = get(WORKER_FLUSHER_SHUTDOWN_TIMEOUT)
@@ -2593,11 +2595,19 @@ object CelebornConf extends Logging {
   val WORKER_GRACEFUL_SHUTDOWN_RECOVER_PATH: ConfigEntry[String] =
     buildConf("celeborn.worker.graceful.shutdown.recoverPath")
       .categories("worker")
-      .doc("The path to store levelDB.")
+      .doc("The path to store DB.")
       .version("0.2.0")
       .stringConf
       .transform(_.replace("<tmp>", System.getProperty("java.io.tmpdir")))
       .createWithDefault(s"<tmp>/recover")
+
+  val WORKER_GRACEFUL_SHUTDOWN_RECOVER_DB_BACKEND: ConfigEntry[String] =
+    buildConf("celeborn.worker.graceful.shutdown.recoverDbBackend")
+      .categories("worker")
+      .doc("Specifies a disk-based store used in local db. LEVELDB or ROCKSDB.")
+      .version("0.4.0")
+      .stringConf
+      .createWithDefault("LEVELDB")
 
   val WORKER_PARTITION_SORTER_SHUTDOWN_TIMEOUT: ConfigEntry[Long] =
     buildConf("celeborn.worker.graceful.shutdown.partitionSorter.shutdownTimeout")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2607,6 +2607,8 @@ object CelebornConf extends Logging {
       .doc("Specifies a disk-based store used in local db. LEVELDB or ROCKSDB.")
       .version("0.4.0")
       .stringConf
+      .transform(_.toUpperCase(Locale.ROOT))
+      .checkValues(Set("LEVELDB", "ROCKSDB"))
       .createWithDefault("LEVELDB")
 
   val WORKER_PARTITION_SORTER_SHUTDOWN_TIMEOUT: ConfigEntry[Long] =

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -84,6 +84,7 @@ ratis-server/2.5.1//ratis-server-2.5.1.jar
 ratis-shell/2.5.1//ratis-shell-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 reflections/0.10.2//reflections-0.10.2.jar
+rocksdbjni/8.5.3//rocksdbjni-8.5.3.jar
 scala-library/2.12.15//scala-library-2.12.15.jar
 scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 shims/0.9.32//shims-0.9.32.jar

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -56,7 +56,8 @@ license: |
 | celeborn.worker.graceful.shutdown.checkSlotsFinished.timeout | 480s | The wait time of waiting for the released slots to be committed or destroyed during worker graceful shutdown. | 0.2.0 | 
 | celeborn.worker.graceful.shutdown.enabled | false | When true, during worker shutdown, the worker will wait for all released slots to be committed or destroyed. | 0.2.0 | 
 | celeborn.worker.graceful.shutdown.partitionSorter.shutdownTimeout | 120s | The wait time of waiting for sorting partition files during worker graceful shutdown. | 0.2.0 | 
-| celeborn.worker.graceful.shutdown.recoverPath | &lt;tmp&gt;/recover | The path to store levelDB. | 0.2.0 | 
+| celeborn.worker.graceful.shutdown.recoverDbBackend | LEVELDB | Specifies a disk-based store used in local db. LEVELDB or ROCKSDB. | 0.4.0 | 
+| celeborn.worker.graceful.shutdown.recoverPath | &lt;tmp&gt;/recover | The path to store DB. | 0.2.0 | 
 | celeborn.worker.graceful.shutdown.saveCommittedFileInfo.interval | 5s | Interval for a Celeborn worker to flush committed file infos into Level DB. | 0.3.1 | 
 | celeborn.worker.graceful.shutdown.saveCommittedFileInfo.sync | false | Whether to call sync method to save committed file infos into Level DB to handle OS crash. | 0.3.1 | 
 | celeborn.worker.graceful.shutdown.timeout | 600s | The worker's graceful shutdown timeout time. | 0.2.0 | 

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <snakeyaml.version>1.33</snakeyaml.version>
     <zstd-jni.version>1.5.2-1</zstd-jni.version>
     <kubernetes-client.version>6.7.0</kubernetes-client.version>
+    <rocksdbjni.version>8.5.3</rocksdbjni.version>
 
     <shading.prefix>org.apache.celeborn.shaded</shading.prefix>
 
@@ -440,6 +441,11 @@
         <artifactId>kubernetes-client</artifactId>
         <version>${kubernetes-client.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.rocksdb</groupId>
+        <artifactId>rocksdbjni</artifactId>
+        <version>${rocksdbjni.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -405,8 +405,8 @@ object CelebornWorker {
         Dependencies.log4j12Api,
         Dependencies.log4jSlf4jImpl,
         Dependencies.leveldbJniAll,
-        Dependencies.rocksdbJni,
         Dependencies.roaringBitmap,
+        Dependencies.rocksdbJni,
         Dependencies.scalatestMockito % "test"
       ) ++ commonUnitTestDependencies
     )

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -57,6 +57,7 @@ object Dependencies {
   val scalatestVersion = "3.2.16"
   val slf4jVersion = "1.7.36"
   val snakeyamlVersion = "1.33"
+  val rocksdbJniVersion = "8.5.3"
   
   // Versions for proto
   val protocVersion = "3.19.2"
@@ -95,6 +96,7 @@ object Dependencies {
   val slf4jJclOverSlf4j = "org.slf4j" % "jcl-over-slf4j" % slf4jVersion
   val snakeyaml = "org.yaml" % "snakeyaml" % snakeyamlVersion
   val zstdJni = "com.github.luben" % "zstd-jni" % zstdJniVersion
+  val rocksdbJni = "org.rocksdb" % "rocksdbjni" % rocksdbJniVersion
 
   // Test dependencies
   // https://www.scala-sbt.org/1.x/docs/Testing.html
@@ -403,6 +405,7 @@ object CelebornWorker {
         Dependencies.log4j12Api,
         Dependencies.log4jSlf4jImpl,
         Dependencies.leveldbJniAll,
+        Dependencies.rocksdbJni,
         Dependencies.roaringBitmap,
         Dependencies.scalatestMockito % "test"
       ) ++ commonUnitTestDependencies

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -53,12 +53,12 @@ object Dependencies {
   val nettyVersion = "4.1.93.Final"
   val ratisVersion = "2.5.1"
   val roaringBitmapVersion = "0.9.32"
+  val rocksdbJniVersion = "8.5.3"
   val scalatestMockitoVersion = "1.17.14"
   val scalatestVersion = "3.2.16"
   val slf4jVersion = "1.7.36"
   val snakeyamlVersion = "1.33"
-  val rocksdbJniVersion = "8.5.3"
-  
+
   // Versions for proto
   val protocVersion = "3.19.2"
   val protoVersion = "3.19.2"
@@ -90,13 +90,13 @@ object Dependencies {
   val ratisShell = "org.apache.ratis" % "ratis-shell" % ratisVersion excludeAll(
     ExclusionRule("org.slf4j", "slf4j-simple"))
   val roaringBitmap = "org.roaringbitmap" % "RoaringBitmap" % roaringBitmapVersion
+  val rocksdbJni = "org.rocksdb" % "rocksdbjni" % rocksdbJniVersion
   val scalaReflect = "org.scala-lang" % "scala-reflect" % projectScalaVersion
   val slf4jApi = "org.slf4j" % "slf4j-api" % slf4jVersion
   val slf4jJulToSlf4j = "org.slf4j" % "jul-to-slf4j" % slf4jVersion
   val slf4jJclOverSlf4j = "org.slf4j" % "jcl-over-slf4j" % slf4jVersion
   val snakeyaml = "org.yaml" % "snakeyaml" % snakeyamlVersion
   val zstdJni = "com.github.luben" % "zstd-jni" % zstdJniVersion
-  val rocksdbJni = "org.rocksdb" % "rocksdbjni" % rocksdbJniVersion
 
   // Test dependencies
   // https://www.scala-sbt.org/1.x/docs/Testing.html

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -76,6 +76,10 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.celeborn</groupId>

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/DB.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/DB.java
@@ -15,24 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.service.deploy.worker;
+package org.apache.celeborn.service.deploy.worker.shuffledb;
 
-import java.nio.charset.StandardCharsets;
+import java.io.Closeable;
 
-import org.apache.celeborn.service.deploy.worker.shuffledb.StoreVersion;
+/** Note: code copied from Apache Spark. */
+public interface DB extends Closeable {
+  /** Set the DB entry for "key" to "value". */
+  void put(byte[] key, byte[] value);
 
-public abstract class ShuffleRecoverHelper {
-  protected String SHUFFLE_KEY_PREFIX = "SHUFFLE-KEY";
-  protected StoreVersion CURRENT_VERSION = new StoreVersion(1, 0);
+  /** Set the DB entry for "key" to "value". Support Sync option */
+  void put(byte[] key, byte[] value, boolean sync);
 
-  protected byte[] dbShuffleKey(String shuffleKey) {
-    return (SHUFFLE_KEY_PREFIX + ";" + shuffleKey).getBytes(StandardCharsets.UTF_8);
-  }
+  /**
+   * Get which returns a new byte array storing the value associated with the specified input key if
+   * any.
+   */
+  byte[] get(byte[] key);
 
-  protected String parseDbShuffleKey(String s) {
-    if (!s.startsWith(SHUFFLE_KEY_PREFIX)) {
-      throw new IllegalArgumentException("Expected a string starting with " + SHUFFLE_KEY_PREFIX);
-    }
-    return s.substring(SHUFFLE_KEY_PREFIX.length() + 1);
-  }
+  /** Delete the DB entry (if any) for "key". */
+  void delete(byte[] key);
+
+  /** Return an iterator over the contents of the DB. */
+  DBIterator iterator();
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/DBBackend.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/DBBackend.java
@@ -15,24 +15,31 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.service.deploy.worker;
+package org.apache.celeborn.service.deploy.worker.shuffledb;
 
-import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
-import org.apache.celeborn.service.deploy.worker.shuffledb.StoreVersion;
+/**
+ * The enum `DBBackend` use to specify a disk-based store used in shuffle service local db. Support
+ * the use of LevelDB and RocksDB.
+ *
+ * <p>Note: code copied from Apache Spark.
+ */
+public enum DBBackend {
+  LEVELDB(".ldb"),
+  ROCKSDB(".rdb");
 
-public abstract class ShuffleRecoverHelper {
-  protected String SHUFFLE_KEY_PREFIX = "SHUFFLE-KEY";
-  protected StoreVersion CURRENT_VERSION = new StoreVersion(1, 0);
+  private final String fileSuffix;
 
-  protected byte[] dbShuffleKey(String shuffleKey) {
-    return (SHUFFLE_KEY_PREFIX + ";" + shuffleKey).getBytes(StandardCharsets.UTF_8);
+  DBBackend(String fileSuffix) {
+    this.fileSuffix = fileSuffix;
   }
 
-  protected String parseDbShuffleKey(String s) {
-    if (!s.startsWith(SHUFFLE_KEY_PREFIX)) {
-      throw new IllegalArgumentException("Expected a string starting with " + SHUFFLE_KEY_PREFIX);
-    }
-    return s.substring(SHUFFLE_KEY_PREFIX.length() + 1);
+  public String fileName(String prefix) {
+    return prefix + fileSuffix;
+  }
+
+  public static DBBackend byName(String value) {
+    return DBBackend.valueOf(value.toUpperCase(Locale.ROOT));
   }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/DBIterator.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/DBIterator.java
@@ -15,24 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.service.deploy.worker;
+package org.apache.celeborn.service.deploy.worker.shuffledb;
 
-import java.nio.charset.StandardCharsets;
+import java.io.Closeable;
+import java.util.Iterator;
+import java.util.Map;
 
-import org.apache.celeborn.service.deploy.worker.shuffledb.StoreVersion;
+/** Note: code copied from Apache Spark. */
+public interface DBIterator extends Iterator<Map.Entry<byte[], byte[]>>, Closeable {
 
-public abstract class ShuffleRecoverHelper {
-  protected String SHUFFLE_KEY_PREFIX = "SHUFFLE-KEY";
-  protected StoreVersion CURRENT_VERSION = new StoreVersion(1, 0);
+  /** Position at the first entry in the source whose `key` is at target. */
+  void seek(byte[] key);
 
-  protected byte[] dbShuffleKey(String shuffleKey) {
-    return (SHUFFLE_KEY_PREFIX + ";" + shuffleKey).getBytes(StandardCharsets.UTF_8);
-  }
-
-  protected String parseDbShuffleKey(String s) {
-    if (!s.startsWith(SHUFFLE_KEY_PREFIX)) {
-      throw new IllegalArgumentException("Expected a string starting with " + SHUFFLE_KEY_PREFIX);
-    }
-    return s.substring(SHUFFLE_KEY_PREFIX.length() + 1);
+  default void remove() {
+    throw new UnsupportedOperationException();
   }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/LevelDB.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/LevelDB.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.shuffledb;
+
+import java.io.IOException;
+
+import org.iq80.leveldb.WriteOptions;
+
+/** Note: code copied from Apache Spark. */
+public class LevelDB implements DB {
+  private final org.iq80.leveldb.DB db;
+  private final WriteOptions SYNC_WRITE_OPTIONS = new WriteOptions().sync(true);
+
+  public LevelDB(org.iq80.leveldb.DB db) {
+    this.db = db;
+  }
+
+  @Override
+  public void put(byte[] key, byte[] value) {
+    db.put(key, value);
+  }
+
+  @Override
+  public void put(byte[] key, byte[] value, boolean sync) {
+    if (sync) {
+      db.put(key, value, SYNC_WRITE_OPTIONS);
+    } else {
+      db.put(key, value);
+    }
+  }
+
+  @Override
+  public byte[] get(byte[] key) {
+    return db.get(key);
+  }
+
+  @Override
+  public void delete(byte[] key) {
+    db.delete(key);
+  }
+
+  @Override
+  public void close() throws IOException {
+    db.close();
+  }
+
+  @Override
+  public DBIterator iterator() {
+    return new LevelDBIterator(db.iterator());
+  }
+}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/LevelDBIterator.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/LevelDBIterator.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.shuffledb;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import com.google.common.base.Throwables;
+
+/** Note: code copied from Apache Spark. */
+public class LevelDBIterator implements DBIterator {
+
+  private final org.iq80.leveldb.DBIterator it;
+
+  private boolean checkedNext;
+
+  private boolean closed;
+
+  private Map.Entry<byte[], byte[]> next;
+
+  public LevelDBIterator(org.iq80.leveldb.DBIterator it) {
+    this.it = it;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (!checkedNext && !closed) {
+      next = loadNext();
+      checkedNext = true;
+    }
+    if (!closed && next == null) {
+      try {
+        close();
+      } catch (IOException ioe) {
+        throw Throwables.propagate(ioe);
+      }
+    }
+    return next != null;
+  }
+
+  @Override
+  public Map.Entry<byte[], byte[]> next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    checkedNext = false;
+    Map.Entry<byte[], byte[]> ret = next;
+    next = null;
+    return ret;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!closed) {
+      it.close();
+      closed = true;
+      next = null;
+    }
+  }
+
+  @Override
+  public void seek(byte[] key) {
+    it.seek(key);
+  }
+
+  private Map.Entry<byte[], byte[]> loadNext() {
+    boolean hasNext = it.hasNext();
+    if (!hasNext) {
+      return null;
+    }
+    return it.next();
+  }
+}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDB.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDB.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.shuffledb;
+
+import java.io.IOException;
+
+import com.google.common.base.Throwables;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteOptions;
+
+/**
+ * RocksDB implementation of the local KV storage used to persist the shuffle state.
+ *
+ * <p>Note: code copied from Apache Spark.
+ */
+public class RocksDB implements DB {
+  private final org.rocksdb.RocksDB db;
+  private final WriteOptions SYNC_WRITE_OPTIONS = new WriteOptions().setSync(true);
+
+  public RocksDB(org.rocksdb.RocksDB db) {
+    this.db = db;
+  }
+
+  @Override
+  public void put(byte[] key, byte[] value) {
+    try {
+      db.put(key, value);
+    } catch (RocksDBException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void put(byte[] key, byte[] value, boolean sync) {
+    try {
+      if (sync) {
+        db.put(SYNC_WRITE_OPTIONS, key, value);
+      } else {
+        db.put(key, value);
+      }
+    } catch (RocksDBException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public byte[] get(byte[] key) {
+    try {
+      return db.get(key);
+    } catch (RocksDBException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void delete(byte[] key) {
+    try {
+      db.delete(key);
+    } catch (RocksDBException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public DBIterator iterator() {
+    return new RocksDBIterator(db.newIterator());
+  }
+
+  @Override
+  public void close() throws IOException {
+    db.close();
+  }
+}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDBIterator.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDBIterator.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.shuffledb;
+
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import com.google.common.base.Throwables;
+import org.rocksdb.RocksIterator;
+
+/**
+ * RocksDB implementation of `DBIterator`.
+ *
+ * <p>Note: code copied from Apache Spark.
+ */
+public class RocksDBIterator implements DBIterator {
+
+  private final RocksIterator it;
+
+  private boolean checkedNext;
+
+  private boolean closed;
+
+  private Map.Entry<byte[], byte[]> next;
+
+  public RocksDBIterator(RocksIterator it) {
+    this.it = it;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (!checkedNext && !closed) {
+      next = loadNext();
+      checkedNext = true;
+    }
+    if (!closed && next == null) {
+      try {
+        close();
+      } catch (IOException ioe) {
+        throw Throwables.propagate(ioe);
+      }
+    }
+    return next != null;
+  }
+
+  @Override
+  public Map.Entry<byte[], byte[]> next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    checkedNext = false;
+    Map.Entry<byte[], byte[]> ret = next;
+    next = null;
+    return ret;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!closed) {
+      it.close();
+      closed = true;
+      next = null;
+    }
+  }
+
+  @Override
+  public void seek(byte[] key) {
+    it.seek(key);
+  }
+
+  private Map.Entry<byte[], byte[]> loadNext() {
+    if (it.isValid()) {
+      Map.Entry<byte[], byte[]> nextEntry = new AbstractMap.SimpleEntry<>(it.key(), it.value());
+      it.next();
+      return nextEntry;
+    }
+    return null;
+  }
+}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDBProvider.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDBProvider.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker.shuffledb;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+import org.rocksdb.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.util.PbSerDeUtils;
+
+/** RocksDB utility class available in the network package. */
+public class RocksDBProvider {
+
+  static {
+    org.rocksdb.RocksDB.loadLibrary();
+  }
+
+  private static final Logger logger = LoggerFactory.getLogger(RocksDBProvider.class);
+
+  public static org.rocksdb.RocksDB initRockDB(File dbFile, StoreVersion version)
+      throws IOException {
+    org.rocksdb.RocksDB tmpDb = null;
+    if (dbFile != null) {
+      BloomFilter fullFilter = new BloomFilter(10.0D /* BloomFilter.DEFAULT_BITS_PER_KEY */, false);
+      BlockBasedTableConfig tableFormatConfig =
+          new BlockBasedTableConfig()
+              .setFilterPolicy(fullFilter)
+              .setEnableIndexCompression(false)
+              .setIndexBlockRestartInterval(8)
+              .setFormatVersion(5);
+
+      Options dbOptions = new Options();
+      RocksDBLogger rocksDBLogger = new RocksDBLogger(dbOptions);
+
+      dbOptions.setCreateIfMissing(false);
+      dbOptions.setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION);
+      dbOptions.setCompressionType(CompressionType.LZ4_COMPRESSION);
+      dbOptions.setTableFormatConfig(tableFormatConfig);
+      dbOptions.setLogger(rocksDBLogger);
+
+      try {
+        tmpDb = org.rocksdb.RocksDB.open(dbOptions, dbFile.toString());
+      } catch (RocksDBException e) {
+        if (e.getStatus().getCode() == Status.Code.NotFound) {
+          logger.info("Creating state database at " + dbFile);
+          dbOptions.setCreateIfMissing(true);
+          try {
+            tmpDb = org.rocksdb.RocksDB.open(dbOptions, dbFile.toString());
+          } catch (RocksDBException dbExc) {
+            throw new IOException("Unable to create state store", dbExc);
+          }
+        } else {
+          // the RocksDB file seems to be corrupt somehow.  Let's just blow it away and create
+          // a new one, so we can keep processing new apps
+          logger.error(
+              "error opening rocksdb file {}. Creating new file, will not be able to "
+                  + "recover state for existing applications",
+              dbFile,
+              e);
+          if (dbFile.isDirectory()) {
+            for (File f : Objects.requireNonNull(dbFile.listFiles())) {
+              if (!f.delete()) {
+                logger.warn("error deleting {}", f.getPath());
+              }
+            }
+          }
+          if (!dbFile.delete()) {
+            logger.warn("error deleting {}", dbFile.getPath());
+          }
+          dbOptions.setCreateIfMissing(true);
+          try {
+            tmpDb = org.rocksdb.RocksDB.open(dbOptions, dbFile.toString());
+          } catch (RocksDBException dbExc) {
+            throw new IOException("Unable to create state store", dbExc);
+          }
+        }
+      }
+      try {
+        // if there is a version mismatch, we throw an exception, which means the service
+        // is unusable
+        checkVersion(tmpDb, version);
+      } catch (RocksDBException e) {
+        throw new IOException(e.getMessage(), e);
+      }
+    }
+    return tmpDb;
+  }
+
+  private static class RocksDBLogger extends org.rocksdb.Logger {
+    private static final Logger LOG = LoggerFactory.getLogger(RocksDBLogger.class);
+
+    RocksDBLogger(Options options) {
+      super(options);
+    }
+
+    @Override
+    protected void log(InfoLogLevel infoLogLevel, String message) {
+      if (infoLogLevel == InfoLogLevel.INFO_LEVEL) {
+        LOG.info(message);
+      }
+    }
+  }
+
+  /**
+   * Simple major.minor versioning scheme. Any incompatible changes should be across major versions.
+   * Minor version differences are allowed -- meaning we should be able to read dbs that are either
+   * earlier *or* later on the minor version.
+   */
+  public static void checkVersion(org.rocksdb.RocksDB db, StoreVersion newversion)
+      throws IOException, RocksDBException {
+    byte[] bytes = db.get(StoreVersion.KEY);
+    if (bytes == null) {
+      storeVersion(db, newversion);
+    } else {
+      ArrayList<Integer> versions = PbSerDeUtils.fromPbStoreVersion(bytes);
+      StoreVersion version = new StoreVersion(versions.get(0), versions.get(1));
+      if (version.major != newversion.major) {
+        throw new IOException(
+            "cannot read state DB with version "
+                + version
+                + ", incompatible "
+                + "with current version "
+                + newversion);
+      }
+      storeVersion(db, newversion);
+    }
+  }
+
+  public static void storeVersion(org.rocksdb.RocksDB db, StoreVersion version)
+      throws IOException, RocksDBException {
+    db.put(StoreVersion.KEY, PbSerDeUtils.toPbStoreVersion(version.major, version.minor));
+  }
+}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDBProvider.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/RocksDBProvider.java
@@ -28,7 +28,11 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.util.PbSerDeUtils;
 
-/** RocksDB utility class available in the network package. */
+/**
+ * RocksDB utility class available in the network package.
+ *
+ * <p>Note: code copied from Apache Spark.
+ */
 public class RocksDBProvider {
 
   static {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/StoreVersion.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/StoreVersion.java
@@ -19,7 +19,11 @@ package org.apache.celeborn.service.deploy.worker.shuffledb;
 
 import java.nio.charset.StandardCharsets;
 
-/** Used to identify the version of data stored in local shuffle state DB. */
+/**
+ * Used to identify the version of data stored in local shuffle state DB.
+ *
+ * <p>Note: code copied from Apache Spark.
+ */
 public class StoreVersion {
 
   public static final byte[] KEY = "StoreVersion".getBytes(StandardCharsets.UTF_8);

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/StoreVersion.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/StoreVersion.java
@@ -15,24 +15,37 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.service.deploy.worker;
+package org.apache.celeborn.service.deploy.worker.shuffledb;
 
 import java.nio.charset.StandardCharsets;
 
-import org.apache.celeborn.service.deploy.worker.shuffledb.StoreVersion;
+/** Used to identify the version of data stored in local shuffle state DB. */
+public class StoreVersion {
 
-public abstract class ShuffleRecoverHelper {
-  protected String SHUFFLE_KEY_PREFIX = "SHUFFLE-KEY";
-  protected StoreVersion CURRENT_VERSION = new StoreVersion(1, 0);
+  public static final byte[] KEY = "StoreVersion".getBytes(StandardCharsets.UTF_8);
 
-  protected byte[] dbShuffleKey(String shuffleKey) {
-    return (SHUFFLE_KEY_PREFIX + ";" + shuffleKey).getBytes(StandardCharsets.UTF_8);
+  public final int major;
+  public final int minor;
+
+  public StoreVersion(int major, int minor) {
+    this.major = major;
+    this.minor = minor;
   }
 
-  protected String parseDbShuffleKey(String s) {
-    if (!s.startsWith(SHUFFLE_KEY_PREFIX)) {
-      throw new IllegalArgumentException("Expected a string starting with " + SHUFFLE_KEY_PREFIX);
-    }
-    return s.substring(SHUFFLE_KEY_PREFIX.length() + 1);
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    StoreVersion that = (StoreVersion) o;
+
+    return major == that.major && minor == that.minor;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = major;
+    result = 31 * result + minor;
+    return result;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?

LevelDB does not support mac arm version.

```java
java.lang.UnsatisfiedLinkError: Could not load library. Reasons: [no leveldbjni64-1.8 in java.library.path, no leveldbjni-1.8 in java.library.path, no leveldbjni in java.library.path, /private/var/folders/tc/r2n_8g6j4731h7clfqwntg880000gn/T/libleveldbjni-64-1-4616234670453989010.8: dlopen(/private/var/folders/tc/r2n_8g6j4731h7clfqwntg880000gn/T/libleveldbjni-64-1-4616234670453989010.8, 0x0001): tried: '/private/var/folders/tc/r2n_8g6j4731h7clfqwntg880000gn/T/libleveldbjni-64-1-4616234670453989010.8' (fat file, but missing compatible architecture (have 'x86_64,i386', need 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/private/var/folders/tc/r2n_8g6j4731h7clfqwntg880000gn/T/libleveldbjni-64-1-4616234670453989010.8' (no such file), '/private/var/folders/tc/r2n_8g6j4731h7clfqwntg880000gn/T/libleveldbjni-64-1-4616234670453989010.8' (fat file, but missing compatible architecture (have 'x86_64,i386', need 'arm64'))]
  	at org.fusesource.hawtjni.runtime.Library.doLoad(Library.java:182)
  	at org.fusesource.hawtjni.runtime.Library.load(Library.java:140)
  	at org.fusesource.leveldbjni.JniDBFactory.<clinit>(JniDBFactory.java:48)
  	at org.apache.celeborn.service.deploy.worker.shuffledb.LevelDBProvider.initLevelDB(LevelDBProvider.java:49)
  	at org.apache.celeborn.service.deploy.worker.shuffledb.DBProvider.initDB(DBProvider.java:30)
  	at org.apache.celeborn.service.deploy.worker.storage.StorageManager.<init>(StorageManager.scala:197)
  	at org.apache.celeborn.service.deploy.worker.Worker.<init>(Worker.scala:109)
  	at org.apache.celeborn.service.deploy.worker.Worker$.main(Worker.scala:734)
  	at org.apache.celeborn.service.deploy.worker.Worker.main(Worker.scala)
```

The released `leveldbjni-all` for `org.fusesource.leveldbjni` does not support AArch64 Linux, we need to use `org.openlabtesting.leveldbjni`.

See https://issues.apache.org/jira/browse/HADOOP-16614

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
local test
