### PR TITLE
[CELEBORN-1038] Clean up deprecated api

### DIFF
--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -295,6 +295,6 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
         masterStatusSystem.appDiskUsageMetric.currentSnapShot().get().topNItems().length);
     Assert.assertEquals(
         originCurrentSnapshot, masterStatusSystem.appDiskUsageMetric.currentSnapShot().get());
-    Assert.assertEquals(originSnapshots, masterStatusSystem.appDiskUsageMetric.snapShots());
+    Assert.assertArrayEquals(originSnapshots, masterStatusSystem.appDiskUsageMetric.snapShots());
   }
 }

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolverSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolverSuite.scala
@@ -18,9 +18,9 @@
 package org.apache.celeborn.service.deploy.master.network
 
 import java.io.{File, FileWriter}
+import java.nio.charset.StandardCharsets
 
 import com.google.common.io.Files
-import org.apache.commons.io.Charsets
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic.{NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY, NET_TOPOLOGY_TABLE_MAPPING_FILE_KEY}
 import org.apache.hadoop.net.{Node, TableMapping}
 import org.junit.Assert.assertEquals
@@ -63,7 +63,7 @@ class CelebornRackResolverSuite extends AnyFunSuite {
     val hostName5 = "1.2.3.8"
     val hostName6 = "1.2.3.9"
     val mapFile: File = File.createTempFile(getClass.getSimpleName + ".testResolve2", ".txt")
-    Files.asCharSink(mapFile, Charsets.UTF_8).write(
+    Files.asCharSink(mapFile, StandardCharsets.UTF_8).write(
       s"""
          |$hostName1 /default/rack1
          |$hostName2 /default/rack1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Replace `org.apache.commons.io.Charsets.UTF_8` to `java.nio.charset.StandardCharsets.UTF_8`.
Replace `Assert.assertEquals` to `Assert.assertArrayEquals`.


### Why are the changes needed?

Clean up deprecated api.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Existing UT.
