### PR TITLE
[CELEBORN-951][FOLLOWUP] IssueNavigationLink adapts to early Github Issues

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -20,12 +20,16 @@
     <option name="links">
       <list>
         <IssueNavigationLink>
-          <option name="issueRegexp" value="[A-Z]+\-\d+" />
-          <option name="linkRegexp" value="https://issues.apache.org/jira/browse/$0" />
+          <option name="issueRegexp" value="ISSUE-(\d+)"/>
+          <option name="linkRegexp" value="https://github.com/apache/incubator-celeborn/issues/$1"/>
         </IssueNavigationLink>
         <IssueNavigationLink>
-          <option name="issueRegexp" value="#(\d+)" />
-          <option name="linkRegexp" value="https://github.com/apache/incubator-celeborn/pull/$1" />
+          <option name="issueRegexp" value="CELEBORN\-\d+"/>
+          <option name="linkRegexp" value="https://issues.apache.org/jira/browse/$0"/>
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)"/>
+          <option name="linkRegexp" value="https://github.com/apache/incubator-celeborn/pull/$1"/>
         </IssueNavigationLink>
       </list>
     </option>


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://github.com/apache/incubator-celeborn/pull/1883

![image](https://github.com/apache/incubator-celeborn/assets/3898450/b39d58a7-1466-46e2-b157-fc765960edd4)



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

