### PR TITLE
CELEBORN-1069: Avoid double brace initialization

### DIFF
--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -309,12 +310,7 @@ public class DefaultMetaSystemSuiteJ {
         HOSTNAME1 + ":" + RPCPORT1 + ":" + PUSHPORT1 + ":" + FETCHPORT1 + ":" + REPLICATEPORT1);
 
     List<Map<String, Integer>> workerSlots = new ArrayList<>();
-    workerSlots.add(
-        new HashMap() {
-          {
-            put("disk1", 3);
-          }
-        });
+    workerSlots.add(ImmutableMap.of("disk1", 3));
 
     Assert.assertEquals(
         0,

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.*;
 import org.mockito.Mockito;
 
@@ -167,7 +168,7 @@ public class RatisMasterStatusSystemSuiteJ {
   private static int PUSHPORT1 = 1112;
   private static int FETCHPORT1 = 1113;
   private static int REPLICATEPORT1 = 1114;
-  private static Map<String, DiskInfo> disks1 = new HashMap() {};
+  private static Map<String, DiskInfo> disks1 = new HashMap();
   private static Map<UserIdentifier, ResourceConsumption> userResourceConsumption1 =
       new HashMap<>();
 
@@ -487,12 +488,7 @@ public class RatisMasterStatusSystemSuiteJ {
         HOSTNAME1 + ":" + RPCPORT1 + ":" + PUSHPORT1 + ":" + FETCHPORT1 + ":" + REPLICATEPORT1);
 
     List<Map<String, Integer>> workerSlots = new ArrayList<>();
-    workerSlots.add(
-        new HashMap() {
-          {
-            put("disk1", 3);
-          }
-        });
+    workerSlots.add(ImmutableMap.of("disk1", 3));
 
     Thread.sleep(3000L);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid double brace initialization. See more [here](https://errorprone.info/bugpattern/DoubleBraceInitialization)
Note that in this case, there is no actual functional or performance issue - since it is happening in test cases.


### Why are the changes needed?

Once fixed, error-prone can catch future violations as part of build as Celeborn evolves.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit tests
