### PR TITLE
[CELEBORN-299] Deprecate `celeborn.worker.storage.baseDir.prefix` and `celeborn.worker.storage.baseDir.number`

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1088,7 +1088,14 @@ object CelebornConf extends Logging {
    */
   private val deprecatedConfigs: Map[String, DeprecatedConfig] = {
     val configs = Seq(
-      DeprecatedConfig("none", "1.0", "None"))
+      DeprecatedConfig(
+        "celeborn.worker.storage.baseDir.prefix",
+        "0.4.0",
+        "Please use celeborn.worker.storage.dirs"),
+      DeprecatedConfig(
+        "celeborn.worker.storage.baseDir.number",
+        "0.4.0",
+        "Please use celeborn.worker.storage.dirs"))
 
     Map(configs.map { cfg => (cfg.key -> cfg) }: _*)
   }

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -39,6 +39,9 @@ license: |
     | `celeborn.metrics.worker.prometheus.host` | `celeborn.worker.http.host` |
     | `celeborn.metrics.worker.prometheus.port` | `celeborn.worker.http.port` |
 
+- Since 0.4.0, Celeborn deprecate `celeborn.worker.storage.baseDir.prefix` and `celeborn.worker.storage.baseDir.number`.
+  Please use `celeborn.worker.storage.dirs` instead.
+
 ## Upgrading from 0.3.0 to 0.3.1
 
 - Since 0.3.1, Celeborn changed the default value of `celeborn.worker.directMemoryRatioToResume` from `0.5` to `0.7`.


### PR DESCRIPTION
### What changes were proposed in this pull request?

<img width="1460" alt="image" src="https://github.com/apache/incubator-celeborn/assets/3898450/ac3b29be-7c39-4c18-b71d-0e243797273e">



### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?
```
23/10/16 03:31:13,399 WARN [pool-1-thread-1-ScalaTest-running-CelebornConfSuite] CelebornConf: The configuration key 'celeborn.worker.storage.baseDir.prefix' has been deprecated in v0.4.0 and may be removed in the future. Please use celeborn.worker.storage.dirs
23/10/16 03:31:13,399 WARN [pool-1-thread-1-ScalaTest-running-CelebornConfSuite] CelebornConf: The configuration key 'celeborn.worker.storage.baseDir.number' has been deprecated in v0.4.0 and may be removed in the future. Please use celeborn.worker.storage.dirs
```


