### PR TITLE
[MINOR] Adjust log level for `PushDataHandler#checkDiskFullAndSplit` from debug to trace

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -1209,11 +1209,11 @@ class PushDataHandler extends BaseMessageHandler with Logging {
       softSplit: AtomicBoolean,
       callback: RpcResponseCallback): Boolean = {
     val diskFull = checkDiskFull(fileWriter)
-    logDebug(
+    logTrace(
       s"""
          |CheckDiskFullAndSplit in
          |diskFull:$diskFull,
-         |partitionSplitMinimumSize: $partitionSplitMinimumSize,
+         |partitionSplitMinimumSize:$partitionSplitMinimumSize,
          |splitThreshold:${fileWriter.getSplitThreshold()},
          |fileLength:${fileWriter.getFileInfo.getFileLength}
          |fileName:${fileWriter.getFileInfo.getFilePath}
@@ -1225,7 +1225,7 @@ class PushDataHandler extends BaseMessageHandler with Logging {
         softSplit.set(true)
       } else {
         callback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
-        logDebug(
+        logTrace(
           s"""
              |CheckDiskFullAndSplit hardSplit
              |diskFull:$diskFull,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?


This PR modifies the log level from debug to trace for the `PushDataHandler#checkDiskFullAndSplit` method, which is invoked with each `PushData` request. This change is aimed at addressing the issue of excessive log volume caused by the high frequency of `PushData` requests.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass GA