### PR TITLE
[CELEBORN-1030] Improve the logic of delete md5 files when initializing SimpleStateMachineStorage

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/StateMachine.java
@@ -25,17 +25,9 @@ import static org.apache.ratis.util.LifeCycle.State.STARTING;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -47,10 +39,8 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.RaftLog;
-import org.apache.ratis.server.storage.FileInfo;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.statemachine.SnapshotInfo;
-import org.apache.ratis.statemachine.SnapshotRetentionPolicy;
 import org.apache.ratis.statemachine.StateMachineStorage;
 import org.apache.ratis.statemachine.TransactionContext;
 import org.apache.ratis.statemachine.impl.BaseStateMachine;
@@ -59,7 +49,6 @@ import org.apache.ratis.statemachine.impl.SimpleStateMachineStorageUtil;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.ExitUtils;
-import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.MD5FileUtil;
 import org.slf4j.Logger;
@@ -72,94 +61,7 @@ import org.apache.celeborn.service.deploy.master.clustermeta.ResourceProtos.Reso
 public class StateMachine extends BaseStateMachine {
   private static final Logger LOG = LoggerFactory.getLogger(StateMachine.class);
 
-  public static final Pattern MD5_REGEX = Pattern.compile("snapshot\\.(\\d+)_(\\d+)\\.md5");
-
-  private final SimpleStateMachineStorage storage =
-      new SimpleStateMachineStorage() {
-        /**
-         * we need to delete md5 file as the same time as snapshot file deleted, so we override the
-         * SimpleStateMachineStorage.cleanupOldSnapshots method, add delete md5 file action.
-         *
-         * @param snapshotRetentionPolicy snapshot retention policy
-         * @throws IOException
-         */
-        @Override
-        public void cleanupOldSnapshots(SnapshotRetentionPolicy snapshotRetentionPolicy)
-            throws IOException {
-          if (snapshotRetentionPolicy != null
-              && snapshotRetentionPolicy.getNumSnapshotsRetained() > 0) {
-            List<SingleFileSnapshotInfo> allSnapshotFiles = new ArrayList<>();
-            List<SingleFileSnapshotInfo> allMD5Files = new ArrayList<>();
-            try (DirectoryStream<Path> stream =
-                Files.newDirectoryStream(SimpleStateMachineStorageUtil.getSmDir(this).toPath())) {
-              for (Path path : stream) {
-                if (filePatternMatches(SNAPSHOT_REGEX, allSnapshotFiles, path)) {
-                  continue;
-                } else {
-                  filePatternMatches(MD5_REGEX, allMD5Files, path);
-                }
-              }
-            }
-            // first step, cleanup old snapshot and md5 file
-            SingleFileSnapshotInfo snapshotInfo =
-                cleanupOldFiles(
-                    allSnapshotFiles,
-                    snapshotRetentionPolicy.getNumSnapshotsRetained(),
-                    false,
-                    null);
-            // second step, cleanup only old md5 file
-            cleanupOldFiles(
-                allMD5Files, snapshotRetentionPolicy.getNumSnapshotsRetained(), true, snapshotInfo);
-          }
-        }
-
-        private boolean filePatternMatches(
-            Pattern pattern, List<SingleFileSnapshotInfo> result, Path filePath) {
-          Matcher md5Matcher = pattern.matcher(filePath.getFileName().toString());
-          if (md5Matcher.matches()) {
-            final long endIndex = Long.parseLong(md5Matcher.group(2));
-            final long term = Long.parseLong(md5Matcher.group(1));
-            final FileInfo fileInfo = new FileInfo(filePath, null);
-            result.add(new SingleFileSnapshotInfo(fileInfo, term, endIndex));
-            return true;
-          }
-          return false;
-        }
-
-        private SingleFileSnapshotInfo cleanupOldFiles(
-            List<SingleFileSnapshotInfo> inputFiles,
-            int retainedNum,
-            boolean onlyCleanupMD5Files,
-            SingleFileSnapshotInfo snapshotInfo) {
-          SingleFileSnapshotInfo result = null;
-          if (inputFiles.size() > retainedNum) {
-            inputFiles.sort(new RatisSnapshotFileComparator());
-            List<SingleFileSnapshotInfo> filesToBeCleaned =
-                inputFiles.subList(retainedNum, inputFiles.size());
-            result = filesToBeCleaned.get(0);
-            for (SingleFileSnapshotInfo fileInfo : filesToBeCleaned) {
-              if ((null != snapshotInfo && (fileInfo.getIndex() >= snapshotInfo.getIndex())
-                  || (onlyCleanupMD5Files && null == snapshotInfo))) {
-                continue;
-              }
-              File file = fileInfo.getFile().getPath().toFile();
-              if (onlyCleanupMD5Files) {
-                LOG.info("Deleting old md5 file at {}.", file.getAbsolutePath());
-                FileUtils.deleteFileQuietly(file);
-              } else {
-                File md5File = new File(file.getAbsolutePath() + MD5FileUtil.MD5_SUFFIX);
-                LOG.info(
-                    "Deleting old snapshot at {}, md5 file at {}.",
-                    file.getAbsolutePath(),
-                    md5File.getAbsolutePath());
-                FileUtils.deleteFileQuietly(file);
-                FileUtils.deleteFileQuietly(md5File);
-              }
-            }
-          }
-          return result;
-        }
-      };
+  private final SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
 
   private final HARaftServer masterRatisServer;
   private RaftGroupId raftGroupId;
@@ -417,16 +319,5 @@ public class StateMachine extends BaseStateMachine {
   @Override
   public StateMachineStorage getStateMachineStorage() {
     return this.storage;
-  }
-}
-
-/**
- * Compare snapshot files based on transaction indexes. Copy from
- * org.apache.ratis.statemachine.impl.SnapshotFileComparator
- */
-class RatisSnapshotFileComparator implements Comparator<SingleFileSnapshotInfo> {
-  @Override
-  public int compare(SingleFileSnapshotInfo file1, SingleFileSnapshotInfo file2) {
-    return (int) (file2.getIndex() - file1.getIndex());
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

We need to delete md5 file init SimpleStateMachineStorage based on ratis-2.0.0, but the logic about cleanup md5 files already support after RATIS-1752, so we can optimize initialization.

Remove `MasterStateMachineSuiteJ#testSnapshotCleanup`, it already test cleanup snapshots and md5 files in
https://github.com/apache/ratis/blob/release-2.5.1/ratis-test/src/test/java/org/apache/ratis/server/storage/TestRaftStorage.java#L221

<br>

**links:**

https://issues.apache.org/jira/browse/RATIS-1752

https://github.com/apache/ratis/blob/release-2.5.1/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java#L105


### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

local test.