### PR TITLE
[METRICS] Return metrics snapshot separated by new line

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/sink/PrometheusServlet.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/sink/PrometheusServlet.scala
@@ -39,7 +39,7 @@ class PrometheusServlet(
   }
 
   def getMetricsSnapshot: String = {
-    sources.map(_.getMetrics).mkString
+    sources.map(_.getMetrics).mkString("\n")
   }
 
   override def start(): Unit = {}

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -412,7 +412,7 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
     val sb = new mutable.StringBuilder
     innerMetrics.synchronized {
       while (!innerMetrics.isEmpty) {
-        sb.append(innerMetrics.poll())
+        sb.append(innerMetrics.poll()).append("\n")
       }
       innerMetrics.clear()
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Now for the metrics snapshot, all of them flatten in one line.
<img width="1722" alt="image" src="https://github.com/apache/incubator-celeborn/assets/6757692/97085a08-6499-4a86-b787-6ac758ad6606">

In this pr, the metrics snapshot will be separated by new line.


### Why are the changes needed?
User friendly for metrics review.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Test locally.