### PR TITLE
[CELEBORN-1031] SBT correct the LICENSE and NOTICE for shaded client jars

### DIFF
--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -964,7 +964,7 @@ object MRClientProjects {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           // For netty-3.x.y.Final.jar
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case m if m == "META-INF/LICENSE" || m == "META-INF/NOTICE" => MergeStrategy.preferProject
+          case "META-INF/LICENSE" | "META-INF/NOTICE" => MergeStrategy.preferProject
           case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -690,7 +690,7 @@ trait SparkClientProjects {
   
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
-          case m if m == "META-INF/LICENSE" || m == "META-INF/NOTICE" => MergeStrategy.preferProject
+          case "META-INF/LICENSE" | "META-INF/NOTICE" => MergeStrategy.preferProject
           case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -217,14 +217,14 @@ object CelebornCommonSettings {
     // https://www.scala-sbt.org/1.x/docs/Testing.html
     Dependencies.junitInterface % "test")
 
-  def licenseFileOnlyProjectMergeStrategy(path: String) =
+  def licenseFileOnlyProjectMergeStrategy(path: String, log: Logger) =
     CustomMergeStrategy("LicenseFileOnlyProjectMergeStrategy") { conflicts =>
       Right(conflicts.map {
         case dep if dep.isProjectDependency =>
-          println(s"$path from Project dependency: $dep")
+          log.info(s"assembly - including file: ${path}")
           Some(JarEntry(dep.target, dep.stream))
         case dep =>
-          println(s"[Discard] $path Not from Project dependency: $dep")
+          log.info(s"assembly - excluding file: $dep:$path")
           None
       }.flatMap(_.toVector))
     }
@@ -703,7 +703,8 @@ trait SparkClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator))
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) =>
+            licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator), sLog.value)
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -896,7 +897,7 @@ trait FlinkClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator))
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator), sLog.value)
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -975,7 +976,7 @@ object MRClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator))
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator), sLog.value)
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -690,7 +690,7 @@ trait SparkClientProjects {
   
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
-          case PathList(ps@_*) if ps.last == "LICENSE" || ps.last == "NOTICE" => MergeStrategy.preferProject
+          case m if m == "META-INF/LICENSE" || m == "META-INF/NOTICE" => MergeStrategy.preferProject
           case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
@@ -883,7 +883,7 @@ trait FlinkClientProjects {
   
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
-          case PathList(ps@_*) if ps.last == "LICENSE" || ps.last == "NOTICE" => MergeStrategy.preferProject
+          case m if m == "META-INF/LICENSE" || m == "META-INF/NOTICE" => MergeStrategy.preferProject
           case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
@@ -964,7 +964,7 @@ object MRClientProjects {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           // For netty-3.x.y.Final.jar
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case PathList(ps@_*) if ps.last == "LICENSE" || ps.last == "NOTICE" => MergeStrategy.preferProject
+          case m if m == "META-INF/LICENSE" || m == "META-INF/NOTICE" => MergeStrategy.preferProject
           case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -691,10 +691,8 @@ trait SparkClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case m if m == "META-INF/LICENSE.txt" => MergeStrategy.discard
-          case m if m == "META-INF/NOTICE.txt" => MergeStrategy.discard
-          case m if m == "LICENSE.txt" => MergeStrategy.discard
-          case m if m == "NOTICE.txt" => MergeStrategy.discard
+          case m if m.contains("LICENSE.txt") => MergeStrategy.discard
+          case m if m.contains("NOTICE.txt") => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -887,10 +885,8 @@ trait FlinkClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case m if m == "META-INF/LICENSE.txt" => MergeStrategy.discard
-          case m if m == "META-INF/NOTICE.txt" => MergeStrategy.discard
-          case m if m == "LICENSE.txt" => MergeStrategy.discard
-          case m if m == "NOTICE.txt" => MergeStrategy.discard
+          case m if m.contains("LICENSE.txt") => MergeStrategy.discard
+          case m if m.contains("NOTICE.txt") => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -969,10 +965,8 @@ object MRClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case m if m == "META-INF/LICENSE.txt" => MergeStrategy.discard
-          case m if m == "META-INF/NOTICE.txt" => MergeStrategy.discard
-          case m if m == "LICENSE.txt" => MergeStrategy.discard
-          case m if m == "NOTICE.txt" => MergeStrategy.discard
+          case m if m.contains("LICENSE.txt") => MergeStrategy.discard
+          case m if m.contains("NOTICE.txt") => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -690,6 +690,11 @@ trait SparkClientProjects {
   
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
+          case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
+          case m if m == "META-INF/LICENSE.txt" => MergeStrategy.discard
+          case m if m == "META-INF/NOTICE.txt" => MergeStrategy.discard
+          case m if m == "LICENSE.txt" => MergeStrategy.discard
+          case m if m == "NOTICE.txt" => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -881,6 +886,11 @@ trait FlinkClientProjects {
   
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
+          case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
+          case m if m == "META-INF/LICENSE.txt" => MergeStrategy.discard
+          case m if m == "META-INF/NOTICE.txt" => MergeStrategy.discard
+          case m if m == "LICENSE.txt" => MergeStrategy.discard
+          case m if m == "NOTICE.txt" => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -702,7 +702,6 @@ trait SparkClientProjects {
   
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
-          case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
           case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) =>
             licenseFileOnlyProjectMergeStrategy(sLog.value)
           // Drop all proto files that are not needed as artifacts of the build.
@@ -896,7 +895,6 @@ trait FlinkClientProjects {
   
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
-          case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
           case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(sLog.value)
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
@@ -975,6 +973,7 @@ object MRClientProjects {
 
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
+          // For netty-3.x.y.Final.jar
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
           case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(sLog.value)
           // Drop all proto files that are not needed as artifacts of the build.

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -883,7 +883,7 @@ trait FlinkClientProjects {
   
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
-          case m if m == "META-INF/LICENSE" || m == "META-INF/NOTICE" => MergeStrategy.preferProject
+          case "META-INF/LICENSE" | "META-INF/NOTICE" => MergeStrategy.preferProject
           case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -216,18 +216,6 @@ object CelebornCommonSettings {
     Dependencies.junit % "test",
     // https://www.scala-sbt.org/1.x/docs/Testing.html
     Dependencies.junitInterface % "test")
-
-  def licenseFileOnlyProjectMergeStrategy(log: Logger) =
-    CustomMergeStrategy("LicenseFileOnlyProjectMergeStrategy") { conflicts =>
-      Right(conflicts.map {
-        case dep if dep.isProjectDependency =>
-          log.info(s"assembly - including file: ${dep.target}")
-          Some(JarEntry(dep.target, dep.stream))
-        case dep =>
-          log.info(s"assembly - excluding file: $dep")
-          None
-      }.flatMap(_.toVector))
-    }
 }
 
 object CelebornBuild extends sbt.internal.BuildDef {
@@ -702,8 +690,8 @@ trait SparkClientProjects {
   
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
-          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) =>
-            licenseFileOnlyProjectMergeStrategy(sLog.value)
+          case PathList(ps@_*) if ps.last == "LICENSE" || ps.last == "NOTICE" => MergeStrategy.preferProject
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -895,7 +883,8 @@ trait FlinkClientProjects {
   
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
-          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(sLog.value)
+          case PathList(ps@_*) if ps.last == "LICENSE" || ps.last == "NOTICE" => MergeStrategy.preferProject
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -975,7 +964,8 @@ object MRClientProjects {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           // For netty-3.x.y.Final.jar
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(sLog.value)
+          case PathList(ps@_*) if ps.last == "LICENSE" || ps.last == "NOTICE" => MergeStrategy.preferProject
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => MergeStrategy.discard
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -216,6 +216,18 @@ object CelebornCommonSettings {
     Dependencies.junit % "test",
     // https://www.scala-sbt.org/1.x/docs/Testing.html
     Dependencies.junitInterface % "test")
+
+  def licenseFileOnlyProjectMergeStrategy(path: String) =
+    CustomMergeStrategy("LicenseFileOnlyProjectMergeStrategy") { conflicts =>
+      Right(conflicts.map {
+        case dep if dep.isProjectDependency =>
+          println(s"$path from Project dependency: $dep")
+          Some(JarEntry(dep.target, dep.stream))
+        case dep =>
+          println(s"[Discard] $path Not from Project dependency: $dep")
+          None
+      }.flatMap(_.toVector))
+    }
 }
 
 object CelebornBuild extends sbt.internal.BuildDef {
@@ -691,8 +703,7 @@ trait SparkClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case m if m.contains("LICENSE.txt") => MergeStrategy.discard
-          case m if m.contains("NOTICE.txt") => MergeStrategy.discard
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator))
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -885,8 +896,7 @@ trait FlinkClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case m if m.contains("LICENSE.txt") => MergeStrategy.discard
-          case m if m.contains("NOTICE.txt") => MergeStrategy.discard
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator))
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -965,8 +975,7 @@ object MRClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case m if m.contains("LICENSE.txt") => MergeStrategy.discard
-          case m if m.contains("NOTICE.txt") => MergeStrategy.discard
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator))
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -217,14 +217,14 @@ object CelebornCommonSettings {
     // https://www.scala-sbt.org/1.x/docs/Testing.html
     Dependencies.junitInterface % "test")
 
-  def licenseFileOnlyProjectMergeStrategy(path: String, log: Logger) =
+  def licenseFileOnlyProjectMergeStrategy(log: Logger) =
     CustomMergeStrategy("LicenseFileOnlyProjectMergeStrategy") { conflicts =>
       Right(conflicts.map {
         case dep if dep.isProjectDependency =>
-          log.info(s"assembly - including file: ${path}")
+          log.info(s"assembly - including file: ${dep.target}")
           Some(JarEntry(dep.target, dep.stream))
         case dep =>
-          log.info(s"assembly - excluding file: $dep:$path")
+          log.info(s"assembly - excluding file: $dep")
           None
       }.flatMap(_.toVector))
     }
@@ -704,7 +704,7 @@ trait SparkClientProjects {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
           case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) =>
-            licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator), sLog.value)
+            licenseFileOnlyProjectMergeStrategy(sLog.value)
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -897,7 +897,7 @@ trait FlinkClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator), sLog.value)
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(sLog.value)
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard
@@ -976,7 +976,7 @@ object MRClientProjects {
         (assembly / assemblyMergeStrategy) := {
           case m if m.toLowerCase(Locale.ROOT).endsWith("manifest.mf") => MergeStrategy.discard
           case m if m.startsWith("META-INF/license/") => MergeStrategy.discard
-          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(ps.mkString(java.io.File.separator), sLog.value)
+          case PathList(ps@_*) if Assembly.isLicenseFile(ps.last) => licenseFileOnlyProjectMergeStrategy(sLog.value)
           // Drop all proto files that are not needed as artifacts of the build.
           case m if m.toLowerCase(Locale.ROOT).endsWith(".proto") => MergeStrategy.discard
           case m if m.toLowerCase(Locale.ROOT).startsWith("meta-inf/native-image") => MergeStrategy.discard


### PR DESCRIPTION
### What changes were proposed in this pull request?
Flink/Spark jars packaged with SBT use the correct LICENSE and NOTICE.

### Why are the changes needed?
https://github.com/apache/incubator-celeborn/pull/1930#discussion_r1340410526



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

