### PR TITLE
CELEBORN-1068: Fix hashCode computation

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
@@ -81,8 +81,8 @@ public final class OpenStream extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(Arrays.hashCode(shuffleKey), Arrays.hashCode(fileName),
-        startMapIndex, endMapIndex);
+    return Objects.hashCode(
+        Arrays.hashCode(shuffleKey), Arrays.hashCode(fileName), startMapIndex, endMapIndex);
   }
 
   @Override

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
@@ -81,7 +81,8 @@ public final class OpenStream extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(shuffleKey, fileName, startMapIndex, endMapIndex);
+    return Objects.hashCode(Arrays.hashCode(shuffleKey), Arrays.hashCode(fileName),
+        startMapIndex, endMapIndex);
   }
 
   @Override

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushMergedData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushMergedData.java
@@ -99,7 +99,7 @@ public final class PushMergedData extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(requestId, mode, shuffleKey, partitionUniqueIds, batchOffsets, body());
+    return Objects.hashCode(requestId, mode, shuffleKey);
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `hashCode` for an array does not hash the content - but just the identity array reference.
This was identified as part of enabling error prone (See #2016)
See more [here](https://errorprone.info/bugpattern/ArrayHashCode)


### Why are the changes needed?
Fix bug with `hashCode` computation as identified by error-prone


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit tests
