### PR TITLE
[CELEBORN-1026] Optimize registerShuffle fallback log

### DIFF
--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -143,7 +143,8 @@ public class SparkShuffleManager implements ShuffleManager {
 
     if (fallbackPolicyRunner.applyAllFallbackPolicy(
         lifecycleManager, dependency.partitioner().numPartitions())) {
-      if (conf.getBoolean("spark.dynamicAllocation.enabled", false)) {
+      if (conf.getBoolean("spark.dynamicAllocation.enabled", false)
+          && !conf.getBoolean("spark.shuffle.service.enabled", false)) {
         logger.error(
             "DRA is enabled but we fallback to vanilla Spark SortShuffleManager for "
                 + "shuffle: {} due to fallback policy. It may cause block can not found when reducer "


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
According to https://github.com/apache/incubator-celeborn/pull/1955 , when celeborn is not available, `spark.dynamicAllocation.enabled=true` and  `spark.shuffle.service. enabled=true`, shuffle data should not be lost.


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

