### PR TITLE
[MINOR] Fix incorrect default resume ratio in trafficcontrol doc

### DIFF
--- a/docs/developers/trafficcontrol.md
+++ b/docs/developers/trafficcontrol.md
@@ -47,7 +47,7 @@ time force flush to release memory.
 - `Pause Replicate` watermark (defaults to 0.95). If used direct memory ratio exceeds this, `Worker` will pause
   receiving both data from `ShuffleClient` and replica data from primary `Worker`, and force flush buffered
   data into file.
-- `Resume` watermark (defaults to 0.5). When either `Pause Receive` or `Pause Replicate` is triggered, to resume
+- `Resume` watermark (defaults to 0.7). When either `Pause Receive` or `Pause Replicate` is triggered, to resume
   receiving data from `ShuffleClient`, the used direct memory ratio should decrease under this watermark.
 
 `Worker` high-frequently checks used direct memory ratio, and triggers `Pause Receive`, `Pause Replicate` and `Resume`


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As Title

### Why are the changes needed?

Since 0.3.1, Celeborn changed the default value of `celeborn.worker.directMemoryRatioToResume` from `0.5` to `0.7`.

the doc should be update

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

PASS GA