### PR TITLE
[CELEBORN-688] Add JVM metrics grafana template

### DIFF
--- a/assets/grafana/celeborn-jvm-dashboard.json
+++ b/assets/grafana/celeborn-jvm-dashboard.json
@@ -1874,7 +1874,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(metrics_jvm_memory_pools_init_Value, name)",
+        "definition": "label_values(metrics_jvm_memory_pools_init_Value{instance=~\"${instance}\"}, name)",
         "hide": 0,
         "includeAll": true,
         "label": "pool",
@@ -1884,7 +1884,7 @@
         "name": "pool",
         "options": [],
         "query": {
-          "query": "label_values(metrics_jvm_memory_pools_init_Value, name)",
+          "query": "label_values(metrics_jvm_memory_pools_init_Value{instance=~\"${instance}\"}, name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1903,6 +1903,6 @@
   "timezone": "",
   "title": "JVM Metrics",
   "uid": "_7trpcMIk",
-  "version": 5,
+  "version": 1,
   "weekStart": ""
 }

--- a/assets/grafana/celeborn-jvm-dashboard.json
+++ b/assets/grafana/celeborn-jvm-dashboard.json
@@ -1,0 +1,1908 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.3.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 15,
+      "panels": [],
+      "title": "JVM Memory",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_heap_init_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "init",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_heap_used_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "used",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_heap_max_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "max",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_heap_committed_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "committed",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "JVM Heap",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_non_heap_init_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "init",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_non_heap_used_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "used",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_non_heap_max_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "max",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_non_heap_committed_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "committed",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "JVM Non-Heap",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_total_init_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "init",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_total_used_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "used",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_total_max_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "max",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_total_committed_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "committed",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "JVM Total",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 28,
+      "panels": [],
+      "title": "JVM Memory Pools",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 20
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "repeat": "pool",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_pools_init_Value{instance=~\"${instance}\", name=~\"$pool\"}",
+          "legendFormat": "init",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_pools_used_Value{instance=~\"${instance}\", name=~\"$pool\"}",
+          "hide": false,
+          "legendFormat": "used",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_pools_max_Value{instance=~\"${instance}\", name=~\"$pool\"}",
+          "hide": false,
+          "legendFormat": "max",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_memory_pools_committed_Value{instance=~\"${instance}\", name=~\"$pool\"}",
+          "hide": false,
+          "legendFormat": "committed",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "$pool",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 37,
+      "panels": [],
+      "title": "Garbage Collection",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "increase(metrics_jvm_gc_time_Value{instance=~\"${instance}\"})",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Collection Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "increase(metrics_jvm_gc_count_Value{instance=~\"${instance}\"})",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Collection Counts",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 13,
+      "panels": [],
+      "title": "JVM Misc",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 46
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "increase(metrics_JVMCPUTime_Value{instance=~\"${instance}\"})",
+          "legendFormat": "CPU time",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 46
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_LastMinuteSystemLoad_Value{instance=~\"${instance}\"}",
+          "legendFormat": "system",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Load",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 46
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.0",
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_AvailableProcessors_Value{instance=~\"${instance}\"}",
+          "legendFormat": "AvailableProcessors",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Available Processors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_count_Value{instance=~\"${instance}\"}",
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_daemon_count_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "daemon",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Thread Counts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_blocked_count_Value{instance=~\"${instance}\"}",
+          "legendFormat": "blocked",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_new_count_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "new",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_runnable_count_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "runnable",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_timed_waiting_count_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "timed_waiting",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_waiting_count_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "waiting",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_terminated_count_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "terminated",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_thread_deadlock_count_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "deadlock",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "title": "Thread States",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Buffer Pools",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_direct_capacity_Value{instance=~\"${instance}\"}",
+          "legendFormat": "capacity",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_direct_used_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "used",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Direct Buffers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 63
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_direct_count_Value{instance=~\"${instance}\"}",
+          "legendFormat": "count",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Direct Buffers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 71
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_mapped_capacity_Value{instance=~\"${instance}\"}",
+          "legendFormat": "capacity",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "metrics_jvm_mapped_used_Value{instance=~\"${instance}\"}",
+          "hide": false,
+          "legendFormat": "used",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Mapped Buffers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 71
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "aggregator": "sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "editorMode": "code",
+          "expr": "metrics_jvm_mapped_count_Value{instance=~\"${instance}\"}",
+          "legendFormat": "count",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Mapped Buffers",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 37,
+  "style": "dark",
+  "submenuSticky": 0,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(metrics_JVMCPUTime_Value, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "instance",
+        "mapping": "",
+        "mappingOnLegend": true,
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(metrics_JVMCPUTime_Value, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(metrics_jvm_memory_pools_init_Value, name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "pool",
+        "mapping": "",
+        "mappingOnLegend": true,
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "label_values(metrics_jvm_memory_pools_init_Value, name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "JVM Metrics",
+  "uid": "_7trpcMIk",
+  "version": 5,
+  "weekStart": ""
+}

--- a/assets/grafana/celeborn-jvm-dashboard.json
+++ b/assets/grafana/celeborn-jvm-dashboard.json
@@ -164,7 +164,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_heap_init_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "init",
+          "legendFormat": "init_{{instance}}",
           "range": true,
           "refId": "A"
         },
@@ -176,7 +176,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_heap_used_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "used",
+          "legendFormat": "used_{{instance}}",
           "range": true,
           "refId": "B"
         },
@@ -188,7 +188,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_heap_max_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "max",
+          "legendFormat": "max_{{instance}}",
           "range": true,
           "refId": "C"
         },
@@ -200,7 +200,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_heap_committed_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "committed",
+          "legendFormat": "committed_{{instance}}",
           "range": true,
           "refId": "D"
         }
@@ -300,7 +300,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_non_heap_init_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "init",
+          "legendFormat": "init_{{instance}}",
           "range": true,
           "refId": "A"
         },
@@ -312,7 +312,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_non_heap_used_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "used",
+          "legendFormat": "used_{{instance}}",
           "range": true,
           "refId": "B"
         },
@@ -324,7 +324,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_non_heap_max_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "max",
+          "legendFormat": "max_{{instance}}",
           "range": true,
           "refId": "C"
         },
@@ -336,7 +336,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_non_heap_committed_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "committed",
+          "legendFormat": "committed_{{instance}}",
           "range": true,
           "refId": "D"
         }
@@ -436,7 +436,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_total_init_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "init",
+          "legendFormat": "init_{{instance}}",
           "range": true,
           "refId": "A"
         },
@@ -448,7 +448,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_total_used_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "used",
+          "legendFormat": "used_{{instance}}",
           "range": true,
           "refId": "B"
         },
@@ -460,7 +460,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_total_max_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "max",
+          "legendFormat": "max_{{instance}}",
           "range": true,
           "refId": "C"
         },
@@ -472,7 +472,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_total_committed_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "committed",
+          "legendFormat": "committed_{{instance}}",
           "range": true,
           "refId": "D"
         }
