### PR TITLE
[CELEBORN-1017] Make checkPushTimeout and checkFetchTimeout conditions independent

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -96,13 +96,6 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
               ThreadUtils.newDaemonThreadPoolScheduledExecutor(
                   "push-timeout-checker", conf.pushDataTimeoutCheckerThreads());
         }
-
-        pushCheckerScheduleFuture =
-            pushTimeoutChecker.scheduleAtFixedRate(
-                () -> failExpiredPushRequest(),
-                pushTimeoutCheckerInterval,
-                pushTimeoutCheckerInterval,
-                TimeUnit.MILLISECONDS);
       }
 
       if (checkFetchTimeout) {
@@ -111,14 +104,25 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
               ThreadUtils.newDaemonThreadPoolScheduledExecutor(
                   "fetch-timeout-checker", conf.fetchDataTimeoutCheckerThreads());
         }
-
-        fetchCheckerScheduleFuture =
-            fetchTimeoutChecker.scheduleAtFixedRate(
-                () -> failExpiredFetchRequest(),
-                fetchTimeoutCheckerInterval,
-                fetchTimeoutCheckerInterval,
-                TimeUnit.MILLISECONDS);
       }
+    }
+
+    if (checkPushTimeout) {
+      pushCheckerScheduleFuture =
+          pushTimeoutChecker.scheduleAtFixedRate(
+              () -> failExpiredPushRequest(),
+              pushTimeoutCheckerInterval,
+              pushTimeoutCheckerInterval,
+              TimeUnit.MILLISECONDS);
+    }
+
+    if (checkFetchTimeout) {
+      fetchCheckerScheduleFuture =
+          fetchTimeoutChecker.scheduleAtFixedRate(
+              () -> failExpiredFetchRequest(),
+              fetchTimeoutCheckerInterval,
+              fetchTimeoutCheckerInterval,
+              TimeUnit.MILLISECONDS);
     }
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -96,31 +96,29 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
               ThreadUtils.newDaemonThreadPoolScheduledExecutor(
                   "push-timeout-checker", conf.pushDataTimeoutCheckerThreads());
         }
-        if (checkFetchTimeout) {
-          if (fetchTimeoutChecker == null) {
-            fetchTimeoutChecker =
-                ThreadUtils.newDaemonThreadPoolScheduledExecutor(
-                    "fetch-timeout-checker", conf.fetchDataTimeoutCheckerThreads());
-          }
-        }
-      }
-    }
-    if (checkPushTimeout) {
-      pushCheckerScheduleFuture =
-          pushTimeoutChecker.scheduleAtFixedRate(
-              () -> failExpiredPushRequest(),
-              pushTimeoutCheckerInterval,
-              pushTimeoutCheckerInterval,
-              TimeUnit.MILLISECONDS);
-    }
 
-    if (checkFetchTimeout) {
-      fetchCheckerScheduleFuture =
-          fetchTimeoutChecker.scheduleAtFixedRate(
-              () -> failExpiredFetchRequest(),
-              fetchTimeoutCheckerInterval,
-              fetchTimeoutCheckerInterval,
-              TimeUnit.MILLISECONDS);
+        pushCheckerScheduleFuture =
+            pushTimeoutChecker.scheduleAtFixedRate(
+                () -> failExpiredPushRequest(),
+                pushTimeoutCheckerInterval,
+                pushTimeoutCheckerInterval,
+                TimeUnit.MILLISECONDS);
+      }
+
+      if (checkFetchTimeout) {
+        if (fetchTimeoutChecker == null) {
+          fetchTimeoutChecker =
+              ThreadUtils.newDaemonThreadPoolScheduledExecutor(
+                  "fetch-timeout-checker", conf.fetchDataTimeoutCheckerThreads());
+        }
+
+        fetchCheckerScheduleFuture =
+            fetchTimeoutChecker.scheduleAtFixedRate(
+                () -> failExpiredFetchRequest(),
+                fetchTimeoutCheckerInterval,
+                fetchTimeoutCheckerInterval,
+                TimeUnit.MILLISECONDS);
+      }
     }
   }
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Make checkPushTimeout and checkFetchTimeout conditions independent

### Why are the changes needed?

https://github.com/apache/incubator-celeborn/pull/1940 introduced a bug

![image](https://github.com/apache/incubator-celeborn/assets/14961757/8e8764d4-235d-49cf-8a87-1052ffbe4697)

The judgment logic of checkFetchTimeout is added to the judgment logic of checkPushTimeout. The two of them should be independent.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

PASS GA