### PR TITLE
[CELEBORN-1010] Update docs about `spark.shuffle.service.enabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ spark.serializer org.apache.spark.serializer.KryoSerializer
 
 # celeborn master
 spark.celeborn.master.endpoints clb-1:9097,clb-2:9097,clb-3:9097
-# This is not necessary for Spark 3.1 or newer
+# This is not necessary if your Spark external shuffle service is Spark 3.1 or newer
 spark.shuffle.service.enabled false
 
 # options: hash, sort

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ spark.serializer org.apache.spark.serializer.KryoSerializer
 
 # celeborn master
 spark.celeborn.master.endpoints clb-1:9097,clb-2:9097,clb-3:9097
+# This is not necessary for Spark 3.1 or newer
 spark.shuffle.service.enabled false
 
 # options: hash, sort

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -167,7 +167,7 @@ spark.serializer org.apache.spark.serializer.KryoSerializer
 
 # celeborn master
 spark.celeborn.master.endpoints clb-1:9097,clb-2:9097,clb-3:9097
-# This is not necessary for Spark 3.1 or newer
+# This is not necessary if your Spark external shuffle service is Spark 3.1 or newer
 spark.shuffle.service.enabled false
 
 # options: hash, sort

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -167,6 +167,7 @@ spark.serializer org.apache.spark.serializer.KryoSerializer
 
 # celeborn master
 spark.celeborn.master.endpoints clb-1:9097,clb-2:9097,clb-3:9097
+# This is not necessary for Spark 3.1 or newer
 spark.shuffle.service.enabled false
 
 # options: hash, sort

--- a/docs/developers/glutensupport.md
+++ b/docs/developers/glutensupport.md
@@ -47,6 +47,7 @@ spark.celeborn.master.endpoints clb-master:9097
 spark.celeborn.client.push.replicate.enabled true
 
 spark.celeborn.client.spark.shuffle.writer hash
+# This is not necessary for Spark 3.1 or newer
 spark.shuffle.service.enabled false
 spark.sql.adaptive.localShuffleReader.enabled false
 

--- a/docs/developers/glutensupport.md
+++ b/docs/developers/glutensupport.md
@@ -47,7 +47,7 @@ spark.celeborn.master.endpoints clb-master:9097
 spark.celeborn.client.push.replicate.enabled true
 
 spark.celeborn.client.spark.shuffle.writer hash
-# This is not necessary for Spark 3.1 or newer
+# This is not necessary if your Spark external shuffle service is Spark 3.1 or newer
 spark.shuffle.service.enabled false
 spark.sql.adaptive.localShuffleReader.enabled false
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
To clarify a spark config to work with Celeborn.


### Why are the changes needed?
After some tests, I found that Spark 3.1 and newer can work with Celeborn with `spark.shuffle.service.enabled=true`.

ExternalShuffleBlockResolver won't check the shuffle manager's type since Spark 3.1 and newer. 


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
I tested two scenarios about this PR.
1. Check whether Spark can release the executors in time.
2. Check data correctness by running TPC-DS.
All checks are good.
