### PR TITLE
[CELEBORN-1014] Output log with bound address and port

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
@@ -116,7 +116,7 @@ public class TransportServer implements Closeable {
     channelFuture.syncUninterruptibly();
 
     port = ((InetSocketAddress) channelFuture.channel().localAddress()).getPort();
-    logger.debug("Shuffle server started on port: {}", port);
+    logger.debug("Shuffle server started on {} with port: {}", address.getHostString(), port);
   }
 
   protected void initializeChannel(ServerBootstrap bootstrap) {

--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportServer.java
@@ -116,7 +116,7 @@ public class TransportServer implements Closeable {
     channelFuture.syncUninterruptibly();
 
     port = ((InetSocketAddress) channelFuture.channel().localAddress()).getPort();
-    logger.debug("Shuffle server started on {} with port: {}", address.getHostString(), port);
+    logger.debug("Shuffle server started on {}:{}", address.getHostString(), port);
   }
 
   protected void initializeChannel(ServerBootstrap bootstrap) {

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
@@ -50,9 +50,10 @@ class HttpServer(
       .channel(classOf[NioServerSocketChannel])
       .childHandler(channelInitializer)
 
-    bindFuture = bootstrap.bind(new InetSocketAddress(host, port)).sync
+    val address = new InetSocketAddress(host, port)
+    bindFuture = bootstrap.bind(address).sync
     bindFuture.syncUninterruptibly()
-    logInfo(s"$role: HttpServer started on port $port.")
+    logInfo(s"$role: HttpServer started on ${address.getHostString} with port $port.")
     isStarted = true
   }
 

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpServer.scala
@@ -53,7 +53,7 @@ class HttpServer(
     val address = new InetSocketAddress(host, port)
     bindFuture = bootstrap.bind(address).sync
     bindFuture.syncUninterruptibly()
-    logInfo(s"$role: HttpServer started on ${address.getHostString} with port $port.")
+    logInfo(s"$role: HttpServer started on ${address.getHostString}:$port.")
     isStarted = true
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?
Make it easy for administrators to find the address of the http service bindings.



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

```
23/09/28 17:10:50,465 INFO [main] HttpServer: master: HttpServer started on port 9983.
```

PR
```
23/09/28 17:28:29,797 INFO [main] HttpServer: master: HttpServer started on clb-3 with port 9983.
```
