### PR TITLE
[CELEBORN-916] Add new metric about active shuffle file count in worker

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -95,8 +95,8 @@ Here is an example of grafana dashboard importing.
 |               DiskBuffer               |      worker       | Disk buffers are part of netty used memory, means data need to write to disk but haven't been written to disk.  |
 |             PausePushData              |      worker       |                   PausePushData means the count of worker stopped receiving data from client.                   |
 |       PausePushDataAndReplicate        |      worker       |    PausePushDataAndReplicate means the count of worker stopped receiving data from client and other workers.    |
-|           ActiveShuffleSize            |      worker       |                                     The active shuffle size of peer worker.                                     |
-|         ActiveShuffleFileCount         |      worker       |                                  The active shuffle file count of peer worker.                                  |
+|           ActiveShuffleSize            |      worker       |                 The active shuffle size of a worker including master replica and slave replica.                 |
+|         ActiveShuffleFileCount         |      worker       |              The active shuffle file count of a worker including master replica and slave replica.              |
 |         OutstandingFetchCount          |      worker       |                         The count of outstanding fetch request received in peer worker.                         |
 |          OutstandingRpcCount           |      worker       |                          The count of outstanding rpc request received in peer worker.                          |
 |          OutstandingPushCount          |      worker       |                         The count of outstanding push request received in peer worker.                          |

--- a/METRICS.md
+++ b/METRICS.md
@@ -95,6 +95,8 @@ Here is an example of grafana dashboard importing.
 |               DiskBuffer               |      worker       | Disk buffers are part of netty used memory, means data need to write to disk but haven't been written to disk.  |
 |             PausePushData              |      worker       |                   PausePushData means the count of worker stopped receiving data from client.                   |
 |       PausePushDataAndReplicate        |      worker       |    PausePushDataAndReplicate means the count of worker stopped receiving data from client and other workers.    |
+|           ActiveShuffleSize            |      worker       |                                     The active shuffle size of peer worker.                                     |
+|         ActiveShuffleFileCount         |      worker       |                                  The active shuffle file count of peer worker.                                  |
 |         OutstandingFetchCount          |      worker       |                         The count of outstanding fetch request received in peer worker.                         |
 |          OutstandingRpcCount           |      worker       |                          The count of outstanding rpc request received in peer worker.                          |
 |          OutstandingPushCount          |      worker       |                         The count of outstanding push request received in peer worker.                          |

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -1722,7 +1722,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "The active shuffle size of peer worker.",
+          "description": "The active shuffle size of a worker including master replica and slave replica.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1841,7 +1841,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "The active shuffle file count of peer worker.",
+          "description": "The active shuffle file count of a worker including master replica and slave replica.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -542,7 +542,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "The active shuffle size.",
+          "description": "The active shuffle size of workers.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -634,7 +634,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "The active shuffle partition count.",
+          "description": "The active shuffle file count of workers.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1722,6 +1722,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "description": "The active shuffle size of peer worker.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1833,6 +1834,124 @@
             }
           ],
           "title": "metrics_ActiveShuffleSize_Value",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The active shuffle file count of peer worker.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": [
+                      "metrics_ActiveShuffleFileCount_Value{instance=\"core-1-1:9096\", job=\"RSS\", role=\"Worker\"}"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 30
+          },
+          "id": 181,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "builder",
+              "expr": "metrics_ActiveShuffleFileCount_Value",
+              "instant": false,
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_ActiveShuffleFileCount_Value",
           "type": "timeseries"
         }
       ],

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -195,9 +195,9 @@ These metrics are exposed by Celeborn worker.
     - UserProduceSpeed
     - WorkerConsumeSpeed
     - ActiveShuffleSize
-        - The active shuffle size of peer worker. 
+        - The active shuffle size of a worker including master replica and slave replica.
     - ActiveShuffleFileCount
-        - The active shuffle file count of peer worker.
+        - The active shuffle file count of a worker including master replica and slave replica.
     - OutstandingFetchCount
         - The count of outstanding fetch request.
     - OutstandingRpcCount

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -100,9 +100,9 @@ These metrics are exposed by Celeborn master.
     - PartitionSize
         - The size of estimated shuffle partition.
     - PartitionWritten
-        - The active shuffle size.
+        - The active shuffle size of workers.
     - PartitionFileCount
-        - The active shuffle partition count.
+        - The active shuffle file count of workers.
     - OfferSlotsTime
         - The time for masters to handle `RequestSlots` request when registering shuffle.
 
@@ -194,6 +194,10 @@ These metrics are exposed by Celeborn worker.
     - PotentialConsumeSpeed
     - UserProduceSpeed
     - WorkerConsumeSpeed
+    - ActiveShuffleSize
+        - The active shuffle size of peer worker. 
+    - ActiveShuffleFileCount
+        - The active shuffle file count of peer worker.
     - OutstandingFetchCount
         - The count of outstanding fetch request.
     - OutstandingRpcCount

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -304,6 +304,9 @@ private[celeborn] class Worker(
   workerSource.addGauge(WorkerSource.ACTIVE_SHUFFLE_SIZE) { () =>
     storageManager.getActiveShuffleSize()
   }
+  workerSource.addGauge(WorkerSource.ACTIVE_SHUFFLE_FILE_COUNT) { () =>
+    storageManager.getActiveShuffleFileCount()
+  }
   workerSource.addGauge(WorkerSource.PAUSE_PUSH_DATA_TIME) { () =>
     memoryManager.getPausePushDataTime
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -100,6 +100,7 @@ object WorkerSource {
   // slots
   val SLOTS_ALLOCATED = "SlotsAllocated"
 
+  // connection
   val ACTIVE_CONNECTION_COUNT = "ActiveConnectionCount"
 
   // memory
@@ -124,11 +125,12 @@ object WorkerSource {
   val DEVICE_CELEBORN_FREE_CAPACITY = "DeviceCelebornFreeBytes"
   val DEVICE_CELEBORN_TOTAL_CAPACITY = "DeviceCelebornTotalBytes"
 
-  // Congestion control
+  // congestion control
   val POTENTIAL_CONSUME_SPEED = "PotentialConsumeSpeed"
   val USER_PRODUCE_SPEED = "UserProduceSpeed"
   val WORKER_CONSUME_SPEED = "WorkerConsumeSpeed"
 
   // active shuffle size
   val ACTIVE_SHUFFLE_SIZE = "ActiveShuffleSize"
+  val ACTIVE_SHUFFLE_FILE_COUNT = "ActiveShuffleFileCount"
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -846,7 +846,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   }
 
   def getActiveShuffleFileCount(): Long = {
-    fileInfos.size()
+    fileInfos.asScala.values.map(_.size()).sum
   }
 }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -845,6 +845,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     fileInfos.values().asScala.map(_.values().asScala.map(_.getBytesFlushed).sum).sum
   }
 
+  def getActiveShuffleFileCount(): Long = {
+    fileInfos.size()
+  }
 }
 
 object StorageManager {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds new metric `ActiveShuffleFileCount` about active shuffle file count of Celeborn Worker.

### Why are the changes needed?

`ActiveShuffleSize` metric report the active shuffle size of peer worker at present. Therefore, it's better to introduce `ActiveShuffleFileCount` to report the active shuffle file count of Celeborn Worker.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal tests.