### PR TITLE
[CELEBORN-1018] Fix throw exception when exec create-package.sh script

### DIFF
--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -338,7 +338,7 @@ else
     build_flink_client -Pflink-1.14
     build_flink_client -Pflink-1.15
     build_flink_client -Pflink-1.17
-    build_mr_client mr
+    build_mr_client -Pmr
   else
     ## build release package on demand
     build_service $@


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

when exec the release script, throw exception
```
build/make-distribution.sh --release 
```

```
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[ERROR] [ERROR] Could not find the selected project in the reactor: :celeborn-client-mr-shaded_2.12 @ 
[ERROR] Could not find the selected project in the reactor: :celeborn-client-mr-shaded_2.12 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MavenExecutionException
```

### Why are the changes needed?

Fix bug.

### Does this PR introduce _any_ user-facing change?

Local tested.

### How was this patch tested?