@@ -586,7 +586,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "metrics_jvm_memory_pools_init_Value{instance=~\"${instance}\", name=~\"$pool\"}",
-          "legendFormat": "init",
+          "legendFormat": "init_{{instance}}",
           "range": true,
           "refId": "A"
         },
@@ -601,7 +601,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_pools_used_Value{instance=~\"${instance}\", name=~\"$pool\"}",
           "hide": false,
-          "legendFormat": "used",
+          "legendFormat": "used_{{instance}}",
           "range": true,
           "refId": "B"
         },
@@ -616,7 +616,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_pools_max_Value{instance=~\"${instance}\", name=~\"$pool\"}",
           "hide": false,
-          "legendFormat": "max",
+          "legendFormat": "max_{{instance}}",
           "range": true,
           "refId": "C"
         },
@@ -631,7 +631,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_memory_pools_committed_Value{instance=~\"${instance}\", name=~\"$pool\"}",
           "hide": false,
-          "legendFormat": "committed",
+          "legendFormat": "committed_{{instance}}",
           "range": true,
           "refId": "D"
         }
@@ -740,7 +740,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "increase(metrics_jvm_gc_time_Value{instance=~\"${instance}\"})",
-          "legendFormat": "{{name}}",
+          "legendFormat": "{{name}}_{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -835,7 +835,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "increase(metrics_jvm_gc_count_Value{instance=~\"${instance}\"})",
-          "legendFormat": "{{name}}",
+          "legendFormat": "{{name}}_{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -944,7 +944,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "increase(metrics_JVMCPUTime_Value{instance=~\"${instance}\"})",
-          "legendFormat": "CPU time",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -1039,7 +1039,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "metrics_LastMinuteSystemLoad_Value{instance=~\"${instance}\"}",
-          "legendFormat": "system",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -1135,7 +1135,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "metrics_AvailableProcessors_Value{instance=~\"${instance}\"}",
-          "legendFormat": "AvailableProcessors",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -1230,7 +1230,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "metrics_jvm_thread_count_Value{instance=~\"${instance}\"}",
-          "legendFormat": "total",
+          "legendFormat": "total_{{instance}}",
           "range": true,
           "refId": "A"
         },
@@ -1242,7 +1242,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_thread_daemon_count_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "daemon",
+          "legendFormat": "daemon_{{instance}}",
           "range": true,
           "refId": "B"
         }
@@ -1337,7 +1337,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "metrics_jvm_thread_blocked_count_Value{instance=~\"${instance}\"}",
-          "legendFormat": "blocked",
+          "legendFormat": "blocked_{{instance}}",
           "range": true,
           "refId": "A"
         },
@@ -1349,7 +1349,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_thread_new_count_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "new",
+          "legendFormat": "new_{{instance}}",
           "range": true,
           "refId": "B"
         },
