### PR TITLE
[CELEBORN-1057] Introduce /partitionStatistics API provider of Celeborn Master for Rest API

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -307,6 +307,7 @@ API path listed as below:
 | /applications         | List all running application's ids of the cluster.                                                                                  |
 | /shuffles             | List all running shuffle keys of the service. It will return all running shuffle's key of the cluster.                              |
 | /listTopDiskUsedApps  | List the top disk usage application ids. It will return the top disk usage application ids for the cluster.                         |
+| /partitionStatistics  | Statistics of shuffle partitions including the average shuffle size and file count for all partitions written etc.                  |
 | /help                 | List the available API providers of the master.                                                                                     |
 
 #### Worker

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -920,6 +920,17 @@ private[celeborn] class Master(
     sb.toString()
   }
 
+  override def getPartitionStatistics: String = {
+    val sb = new StringBuilder
+    sb.append("================= Shuffle Partition Statistics ======================\n")
+    Map(
+      "PartitionTotalWritten" -> statusSystem.partitionTotalWritten.sum(),
+      "PartitionTotalFileCount" -> statusSystem.partitionTotalFileCount.sum())
+      .toSeq.sortBy(_._2)
+      .foreach { case (key, value) => sb.append(s"${key.padTo(30, " ").mkString}$value\n") }
+    sb.toString()
+  }
+
   override def getShuffleList: String = {
     val sb = new StringBuilder
     sb.append("======================= Shuffle Key List ============================\n")

--- a/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/HttpService.scala
@@ -59,6 +59,8 @@ abstract class HttpService extends Service with Logging {
 
   def getApplicationList: String = throw new UnsupportedOperationException()
 
+  def getPartitionStatistics: String = throw new UnsupportedOperationException()
+
   def getShuffleList: String
 
   def listTopDiskUseApps: String

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpEndpoint.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpEndpoint.scala
@@ -168,6 +168,16 @@ case object Applications extends HttpEndpoint {
     service.getApplicationList
 }
 
+case object PartitionStatistics extends HttpEndpoint {
+  override def path: String = "/partitionStatistics"
+
+  override def description(service: String): String =
+    "Statistics of shuffle partitions including the average shuffle size and file count for all partitions written etc."
+
+  override def handle(service: HttpService, parameters: Map[String, String]): String =
+    service.getPartitionStatistics
+}
+
 case object ListPartitionLocationInfo extends HttpEndpoint {
   override def path: String = "/listPartitionLocationInfo"
 

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpUtils.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpUtils.scala
@@ -32,7 +32,8 @@ object HttpUtils {
     ExcludedWorkers,
     ShutdownWorkers,
     Hostnames,
-    Applications) ++ baseEndpoints
+    Applications,
+    PartitionStatistics) ++ baseEndpoints
   private val workerEndpoints: List[HttpEndpoint] =
     List(
       ListPartitionLocationInfo,

--- a/service/src/test/scala/org/apache/celeborn/server/common/http/HttpUtilsSuite.scala
+++ b/service/src/test/scala/org/apache/celeborn/server/common/http/HttpUtilsSuite.scala
@@ -53,6 +53,7 @@ class HttpUtilsSuite extends AnyFunSuite with Logging {
          |/listTopDiskUsedApps List the top disk usage application ids. It will return the top disk usage application ids for the cluster.
          |/lostWorkers         List all lost workers of the master.
          |/masterGroupInfo     List master group information of the service. It will list all master's LEADER, FOLLOWER information.
+         |/partitionStatistics Statistics of shuffle partitions including the average shuffle size and file count for all partitions written etc.
          |/shuffles            List all running shuffle keys of the service. It will return all running shuffle's key of the cluster.
          |/shutdownWorkers     List all shutdown workers of the master.
          |/threadDump          List the current thread dump of the master.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce `/partitionStatistics` API provider of Celeborn Master to return statistics of shuffle partitions including the average shuffle size and file count for all partitions written etc.

### Why are the changes needed?

Metric `PartitionWritten` reports the size of the data written to disk in the shuffle partition and `PartitionFileCount` reports the count of shuffle partition files at present. It's recommended to introduce  `/partitionStatistics` API provider of Celeborn Master, which interface returns the average shuffle size for all partitions handled by Celeborn.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

`HttpUtilsSuite`