### PR TITLE
[CELEBORN-1040] Adjust local read logs and refine createReader

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -107,12 +107,14 @@ public abstract class ShuffleClient {
     totalReadCounter.increment();
   }
 
-  public static String getReadCounters() {
+  public static void printReadStats(Logger logger) {
     long totalReadCount = totalReadCounter.longValue();
     long localReadCount = localShuffleReadCounter.longValue();
-    return String.format(
-        "Current client read %d(local)/%d(total) partitions, local ratio %.2f",
-        localReadCount, totalReadCount, (localReadCount * 1.0d / totalReadCount) * 100);
+    logger.info(
+        "Current client read {}/{} (local/total) partitions, local read ratio {}",
+        localReadCount,
+        totalReadCount,
+        String.format("%.2f", (localReadCount * 1.0d / totalReadCount) * 100));
   }
 
   public abstract void setupLifecycleManagerRef(String host, int port);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adjust the local reader logs. Before, it will log local read stats in each stream clos whether it really contains local read.
And refine the CelebornInputStreamImpl#createReader code to be more clearer.


### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
Adjust local read logs.


### How was this patch tested?
Manual test.
