### PR TITLE
[CELEBORN-1076] Using text/plain content type for prometheus metrics

### DIFF
--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpRequestHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpRequestHandler.scala
@@ -61,7 +61,7 @@ class HttpRequestHandler(
       HttpVersion.HTTP_1_1,
       HttpResponseStatus.OK,
       Unpooled.copiedBuffer(response, CharsetUtil.UTF_8))
-    res.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8\\n")
+    res.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8")
     ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE)
   }
 }

--- a/service/src/main/scala/org/apache/celeborn/server/common/http/HttpRequestHandler.scala
+++ b/service/src/main/scala/org/apache/celeborn/server/common/http/HttpRequestHandler.scala
@@ -61,7 +61,7 @@ class HttpRequestHandler(
       HttpVersion.HTTP_1_1,
       HttpResponseStatus.OK,
       Unpooled.copiedBuffer(response, CharsetUtil.UTF_8))
-    res.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+    res.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8\\n")
     ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Refer https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#basic-info

The http content type is better be `text/plain`.


### Why are the changes needed?

As describe in https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#basic-info.

Advantages
```
Human-readable
Easy to assemble, especially for minimalistic cases (no nesting required)
Readable line by line (with the exception of type hints and docstrings)
```
### Does this PR introduce _any_ user-facing change?
The http content type change.


### How was this patch tested?
<img width="910" alt="image" src="https://github.com/apache/incubator-celeborn/assets/6757692/6cc9b071-3149-48fb-9aab-66506a72be3f">

