### PR TITLE
[CELEBORN-1066] Skip looping streamimg sets in numShuffleSteams of ChunkStreamManager

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
@@ -206,6 +206,6 @@ public class ChunkStreamManager {
 
   @VisibleForTesting
   public long numShuffleSteams() {
-    return shuffleStreamIds.values().stream().flatMap(Set::stream).count();
+    return shuffleStreamIds.values().stream().mapToLong(Set::size).sum();
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- Minor improvement in `ChunkStreamManager.numShuffleSteams`, by replacing `.flatMap(Set::stream).count()` to `.mapToLong(Set::size).sum()`

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI tests.