@@ -1361,7 +1361,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_thread_runnable_count_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "runnable",
+          "legendFormat": "runnable_{{instance}}",
           "range": true,
           "refId": "C"
         },
@@ -1373,7 +1373,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_thread_timed_waiting_count_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "timed_waiting",
+          "legendFormat": "timed_waiting_{{instance}}",
           "range": true,
           "refId": "D"
         },
@@ -1385,7 +1385,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_thread_waiting_count_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "waiting",
+          "legendFormat": "waiting_{{instance}}",
           "range": true,
           "refId": "E"
         },
@@ -1397,7 +1397,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_thread_terminated_count_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "terminated",
+          "legendFormat": "terminated_{{instance}}",
           "range": true,
           "refId": "F"
         },
@@ -1409,7 +1409,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_thread_deadlock_count_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "deadlock",
+          "legendFormat": "deadlock_{{instance}}",
           "range": true,
           "refId": "G"
         }
@@ -1518,7 +1518,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "metrics_jvm_direct_capacity_Value{instance=~\"${instance}\"}",
-          "legendFormat": "capacity",
+          "legendFormat": "capacity_{{instance}}",
           "range": true,
           "refId": "A"
         },
@@ -1530,7 +1530,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_direct_used_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "used",
+          "legendFormat": "used_{{instance}}",
           "range": true,
           "refId": "B"
         }
@@ -1625,7 +1625,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "metrics_jvm_direct_count_Value{instance=~\"${instance}\"}",
-          "legendFormat": "count",
+          "legendFormat": "count_{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -1721,7 +1721,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "metrics_jvm_mapped_capacity_Value{instance=~\"${instance}\"}",
-          "legendFormat": "capacity",
+          "legendFormat": "capacity_{{instance}}",
           "range": true,
           "refId": "A"
         },
@@ -1733,7 +1733,7 @@
           "editorMode": "code",
           "expr": "metrics_jvm_mapped_used_Value{instance=~\"${instance}\"}",
           "hide": false,
-          "legendFormat": "used",
+          "legendFormat": "used_{{instance}}",
           "range": true,
           "refId": "B"
         }
@@ -1828,7 +1828,7 @@
           "downsampleFillPolicy": "none",
           "editorMode": "code",
           "expr": "metrics_jvm_mapped_count_Value{instance=~\"${instance}\"}",
-          "legendFormat": "count",
+          "legendFormat": "count_{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -1851,11 +1851,11 @@
         },
         "definition": "label_values(metrics_JVMCPUTime_Value, instance)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "instance",
         "mapping": "",
         "mappingOnLegend": true,
-        "multi": false,
+        "multi": true,
         "name": "instance",
         "options": [],
         "query": {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently there is no JVM metrics grafana template, nor in grafana labs. For better use, it is necessary to add one.
According the change in #1939 
This template uses two variables(instance, pool).
The layout is divided into 5 rows.
![image](https://github.com/apache/incubator-celeborn/assets/19429353/732cff90-463c-47b5-89b8-fa8dbbf33b1e)

The panels with g1 look like below：
![image](https://github.com/apache/incubator-celeborn/assets/19429353/919b7e9e-f86a-4341-a004-7f0394e1d8b2)

JVM Memory Pools row uses replicated panel mode which panels are automatically deplicated by `pool` variables.
![image](https://github.com/apache/incubator-celeborn/assets/19429353/3bdf7a3c-d4e0-42ea-bbe0-012da55a61d1)
![image](https://github.com/apache/incubator-celeborn/assets/19429353/8feaf9b7-156d-453e-8188-40a0399ea516)
![image](https://github.com/apache/incubator-celeborn/assets/19429353/cba4b61c-7d66-4893-9f07-6157c64869bd)
![image](https://github.com/apache/incubator-celeborn/assets/19429353/09b473ef-434c-4fd0-aa4b-084f7588a4f7)


### Why are the changes needed?
Ditto


### Does this PR introduce _any_ user-facing change?
Yes, this dashboard is based on changes in #1939 


### How was this patch tested?
Cluster test
