### PR TITLE
[CELEBORN-1061] Fix the bug if `celeborn.client.spark.shuffle.writer` is sort and `celeborn.client.spark.push.sort.pipeline.enabled` is false

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -43,8 +43,8 @@ public class SparkShuffleManager implements ShuffleManager {
 
   private static final Logger logger = LoggerFactory.getLogger(SparkShuffleManager.class);
 
-  private static final String sortShuffleManagerName =
-      "org.apache.spark.shuffle.sort.SortShuffleManager";
+  private static final String SORT_SHUFFLE_MANAGER_NAME =
+      org.apache.spark.shuffle.sort.SortShuffleManager.class.getName();
 
   private final SparkConf conf;
   private final Boolean isDriver;
@@ -89,7 +89,8 @@ public class SparkShuffleManager implements ShuffleManager {
     if (_sortShuffleManager == null) {
       synchronized (this) {
         if (_sortShuffleManager == null) {
-          _sortShuffleManager = SparkUtils.instantiateClass(sortShuffleManagerName, conf, isDriver);
+          _sortShuffleManager =
+              SparkUtils.instantiateClass(SORT_SHUFFLE_MANAGER_NAME, conf, isDriver);
         }
       }
     }
@@ -186,16 +187,15 @@ public class SparkShuffleManager implements ShuffleManager {
                 h.lifecycleManagerPort(),
                 celebornConf,
                 h.userIdentifier());
-        if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())) {
-          ExecutorService pushThread =
-              celebornConf.clientPushSortPipelineEnabled() ? getPusherThread() : null;
+        if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())
+            && celebornConf.clientPushSortPipelineEnabled()) {
           return new SortBasedShuffleWriter<>(
               h.dependency(),
               h.numMaps(),
               context,
               celebornConf,
               client,
-              pushThread,
+              getPusherThread(),
               SendBufferPool.get(cores, sendBufferPoolCheckInterval, sendBufferPoolExpireTimeout));
         } else if (ShuffleMode.HASH.equals(celebornConf.shuffleWriterMode())) {
           return new HashBasedShuffleWriter<>(

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -43,7 +43,7 @@ public class SparkShuffleManager implements ShuffleManager {
   private static final Logger logger = LoggerFactory.getLogger(SparkShuffleManager.class);
 
   private static final String SORT_SHUFFLE_MANAGER_NAME =
-      "org.apache.spark.shuffle.sort.SortShuffleManager";
+      org.apache.spark.shuffle.sort.SortShuffleManager.class.getName();
 
   private static final boolean COLUMNAR_SHUFFLE_CLASSES_PRESENT;
 
@@ -216,9 +216,8 @@ public class SparkShuffleManager implements ShuffleManager {
                 h.lifecycleManagerPort(),
                 celebornConf,
                 h.userIdentifier());
-        if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())) {
-          ExecutorService pushThread =
-              celebornConf.clientPushSortPipelineEnabled() ? getPusherThread() : null;
+        if (ShuffleMode.SORT.equals(celebornConf.shuffleWriterMode())
+            && celebornConf.clientPushSortPipelineEnabled()) {
           return new SortBasedShuffleWriter<>(
               h.dependency(),
               h.numMappers(),
@@ -226,7 +225,7 @@ public class SparkShuffleManager implements ShuffleManager {
               celebornConf,
               shuffleClient,
               metrics,
-              pushThread,
+              getPusherThread(),
               SendBufferPool.get(cores, sendBufferPoolCheckInterval, sendBufferPoolExpireTimeout));
         } else if (ShuffleMode.HASH.equals(celebornConf.shuffleWriterMode())) {
           SendBufferPool pool =


### PR DESCRIPTION
### What changes were proposed in this pull request?
`SparkShuffleManager` may throws `NullPointerException` if `celeborn.client.spark.shuffle.writer` is sort and `celeborn.client.spark.push.sort.pipeline.enabled` is false.

### Why are the changes needed?
Currently, if `celeborn.client.spark.shuffle.writer` is sort and `celeborn.client.spark.push.sort.pipeline.enabled` is false, the `SparkShuffleManager.asyncPushers` will be null. When calling `SparkShuffleManager. getWriter `, the null pusher thread used to construct `SortBasedShuffleWriter`. `SortBasedPusher.triggerPush` causes `NullPointerException`.


### Does this PR introduce _any_ user-facing change?
Yes.
Fix a bug.


### How was this patch tested?
Exists test cases.
