### PR TITLE
[CELEBORN-1044] Enhance the check of parameter array length

### DIFF
--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.service.deploy.master
 
+import com.google.common.io.Files
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -30,7 +31,7 @@ class MasterSuite extends AnyFunSuite
   with Logging {
 
   def getTmpDir(): String = {
-    val tmpDir = com.google.common.io.Files.createTempDir()
+    val tmpDir = Files.createTempDir()
     tmpDir.deleteOnExit()
     tmpDir.getAbsolutePath
   }

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -33,10 +33,12 @@ abstract class HttpService extends Service with Logging {
 
   def getConf: String = {
     val sb = new StringBuilder
-    val maxKeyLength = conf.getAll.toMap.keys.map(_.length).max
     sb.append("=========================== Configuration ============================\n")
-    conf.getAll.foreach { case (key, value) =>
-      sb.append(s"${key.padTo(maxKeyLength + 10, " ").mkString}$value\n")
+    if (conf.getAll.length > 0) {
+      val maxKeyLength = conf.getAll.toMap.keys.map(_.length).max
+      conf.getAll.foreach { case (key, value) =>
+        sb.append(s"${key.padTo(maxKeyLength + 10, " ").mkString}$value\n")
+      }
     }
     sb.toString()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

We can't get any response from /conf when the master started with default celeborn conf.

![e8c649b733e0c8495bb6555dfb7c5e58_13063594_image-2023-10-17-11-37-15-261](https://github.com/apache/incubator-celeborn/assets/95013770/a6de4496-f53f-46ad-94b6-e02adaa6fbfc)

**Internal Exception**
```
empty.max
java.lang.UnsupportedOperationException: empty.max
	at scala.collection.TraversableOnce.max(TraversableOnce.scala:275)
	at scala.collection.TraversableOnce.max$(TraversableOnce.scala:273)
	at scala.collection.AbstractTraversable.max(Traversable.scala:108)
	at org.apache.celeborn.server.common.HttpService.getConf(HttpService.scala:36)
	at org.apache.celeborn.service.deploy.master.MasterSuite.$anonfun$new$1(MasterSuite.scala:46)
```


### Why are the changes needed?

Bug.

### How was this patch tested?

Local