### PR TITLE
[CELEBORN-772] Convert StreamChunkSlice, ChunkFetchRequest, TransportableError to PB

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/ReadClientHandler.java
@@ -19,6 +19,7 @@ package org.apache.celeborn.plugin.flink.network;
 
 import static org.apache.celeborn.common.protocol.MessageType.BACKLOG_ANNOUNCEMENT_VALUE;
 import static org.apache.celeborn.common.protocol.MessageType.BUFFER_STREAM_END_VALUE;
+import static org.apache.celeborn.common.protocol.MessageType.TRANSPORTABLE_ERROR_VALUE;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -102,6 +103,9 @@ public class ReadClientHandler extends BaseMessageHandler {
               break;
             case BUFFER_STREAM_END_VALUE:
               receive(client, BufferStreamEnd.fromProto(transportMessage.getParsedPayload()));
+              break;
+            case TRANSPORTABLE_ERROR_VALUE:
+              receive(client, TransportableError.fromProto(transportMessage.getParsedPayload()));
               break;
           }
         } catch (IOException e) {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
@@ -20,7 +20,9 @@ package org.apache.celeborn.common.network.protocol;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
-/** Response to {@link ChunkFetchRequest} when there is an error fetching the chunk. */
+import org.apache.celeborn.common.protocol.PbChunkFetchRequest;
+
+/** Response to {@link PbChunkFetchRequest} when there is an error fetching the chunk. */
 public final class ChunkFetchFailure extends ResponseMessage {
   public final StreamChunkSlice streamChunkSlice;
   public final String errorString;

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchRequest.java
@@ -24,6 +24,7 @@ import io.netty.buffer.ByteBuf;
  * Request to fetch a sequence of a single chunk of a stream. This will correspond to a single
  * {@link ResponseMessage} (either success or failure).
  */
+@Deprecated
 public final class ChunkFetchRequest extends RequestMessage {
   public final StreamChunkSlice streamChunkSlice;
 

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
@@ -22,9 +22,10 @@ import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
+import org.apache.celeborn.common.protocol.PbChunkFetchRequest;
 
 /**
- * Response to {@link ChunkFetchRequest} when a chunk exists and has been successfully fetched.
+ * Response to {@link PbChunkFetchRequest} when a chunk exists and has been successfully fetched.
  *
  * <p>Note that the server-side encoding of this message does NOT include the buffer itself, as this
  * may be written by Netty in a more efficient manner (i.e., zero-copy write). Similarly, the

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamChunkSlice.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamChunkSlice.java
@@ -20,6 +20,8 @@ package org.apache.celeborn.common.network.protocol;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
+import org.apache.celeborn.common.protocol.PbStreamChunkSlice;
+
 /** Encapsulates a request for a particular chunk of a stream. */
 public final class StreamChunkSlice implements Encodable {
   public final long streamId;
@@ -89,5 +91,18 @@ public final class StreamChunkSlice implements Encodable {
         .add("offset", offset)
         .add("len", len)
         .toString();
+  }
+
+  public PbStreamChunkSlice toProto() {
+    return PbStreamChunkSlice.newBuilder()
+        .setStreamId(streamId)
+        .setChunkIndex(chunkIndex)
+        .setOffset(offset)
+        .setLen(len)
+        .build();
+  }
+
+  public static StreamChunkSlice fromProto(PbStreamChunkSlice pb) {
+    return new StreamChunkSlice(pb.getStreamId(), pb.getChunkIndex(), pb.getOffset(), pb.getLen());
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
@@ -31,12 +31,15 @@ import org.apache.celeborn.common.exception.CelebornIOException;
 import org.apache.celeborn.common.protocol.MessageType;
 import org.apache.celeborn.common.protocol.PbBacklogAnnouncement;
 import org.apache.celeborn.common.protocol.PbBufferStreamEnd;
+import org.apache.celeborn.common.protocol.PbChunkFetchRequest;
 import org.apache.celeborn.common.protocol.PbOpenStream;
 import org.apache.celeborn.common.protocol.PbPushDataHandShake;
 import org.apache.celeborn.common.protocol.PbReadAddCredit;
 import org.apache.celeborn.common.protocol.PbRegionFinish;
 import org.apache.celeborn.common.protocol.PbRegionStart;
+import org.apache.celeborn.common.protocol.PbStreamChunkSlice;
 import org.apache.celeborn.common.protocol.PbStreamHandler;
+import org.apache.celeborn.common.protocol.PbTransportableError;
 
 public class TransportMessage implements Serializable {
   private static final long serialVersionUID = -3259000920699629773L;
@@ -81,6 +84,12 @@ public class TransportMessage implements Serializable {
         return (T) PbBufferStreamEnd.parseFrom(payload);
       case READ_ADD_CREDIT_VALUE:
         return (T) PbReadAddCredit.parseFrom(payload);
+      case STREAM_CHUNK_SLICE_VALUE:
+        return (T) PbStreamChunkSlice.parseFrom(payload);
+      case CHUNK_FETCH_REQUEST_VALUE:
+        return (T) PbChunkFetchRequest.parseFrom(payload);
+      case TRANSPORTABLE_ERROR_VALUE:
+        return (T) PbTransportableError.parseFrom(payload);
       default:
         logger.error("Unexpected type {}", type);
     }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportableError.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportableError.java
@@ -74,6 +74,6 @@ public class TransportableError extends RequestMessage {
 
   public static TransportableError fromProto(PbTransportableError pb) {
     return new TransportableError(
-        pb.getStreamId(), pb.getErrorMessage().getBytes(StandardCharsets.UTF_8));
+        pb.getStreamId(), pb.getMessage().getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportableError.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportableError.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 
 import io.netty.buffer.ByteBuf;
 
+import org.apache.celeborn.common.protocol.PbTransportableError;
 import org.apache.celeborn.common.util.ExceptionUtils;
 
 public class TransportableError extends RequestMessage {
@@ -69,5 +70,10 @@ public class TransportableError extends RequestMessage {
 
   public String getErrorMessage() {
     return new String(errorMessage, StandardCharsets.UTF_8);
+  }
+
+  public static TransportableError fromProto(PbTransportableError pb) {
+    return new TransportableError(
+        pb.getStreamId(), pb.getErrorMessage().getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -568,5 +568,5 @@ message PbChunkFetchRequest {
 
 message PbTransportableError {
   int64 streamId = 1;
-  string errorMessage = 2;
+  string message = 2;
 }

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -82,6 +82,9 @@ enum MessageType {
   BACKLOG_ANNOUNCEMENT = 59;
   BUFFER_STREAM_END = 60;
   READ_ADD_CREDIT = 61;
+  STREAM_CHUNK_SLICE = 62;
+  CHUNK_FETCH_REQUEST = 63;
+  TRANSPORTABLE_ERROR = 64;
 }
 
 enum StreamType {
@@ -550,4 +553,20 @@ message PbBufferStreamEnd {
 message PbReadAddCredit {
   int64 streamId = 1;
   int32 credit = 2;
+}
+
+message PbStreamChunkSlice {
+  int64 streamId = 1;
+  int32 chunkIndex = 2;
+  int32 offset = 3;
+  int32 len = 4;
+}
+
+message PbChunkFetchRequest {
+  PbStreamChunkSlice streamChunkSlice = 1;
+}
+
+message PbTransportableError {
+  int64 streamId = 1;
+  string errorMessage = 2;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`StreamChunkSlice`, `ChunkFetchRequest` and `TransportableError` should merge to transport messages to enhance celeborn's compatibility.

### Why are the changes needed?

1. Improves celeborn's transport flexibility to change RPC.
2. Makes Compatible with 0.2 client.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `FetchHandlerSuiteJ`
- `RequestTimeoutIntegrationSuiteJ`
- `ChunkFetchIntegrationSuiteJ`