### PR TITLE
[CELEBORN-468] Timeout useless lostWorkers/shutdownWorkers meta

### DIFF
--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -75,6 +75,7 @@ enum MessageType {
   STREAM_HANDLER = 52;
   CHECK_WORKERS_AVAILABLE = 53;
   CHECK_WORKERS_AVAILABLE_RESPONSE = 54;
+  REMOVE_WORKERS_UNAVAILABLE_INFO = 55;
 }
 
 message PbStorageInfo {
@@ -392,6 +393,11 @@ message PbDestroyWorkerSlotsResponse {
 }
 
 message PbCheckForWorkerTimeout {
+}
+
+message PbRemoveWorkersUnavailableInfo {
+  repeated PbWorkerInfo workerInfo = 1;
+  string requestId = 2;
 }
 
 message PbWorkerLost {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1582,7 +1582,7 @@ object CelebornConf extends Logging {
   val WORKER_UNAVAILABLE_INFO_EXPIRE_TIMEOUT: ConfigEntry[Long] =
     buildConf("celeborn.master.workerUnavailableInfo.expireTimeout")
       .categories("master")
-      .version("0.3.0")
+      .version("0.3.2")
       .doc("Worker unavailable info would be cleared when the retention period is expired")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("1800s")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -640,6 +640,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerCheckFileCleanMaxRetries: Int = get(WORKER_CHECK_FILE_CLEAN_MAX_RETRIES)
   def workerCheckFileCleanTimeout: Long = get(WORKER_CHECK_FILE_CLEAN_TIMEOUT)
   def workerHeartbeatTimeout: Long = get(WORKER_HEARTBEAT_TIMEOUT)
+  def workerUnavailableInfoExpireTimeout: Long = get(WORKER_UNAVAILABLE_INFO_EXPIRE_TIMEOUT)
+
   def workerReplicateThreads: Int = get(WORKER_REPLICATE_THREADS)
   def workerCommitThreads: Int =
     if (hasHDFSStorage) Math.max(128, get(WORKER_COMMIT_THREADS)) else get(WORKER_COMMIT_THREADS)
@@ -1576,6 +1578,14 @@ object CelebornConf extends Logging {
       .doc("Worker heartbeat timeout.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("120s")
+
+  val WORKER_UNAVAILABLE_INFO_EXPIRE_TIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.master.workerUnavailableInfo.expireTimeout")
+      .categories("master")
+      .version("0.3.0")
+      .doc("Worker unavailable info would be cleared when the retention period is expired")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("1800s")
 
   val MASTER_HOST: ConfigEntry[String] =
     buildConf("celeborn.master.host")

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -363,12 +363,14 @@ object ControlMessages extends Logging {
   }
 
   object RemoveWorkersUnavailableInfo {
-    def apply(unavailable: util.List[WorkerInfo],
-              requestId: String): PbRemoveWorkersUnavailableInfo =
+    def apply(
+        unavailable: util.List[WorkerInfo],
+        requestId: String): PbRemoveWorkersUnavailableInfo =
       PbRemoveWorkersUnavailableInfo.newBuilder()
         .setRequestId(requestId)
         .addAllWorkerInfo(unavailable.asScala.map { workerInfo =>
-          PbSerDeUtils.toPbWorkerInfo(workerInfo, true)}.toList.asJava)
+          PbSerDeUtils.toPbWorkerInfo(workerInfo, true)
+        }.toList.asJava)
         .build()
   }
 

--- a/docs/configuration/master.md
+++ b/docs/configuration/master.md
@@ -35,6 +35,7 @@ license: |
 | celeborn.master.slot.assign.maxWorkers | 10000 | Max workers that slots of one shuffle can be allocated on. Will choose the smaller positive one from Master side and Client side, see `celeborn.client.slot.assign.maxWorkers`. | 0.3.1 | 
 | celeborn.master.slot.assign.policy | ROUNDROBIN | Policy for master to assign slots, Celeborn supports two types of policy: roundrobin and loadaware. Loadaware policy will be ignored when `HDFS` is enabled in `celeborn.storage.activeTypes` | 0.3.0 | 
 | celeborn.master.userResourceConsumption.update.interval | 30s | Time length for a window about compute user resource consumption. | 0.3.0 | 
+| celeborn.master.workerUnavailableInfo.expireTimeout | 1800s | Worker unavailable info would be cleared when the retention period is expired | 0.3.2 | 
 | celeborn.storage.activeTypes | HDD,SSD | Enabled storage levels. Available options: HDD,SSD,HDFS.  | 0.3.0 | 
 | celeborn.storage.hdfs.dir | &lt;undefined&gt; | HDFS base directory for Celeborn to store shuffle data. | 0.2.0 | 
 <!--end-include-->

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -135,6 +135,17 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     excludedWorkers.remove(worker);
   }
 
+  public void removeWorkersUnavailableInfoMeta(List<WorkerInfo> unavailableWorkers) {
+    synchronized (workers) {
+      for (WorkerInfo workerInfo : unavailableWorkers) {
+        if (lostWorkers.containsKey(workerInfo)) {
+          lostWorkers.remove(workerInfo);
+          shutdownWorkers.remove(workerInfo);
+        }
+      }
+    }
+  }
+
   public void updateWorkerHeartbeatMeta(
       String host,
       int rpcPort,

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
@@ -45,6 +45,8 @@ public interface IMetadataHandler {
   void handleWorkerRemove(
       String host, int rpcPort, int pushPort, int fetchPort, int replicatePort, String requestId);
 
+  void handleRemoveWorkersUnavailableInfo(List<WorkerInfo> unavailableWorkers, String requestId);
+
   void handleWorkerHeartbeat(
       String host,
       int rpcPort,

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
@@ -82,6 +82,12 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
   }
 
   @Override
+  public void handleRemoveWorkersUnavailableInfo(
+      List<WorkerInfo> unavailableWorkers, String requestId) {
+    removeWorkersUnavailableInfoMeta(unavailableWorkers);
+  }
+
+  @Override
   public void handleWorkerHeartbeat(
       String host,
       int rpcPort,

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAMasterMetaManager.java
@@ -187,6 +187,27 @@ public class HAMasterMetaManager extends AbstractMetaManager {
   }
 
   @Override
+  public void handleRemoveWorkersUnavailableInfo(
+      List<WorkerInfo> unavailableWorkers, String requestId) {
+    try {
+      List<ResourceProtos.WorkerAddress> addrs =
+          unavailableWorkers.stream().map(MetaUtil::infoToAddr).collect(Collectors.toList());
+      ratisServer.submitRequest(
+          ResourceRequest.newBuilder()
+              .setCmdType(Type.RemoveWorkersUnavailableInfo)
+              .setRequestId(requestId)
+              .setRemoveWorkersUnavailableInfoRequest(
+                  ResourceProtos.RemoveWorkersUnavailableInfoRequest.newBuilder()
+                      .addAllUnavailable(addrs)
+                      .build())
+              .build());
+    } catch (CelebornRuntimeException e) {
+      LOG.error("Handle remove workers unavailable info failed!", e);
+      throw e;
+    }
+  }
+
+  @Override
   public void handleWorkerHeartbeat(
       String host,
       int rpcPort,

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
@@ -228,6 +228,14 @@ public class MetaHandler {
           metaSystem.updatePartitionSize();
           break;
 
+        case RemoveWorkersUnavailableInfo:
+          List<ResourceProtos.WorkerAddress> unavailableList =
+              request.getRemoveWorkersUnavailableInfoRequest().getUnavailableList();
+          List<WorkerInfo> unavailableWorkers =
+              unavailableList.stream().map(MetaUtil::addrToInfo).collect(Collectors.toList());
+          metaSystem.removeWorkersUnavailableInfoMeta(unavailableWorkers);
+          break;
+
         default:
           throw new IOException("Can not parse this command!" + request);
       }

--- a/master/src/main/proto/Resource.proto
+++ b/master/src/main/proto/Resource.proto
@@ -35,6 +35,7 @@ enum Type {
   ReportWorkerUnavailable = 20;
   UpdatePartitionSize = 21;
   WorkerRemove = 22;
+  RemoveWorkersUnavailableInfo = 23;
 }
 
 message ResourceRequest {
@@ -53,6 +54,7 @@ message ResourceRequest {
   optional RegisterWorkerRequest registerWorkerRequest = 17;
   optional ReportWorkerUnavailableRequest reportWorkerUnavailableRequest = 18;
   optional WorkerRemoveRequest workerRemoveRequest = 19;
+  optional RemoveWorkersUnavailableInfoRequest removeWorkersUnavailableInfoRequest = 20;
 }
 
 message DiskInfo {
@@ -135,6 +137,10 @@ message RegisterWorkerRequest {
 }
 
 message ReportWorkerUnavailableRequest {
+  repeated WorkerAddress unavailable = 1;
+}
+
+message RemoveWorkersUnavailableInfoRequest {
   repeated WorkerAddress unavailable = 1;
 }
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -271,10 +271,12 @@ private[celeborn] class Master(
       executeWithLeaderChecker(
         null,
         handleWorkerLost(null, host, rpcPort, pushPort, fetchPort, replicatePort, requestId))
-    case RemoveWorkersUnavailableInfo(unavailableWorkers, requestId) =>
+    case pb: PbRemoveWorkersUnavailableInfo =>
+      val unavailableWorkers = new util.ArrayList[WorkerInfo](pb.getWorkerInfoList
+        .asScala.map(PbSerDeUtils.fromPbWorkerInfo).toList.asJava)
       executeWithLeaderChecker(
         null,
-        handleRemoveWorkersUnavailableInfos(unavailableWorkers, requestId))
+        handleRemoveWorkersUnavailableInfos(unavailableWorkers, pb.getRequestId))
   }
 
   override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -908,6 +908,79 @@ public class RatisMasterStatusSystemSuiteJ {
   }
 
   @Test
+  public void testHandleRemoveWorkersUnavailableInfo() throws InterruptedException {
+    AbstractMetaManager statusSystem = pickLeaderStatusSystem();
+    Assert.assertNotNull(statusSystem);
+
+    statusSystem.handleRegisterWorker(
+        HOSTNAME1,
+        RPCPORT1,
+        PUSHPORT1,
+        FETCHPORT1,
+        REPLICATEPORT1,
+        disks1,
+        userResourceConsumption1,
+        getNewReqeustId());
+    statusSystem.handleRegisterWorker(
+        HOSTNAME2,
+        RPCPORT2,
+        PUSHPORT2,
+        FETCHPORT2,
+        REPLICATEPORT2,
+        disks2,
+        userResourceConsumption2,
+        getNewReqeustId());
+    statusSystem.handleRegisterWorker(
+        HOSTNAME3,
+        RPCPORT3,
+        PUSHPORT3,
+        FETCHPORT3,
+        REPLICATEPORT3,
+        disks3,
+        userResourceConsumption3,
+        getNewReqeustId());
+
+    WorkerInfo workerInfo1 =
+        new WorkerInfo(
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            disks1,
+            userResourceConsumption1);
+
+    List<WorkerInfo> unavailableWorkers = new ArrayList<>();
+    unavailableWorkers.add(workerInfo1);
+
+    statusSystem.handleWorkerLost(
+        HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
+    statusSystem.handleReportWorkerUnavailable(unavailableWorkers, getNewReqeustId());
+
+    Thread.sleep(3000L);
+    Assert.assertEquals(2, STATUSSYSTEM1.workers.size());
+
+    Assert.assertEquals(1, STATUSSYSTEM1.shutdownWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM2.shutdownWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM3.shutdownWorkers.size());
+
+    Assert.assertEquals(1, STATUSSYSTEM1.lostWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM2.lostWorkers.size());
+    Assert.assertEquals(1, STATUSSYSTEM3.lostWorkers.size());
+
+    statusSystem.handleRemoveWorkersUnavailableInfo(unavailableWorkers, getNewReqeustId());
+    Thread.sleep(3000L);
+
+    Assert.assertEquals(0, STATUSSYSTEM1.shutdownWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM2.shutdownWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM3.shutdownWorkers.size());
+
+    Assert.assertEquals(0, STATUSSYSTEM1.lostWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM2.lostWorkers.size());
+    Assert.assertEquals(0, STATUSSYSTEM3.lostWorkers.size());
+  }
+
+  @Test
   public void testHandleUpdatePartitionSize() throws InterruptedException {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title


### Why are the changes needed?
If Worker lost or lost after graceful shutdown, Master would retain these lostWorker/shutdownWorkers meta permanently,
These meta would cause some noisy message in lifecycleManager. For these meta better to delete them after a while

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT & E2E test
