### PR TITLE
[CELEBORN-1033][FOLLOWUP] MasterNotLeaderException should provide the cause of exception

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/haclient/MasterNotLeaderException.java
+++ b/common/src/main/java/org/apache/celeborn/common/haclient/MasterNotLeaderException.java
@@ -19,23 +19,30 @@ package org.apache.celeborn.common.haclient;
 
 import java.io.IOException;
 
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
+
 // This class is reserved for compatible with 0.2 client
 public class MasterNotLeaderException extends IOException {
 
-  private final String currentPeer;
+  private static final long serialVersionUID = -6230015203034327259L;
+
   private final String leaderPeer;
 
   public static final String LEADER_NOT_PRESENTED = "leader is not present";
 
-  public MasterNotLeaderException(String currentPeer, String suggestedLeaderPeer) {
+  public MasterNotLeaderException(
+      String currentPeer, String suggestedLeaderPeer, @Nullable Throwable cause) {
     super(
-        "Master:"
-            + currentPeer
-            + " is not the leader. Suggested leader is"
-            + " Master:"
-            + suggestedLeaderPeer
-            + ".");
-    this.currentPeer = currentPeer;
+        String.format(
+            "Master:%s is not the leader. Suggested leader is Master:%s.%s",
+            currentPeer,
+            suggestedLeaderPeer,
+            cause == null
+                ? StringUtils.EMPTY
+                : String.format(" Exception:%s.", cause.getMessage())),
+        cause);
     this.leaderPeer = suggestedLeaderPeer;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`HAHelper#sendFailure` only sends `MasterNotLeaderException` without cause, which causes that the actual exception of `MasterNotLeaderException` could not catch for troubleshooting.

### Why are the changes needed?

`MasterNotLeaderException` provides the cause of exception.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`MasterClientSuiteJ`