### PR TITLE
[CELEBORN-1059] Fix callback not update if push worker excluded during retry

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -67,6 +67,8 @@ class ChangePartitionManager(
 
   private var batchHandleChangePartition: Option[ScheduledFuture[_]] = _
 
+  private val testRetryRevive = conf.testRetryRevive
+
   def start(): Unit = {
     batchHandleChangePartition = batchHandleChangePartitionSchedulerThread.map {
       // noinspection ConvertExpressionToSAM
@@ -204,7 +206,7 @@ class ChangePartitionManager(
     logWarning(s"Batch handle change partition for $changes")
 
     // Exclude all failed workers
-    if (changePartitions.exists(_.causes.isDefined)) {
+    if (changePartitions.exists(_.causes.isDefined) && !testRetryRevive) {
       changePartitions.filter(_.causes.isDefined).foreach { changePartition =>
         lifecycleManager.workerStatusTracker.excludeWorkerFromPartition(
           shuffleId,

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala
@@ -51,7 +51,7 @@ class RetryReviveTest extends AnyFunSuite
       .config(updateSparkConf(sparkConf, ShuffleMode.HASH))
       .getOrCreate()
     val result = ss.sparkContext.parallelize(1 to 1000, 2)
-      .map { i => (i, Range(1, 1000).mkString(",")) }.groupByKey(16).collect()
+      .map { i => (i, Range(1, 1000).mkString(",")) }.groupByKey(4).collect()
     assert(result.size == 1000)
     ss.stop()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When retry push data and revive succeed in ShuffleClientImpl#submitRetryPushData, if new location is excluded, the callback's `lastest` location has not been updated when wrappedCallback.onFailure is called in ShuffleClientImpl#isPushTargetWorkerExcluded. Therefore there may be problems with subsequent revive.


### Why are the changes needed?
Ditto


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test.
