### PR TITLE
[CELEBORN-978] Improve dependency.sh replacement mode

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -26,6 +26,7 @@ on:
       - '**/pom.xml'
       - 'project/**'
       - '.github/workflows/deps.yml'
+      - 'dev/dependencies.sh'
 
 concurrency:
   group: deps-${{ github.head_ref || github.run_id }}

--- a/dev/dependencies.sh
+++ b/dev/dependencies.sh
@@ -37,8 +37,8 @@ DEP_PR=""
 DEP=""
 
 function mvn_build_classpath() {
-  $MVN clean install -DskipTests -am -pl $MVN_MODULES
-  $MVN dependency:build-classpath -am -pl $MVN_MODULES | \
+  $MVN -P$MODULE clean install -DskipTests -am -pl $MVN_MODULES
+  $MVN -P$MODULE dependency:build-classpath -am -pl $MVN_MODULES | \
     grep -v "INFO\|WARN" | \
     grep -v "Downloading from" | \
     # This will skip the first two lines

--- a/dev/dependencies.sh
+++ b/dev/dependencies.sh
@@ -39,8 +39,9 @@ DEP=""
 function mvn_build_classpath() {
   $MVN -P$MODULE clean install -DskipTests -am -pl $MVN_MODULES
   $MVN -P$MODULE dependency:build-classpath -am -pl $MVN_MODULES | \
-    grep -v "INFO\|WARN" | \
-    grep -v "Downloading from" | \
+    grep -A1 "Dependencies classpath:" | \
+    grep -v "^--$" | \
+    grep -v "Dependencies classpath:" | \
     # This will skip the first two lines
     tail -n +3 | \
     tr ":" "\n" | \

--- a/dev/dependencies.sh
+++ b/dev/dependencies.sh
@@ -37,10 +37,11 @@ DEP_PR=""
 DEP=""
 
 function mvn_build_classpath() {
-  $MVN -P$MODULE clean install -DskipTests -am -pl $MVN_MODULES
-  $MVN -P$MODULE dependency:build-classpath -am -pl $MVN_MODULES | \
+  $MVN clean install -DskipTests -am -pl $MVN_MODULES
+  $MVN dependency:build-classpath -am -pl $MVN_MODULES | \
     grep -v "INFO\|WARN" | \
-    # This will skip the first two lines 
+    grep -v "Downloading from" | \
+    # This will skip the first two lines
     tail -n +3 | \
     tr ":" "\n" | \
     awk -F '/' '{
@@ -186,6 +187,7 @@ case "$MODULE" in
     SBT_PROJECT="celeborn-client-flink-1_17"
     ;;
   *)
+    MODULE="server"
     MVN_MODULES="worker,master"
     ;;
 esac

--- a/dev/dependencies.sh
+++ b/dev/dependencies.sh
@@ -37,13 +37,12 @@ DEP_PR=""
 DEP=""
 
 function mvn_build_classpath() {
-  $MVN -P$MODULE clean install -DskipTests -am -pl $MVN_MODULES
+  #$MVN -P$MODULE clean install -DskipTests -am -pl $MVN_MODULES
   $MVN -P$MODULE dependency:build-classpath -am -pl $MVN_MODULES | \
     grep -A1 "Dependencies classpath:" | \
     grep -v "^--$" | \
     grep -v "Dependencies classpath:" | \
-    # This will skip the first two lines
-    tail -n +3 | \
+    grep -v '^$' | \
     tr ":" "\n" | \
     awk -F '/' '{
       artifact_id=$(NF-2);

--- a/dev/dependencies.sh
+++ b/dev/dependencies.sh
@@ -37,7 +37,7 @@ DEP_PR=""
 DEP=""
 
 function mvn_build_classpath() {
-  #$MVN -P$MODULE clean install -DskipTests -am -pl $MVN_MODULES
+  $MVN -P$MODULE clean install -DskipTests -am -pl $MVN_MODULES
   $MVN -P$MODULE dependency:build-classpath -am -pl $MVN_MODULES | \
     grep -A1 "Dependencies classpath:" | \
     grep -v "^--$" | \


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
When executing the update script locally, it may generate such a Log, which causes awk to exit with an error.
```
Downloading from nexus: httpxxxx
```


```bash
./dev/dependencies.sh --replace
```

```
awk: trying to access out of range field -1
 input record number 1, file 
 source line number 2
```


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

