### PR TITLE
[CELEBORN-1022][TEST] Update log level from `FATAL` to `ERROR` for console output in unit tests

### DIFF
--- a/client-flink/flink-1.14/src/test/resources/log4j2-test.xml
+++ b/client-flink/flink-1.14/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/client-spark/common/src/test/resources/log4j2-test.xml
+++ b/client-spark/common/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/client-spark/spark-3-columnar-shuffle/src/test/resources/log4j2-test.xml
+++ b/client-spark/spark-3-columnar-shuffle/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/client-spark/spark-3/src/test/resources/log4j2-test.xml
+++ b/client-spark/spark-3/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/client/src/test/resources/log4j2-test.xml
+++ b/client/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/common/src/test/resources/log4j2-test.xml
+++ b/common/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="error"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/master/src/test/resources/log4j2-test.xml
+++ b/master/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/tests/kubernetes-it/src/test/resources/log4j2-test.xml
+++ b/tests/kubernetes-it/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/tests/spark-it/src/test/resources/log4j2-test.xml
+++ b/tests/spark-it/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/worker/src/test/resources/log4j2-test.xml
+++ b/worker/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?

1. this is developer-friendly for debugging unit tests in IntelliJ IDEA, for example: Netty's memory leak reports are logged at the error level and won't cause unit tests to be marked as fatal.


```
23/10/09 09:57:26,422 ERROR [fetch-server-52-2] ResourceLeakDetector: LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records: 
Created at:
	io.netty.buffer.PooledByteBufAllocator.newDirectBuffer(PooledByteBufAllocator.java:403)
	io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:188)
	io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:179)
	io.netty.buffer.AbstractByteBufAllocator.ioBuffer(AbstractByteBufAllocator.java:140)
	io.netty.channel.DefaultMaxMessagesRecvByteBufAllocator$MaxMessageHandle.allocate(DefaultMaxMessagesRecvByteBufAllocator.java:120)
	io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:150)
	io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	java.lang.Thread.run(Thread.java:750)
```

2. this won't increase console output and affect the stability of CI.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass GA