### PR TITLE
[CELEBORN-990] Add exception handler when calling CelebornHadoopUtils.getHadoopFS

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -722,7 +722,13 @@ private[celeborn] class Master(
 
   private def checkAndCleanExpiredAppDirsOnHDFS(expiredDir: String = ""): Unit = {
     if (hadoopFs == null) {
-      hadoopFs = CelebornHadoopUtils.getHadoopFS(conf)
+      try {
+        hadoopFs = CelebornHadoopUtils.getHadoopFS(conf)
+      } catch {
+        case e: Exception => 
+          logError("Celeborn initialize HDFS failed.", e)
+          return
+      }
     }
     val hdfsWorkPath = new Path(conf.hdfsDir, conf.workerWorkingDir)
     if (hadoopFs.exists(hdfsWorkPath)) {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -725,9 +725,9 @@ private[celeborn] class Master(
       try {
         hadoopFs = CelebornHadoopUtils.getHadoopFS(conf)
       } catch {
-        case e: Exception => 
+        case e: Exception =>
           logError("Celeborn initialize HDFS failed.", e)
-          return
+          throw e
       }
     }
     val hdfsWorkPath = new Path(conf.hdfsDir, conf.workerWorkingDir)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -135,7 +135,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       try {
         StorageManager.hadoopFs = CelebornHadoopUtils.getHadoopFS(conf)
       } catch {
-        case e: Exception => logError("Celeborn initialize HDFS failed.", e)
+        case e: Exception =>
+          logError("Celeborn initialize HDFS failed.", e)
+          throw e
       }
       (
         Some(new HdfsFlusher(

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -132,7 +132,11 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   val (hdfsFlusher, _totalHdfsFlusherThread) =
     if (hasHDFSStorage) {
       logInfo(s"Initialize HDFS support with path ${hdfsDir}")
-      StorageManager.hadoopFs = CelebornHadoopUtils.getHadoopFS(conf)
+      try {
+        StorageManager.hadoopFs = CelebornHadoopUtils.getHadoopFS(conf)
+      } catch {
+        case e: Exception => logError("Celeborn initialize HDFS failed.", e)
+      }
       (
         Some(new HdfsFlusher(
           workerSource,


### PR DESCRIPTION
Add exception handler when calling CelebornHadoopUtils.getHadoopFS(conf) on Master and Worker, Avoid Concealing Initialization HDFS Exception Information

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

