### PR TITLE
[CELEBORN-1033] MasterNotLeaderException should provide the cause of exception

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
@@ -19,22 +19,29 @@ package org.apache.celeborn.common.client;
 
 import java.io.IOException;
 
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
+
 public class MasterNotLeaderException extends IOException {
 
-  private final String currentPeer;
+  private static final long serialVersionUID = -2552475565785098271L;
+
   private final String leaderPeer;
 
   public static final String LEADER_NOT_PRESENTED = "leader is not present";
 
-  public MasterNotLeaderException(String currentPeer, String suggestedLeaderPeer) {
+  public MasterNotLeaderException(
+      String currentPeer, String suggestedLeaderPeer, @Nullable Throwable cause) {
     super(
-        "Master:"
-            + currentPeer
-            + " is not the leader. Suggested leader is"
-            + " Master:"
-            + suggestedLeaderPeer
-            + ".");
-    this.currentPeer = currentPeer;
+        String.format(
+            "Master:%s is not the leader. Suggested leader is Master:%s.%s",
+            currentPeer,
+            suggestedLeaderPeer,
+            cause == null
+                ? StringUtils.EMPTY
+                : String.format(" Exception:%s.", cause.getMessage())),
+        cause);
     this.leaderPeer = suggestedLeaderPeer;
   }
 

--- a/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/client/MasterClientSuiteJ.java
@@ -227,7 +227,7 @@ public class MasterClientSuiteJ {
 
     // master leader switch to host2
     Mockito.doReturn(
-            Future$.MODULE$.failed(new MasterNotLeaderException("host1:9097", "host2:9097")))
+            Future$.MODULE$.failed(new MasterNotLeaderException("host1:9097", "host2:9097", null)))
         .when(master1)
         .ask(Mockito.any(), Mockito.any(), Mockito.any());
 
@@ -275,7 +275,7 @@ public class MasterClientSuiteJ {
 
     // master leader switch to host2
     Mockito.doReturn(
-            Future$.MODULE$.failed(new MasterNotLeaderException("host1:9097", "host2:9097")))
+            Future$.MODULE$.failed(new MasterNotLeaderException("host1:9097", "host2:9097", null)))
         .when(ref1)
         .ask(Mockito.any(), Mockito.any(), Mockito.any());
     // Assume host2 down.

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAHelper.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/HAHelper.java
@@ -55,11 +55,14 @@ public class HAHelper {
           context.sendFailure(
               new MasterNotLeaderException(
                   ratisServer.getRpcEndpoint(),
-                  ratisServer.getCachedLeaderPeerRpcEndpoint().get()));
+                  ratisServer.getCachedLeaderPeerRpcEndpoint().get(),
+                  cause));
         } else {
           context.sendFailure(
               new MasterNotLeaderException(
-                  ratisServer.getRpcEndpoint(), MasterNotLeaderException.LEADER_NOT_PRESENTED));
+                  ratisServer.getRpcEndpoint(),
+                  MasterNotLeaderException.LEADER_NOT_PRESENTED,
+                  cause));
         }
       } else {
         context.sendFailure(new CelebornIOException(cause.getMessage(), cause));


### PR DESCRIPTION
### What changes were proposed in this pull request?

`HAHelper#sendFailure` only sends `MasterNotLeaderException` without cause, which causes that the actual exception of `MasterNotLeaderException` could not catch for troubleshooting.

### Why are the changes needed?

`MasterNotLeaderException` provides the cause of exception.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`MasterClientSuiteJ`