### PR TITLE
[CELEBORN-955] Re-run Spark Stage for Celeborn Shuffle Fetch Failure

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/ExecutorShuffleIdTracker.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/ExecutorShuffleIdTracker.java
@@ -17,30 +17,31 @@
 
 package org.apache.spark.shuffle.celeborn;
 
-import java.io.IOException;
-
-import org.apache.spark.TaskContext;
-import org.apache.spark.shuffle.ShuffleWriter;
+import java.util.HashSet;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.celeborn.client.ShuffleClient;
-import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.util.JavaUtils;
 
-public class HashBasedShuffleWriterSuiteJ extends CelebornShuffleWriterSuiteBase {
+public class ExecutorShuffleIdTracker {
+  // track appShuffleId -> shuffleId Set in executor for cleanup
+  private ConcurrentHashMap<Integer, HashSet<Integer>> shuffleIdMap =
+      JavaUtils.newConcurrentHashMap();
 
-  public HashBasedShuffleWriterSuiteJ() throws IOException {}
+  public void track(int appShuffleId, int shuffleId) {
+    HashSet<Integer> shuffleIds = shuffleIdMap.computeIfAbsent(appShuffleId, id -> new HashSet<>());
 
-  @Override
-  protected ShuffleWriter<Integer, String> createShuffleWriter(
-      CelebornShuffleHandle handle, TaskContext context, CelebornConf conf, ShuffleClient client)
-      throws IOException {
-    // this test case is independent of the `mapId` value
-    return new HashBasedShuffleWriter<Integer, String, String>(
-        SparkUtils.celebornShuffleId(client, handle, context, true),
-        handle,
-        /*mapId=*/ 0,
-        context,
-        conf,
-        client,
-        SendBufferPool.get(1, 30, 60));
+    synchronized (shuffleIds) {
+      shuffleIds.add(shuffleId);
+    }
+  }
+
+  public void unregisterAppShuffleId(ShuffleClient shuffleClient, int appShuffleId) {
+    HashSet<Integer> shuffleIds = shuffleIdMap.remove(appShuffleId);
+    if (shuffleIds != null) {
+      synchronized (shuffleIds) {
+        shuffleIds.forEach(shuffleId -> shuffleClient.cleanupShuffle(shuffleId));
+      }
+    }
   }
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/ExecutorShuffleIdTracker.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/celeborn/ExecutorShuffleIdTracker.java
@@ -40,7 +40,7 @@ public class ExecutorShuffleIdTracker {
     HashSet<Integer> shuffleIds = shuffleIdMap.remove(appShuffleId);
     if (shuffleIds != null) {
       synchronized (shuffleIds) {
-        shuffleIds.forEach(shuffleId -> shuffleClient.cleanupShuffle(shuffleId));
+        shuffleIds.forEach(shuffleClient::cleanupShuffle);
       }
     }
   }

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -101,6 +101,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   // In order to facilitate the writing of unit test code, ShuffleClient needs to be passed in as
   // parameters. By the way, simplify the passed parameters.
   public HashBasedShuffleWriter(
+      int shuffleId,
       CelebornShuffleHandle<K, V, C> handle,
       int mapId,
       TaskContext taskContext,
@@ -110,7 +111,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException {
     this.mapId = mapId;
     this.dep = handle.dependency();
-    this.shuffleId = dep.shuffleId();
+    this.shuffleId = shuffleId;
     SerializerInstance serializer = dep.serializer().newInstance();
     this.partitioner = dep.partitioner();
     this.writeMetrics = taskContext.taskMetrics().shuffleWriteMetrics();

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -94,6 +94,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   // In order to facilitate the writing of unit test code, ShuffleClient needs to be passed in as
   // parameters. By the way, simplify the passed parameters.
   public SortBasedShuffleWriter(
+      int shuffleId,
       ShuffleDependency<K, V, C> dep,
       int numMappers,
       TaskContext taskContext,
@@ -104,7 +105,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException {
     this.mapId = taskContext.partitionId();
     this.dep = dep;
-    this.shuffleId = dep.shuffleId();
+    this.shuffleId = shuffleId;
     SerializerInstance serializer = dep.serializer().newInstance();
     this.partitioner = dep.partitioner();
     this.writeMetrics = taskContext.taskMetrics().shuffleWriteMetrics();

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -66,6 +66,8 @@ public class SparkShuffleManager implements ShuffleManager {
   private long sendBufferPoolCheckInterval;
   private long sendBufferPoolExpireTimeout;
 
+  private ExecutorShuffleIdTracker shuffleIdTracker = new ExecutorShuffleIdTracker();
+
   public SparkShuffleManager(SparkConf conf, boolean isDriver) {
     this.conf = conf;
     this.isDriver = isDriver;
@@ -105,6 +107,12 @@ public class SparkShuffleManager implements ShuffleManager {
       synchronized (this) {
         if (lifecycleManager == null) {
           lifecycleManager = new LifecycleManager(appId, celebornConf);
+          if (celebornConf.clientFetchThrowsFetchFailure()) {
+            MapOutputTrackerMaster mapOutputTracker =
+                (MapOutputTrackerMaster) SparkEnv.get().mapOutputTracker();
+            lifecycleManager.registerShuffleTrackerCallback(
+                shuffleId -> mapOutputTracker.unregisterAllMapOutput(shuffleId));
+          }
         }
       }
     }
@@ -131,23 +139,24 @@ public class SparkShuffleManager implements ShuffleManager {
           lifecycleManager.getPort(),
           lifecycleManager.getUserIdentifier(),
           shuffleId,
+          celebornConf.clientFetchThrowsFetchFailure(),
           numMaps,
           dependency);
     }
   }
 
   @Override
-  public boolean unregisterShuffle(int shuffleId) {
-    if (sortShuffleIds.contains(shuffleId)) {
-      return sortShuffleManager().unregisterShuffle(shuffleId);
+  public boolean unregisterShuffle(int appShuffleId) {
+    if (sortShuffleIds.contains(appShuffleId)) {
+      return sortShuffleManager().unregisterShuffle(appShuffleId);
     }
     // For Spark driver side trigger unregister shuffle.
     if (lifecycleManager != null) {
-      lifecycleManager.unregisterShuffle(shuffleId);
+      lifecycleManager.unregisterAppShuffle(appShuffleId);
     }
     // For Spark executor side cleanup shuffle related info.
     if (shuffleClient != null) {
-      shuffleClient.cleanupShuffle(shuffleId);
+      shuffleIdTracker.unregisterAppShuffleId(shuffleClient, appShuffleId);
     }
     return true;
   }
@@ -187,10 +196,14 @@ public class SparkShuffleManager implements ShuffleManager {
                 h.lifecycleManagerPort(),
                 celebornConf,
                 h.userIdentifier());
+        int shuffleId = SparkUtils.celebornShuffleId(shuffleClient, h, context, true);
+        shuffleIdTracker.track(h.shuffleId(), shuffleId);
+
         if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())) {
           ExecutorService pushThread =
               celebornConf.clientPushSortPipelineEnabled() ? getPusherThread() : null;
           return new SortBasedShuffleWriter<>(
+              shuffleId,
               h.dependency(),
               h.numMaps(),
               context,
@@ -200,6 +213,7 @@ public class SparkShuffleManager implements ShuffleManager {
               SendBufferPool.get(cores, sendBufferPoolCheckInterval, sendBufferPoolExpireTimeout));
         } else if (ShuffleMode.HASH.equals(celebornConf.shuffleWriterMode())) {
           return new HashBasedShuffleWriter<>(
+              shuffleId,
               h,
               mapId,
               context,
@@ -225,7 +239,14 @@ public class SparkShuffleManager implements ShuffleManager {
       @SuppressWarnings("unchecked")
       CelebornShuffleHandle<K, ?, C> h = (CelebornShuffleHandle<K, ?, C>) handle;
       return new CelebornShuffleReader<>(
-          h, startPartition, endPartition, 0, Int.MaxValue(), context, celebornConf);
+          h,
+          startPartition,
+          endPartition,
+          0,
+          Int.MaxValue(),
+          context,
+          celebornConf,
+          shuffleIdTracker);
     }
     return _sortShuffleManager.getReader(handle, startPartition, endPartition, context);
   }

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -196,7 +196,7 @@ public class SparkShuffleManager implements ShuffleManager {
                 h.lifecycleManagerPort(),
                 celebornConf,
                 h.userIdentifier());
-        int shuffleId = SparkUtils.celebornShuffleId(shuffleClient, h, context, true);
+        int shuffleId = SparkUtils.celebornShuffleId(client, h, context, true);
         shuffleIdTracker.track(h.shuffleId(), shuffleId);
 
         if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())) {

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -26,6 +26,7 @@ import scala.Int;
 
 import org.apache.spark.*;
 import org.apache.spark.launcher.SparkLauncher;
+import org.apache.spark.rdd.DeterministicLevel;
 import org.apache.spark.shuffle.*;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
 import org.apache.spark.util.Utils;
@@ -126,6 +127,10 @@ public class SparkShuffleManager implements ShuffleManager {
     // This method may be called many times.
     appUniqueId = SparkUtils.appUniqueId(dependency.rdd().context());
     initializeLifecycleManager(appUniqueId);
+
+    lifecycleManager.registerAppShuffleDeterminate(
+        shuffleId,
+        dependency.rdd().getOutputDeterministicLevel() != DeterministicLevel.INDETERMINATE());
 
     if (fallbackPolicyRunner.applyAllFallbackPolicy(
         lifecycleManager, dependency.partitioner().numPartitions())) {

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -42,7 +42,7 @@ import org.apache.celeborn.common.util.Utils;
 public class SparkUtils {
   private static final Logger logger = LoggerFactory.getLogger(SparkUtils.class);
 
-  public static final String FETCH_FAILURE_ERROR_MSG = "Celeborn FetchFailure";
+  public static final String FETCH_FAILURE_ERROR_MSG = "Celeborn FetchFailure with shuffle id ";
 
   public static MapStatus createMapStatus(
       BlockManagerId loc, long[] uncompressedSizes, long[] uncompressedRecords) throws IOException {

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -26,6 +26,7 @@ import scala.Tuple2;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
+import org.apache.spark.TaskContext;
 import org.apache.spark.scheduler.MapStatus;
 import org.apache.spark.scheduler.MapStatus$;
 import org.apache.spark.sql.execution.UnsafeRowSerializer;
@@ -34,11 +35,14 @@ import org.apache.spark.storage.BlockManagerId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.util.Utils;
 
 public class SparkUtils {
   private static final Logger logger = LoggerFactory.getLogger(SparkUtils.class);
+
+  public static final String FETCH_FAILURE_ERROR_MSG = "Celeborn FetchFailure! ";
 
   public static MapStatus createMapStatus(
       BlockManagerId loc, long[] uncompressedSizes, long[] uncompressedRecords) throws IOException {
@@ -112,6 +116,23 @@ public class SparkUtils {
       return context.applicationId() + "_" + context.applicationAttemptId().get();
     } else {
       return context.applicationId();
+    }
+  }
+
+  public static String getAppShuffleIdentifier(int appShuffleId, TaskContext context) {
+    return appShuffleId + "-" + context.stageId() + "-" + context.stageAttemptNumber();
+  }
+
+  public static int celebornShuffleId(
+      ShuffleClient client,
+      CelebornShuffleHandle<?, ?, ?> handle,
+      TaskContext context,
+      Boolean isWriter) {
+    if (handle.throwsFetchFailure()) {
+      String appShuffleIdentifier = getAppShuffleIdentifier(handle.shuffleId(), context);
+      return client.getShuffleId(handle.shuffleId(), appShuffleIdentifier, isWriter);
+    } else {
+      return handle.shuffleId();
     }
   }
 

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -42,7 +42,7 @@ import org.apache.celeborn.common.util.Utils;
 public class SparkUtils {
   private static final Logger logger = LoggerFactory.getLogger(SparkUtils.class);
 
-  public static final String FETCH_FAILURE_ERROR_MSG = "Celeborn FetchFailure! ";
+  public static final String FETCH_FAILURE_ERROR_MSG = "Celeborn FetchFailure";
 
   public static MapStatus createMapStatus(
       BlockManagerId loc, long[] uncompressedSizes, long[] uncompressedRecords) throws IOException {

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
@@ -28,6 +28,7 @@ class CelebornShuffleHandle[K, V, C](
     val lifecycleManagerPort: Int,
     val userIdentifier: UserIdentifier,
     shuffleId: Int,
+    val throwsFetchFailure: Boolean,
     numMappers: Int,
     dependency: ShuffleDependency[K, V, C])
   extends BaseShuffleHandle(shuffleId, numMappers, dependency)

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -128,7 +128,7 @@ class CelebornShuffleReader[K, C](
                     handle.shuffleId,
                     -1,
                     partitionId,
-                    SparkUtils.FETCH_FAILURE_ERROR_MSG,
+                    SparkUtils.FETCH_FAILURE_ERROR_MSG + shuffleId,
                     ce)
                 } else
                   throw ce
@@ -160,7 +160,7 @@ class CelebornShuffleReader[K, C](
               handle.shuffleId,
               -1,
               partitionId,
-              SparkUtils.FETCH_FAILURE_ERROR_MSG,
+              SparkUtils.FETCH_FAILURE_ERROR_MSG + shuffleId,
               e)
           } else
             throw e

--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import org.apache.spark.{InterruptibleIterator, TaskContext}
 import org.apache.spark.internal.Logging
-import org.apache.spark.shuffle.ShuffleReader
+import org.apache.spark.shuffle.{FetchFailedException, ShuffleReader}
 import org.apache.spark.shuffle.celeborn.CelebornShuffleReader.streamCreatorPool
 import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection.ExternalSorter
@@ -32,7 +32,7 @@ import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.client.read.CelebornInputStream
 import org.apache.celeborn.client.read.MetricsCallback
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.exception.CelebornIOException
+import org.apache.celeborn.common.exception.{CelebornIOException, PartitionUnRetryAbleException}
 import org.apache.celeborn.common.util.ThreadUtils
 
 class CelebornShuffleReader[K, C](
@@ -42,7 +42,8 @@ class CelebornShuffleReader[K, C](
     startMapIndex: Int = 0,
     endMapIndex: Int = Int.MaxValue,
     context: TaskContext,
-    conf: CelebornConf)
+    conf: CelebornConf,
+    shuffleIdTracker: ExecutorShuffleIdTracker)
   extends ShuffleReader[K, C] with Logging {
 
   private val dep = handle.dependency
@@ -58,6 +59,11 @@ class CelebornShuffleReader[K, C](
   override def read(): Iterator[Product2[K, C]] = {
 
     val serializerInstance = dep.serializer.newInstance()
+
+    val shuffleId = SparkUtils.celebornShuffleId(shuffleClient, handle, context, false)
+    shuffleIdTracker.track(handle.shuffleId, shuffleId)
+    logDebug(
+      s"get shuffleId $shuffleId for appShuffleId ${handle.shuffleId} attemptNum ${context.stageAttemptNumber()}")
 
     // Update the context task metrics for each record read.
     val readMetrics = context.taskMetrics.createTempShuffleReadMetrics()
@@ -87,7 +93,7 @@ class CelebornShuffleReader[K, C](
           if (exceptionRef.get() == null) {
             try {
               val inputStream = shuffleClient.readPartition(
-                handle.shuffleId,
+                shuffleId,
                 partitionId,
                 context.attemptNumber(),
                 startMapIndex,
@@ -113,7 +119,21 @@ class CelebornShuffleReader[K, C](
         var inputStream: CelebornInputStream = streams.get(partitionId)
         while (inputStream == null) {
           if (exceptionRef.get() != null) {
-            throw exceptionRef.get()
+            exceptionRef.get() match {
+              case ce @ (_: CelebornIOException | _: PartitionUnRetryAbleException) =>
+                if (handle.throwsFetchFailure &&
+                  shuffleClient.reportShuffleFetchFailure(handle.shuffleId, shuffleId)) {
+                  throw new FetchFailedException(
+                    null,
+                    handle.shuffleId,
+                    -1,
+                    partitionId,
+                    SparkUtils.FETCH_FAILURE_ERROR_MSG,
+                    ce)
+                } else
+                  throw ce
+              case e => throw e
+            }
           }
           Thread.sleep(50)
           inputStream = streams.get(partitionId)
@@ -122,12 +142,30 @@ class CelebornShuffleReader[K, C](
           TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startFetchWait))
         // ensure inputStream is closed when task completes
         context.addTaskCompletionListener(_ => inputStream.close())
-        inputStream
+        (partitionId, inputStream)
       } else {
-        CelebornInputStream.empty()
+        (partitionId, CelebornInputStream.empty())
       }
-    }).flatMap(
-      serializerInstance.deserializeStream(_).asKeyValueIterator)
+    }).map { case (partitionId, inputStream) =>
+      (partitionId, serializerInstance.deserializeStream(inputStream).asKeyValueIterator)
+    }.flatMap { case (partitionId, iter) =>
+      try {
+        iter
+      } catch {
+        case e @ (_: CelebornIOException | _: PartitionUnRetryAbleException) =>
+          if (handle.throwsFetchFailure &&
+            shuffleClient.reportShuffleFetchFailure(handle.shuffleId, shuffleId)) {
+            throw new FetchFailedException(
+              null,
+              handle.shuffleId,
+              -1,
+              partitionId,
+              SparkUtils.FETCH_FAILURE_ERROR_MSG,
+              e)
+          } else
+            throw e
+      }
+    }
 
     val metricIter = CompletionIterator[(Any, Any), Iterator[(Any, Any)]](
       recordIter.map { record =>

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -227,7 +227,7 @@ public abstract class CelebornShuffleWriterSuiteBase {
     final File tempFile = new File(tempDir, UUID.randomUUID().toString());
     final CelebornShuffleHandle<Integer, String, String> handle =
         new CelebornShuffleHandle<>(
-            appId, host, port, userIdentifier, shuffleId, numMaps, dependency);
+            appId, host, port, userIdentifier, shuffleId, false, numMaps, dependency);
     final ShuffleClient client = new DummyShuffleClient(conf, tempFile);
     ((DummyShuffleClient) client).initReducePartitionMap(shuffleId, numPartitions, 1);
 

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/HookedCelebornShuffleManager.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/HookedCelebornShuffleManager.java
@@ -17,30 +17,29 @@
 
 package org.apache.spark.shuffle.celeborn;
 
-import java.io.IOException;
-
+import org.apache.spark.SparkConf;
 import org.apache.spark.TaskContext;
-import org.apache.spark.shuffle.ShuffleWriter;
+import org.apache.spark.shuffle.ShuffleHandle;
+import org.apache.spark.shuffle.ShuffleReader;
 
-import org.apache.celeborn.client.ShuffleClient;
-import org.apache.celeborn.common.CelebornConf;
+public class HookedCelebornShuffleManager extends SparkShuffleManager {
 
-public class HashBasedShuffleWriterSuiteJ extends CelebornShuffleWriterSuiteBase {
+  private static ShuffleManagerHook shuffleReaderGetHook = null;
 
-  public HashBasedShuffleWriterSuiteJ() throws IOException {}
+  public HookedCelebornShuffleManager(SparkConf conf) {
+    super(conf, true);
+  }
+
+  public static void registerReaderGetHook(ShuffleManagerHook hook) {
+    shuffleReaderGetHook = hook;
+  }
 
   @Override
-  protected ShuffleWriter<Integer, String> createShuffleWriter(
-      CelebornShuffleHandle handle, TaskContext context, CelebornConf conf, ShuffleClient client)
-      throws IOException {
-    // this test case is independent of the `mapId` value
-    return new HashBasedShuffleWriter<Integer, String, String>(
-        SparkUtils.celebornShuffleId(client, handle, context, true),
-        handle,
-        /*mapId=*/ 0,
-        context,
-        conf,
-        client,
-        SendBufferPool.get(1, 30, 60));
+  public <K, C> ShuffleReader<K, C> getReader(
+      ShuffleHandle handle, int startPartition, int endPartition, TaskContext context) {
+    if (shuffleReaderGetHook != null) {
+      shuffleReaderGetHook.exec(handle, startPartition, endPartition, context);
+    }
+    return super.getReader(handle, startPartition, endPartition, context);
   }
 }

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/ShuffleManagerHook.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/ShuffleManagerHook.java
@@ -17,30 +17,19 @@
 
 package org.apache.spark.shuffle.celeborn;
 
-import java.io.IOException;
-
 import org.apache.spark.TaskContext;
-import org.apache.spark.shuffle.ShuffleWriter;
+import org.apache.spark.shuffle.ShuffleHandle;
 
-import org.apache.celeborn.client.ShuffleClient;
-import org.apache.celeborn.common.CelebornConf;
+public interface ShuffleManagerHook {
 
-public class HashBasedShuffleWriterSuiteJ extends CelebornShuffleWriterSuiteBase {
+  default void exec(
+      ShuffleHandle handle, int startPartition, int endPartition, TaskContext context) {}
 
-  public HashBasedShuffleWriterSuiteJ() throws IOException {}
-
-  @Override
-  protected ShuffleWriter<Integer, String> createShuffleWriter(
-      CelebornShuffleHandle handle, TaskContext context, CelebornConf conf, ShuffleClient client)
-      throws IOException {
-    // this test case is independent of the `mapId` value
-    return new HashBasedShuffleWriter<Integer, String, String>(
-        SparkUtils.celebornShuffleId(client, handle, context, true),
-        handle,
-        /*mapId=*/ 0,
-        context,
-        conf,
-        client,
-        SendBufferPool.get(1, 30, 60));
-  }
+  default void exec(
+      ShuffleHandle handle,
+      int startMapIndex,
+      int endMapIndex,
+      int startPartition,
+      int endPartition,
+      TaskContext context) {};
 }

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriterSuiteJ.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriterSuiteJ.java
@@ -34,6 +34,7 @@ public class SortBasedShuffleWriterSuiteJ extends CelebornShuffleWriterSuiteBase
       CelebornShuffleHandle handle, TaskContext context, CelebornConf conf, ShuffleClient client)
       throws IOException {
     return new SortBasedShuffleWriter<Integer, String, String>(
+        SparkUtils.celebornShuffleId(client, handle, context, true),
         handle.dependency(),
         numPartitions,
         context,

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/TestCelebornShuffleManager.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/TestCelebornShuffleManager.java
@@ -20,14 +20,13 @@ package org.apache.spark.shuffle.celeborn;
 import org.apache.spark.SparkConf;
 import org.apache.spark.TaskContext;
 import org.apache.spark.shuffle.ShuffleHandle;
-import org.apache.spark.shuffle.ShuffleReadMetricsReporter;
 import org.apache.spark.shuffle.ShuffleReader;
 
-public class HookedCelebornShuffleManager extends SparkShuffleManager {
+public class TestCelebornShuffleManager extends SparkShuffleManager {
 
   private static ShuffleManagerHook shuffleReaderGetHook = null;
 
-  public HookedCelebornShuffleManager(SparkConf conf) {
+  public TestCelebornShuffleManager(SparkConf conf) {
     super(conf, true);
   }
 
@@ -37,31 +36,10 @@ public class HookedCelebornShuffleManager extends SparkShuffleManager {
 
   @Override
   public <K, C> ShuffleReader<K, C> getReader(
-      ShuffleHandle handle,
-      int startMapIndex,
-      int endMapIndex,
-      int startPartition,
-      int endPartition,
-      TaskContext context,
-      ShuffleReadMetricsReporter metrics) {
-    if (shuffleReaderGetHook != null) {
-      shuffleReaderGetHook.exec(
-          handle, startMapIndex, endMapIndex, startPartition, endPartition, context);
-    }
-    return super.getReader(
-        handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics);
-  }
-
-  @Override
-  public <K, C> ShuffleReader<K, C> getReader(
-      ShuffleHandle handle,
-      int startPartition,
-      int endPartition,
-      TaskContext context,
-      ShuffleReadMetricsReporter metrics) {
+      ShuffleHandle handle, int startPartition, int endPartition, TaskContext context) {
     if (shuffleReaderGetHook != null) {
       shuffleReaderGetHook.exec(handle, startPartition, endPartition, context);
     }
-    return super.getReader(handle, startPartition, endPartition, context, metrics);
+    return super.getReader(handle, startPartition, endPartition, context);
   }
 }

--- a/client-spark/spark-3-columnar-shuffle/src/main/java/org/apache/spark/shuffle/celeborn/ColumnarHashBasedShuffleWriter.java
+++ b/client-spark/spark-3-columnar-shuffle/src/main/java/org/apache/spark/shuffle/celeborn/ColumnarHashBasedShuffleWriter.java
@@ -58,6 +58,7 @@ public class ColumnarHashBasedShuffleWriter<K, V, C> extends HashBasedShuffleWri
   private final double columnarShuffleDictionaryMaxFactor;
 
   public ColumnarHashBasedShuffleWriter(
+      int shuffleId,
       CelebornShuffleHandle<K, V, C> handle,
       TaskContext taskContext,
       CelebornConf conf,
@@ -65,7 +66,7 @@ public class ColumnarHashBasedShuffleWriter<K, V, C> extends HashBasedShuffleWri
       ShuffleWriteMetricsReporter metrics,
       SendBufferPool sendBufferPool)
       throws IOException {
-    super(handle, taskContext, conf, client, metrics, sendBufferPool);
+    super(shuffleId, handle, taskContext, conf, client, metrics, sendBufferPool);
     columnarShuffleBatchSize = conf.columnarShuffleBatchSize();
     columnarShuffleCodeGenEnabled = conf.columnarShuffleCodeGenEnabled();
     columnarShuffleDictionaryEnabled = conf.columnarShuffleDictionaryEnabled();

--- a/client-spark/spark-3-columnar-shuffle/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReader.scala
+++ b/client-spark/spark-3-columnar-shuffle/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReader.scala
@@ -33,7 +33,8 @@ class CelebornColumnarShuffleReader[K, C](
     endMapIndex: Int = Int.MaxValue,
     context: TaskContext,
     conf: CelebornConf,
-    metrics: ShuffleReadMetricsReporter)
+    metrics: ShuffleReadMetricsReporter,
+    shuffleIdTracker: ExecutorShuffleIdTracker)
   extends CelebornShuffleReader[K, C](
     handle,
     startPartition,
@@ -42,7 +43,8 @@ class CelebornColumnarShuffleReader[K, C](
     endMapIndex,
     context,
     conf,
-    metrics) {
+    metrics,
+    shuffleIdTracker) {
 
   override def newSerializerInstance(dep: ShuffleDependency[K, _, C]): SerializerInstance = {
     val schema = CustomShuffleDependencyUtils.getSchema(dep)

--- a/client-spark/spark-3-columnar-shuffle/src/test/java/org/apache/spark/shuffle/celeborn/ColumnarHashBasedShuffleWriterSuiteJ.java
+++ b/client-spark/spark-3-columnar-shuffle/src/test/java/org/apache/spark/shuffle/celeborn/ColumnarHashBasedShuffleWriterSuiteJ.java
@@ -108,7 +108,13 @@ public class ColumnarHashBasedShuffleWriterSuiteJ extends CelebornShuffleWriterS
           .when(() -> CustomShuffleDependencyUtils.getSchema(handle.dependency()))
           .thenReturn(schema);
       return SparkUtils.createColumnarHashBasedShuffleWriter(
-          handle, context, conf, client, metrics, SendBufferPool.get(1, 30, 60));
+          SparkUtils.celebornShuffleId(client, handle, context, true),
+          handle,
+          context,
+          conf,
+          client,
+          metrics,
+          SendBufferPool.get(1, 30, 60));
     }
   }
 

--- a/client-spark/spark-3-columnar-shuffle/src/test/java/org/apache/spark/shuffle/celeborn/ColumnarHashBasedShuffleWriterSuiteJ.java
+++ b/client-spark/spark-3-columnar-shuffle/src/test/java/org/apache/spark/shuffle/celeborn/ColumnarHashBasedShuffleWriterSuiteJ.java
@@ -62,7 +62,7 @@ public class ColumnarHashBasedShuffleWriterSuiteJ extends CelebornShuffleWriterS
     ShuffleWriter<Integer, String> writer =
         createShuffleWriterWithoutSchema(
             new CelebornShuffleHandle<>(
-                "appId", "host", 0, this.userIdentifier, 0, 10, this.dependency),
+                "appId", "host", 0, this.userIdentifier, 0, false, 10, this.dependency),
             taskContext,
             conf,
             client,
@@ -75,7 +75,7 @@ public class ColumnarHashBasedShuffleWriterSuiteJ extends CelebornShuffleWriterS
     writer =
         createShuffleWriter(
             new CelebornShuffleHandle<>(
-                "appId", "host", 0, this.userIdentifier, 0, 10, this.dependency),
+                "appId", "host", 0, this.userIdentifier, 0, false, 10, this.dependency),
             taskContext,
             conf,
             client,
@@ -125,6 +125,12 @@ public class ColumnarHashBasedShuffleWriterSuiteJ extends CelebornShuffleWriterS
       ShuffleClient client,
       ShuffleWriteMetricsReporter metrics) {
     return SparkUtils.createColumnarHashBasedShuffleWriter(
-        handle, context, conf, client, metrics, SendBufferPool.get(1, 30, 60));
+        SparkUtils.celebornShuffleId(client, handle, context, true),
+        handle,
+        context,
+        conf,
+        client,
+        metrics,
+        SendBufferPool.get(1, 30, 60));
   }
 }

--- a/client-spark/spark-3-columnar-shuffle/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReaderSuite.scala
+++ b/client-spark/spark-3-columnar-shuffle/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReaderSuite.scala
@@ -76,6 +76,7 @@ class CelebornColumnarShuffleReaderSuite {
           0,
           new UserIdentifier("mock", "mock"),
           0,
+          false,
           10,
           null),
         0,
@@ -84,7 +85,8 @@ class CelebornColumnarShuffleReaderSuite {
         10,
         null,
         new CelebornConf(),
-        null)
+        null,
+        new ExecutorShuffleIdTracker())
       val shuffleDependency = Mockito.mock(classOf[ShuffleDependency[Int, String, String]])
       Mockito.when(shuffleDependency.shuffleId).thenReturn(0)
       Mockito.when(shuffleDependency.serializer).thenReturn(new KryoSerializer(

--- a/client-spark/spark-3-columnar-shuffle/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReaderSuite.scala
+++ b/client-spark/spark-3-columnar-shuffle/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReaderSuite.scala
@@ -39,6 +39,7 @@ class CelebornColumnarShuffleReaderSuite {
       0,
       new UserIdentifier("mock", "mock"),
       0,
+      false,
       10,
       null)
 

--- a/client-spark/spark-3-columnar-shuffle/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReaderSuite.scala
+++ b/client-spark/spark-3-columnar-shuffle/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornColumnarShuffleReaderSuite.scala
@@ -54,7 +54,8 @@ class CelebornColumnarShuffleReaderSuite {
         10,
         null,
         new CelebornConf(),
-        null)
+        null,
+        new ExecutorShuffleIdTracker())
       assert(shuffleReader.getClass == classOf[CelebornColumnarShuffleReader[Int, String]])
     } finally {
       if (shuffleClient != null) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -101,6 +101,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   // In order to facilitate the writing of unit test code, ShuffleClient needs to be passed in as
   // parameters. By the way, simplify the passed parameters.
   public HashBasedShuffleWriter(
+      int shuffleId,
       CelebornShuffleHandle<K, V, C> handle,
       TaskContext taskContext,
       CelebornConf conf,
@@ -110,7 +111,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException {
     this.mapId = taskContext.partitionId();
     this.dep = handle.dependency();
-    this.shuffleId = dep.shuffleId();
+    this.shuffleId = shuffleId;
     SerializerInstance serializer = dep.serializer().newInstance();
     this.partitioner = dep.partitioner();
     this.writeMetrics = metrics;

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -94,6 +94,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   // In order to facilitate the writing of unit test code, ShuffleClient needs to be passed in as
   // parameters. By the way, simplify the passed parameters.
   public SortBasedShuffleWriter(
+      int shuffleId,
       ShuffleDependency<K, V, C> dep,
       int numMappers,
       TaskContext taskContext,
@@ -105,7 +106,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       throws IOException {
     this.mapId = taskContext.partitionId();
     this.dep = dep;
-    this.shuffleId = dep.shuffleId();
+    this.shuffleId = shuffleId;
     SerializerInstance serializer = dep.serializer().newInstance();
     this.partitioner = dep.partitioner();
     this.writeMetrics = metrics;
@@ -179,6 +180,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       SendBufferPool sendBufferPool)
       throws IOException {
     this(
+        SparkUtils.celebornShuffleId(client, handle, taskContext, true),
         handle.dependency(),
         handle.numMappers(),
         taskContext,

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -38,6 +38,17 @@ import org.apache.celeborn.common.protocol.ShuffleMode;
 import org.apache.celeborn.common.util.ThreadUtils;
 import org.apache.celeborn.reflect.DynMethods;
 
+/**
+ * In order to support Spark Stage resubmit with ShuffleReader FetchFails, Celeborn shuffleId has to
+ * be distinguished from Spark shuffleId. Spark shuffleId is assigned at ShuffleDependency
+ * construction time, and all Attempts of a Spark Stage have the same ShuffleId. When Celeborn
+ * ShuffleReader fails to fetch shuffle data from worker and throws {@link FetchFailedException},
+ * Spark DAGScheduler resubmits the failed ResultStage and corresponding ShuffleMapStage , but
+ * Celeborn can't differentiate shuffle data from previous failed/resubmitted ShuffleMapStage with
+ * the same shuffleId. Current solution takes Stage retry in account, and has LifecycleManager to
+ * generate and track usage of spark shuffle id (appShuffleID) and Celeborn shuffle id (shuffle id).
+ * Spark shuffle Reader/Write gets shuffleId from LifecycleManager with GetShuffleId RPC
+ */
 public class SparkShuffleManager implements ShuffleManager {
 
   private static final Logger logger = LoggerFactory.getLogger(SparkShuffleManager.class);
@@ -78,6 +89,8 @@ public class SparkShuffleManager implements ShuffleManager {
 
   private long sendBufferPoolCheckInterval;
   private long sendBufferPoolExpireTimeout;
+
+  private ExecutorShuffleIdTracker shuffleIdTracker = new ExecutorShuffleIdTracker();
 
   public SparkShuffleManager(SparkConf conf, boolean isDriver) {
     if (conf.getBoolean(SQLConf.LOCAL_SHUFFLE_READER_ENABLED().key(), true)) {
@@ -125,6 +138,13 @@ public class SparkShuffleManager implements ShuffleManager {
       synchronized (this) {
         if (lifecycleManager == null) {
           lifecycleManager = new LifecycleManager(appUniqueId, celebornConf);
+          if (celebornConf.clientFetchThrowsFetchFailure()) {
+            MapOutputTrackerMaster mapOutputTracker =
+                (MapOutputTrackerMaster) SparkEnv.get().mapOutputTracker();
+
+            lifecycleManager.registerShuffleTrackerCallback(
+                shuffleId -> SparkUtils.unregisterAllMapOutput(mapOutputTracker, shuffleId));
+          }
         }
       }
     }
@@ -160,23 +180,24 @@ public class SparkShuffleManager implements ShuffleManager {
           lifecycleManager.getPort(),
           lifecycleManager.getUserIdentifier(),
           shuffleId,
+          celebornConf.clientFetchThrowsFetchFailure(),
           dependency.rdd().getNumPartitions(),
           dependency);
     }
   }
 
   @Override
-  public boolean unregisterShuffle(int shuffleId) {
-    if (sortShuffleIds.contains(shuffleId)) {
-      return sortShuffleManager().unregisterShuffle(shuffleId);
+  public boolean unregisterShuffle(int appShuffleId) {
+    if (sortShuffleIds.contains(appShuffleId)) {
+      return sortShuffleManager().unregisterShuffle(appShuffleId);
     }
     // For Spark driver side trigger unregister shuffle.
     if (lifecycleManager != null) {
-      lifecycleManager.unregisterShuffle(shuffleId);
+      lifecycleManager.unregisterAppShuffle(appShuffleId);
     }
     // For Spark executor side cleanup shuffle related info.
     if (shuffleClient != null) {
-      shuffleClient.cleanupShuffle(shuffleId);
+      shuffleIdTracker.unregisterAppShuffleId(shuffleClient, appShuffleId);
     }
     return true;
   }
@@ -217,10 +238,14 @@ public class SparkShuffleManager implements ShuffleManager {
                 h.lifecycleManagerPort(),
                 celebornConf,
                 h.userIdentifier());
+        int shuffleId = SparkUtils.celebornShuffleId(shuffleClient, h, context, true);
+        shuffleIdTracker.track(h.shuffleId(), shuffleId);
+
         if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())) {
           ExecutorService pushThread =
               celebornConf.clientPushSortPipelineEnabled() ? getPusherThread() : null;
           return new SortBasedShuffleWriter<>(
+              shuffleId,
               h.dependency(),
               h.numMappers(),
               context,
@@ -234,10 +259,10 @@ public class SparkShuffleManager implements ShuffleManager {
               SendBufferPool.get(cores, sendBufferPoolCheckInterval, sendBufferPoolExpireTimeout);
           if (COLUMNAR_SHUFFLE_CLASSES_PRESENT && celebornConf.columnarShuffleEnabled()) {
             return SparkUtils.createColumnarHashBasedShuffleWriter(
-                h, context, celebornConf, shuffleClient, metrics, pool);
+                shuffleId, h, context, celebornConf, shuffleClient, metrics, pool);
           } else {
             return new HashBasedShuffleWriter<>(
-                h, context, celebornConf, shuffleClient, metrics, pool);
+                shuffleId, h, context, celebornConf, shuffleClient, metrics, pool);
           }
         } else {
           throw new UnsupportedOperationException(
@@ -350,7 +375,8 @@ public class SparkShuffleManager implements ShuffleManager {
           endMapIndex,
           context,
           celebornConf,
-          metrics);
+          metrics,
+          shuffleIdTracker);
     }
   }
 

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.spark.*;
 import org.apache.spark.launcher.SparkLauncher;
+import org.apache.spark.rdd.DeterministicLevel;
 import org.apache.spark.shuffle.*;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
 import org.apache.spark.sql.internal.SQLConf;
@@ -158,6 +159,10 @@ public class SparkShuffleManager implements ShuffleManager {
     // This method may be called many times.
     appUniqueId = SparkUtils.appUniqueId(dependency.rdd().context());
     initializeLifecycleManager();
+
+    lifecycleManager.registerAppShuffleDeterminate(
+        shuffleId,
+        dependency.rdd().getOutputDeterministicLevel() != DeterministicLevel.INDETERMINATE());
 
     if (fallbackPolicyRunner.applyAllFallbackPolicy(
         lifecycleManager, dependency.partitioner().numPartitions())) {

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -365,7 +365,8 @@ public class SparkShuffleManager implements ShuffleManager {
           endMapIndex,
           context,
           celebornConf,
-          metrics);
+          metrics,
+          shuffleIdTracker);
     } else {
       return new CelebornShuffleReader<>(
           h,

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -218,7 +218,8 @@ public class SparkUtils {
               int.class,
               TaskContext.class,
               CelebornConf.class,
-              ShuffleReadMetricsReporter.class);
+              ShuffleReadMetricsReporter.class,
+              ExecutorShuffleIdTracker.class);
 
   public static <K, C> CelebornShuffleReader<K, C> createColumnarShuffleReader(
       CelebornShuffleHandle<K, ?, C> handle,
@@ -228,7 +229,8 @@ public class SparkUtils {
       int endMapIndex,
       TaskContext context,
       CelebornConf conf,
-      ShuffleReadMetricsReporter metrics) {
+      ShuffleReadMetricsReporter metrics,
+      ExecutorShuffleIdTracker shuffleIdTracker) {
     return COLUMNAR_SHUFFLE_READER_CONSTRUCTOR_BUILDER
         .build()
         .invoke(
@@ -240,7 +242,8 @@ public class SparkUtils {
             endMapIndex,
             context,
             conf,
-            metrics);
+            metrics,
+            shuffleIdTracker);
   }
 
   // Added in SPARK-32920, for Spark 3.2 and above

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.LongAdder;
 
 import scala.Tuple2;
 
+import org.apache.spark.MapOutputTrackerMaster;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.TaskContext;
@@ -45,6 +46,8 @@ import org.apache.celeborn.reflect.DynMethods;
 
 public class SparkUtils {
   private static final Logger LOG = LoggerFactory.getLogger(SparkUtils.class);
+
+  public static final String FETCH_FAILURE_ERROR_MSG = "Celeborn FetchFailure! ";
 
   public static MapStatus createMapStatus(
       BlockManagerId loc, long[] uncompressedSizes, long mapTaskId) {
@@ -90,6 +93,23 @@ public class SparkUtils {
         .applicationAttemptId()
         .map(id -> context.applicationId() + "_" + id)
         .getOrElse(context::applicationId);
+  }
+
+  public static String getAppShuffleIdentifier(int appShuffleId, TaskContext context) {
+    return appShuffleId + "-" + context.stageId() + "-" + context.stageAttemptNumber();
+  }
+
+  public static int celebornShuffleId(
+      ShuffleClient client,
+      CelebornShuffleHandle<?, ?, ?> handle,
+      TaskContext context,
+      Boolean isWriter) {
+    if (handle.throwsFetchFailure()) {
+      String appShuffleIdentifier = getAppShuffleIdentifier(handle.shuffleId(), context);
+      return client.getShuffleId(handle.shuffleId(), appShuffleIdentifier, isWriter);
+    } else {
+      return handle.shuffleId();
+    }
   }
 
   // Create an instance of the class with the given name, possibly initializing it with our conf
@@ -164,6 +184,7 @@ public class SparkUtils {
       DynConstructors.builder()
           .impl(
               COLUMNAR_HASH_BASED_SHUFFLE_WRITER_CLASS,
+              int.class,
               CelebornShuffleHandle.class,
               TaskContext.class,
               CelebornConf.class,
@@ -172,6 +193,7 @@ public class SparkUtils {
               SendBufferPool.class);
 
   public static <K, V, C> HashBasedShuffleWriter<K, V, C> createColumnarHashBasedShuffleWriter(
+      int shuffleId,
       CelebornShuffleHandle<K, V, C> handle,
       TaskContext taskContext,
       CelebornConf conf,
@@ -180,7 +202,7 @@ public class SparkUtils {
       SendBufferPool sendBufferPool) {
     return COLUMNAR_HASH_BASED_SHUFFLE_WRITER_CONSTRUCTOR_BUILDER
         .build()
-        .invoke(null, handle, taskContext, conf, client, metrics, sendBufferPool);
+        .invoke(null, shuffleId, handle, taskContext, conf, client, metrics, sendBufferPool);
   }
 
   public static final String COLUMNAR_SHUFFLE_READER_CLASS =
@@ -219,5 +241,33 @@ public class SparkUtils {
             context,
             conf,
             metrics);
+  }
+
+  // Added in SPARK-32920, for Spark 3.2 and above
+  private static final DynMethods.UnboundMethod UnregisterAllMapAndMergeOutput_METHOD =
+      DynMethods.builder("unregisterAllMapAndMergeOutput")
+          .impl(MapOutputTrackerMaster.class, Integer.TYPE)
+          .orNoop()
+          .build();
+
+  // for spark 3.1, see detail in SPARK-32920
+  private static final DynMethods.UnboundMethod UnregisterAllMapOutput_METHOD =
+      DynMethods.builder("unregisterAllMapOutput")
+          .impl(MapOutputTrackerMaster.class, Integer.TYPE)
+          .orNoop()
+          .build();
+
+  public static void unregisterAllMapOutput(
+      MapOutputTrackerMaster mapOutputTracker, int shuffleId) {
+    if (!UnregisterAllMapAndMergeOutput_METHOD.isNoop()) {
+      UnregisterAllMapAndMergeOutput_METHOD.bind(mapOutputTracker).invoke(shuffleId);
+      return;
+    }
+    if (!UnregisterAllMapOutput_METHOD.isNoop()) {
+      UnregisterAllMapOutput_METHOD.bind(mapOutputTracker).invoke(shuffleId);
+      return;
+    }
+    throw new UnsupportedOperationException(
+        "unexpected! neither methods unregisterAllMapAndMergeOutput/unregisterAllMapOutput are found in MapOutputTrackerMaster");
   }
 }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -47,7 +47,7 @@ import org.apache.celeborn.reflect.DynMethods;
 public class SparkUtils {
   private static final Logger LOG = LoggerFactory.getLogger(SparkUtils.class);
 
-  public static final String FETCH_FAILURE_ERROR_MSG = "Celeborn FetchFailure! ";
+  public static final String FETCH_FAILURE_ERROR_MSG = "Celeborn FetchFailure with shuffle id ";
 
   public static MapStatus createMapStatus(
       BlockManagerId loc, long[] uncompressedSizes, long mapTaskId) {

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
@@ -28,6 +28,7 @@ class CelebornShuffleHandle[K, V, C](
     val lifecycleManagerPort: Int,
     val userIdentifier: UserIdentifier,
     shuffleId: Int,
+    val throwsFetchFailure: Boolean,
     val numMappers: Int,
     dependency: ShuffleDependency[K, V, C])
   extends BaseShuffleHandle(shuffleId, dependency)

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicReference
 import org.apache.spark.{InterruptibleIterator, ShuffleDependency, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.SerializerInstance
-import org.apache.spark.shuffle.{ShuffleReader, ShuffleReadMetricsReporter}
+import org.apache.spark.shuffle.{FetchFailedException, ShuffleReader, ShuffleReadMetricsReporter}
 import org.apache.spark.shuffle.celeborn.CelebornShuffleReader.streamCreatorPool
 import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection.ExternalSorter
@@ -32,7 +32,7 @@ import org.apache.spark.util.collection.ExternalSorter
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.client.read.{CelebornInputStream, MetricsCallback}
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.exception.CelebornIOException
+import org.apache.celeborn.common.exception.{CelebornIOException, PartitionUnRetryAbleException}
 import org.apache.celeborn.common.util.ThreadUtils
 
 class CelebornShuffleReader[K, C](
@@ -43,7 +43,8 @@ class CelebornShuffleReader[K, C](
     endMapIndex: Int = Int.MaxValue,
     context: TaskContext,
     conf: CelebornConf,
-    metrics: ShuffleReadMetricsReporter)
+    metrics: ShuffleReadMetricsReporter,
+    shuffleIdTracker: ExecutorShuffleIdTracker)
   extends ShuffleReader[K, C] with Logging {
 
   private val dep = handle.dependency
@@ -59,6 +60,11 @@ class CelebornShuffleReader[K, C](
   override def read(): Iterator[Product2[K, C]] = {
 
     val serializerInstance = newSerializerInstance(dep)
+
+    val shuffleId = SparkUtils.celebornShuffleId(shuffleClient, handle, context, false)
+    shuffleIdTracker.track(handle.shuffleId, shuffleId)
+    logDebug(
+      s"get shuffleId $shuffleId for appShuffleId ${handle.shuffleId} attemptNum ${context.stageAttemptNumber()}")
 
     // Update the context task metrics for each record read.
     val metricsCallback = new MetricsCallback {
@@ -89,7 +95,7 @@ class CelebornShuffleReader[K, C](
           if (exceptionRef.get() == null) {
             try {
               val inputStream = shuffleClient.readPartition(
-                handle.shuffleId,
+                shuffleId,
                 partitionId,
                 context.attemptNumber(),
                 startMapIndex,
@@ -115,7 +121,22 @@ class CelebornShuffleReader[K, C](
         var inputStream: CelebornInputStream = streams.get(partitionId)
         while (inputStream == null) {
           if (exceptionRef.get() != null) {
-            throw exceptionRef.get()
+            exceptionRef.get() match {
+              case ce @ (_: CelebornIOException | _: PartitionUnRetryAbleException) =>
+                if (handle.throwsFetchFailure &&
+                  shuffleClient.reportShuffleFetchFailure(handle.shuffleId, shuffleId)) {
+                  throw new FetchFailedException(
+                    null,
+                    handle.shuffleId,
+                    -1,
+                    -1,
+                    partitionId,
+                    SparkUtils.FETCH_FAILURE_ERROR_MSG,
+                    ce)
+                } else
+                  throw ce
+              case e => throw e
+            }
           }
           Thread.sleep(50)
           inputStream = streams.get(partitionId)
@@ -124,12 +145,31 @@ class CelebornShuffleReader[K, C](
           TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startFetchWait))
         // ensure inputStream is closed when task completes
         context.addTaskCompletionListener[Unit](_ => inputStream.close())
-        inputStream
+        (partitionId, inputStream)
       } else {
-        CelebornInputStream.empty()
+        (partitionId, CelebornInputStream.empty())
       }
-    }).flatMap(
-      serializerInstance.deserializeStream(_).asKeyValueIterator)
+    }).map { case (partitionId, inputStream) =>
+      (partitionId, serializerInstance.deserializeStream(inputStream).asKeyValueIterator)
+    }.flatMap { case (partitionId, iter) =>
+      try {
+        iter
+      } catch {
+        case e @ (_: CelebornIOException | _: PartitionUnRetryAbleException) =>
+          if (handle.throwsFetchFailure &&
+            shuffleClient.reportShuffleFetchFailure(handle.shuffleId, shuffleId)) {
+            throw new FetchFailedException(
+              null,
+              handle.shuffleId,
+              -1,
+              -1,
+              partitionId,
+              SparkUtils.FETCH_FAILURE_ERROR_MSG,
+              e)
+          } else
+            throw e
+      }
+    }
 
     val iterWithUpdatedRecordsRead =
       if (GlutenShuffleDependencyHelper.isGlutenDep(dep.getClass.getName)) {

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -131,7 +131,7 @@ class CelebornShuffleReader[K, C](
                     -1,
                     -1,
                     partitionId,
-                    SparkUtils.FETCH_FAILURE_ERROR_MSG,
+                    SparkUtils.FETCH_FAILURE_ERROR_MSG + shuffleId,
                     ce)
                 } else
                   throw ce
@@ -164,7 +164,7 @@ class CelebornShuffleReader[K, C](
               -1,
               -1,
               partitionId,
-              SparkUtils.FETCH_FAILURE_ERROR_MSG,
+              SparkUtils.FETCH_FAILURE_ERROR_MSG + shuffleId,
               e)
           } else
             throw e

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -236,7 +236,7 @@ public abstract class CelebornShuffleWriterSuiteBase {
     final File tempFile = new File(tempDir, UUID.randomUUID().toString());
     final CelebornShuffleHandle<Integer, String, String> handle =
         new CelebornShuffleHandle<>(
-            appId, host, port, userIdentifier, shuffleId, numMaps, dependency);
+            appId, host, port, userIdentifier, shuffleId, false, numMaps, dependency);
     final ShuffleClient client = new DummyShuffleClient(conf, tempFile);
     ((DummyShuffleClient) client).initReducePartitionMap(shuffleId, numPartitions, 1);
 

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriterSuiteJ.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriterSuiteJ.java
@@ -37,6 +37,12 @@ public class HashBasedShuffleWriterSuiteJ extends CelebornShuffleWriterSuiteBase
       ShuffleWriteMetricsReporter metrics)
       throws IOException {
     return new HashBasedShuffleWriter<Integer, String, String>(
-        handle, context, conf, client, metrics, SendBufferPool.get(1, 30, 60));
+        SparkUtils.celebornShuffleId(client, handle, context, true),
+        handle,
+        context,
+        conf,
+        client,
+        metrics,
+        SendBufferPool.get(1, 30, 60));
   }
 }

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/HookedCelebornShuffleManager.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/HookedCelebornShuffleManager.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.celeborn;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.TaskContext;
+import org.apache.spark.shuffle.ShuffleHandle;
+import org.apache.spark.shuffle.ShuffleReadMetricsReporter;
+import org.apache.spark.shuffle.ShuffleReader;
+
+public class HookedCelebornShuffleManager extends SparkShuffleManager {
+
+  private static ShuffleManagerHook shuffleReaderGetHook = null;
+
+  public HookedCelebornShuffleManager(SparkConf conf) {
+    super(conf, true);
+  }
+
+  public static void registerReaderGetHook(ShuffleManagerHook hook) {
+    shuffleReaderGetHook = hook;
+  }
+
+  @Override
+  public <K, C> ShuffleReader<K, C> getReader(
+      ShuffleHandle handle,
+      int startMapIndex,
+      int endMapIndex,
+      int startPartition,
+      int endPartition,
+      TaskContext context,
+      ShuffleReadMetricsReporter metrics) {
+    if (shuffleReaderGetHook != null) {
+      shuffleReaderGetHook.exec(
+          handle, startMapIndex, endMapIndex, startPartition, endPartition, context);
+    }
+    return super.getReader(
+        handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics);
+  }
+
+  @Override
+  public <K, C> ShuffleReader<K, C> getReader(
+      ShuffleHandle handle,
+      int startPartition,
+      int endPartition,
+      TaskContext context,
+      ShuffleReadMetricsReporter metrics) {
+    if (shuffleReaderGetHook != null) {
+      shuffleReaderGetHook.exec(handle, startPartition, endPartition, context);
+    }
+    return super.getReader(handle, startPartition, endPartition, context, metrics);
+  }
+}

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/ShuffleManagerHook.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/ShuffleManagerHook.java
@@ -17,30 +17,19 @@
 
 package org.apache.spark.shuffle.celeborn;
 
-import java.io.IOException;
-
 import org.apache.spark.TaskContext;
-import org.apache.spark.shuffle.ShuffleWriter;
+import org.apache.spark.shuffle.ShuffleHandle;
 
-import org.apache.celeborn.client.ShuffleClient;
-import org.apache.celeborn.common.CelebornConf;
+public interface ShuffleManagerHook {
 
-public class HashBasedShuffleWriterSuiteJ extends CelebornShuffleWriterSuiteBase {
+  default void exec(
+      ShuffleHandle handle, int startPartition, int endPartition, TaskContext context) {}
 
-  public HashBasedShuffleWriterSuiteJ() throws IOException {}
-
-  @Override
-  protected ShuffleWriter<Integer, String> createShuffleWriter(
-      CelebornShuffleHandle handle, TaskContext context, CelebornConf conf, ShuffleClient client)
-      throws IOException {
-    // this test case is independent of the `mapId` value
-    return new HashBasedShuffleWriter<Integer, String, String>(
-        SparkUtils.celebornShuffleId(client, handle, context, true),
-        handle,
-        /*mapId=*/ 0,
-        context,
-        conf,
-        client,
-        SendBufferPool.get(1, 30, 60));
-  }
+  default void exec(
+      ShuffleHandle handle,
+      int startMapIndex,
+      int endMapIndex,
+      int startPartition,
+      int endPartition,
+      TaskContext context) {};
 }

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/TestCelebornShuffleManager.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/TestCelebornShuffleManager.java
@@ -20,13 +20,14 @@ package org.apache.spark.shuffle.celeborn;
 import org.apache.spark.SparkConf;
 import org.apache.spark.TaskContext;
 import org.apache.spark.shuffle.ShuffleHandle;
+import org.apache.spark.shuffle.ShuffleReadMetricsReporter;
 import org.apache.spark.shuffle.ShuffleReader;
 
-public class HookedCelebornShuffleManager extends SparkShuffleManager {
+public class TestCelebornShuffleManager extends SparkShuffleManager {
 
   private static ShuffleManagerHook shuffleReaderGetHook = null;
 
-  public HookedCelebornShuffleManager(SparkConf conf) {
+  public TestCelebornShuffleManager(SparkConf conf) {
     super(conf, true);
   }
 
@@ -36,10 +37,31 @@ public class HookedCelebornShuffleManager extends SparkShuffleManager {
 
   @Override
   public <K, C> ShuffleReader<K, C> getReader(
-      ShuffleHandle handle, int startPartition, int endPartition, TaskContext context) {
+      ShuffleHandle handle,
+      int startMapIndex,
+      int endMapIndex,
+      int startPartition,
+      int endPartition,
+      TaskContext context,
+      ShuffleReadMetricsReporter metrics) {
+    if (shuffleReaderGetHook != null) {
+      shuffleReaderGetHook.exec(
+          handle, startMapIndex, endMapIndex, startPartition, endPartition, context);
+    }
+    return super.getReader(
+        handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics);
+  }
+
+  @Override
+  public <K, C> ShuffleReader<K, C> getReader(
+      ShuffleHandle handle,
+      int startPartition,
+      int endPartition,
+      TaskContext context,
+      ShuffleReadMetricsReporter metrics) {
     if (shuffleReaderGetHook != null) {
       shuffleReaderGetHook.exec(handle, startPartition, endPartition, context);
     }
-    return super.getReader(handle, startPartition, endPartition, context);
+    return super.getReader(handle, startPartition, endPartition, context, metrics);
   }
 }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -212,4 +212,13 @@ public abstract class ShuffleClient {
       int shuffleId, int numMappers, int numPartitions);
 
   public abstract PushState getPushState(String mapKey);
+
+  public abstract int getShuffleId(int appShuffleId, String appShuffleIdentifier, boolean isWriter);
+
+  /**
+   * report shuffle data fetch failure to LifecycleManager for special handling, eg, shuffle status
+   * cleanup for spark app. It must be a sync call and make sure the cleanup is done, otherwise,
+   * incorrect shuffle data can be fetched in re-run tasks
+   */
+  public abstract boolean reportShuffleFetchFailure(int appShuffleId, int shuffleId);
 }

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1353,7 +1353,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     workerStatusTracker.registerWorkerStatusListener(workerStatusListener)
   }
 
-  private var appShuffleTrackerCallback: Option[Consumer[Integer]] = None
+  @volatile private var appShuffleTrackerCallback: Option[Consumer[Integer]] = None
   def registerShuffleTrackerCallback(callback: Consumer[Integer]): Unit = {
     appShuffleTrackerCallback = Some(callback)
   }

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -816,11 +816,13 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   def unregisterAppShuffle(appShuffleId: Int): Unit = {
     logInfo(s"Unregister appShuffleId $appShuffleId starts...")
     val shuffleIds = shuffleIdMapping.remove(appShuffleId)
-    shuffleIds.synchronized(
-      shuffleIds.values.map {
-        case (shuffleId, _) =>
-          unregisterShuffle(shuffleId)
-      })
+    if (shuffleIds != null) {
+      shuffleIds.synchronized(
+        shuffleIds.values.map {
+          case (shuffleId, _) =>
+            unregisterShuffle(shuffleId)
+        })
+    }
   }
 
   /* ========================================================== *

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -82,6 +82,11 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     JavaUtils.newConcurrentHashMap[Int, ConcurrentHashMap[Int, PartitionLocation]]()
   private val userIdentifier: UserIdentifier = IdentityProvider.instantiate(conf).provide()
   private val availableStorageTypes = conf.availableStorageTypes
+  // app shuffle id -> LinkedHashMap of (app shuffle identifier, (shuffle id, fetch status))
+  private val shuffleIdMapping = JavaUtils.newConcurrentHashMap[
+    Int,
+    scala.collection.mutable.LinkedHashMap[String, (Int, Boolean)]]()
+  private val shuffleIdGenerator = new AtomicInteger(0)
 
   private val rpcCacheSize = conf.clientRpcCacheSize
   private val rpcCacheConcurrencyLevel = conf.clientRpcCacheConcurrencyLevel
@@ -312,6 +317,19 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     case GetReducerFileGroup(shuffleId: Int) =>
       logDebug(s"Received GetShuffleFileGroup request for shuffleId $shuffleId.")
       handleGetReducerFileGroup(context, shuffleId)
+
+    case pb: PbGetShuffleId =>
+      val appShuffleId = pb.getAppShuffleId
+      val appShuffleIdentifier = pb.getAppShuffleIdentifier
+      val isWriter = pb.getIsShuffleWriter
+      logDebug(s"Received GetShuffleId request, appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier isWriter $isWriter.")
+      handleGetShuffleIdForApp(context, appShuffleId, appShuffleIdentifier, isWriter)
+
+    case pb: PbReportShuffleFetchFailure =>
+      val appShuffleId = pb.getAppShuffleId
+      val shuffleId = pb.getShuffleId
+      logDebug(s"Received ReportShuffleFetchFailure request, appShuffleId $appShuffleId shuffleId $shuffleId")
+      handleReportShuffleFetchFailure(context, appShuffleId, shuffleId)
   }
 
   private def offerAndReserveSlots(
@@ -628,6 +646,100 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     commitManager.handleGetReducerFileGroup(context, shuffleId)
   }
 
+  private def handleGetShuffleIdForApp(
+      context: RpcCallContext,
+      appShuffleId: Int,
+      appShuffleIdentifier: String,
+      isWriter: Boolean): Unit = {
+    val shuffleIds = shuffleIdMapping.computeIfAbsent(
+      appShuffleId,
+      new function.Function[Int, scala.collection.mutable.LinkedHashMap[String, (Int, Boolean)]]() {
+        override def apply(id: Int)
+            : scala.collection.mutable.LinkedHashMap[String, (Int, Boolean)] = {
+          val newShuffleId = shuffleIdGenerator.getAndIncrement()
+          logInfo(s"generate new shuffleId $newShuffleId for appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier")
+          scala.collection.mutable.LinkedHashMap(appShuffleIdentifier -> (newShuffleId, true))
+        }
+      })
+
+    def isAllMaptaskEnd(shuffleId: Int): Boolean = {
+      !commitManager.getMapperAttempts(shuffleId).exists(_ < 0)
+    }
+
+    shuffleIds.synchronized {
+      if (isWriter) {
+        shuffleIds.get(appShuffleIdentifier) match {
+          case Some((shuffleId, _)) =>
+            val pbGetShuffleIdResponse =
+              PbGetShuffleIdResponse.newBuilder().setShuffleId(shuffleId).build()
+            context.reply(pbGetShuffleIdResponse)
+          case None =>
+            val newShuffleId = shuffleIdGenerator.getAndIncrement()
+            logInfo(s"generate new shuffleId $newShuffleId for appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier")
+            shuffleIds.put(appShuffleIdentifier, (newShuffleId, true))
+            val pbGetShuffleIdResponse =
+              PbGetShuffleIdResponse.newBuilder().setShuffleId(newShuffleId).build()
+            context.reply(pbGetShuffleIdResponse)
+        }
+      } else {
+        shuffleIds.values.map(v => v._1).toSeq.reverse.find(isAllMaptaskEnd) match {
+          case Some(shuffleId) =>
+            val pbGetShuffleIdResponse = {
+              logDebug(
+                s"get shuffleId $shuffleId for appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier isWriter $isWriter")
+              PbGetShuffleIdResponse.newBuilder().setShuffleId(shuffleId).build()
+            }
+            context.reply(pbGetShuffleIdResponse)
+          case None =>
+            throw new UnsupportedOperationException(
+              s"unexpected! there is no finished map stage associated with appShuffleId $appShuffleId")
+        }
+      }
+    }
+  }
+
+  private def handleReportShuffleFetchFailure(
+      context: RpcCallContext,
+      appShuffleId: Int,
+      shuffleId: Int): Unit = {
+
+    val shuffleIds = shuffleIdMapping.get(appShuffleId)
+    if (shuffleIds == null) {
+      throw new UnsupportedOperationException(s"unexpected! unknown appShuffleId $appShuffleId")
+    }
+    var ret = true
+    shuffleIds.synchronized {
+      shuffleIds.find(e => e._2._1 == shuffleId) match {
+        case Some((appShuffleIdentifier, (shuffleId, true))) =>
+          logInfo(s"handle fetch failure for appShuffleId $appShuffleId shuffleId $shuffleId")
+          appShuffleTrackerCallback match {
+            case Some(callback) =>
+              try {
+                callback.accept(appShuffleId)
+              } catch {
+                case t: Throwable =>
+                  logError(t.toString)
+                  ret = false
+              }
+              shuffleIds.put(appShuffleIdentifier, (shuffleId, false))
+            case None =>
+              throw new UnsupportedOperationException(
+                "unexpected! appShuffleTrackerCallback is not registered")
+          }
+        case Some((appShuffleIdentifier, (shuffleId, false))) =>
+          logInfo(
+            s"Ignoring fetch failure from appShuffleIdentifier $appShuffleIdentifier shuffleId $shuffleId, " +
+              "fetch failure is already reported and handled by other reader")
+        case None => throw new UnsupportedOperationException(
+            s"unexpected! unknown shuffleId $shuffleId for appShuffleId $appShuffleId")
+      }
+    }
+
+    val pbReportShuffleFetchFailureResponse =
+      PbReportShuffleFetchFailureResponse.newBuilder().setSuccess(ret).build()
+    context.reply(pbReportShuffleFetchFailureResponse)
+  }
+
   private def handleStageEnd(shuffleId: Int): Unit = {
     // check whether shuffle has registered
     if (!registeredShuffle.contains(shuffleId)) {
@@ -699,6 +811,16 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     unregisterShuffleTime.put(shuffleId, System.currentTimeMillis())
 
     logInfo(s"Unregister for $shuffleId success.")
+  }
+
+  def unregisterAppShuffle(appShuffleId: Int): Unit = {
+    logInfo(s"Unregister appShuffleId $appShuffleId starts...")
+    val shuffleIds = shuffleIdMapping.remove(appShuffleId)
+    shuffleIds.synchronized(
+      shuffleIds.values.map {
+        case (shuffleId, _) =>
+          unregisterShuffle(shuffleId)
+      })
   }
 
   /* ========================================================== *
@@ -1206,6 +1328,11 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   // delegate workerStatusTracker to register listener
   def registerWorkerStatusListener(workerStatusListener: WorkerStatusListener): Unit = {
     workerStatusTracker.registerWorkerStatusListener(workerStatusListener)
+  }
+
+  private var appShuffleTrackerCallback: Option[Consumer[Integer]] = None
+  def registerShuffleTrackerCallback(callback: Consumer[Integer]): Unit = {
+    appShuffleTrackerCallback = Some(callback)
   }
 
   // Initialize at the end of LifecycleManager construction.

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -153,6 +153,16 @@ public class DummyShuffleClient extends ShuffleClient {
     return new PushState(conf);
   }
 
+  @Override
+  public int getShuffleId(int appShuffleId, String appShuffleIdentifier, boolean isWriter) {
+    return appShuffleId;
+  }
+
+  @Override
+  public boolean reportShuffleFetchFailure(int appShuffleId, int shuffleId) {
+    return true;
+  }
+
   public void initReducePartitionMap(int shuffleId, int numPartitions, int workerNum) {
     ConcurrentHashMap<Integer, PartitionLocation> map = JavaUtils.newConcurrentHashMap();
     String host = "host";

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
@@ -32,11 +32,15 @@ import org.apache.celeborn.common.protocol.MessageType;
 import org.apache.celeborn.common.protocol.PbBacklogAnnouncement;
 import org.apache.celeborn.common.protocol.PbBufferStreamEnd;
 import org.apache.celeborn.common.protocol.PbChunkFetchRequest;
+import org.apache.celeborn.common.protocol.PbGetShuffleId;
+import org.apache.celeborn.common.protocol.PbGetShuffleIdResponse;
 import org.apache.celeborn.common.protocol.PbOpenStream;
 import org.apache.celeborn.common.protocol.PbPushDataHandShake;
 import org.apache.celeborn.common.protocol.PbReadAddCredit;
 import org.apache.celeborn.common.protocol.PbRegionFinish;
 import org.apache.celeborn.common.protocol.PbRegionStart;
+import org.apache.celeborn.common.protocol.PbReportShuffleFetchFailure;
+import org.apache.celeborn.common.protocol.PbReportShuffleFetchFailureResponse;
 import org.apache.celeborn.common.protocol.PbStreamChunkSlice;
 import org.apache.celeborn.common.protocol.PbStreamHandler;
 import org.apache.celeborn.common.protocol.PbTransportableError;
@@ -90,6 +94,14 @@ public class TransportMessage implements Serializable {
         return (T) PbChunkFetchRequest.parseFrom(payload);
       case TRANSPORTABLE_ERROR_VALUE:
         return (T) PbTransportableError.parseFrom(payload);
+      case GET_SHUFFLE_ID_VALUE:
+        return (T) PbGetShuffleId.parseFrom(payload);
+      case GET_SHUFFLE_ID_RESPONSE_VALUE:
+        return (T) PbGetShuffleIdResponse.parseFrom(payload);
+      case REPORT_SHUFFLE_FETCH_FAILURE_VALUE:
+        return (T) PbReportShuffleFetchFailure.parseFrom(payload);
+      case REPORT_SHUFFLE_FETCH_FAILURE_RESPONSE_VALUE:
+        return (T) PbReportShuffleFetchFailureResponse.parseFrom(payload);
       default:
         logger.error("Unexpected type {}", type);
     }

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -87,6 +87,10 @@ enum MessageType {
   TRANSPORTABLE_ERROR = 64;
   WORKER_EXCLUDE = 65;
   WORKER_EXCLUDE_RESPONSE = 66;
+  REPORT_SHUFFLE_FETCH_FAILURE = 67;
+  REPORT_SHUFFLE_FETCH_FAILURE_RESPONSE = 68;
+  GET_SHUFFLE_ID = 69;
+  GET_SHUFFLE_ID_RESPONSE = 70;
 }
 
 enum StreamType {
@@ -294,6 +298,25 @@ message PbGetReducerFileGroupResponse {
 
   // only map partition mode has succeed partitionIds
   repeated int32 partitionIds = 4;
+}
+
+message PbGetShuffleId {
+  int32 appShuffleId = 1;
+  string appShuffleIdentifier = 2;
+  bool isShuffleWriter = 3;
+}
+
+message PbGetShuffleIdResponse {
+  int32 shuffleId = 1;
+}
+
+message PbReportShuffleFetchFailure {
+  int32 appShuffleId = 1;
+  int32 shuffleId = 2;
+}
+
+message PbReportShuffleFetchFailureResponse {
+  bool success = 1;
 }
 
 message PbUnregisterShuffle {

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -777,6 +777,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def clientFetchTimeoutMs: Long = get(CLIENT_FETCH_TIMEOUT)
   def clientFetchMaxReqsInFlight: Int = get(CLIENT_FETCH_MAX_REQS_IN_FLIGHT)
   def clientFetchMaxRetriesForEachReplica: Int = get(CLIENT_FETCH_MAX_RETRIES_FOR_EACH_REPLICA)
+  def clientFetchThrowsFetchFailure: Boolean = get(CLIENT_FETCH_THROWS_FETCH_FAILURE)
   def clientFetchExcludeWorkerOnFailureEnabled: Boolean =
     get(CLIENT_FETCH_EXCLUDE_WORKER_ON_FAILURE_ENABLED)
   def clientFetchExcludedWorkerExpireTimeout: Long =
@@ -3227,6 +3228,14 @@ object CelebornConf extends Logging {
       .doc("Max retry times of fetch chunk on each replica")
       .intConf
       .createWithDefault(3)
+
+  val CLIENT_FETCH_THROWS_FETCH_FAILURE: ConfigEntry[Boolean] =
+    buildConf("celeborn.client.spark.fetch.throwsFetchFailure")
+      .categories("client")
+      .version("0.4.0")
+      .doc("client throws FetchFailedException instead of CelebornIOException")
+      .booleanConf
+      .createWithDefault(false)
 
   val CLIENT_FETCH_EXCLUDE_WORKER_ON_FAILURE_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.client.fetch.excludeWorkerOnFailure.enabled")

--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -487,6 +487,18 @@ object ControlMessages extends Logging {
     case pb: PbRegisterWorker =>
       new TransportMessage(MessageType.REGISTER_WORKER, pb.toByteArray)
 
+    case pb: PbGetShuffleId =>
+      new TransportMessage(MessageType.GET_SHUFFLE_ID, pb.toByteArray)
+
+    case pb: PbGetShuffleIdResponse =>
+      new TransportMessage(MessageType.GET_SHUFFLE_ID_RESPONSE, pb.toByteArray)
+
+    case pb: PbReportShuffleFetchFailure =>
+      new TransportMessage(MessageType.REPORT_SHUFFLE_FETCH_FAILURE, pb.toByteArray)
+
+    case pb: PbReportShuffleFetchFailureResponse =>
+      new TransportMessage(MessageType.REPORT_SHUFFLE_FETCH_FAILURE_RESPONSE, pb.toByteArray)
+
     case HeartbeatFromWorker(
           host,
           rpcPort,
@@ -979,6 +991,18 @@ object ControlMessages extends Logging {
           fileGroup,
           attempts,
           partitionIds)
+
+      case GET_SHUFFLE_ID_VALUE =>
+        message.getParsedPayload()
+
+      case GET_SHUFFLE_ID_RESPONSE_VALUE =>
+        message.getParsedPayload()
+
+      case REPORT_SHUFFLE_FETCH_FAILURE_VALUE =>
+        message.getParsedPayload()
+
+      case REPORT_SHUFFLE_FETCH_FAILURE_RESPONSE_VALUE =>
+        message.getParsedPayload()
 
       case UNREGISTER_SHUFFLE_VALUE =>
         PbUnregisterShuffle.parseFrom(message.getPayload)

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -98,6 +98,7 @@ license: |
 | celeborn.client.shuffle.partitionSplit.threshold | 1G | Shuffle file size threshold, if file size exceeds this, trigger split. | 0.3.0 | 
 | celeborn.client.shuffle.rangeReadFilter.enabled | false | If a spark application have skewed partition, this value can set to true to improve performance. | 0.2.0 | 
 | celeborn.client.slot.assign.maxWorkers | 10000 | Max workers that slots of one shuffle can be allocated on. Will choose the smaller positive one from Master side and Client side, see `celeborn.master.slot.assign.maxWorkers`. | 0.3.1 | 
+| celeborn.client.spark.fetch.throwsFetchFailure | false | client throws FetchFailedException instead of CelebornIOException | 0.4.0 | 
 | celeborn.client.spark.push.sort.memory.threshold | 64m | When SortBasedPusher use memory over the threshold, will trigger push data. If the pipeline push feature is enabled (`celeborn.client.spark.push.sort.pipeline.enabled=true`), the SortBasedPusher will trigger a data push when the memory usage exceeds half of the threshold(by default, 32m). | 0.3.0 | 
 | celeborn.client.spark.push.sort.pipeline.enabled | false | Whether to enable pipelining for sort based shuffle writer. If true, double buffering will be used to pipeline push | 0.3.0 | 
 | celeborn.client.spark.push.unsafeRow.fastWrite.enabled | true | This is Celeborn's optimization on UnsafeRow for Spark and it's true by default. If you have changed UnsafeRow's memory layout set this to false. | 0.2.2 | 

--- a/tests/spark-it/pom.xml
+++ b/tests/spark-it/pom.xml
@@ -93,6 +93,13 @@
           <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.apache.celeborn</groupId>
+          <artifactId>celeborn-client-spark-2_${scala.binary.version}</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -124,6 +131,13 @@
           <groupId>org.apache.celeborn</groupId>
           <artifactId>celeborn-client-spark-3_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.celeborn</groupId>
+          <artifactId>celeborn-client-spark-3_${scala.binary.version}</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/tests/spark-it/pom.xml
+++ b/tests/spark-it/pom.xml
@@ -111,6 +111,13 @@
           <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.apache.celeborn</groupId>
+          <artifactId>celeborn-client-spark-3_${scala.binary.version}</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -120,6 +127,13 @@
           <groupId>org.apache.celeborn</groupId>
           <artifactId>celeborn-client-spark-3_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.celeborn</groupId>
+          <artifactId>celeborn-client-spark-3_${scala.binary.version}</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -151,6 +165,13 @@
           <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.apache.celeborn</groupId>
+          <artifactId>celeborn-client-spark-3_${scala.binary.version}</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -162,6 +183,13 @@
           <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.apache.celeborn</groupId>
+          <artifactId>celeborn-client-spark-3_${scala.binary.version}</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -171,6 +199,13 @@
           <groupId>org.apache.celeborn</groupId>
           <artifactId>celeborn-client-spark-3_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.celeborn</groupId>
+          <artifactId>celeborn-client-spark-3_${scala.binary.version}</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.tests.spark
+
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+
+import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.shuffle.ShuffleHandle
+import org.apache.spark.shuffle.celeborn.{CelebornShuffleHandle, HookedCelebornShuffleManager, ShuffleManagerHook, SparkUtils}
+import org.apache.spark.sql.SparkSession
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.client.ShuffleClient
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.protocol.ShuffleMode
+import org.apache.celeborn.service.deploy.worker.Worker
+
+class CelebornFetchFailureSuite extends AnyFunSuite
+  with SparkTestBase
+  with BeforeAndAfterEach {
+
+  override def beforeEach(): Unit = {
+    ShuffleClient.reset()
+  }
+
+  override def afterEach(): Unit = {
+    System.gc()
+  }
+
+  var workerDirs: Seq[String] = Seq.empty
+
+  override def createWorker(map: Map[String, String]): Worker = {
+    val storageDir = createTmpDir()
+    workerDirs = workerDirs :+ storageDir
+    super.createWorker(map, storageDir)
+  }
+
+  class ShuffleReaderGetHook(conf: CelebornConf) extends ShuffleManagerHook {
+    var executed: AtomicBoolean = new AtomicBoolean(false)
+    val lock = new Object
+
+    override def exec(
+        handle: ShuffleHandle,
+        startPartition: Int,
+        endPartition: Int,
+        context: TaskContext): Unit = {
+      if (executed.get() == true) return
+
+      lock.synchronized {
+        handle match {
+          case h: CelebornShuffleHandle[_, _, _] => {
+            val appUniqueId = h.appUniqueId
+            val shuffleClient = ShuffleClient.get(
+              h.appUniqueId,
+              h.lifecycleManagerHost,
+              h.lifecycleManagerPort,
+              conf,
+              h.userIdentifier)
+            val celebornShuffleId = SparkUtils.celebornShuffleId(shuffleClient, h, context, false)
+            val datafile =
+              workerDirs.map(dir => {
+                new File(s"$dir/celeborn-worker/shuffle_data/$appUniqueId/$celebornShuffleId")
+              }).filter(_.exists())
+                .flatMap(_.listFiles().iterator).headOption
+            datafile match {
+              case Some(file) => file.delete()
+              case None => throw new RuntimeException("unexpected, there must be some data file")
+            }
+          }
+          case _ => throw new RuntimeException("unexpected, only support RssShuffleHandle here")
+        }
+        executed.set(true)
+      }
+    }
+  }
+
+  test("celeborn spark integration test - Fetch Failure") {
+    val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[2,3]")
+    val sparkSession = SparkSession.builder()
+      .config(updateSparkConf(sparkConf, ShuffleMode.HASH))
+      .config("spark.sql.shuffle.partitions", 2)
+      .config("spark.celeborn.shuffle.forceFallback.partition.enabled", false)
+      .config("spark.celeborn.shuffle.enabled", "true")
+      .config("spark.celeborn.client.spark.fetch.throwsFetchFailure", "true")
+      .config(
+        "spark.shuffle.manager",
+        "org.apache.spark.shuffle.celeborn.HookedCelebornShuffleManager")
+      .getOrCreate()
+
+    val celebornConf = SparkUtils.fromSparkConf(sparkSession.sparkContext.getConf)
+    val hook = new ShuffleReaderGetHook(celebornConf)
+    HookedCelebornShuffleManager.registerReaderGetHook(hook);
+
+    val value = Range(1, 10000).mkString(",")
+    val tuples = sparkSession.sparkContext.parallelize(1 to 10000, 2)
+      .map { i => (i, value) }.groupByKey(16).collect()
+
+    // verify result
+    assert(hook.executed.get() == true)
+    assert(tuples.length == 10000)
+    for (elem <- tuples) {
+      assert(elem._2.mkString(",").equals(value))
+    }
+
+    sparkSession.stop()
+  }
+
+  test("celeborn spark integration test - Fetch Failure with multiple shuffle data") {
+    val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[2,3]")
+    val sparkSession = SparkSession.builder()
+      .config(updateSparkConf(sparkConf, ShuffleMode.HASH))
+      .config("spark.sql.shuffle.partitions", 2)
+      .config("spark.celeborn.shuffle.forceFallback.partition.enabled", false)
+      .config("spark.celeborn.shuffle.enabled", "true")
+      .config("spark.celeborn.client.spark.fetch.throwsFetchFailure", "true")
+      .config(
+        "spark.shuffle.manager",
+        "org.apache.spark.shuffle.celeborn.HookedCelebornShuffleManager")
+      .getOrCreate()
+
+    val celebornConf = SparkUtils.fromSparkConf(sparkSession.sparkContext.getConf)
+    val hook = new ShuffleReaderGetHook(celebornConf)
+    HookedCelebornShuffleManager.registerReaderGetHook(hook);
+
+    import sparkSession.implicits._
+
+    val df1 = Seq((1, "a"), (2, "b")).toDF("id", "data").groupBy("id").count()
+    val df2 = Seq((2, "c"), (2, "d")).toDF("id", "data").groupBy("id").count()
+    val tuples = df1.hint("merge").join(df2, "id").select("*").collect()
+
+    // verify result
+    assert(hook.executed.get() == true)
+    val expect = "[2,1,2]"
+    assert(tuples.head.toString().equals(expect))
+    sparkSession.stop()
+  }
+
+  test("celeborn spark integration test - Fetch Failure with RDD reuse") {
+    val sparkConf = new SparkConf().setAppName("rss-demo").setMaster("local[2,3]")
+    val sparkSession = SparkSession.builder()
+      .config(updateSparkConf(sparkConf, ShuffleMode.HASH))
+      .config("spark.sql.shuffle.partitions", 2)
+      .config("spark.celeborn.shuffle.forceFallback.partition.enabled", false)
+      .config("spark.celeborn.shuffle.enabled", "true")
+      .config("spark.celeborn.client.spark.fetch.throwsFetchFailure", "true")
+      .config(
+        "spark.shuffle.manager",
+        "org.apache.spark.shuffle.celeborn.HookedCelebornShuffleManager")
+      .getOrCreate()
+
+    val celebornConf = SparkUtils.fromSparkConf(sparkSession.sparkContext.getConf)
+    val hook = new ShuffleReaderGetHook(celebornConf)
+    HookedCelebornShuffleManager.registerReaderGetHook(hook);
+
+    val sc = sparkSession.sparkContext
+    val rdd1 = sc.parallelize(0 until 10000, 3).map(v => (v, v)).groupByKey()
+    val rdd2 = sc.parallelize(0 until 10000, 2).map(v => (v, v)).groupByKey()
+    val rdd3 = rdd1.map(v => (v._2, v._1))
+
+    hook.executed.set(true)
+
+    val x1 = rdd1.count()
+    val x2 = rdd2.count()
+
+    hook.executed.set(false)
+    rdd3.count()
+    hook.executed.set(false)
+    rdd3.count()
+    hook.executed.set(false)
+    rdd3.count()
+    hook.executed.set(false)
+    rdd3.count()
+
+    sparkSession.stop()
+  }
+}

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.spark.{SparkConf, TaskContext}
 import org.apache.spark.shuffle.ShuffleHandle
-import org.apache.spark.shuffle.celeborn.{CelebornShuffleHandle, HookedCelebornShuffleManager, ShuffleManagerHook, SparkUtils}
+import org.apache.spark.shuffle.celeborn.{CelebornShuffleHandle, ShuffleManagerHook, SparkUtils, TestCelebornShuffleManager}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
@@ -101,12 +101,12 @@ class CelebornFetchFailureSuite extends AnyFunSuite
       .config("spark.celeborn.client.spark.fetch.throwsFetchFailure", "true")
       .config(
         "spark.shuffle.manager",
-        "org.apache.spark.shuffle.celeborn.HookedCelebornShuffleManager")
+        "org.apache.spark.shuffle.celeborn.TestCelebornShuffleManager")
       .getOrCreate()
 
     val celebornConf = SparkUtils.fromSparkConf(sparkSession.sparkContext.getConf)
     val hook = new ShuffleReaderGetHook(celebornConf)
-    HookedCelebornShuffleManager.registerReaderGetHook(hook);
+    TestCelebornShuffleManager.registerReaderGetHook(hook)
 
     val value = Range(1, 10000).mkString(",")
     val tuples = sparkSession.sparkContext.parallelize(1 to 10000, 2)
@@ -132,12 +132,12 @@ class CelebornFetchFailureSuite extends AnyFunSuite
       .config("spark.celeborn.client.spark.fetch.throwsFetchFailure", "true")
       .config(
         "spark.shuffle.manager",
-        "org.apache.spark.shuffle.celeborn.HookedCelebornShuffleManager")
+        "org.apache.spark.shuffle.celeborn.TestCelebornShuffleManager")
       .getOrCreate()
 
     val celebornConf = SparkUtils.fromSparkConf(sparkSession.sparkContext.getConf)
     val hook = new ShuffleReaderGetHook(celebornConf)
-    HookedCelebornShuffleManager.registerReaderGetHook(hook);
+    TestCelebornShuffleManager.registerReaderGetHook(hook)
 
     import sparkSession.implicits._
 
@@ -162,12 +162,12 @@ class CelebornFetchFailureSuite extends AnyFunSuite
       .config("spark.celeborn.client.spark.fetch.throwsFetchFailure", "true")
       .config(
         "spark.shuffle.manager",
-        "org.apache.spark.shuffle.celeborn.HookedCelebornShuffleManager")
+        "org.apache.spark.shuffle.celeborn.TestCelebornShuffleManager")
       .getOrCreate()
 
     val celebornConf = SparkUtils.fromSparkConf(sparkSession.sparkContext.getConf)
     val hook = new ShuffleReaderGetHook(celebornConf)
-    HookedCelebornShuffleManager.registerReaderGetHook(hook);
+    TestCelebornShuffleManager.registerReaderGetHook(hook)
 
     val sc = sparkSession.sparkContext
     val rdd1 = sc.parallelize(0 until 10000, 3).map(v => (v, v)).groupByKey()
@@ -176,8 +176,8 @@ class CelebornFetchFailureSuite extends AnyFunSuite
 
     hook.executed.set(true)
 
-    val x1 = rdd1.count()
-    val x2 = rdd2.count()
+    rdd1.count()
+    rdd2.count()
 
     hook.executed.set(false)
     rdd3.count()
@@ -201,22 +201,22 @@ class CelebornFetchFailureSuite extends AnyFunSuite
       .config("spark.celeborn.client.spark.fetch.throwsFetchFailure", "true")
       .config(
         "spark.shuffle.manager",
-        "org.apache.spark.shuffle.celeborn.HookedCelebornShuffleManager")
+        "org.apache.spark.shuffle.celeborn.TestCelebornShuffleManager")
       .getOrCreate()
 
     val celebornConf = SparkUtils.fromSparkConf(sparkSession.sparkContext.getConf)
     val hook = new ShuffleReaderGetHook(celebornConf)
-    HookedCelebornShuffleManager.registerReaderGetHook(hook);
+    TestCelebornShuffleManager.registerReaderGetHook(hook)
 
     val sc = sparkSession.sparkContext
     val rdd1 = sc.parallelize(0 until 10000, 3).map(v => (v, v)).groupByKey()
     val rdd2 = rdd1.map(v => (v._2, v._1)).groupByKey()
 
     hook.executed.set(true)
-    val x1 = rdd1.count()
+    rdd1.count()
 
     hook.executed.set(false)
-    val x2 = rdd2.count()
+    rdd2.count()
 
     sparkSession.stop()
   }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -35,13 +35,13 @@ trait MiniClusterFeature extends Logging {
   var masterInfo: (Master, Thread) = _
   val workerInfos = new mutable.HashMap[Worker, Thread]()
 
-  private def runnerWrap[T](code: => T): Thread = new Thread(new Runnable {
+  def runnerWrap[T](code: => T): Thread = new Thread(new Runnable {
     override def run(): Unit = {
       Utils.tryLogNonFatalError(code)
     }
   })
 
-  private def createTmpDir(): String = {
+  def createTmpDir(): String = {
     val tmpDir = Files.createTempDirectory("celeborn-")
     logInfo(s"created temp dir: $tmpDir")
     tmpDir.toFile.deleteOnExit()
@@ -66,10 +66,14 @@ trait MiniClusterFeature extends Logging {
     master
   }
 
-  private def createWorker(map: Map[String, String] = null): Worker = {
+  def createWorker(map: Map[String, String] = null): Worker = {
+    createWorker(map, createTmpDir())
+  }
+
+  def createWorker(map: Map[String, String], storageDir: String): Worker = {
     logInfo("start create worker for mini cluster")
     val conf = new CelebornConf()
-    conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, createTmpDir())
+    conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, storageDir)
     conf.set(CelebornConf.WORKER_DISK_MONITOR_ENABLED.key, "false")
     conf.set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
     conf.set(CelebornConf.WORKER_HTTP_PORT.key, s"${workerHttpPort.incrementAndGet()}")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Celeborn uses replication to handle shuffle data lost for celeborn shuffle reader, this PR implements an alternative solution by Spark stage resubmission.

Design doc:
https://docs.google.com/document/d/1dkG6fww3g99VAb1wkphNlUES_MpngVPNg8601chmVp8/edit

### Why are the changes needed?
Spark stage resubmission uses less resources compared with replication, and some Celeborn users are also asking for it


### Does this PR introduce _any_ user-facing change?
a new config celeborn.client.fetch.throwsFetchFailure is introduced to enable this feature


### How was this patch tested?
two UTs are attached, and we also tested it in Ant Group's Dev spark cluster
