### PR TITLE
[HELM] Fix: quote image tag

### DIFF
--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
         app.kubernetes.io/role: master
-        app.kubernetes.io/tag: {{ .Values.image.tag }}
+        app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
         {{- include "celeborn.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.affinity.master }}

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
         app.kubernetes.io/role: worker
-        app.kubernetes.io/tag: {{ .Values.image.tag }}
+        app.kubernetes.io/tag: {{ .Values.image.tag | quote }}
         {{- include "celeborn.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.affinity.worker }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

quote for image tag when it is numeric characters

### Why are the changes needed?
when the tag is 0.3
```
helm upgrade --install celeborntest .  -f values.yaml  --set image.repository=myharbor/apache-celeborn --set image.tag=0.3
```
some error as below:
```
rror: StatefulSet in version "v1" cannot be handled as a StatefulSet: v1.StatefulSet.Spec: v1.StatefulSetSpec.Spec: v1.StatefulSetSpec.Template: v1.PodTemplateSpec.ObjectMeta: v1.ObjectMeta.Labels: ReadString: expects " or n, but found 0, error found in #10 byte of ...|.io/tag":0.3,"app.ku|..., bigger context ...|rnetes.io/role":"worker","app.kubernetes.io/tag":0.3,"app.kubernetes.io/version":"0.3.0"}},"spec":{"|...
```
K8s version: v1.22.12
>[The label values must be strings. In yaml, that means all numeric values must be quoted.](https://github.com/kubernetes/kubernetes/issues/57509#issuecomment-353509068)



just quote the tag with `| quote` to fix it 


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

