### PR TITLE
[CELEBORN-1073] Avoid memory copying in TransportMessage.toByteBuffer by using wrapping payload into CompositeByteBuf

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
@@ -17,25 +17,36 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.protobuf.GeneratedMessageV3;
-import com.google.protobuf.InvalidProtocolBufferException;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import org.apache.celeborn.common.exception.CelebornIOException;
-import org.apache.celeborn.common.protocol.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.apache.celeborn.common.protocol.MessageType.*;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 
-import static org.apache.celeborn.common.protocol.MessageType.*;
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.exception.CelebornIOException;
+import org.apache.celeborn.common.protocol.MessageType;
+import org.apache.celeborn.common.protocol.PbBacklogAnnouncement;
+import org.apache.celeborn.common.protocol.PbBufferStreamEnd;
+import org.apache.celeborn.common.protocol.PbChunkFetchRequest;
+import org.apache.celeborn.common.protocol.PbOpenStream;
+import org.apache.celeborn.common.protocol.PbPushDataHandShake;
+import org.apache.celeborn.common.protocol.PbReadAddCredit;
+import org.apache.celeborn.common.protocol.PbRegionFinish;
+import org.apache.celeborn.common.protocol.PbRegionStart;
+import org.apache.celeborn.common.protocol.PbStreamChunkSlice;
+import org.apache.celeborn.common.protocol.PbStreamHandler;
+import org.apache.celeborn.common.protocol.PbTransportableError;
 
 public class TransportMessage implements Serializable {
   private static final long serialVersionUID = -3259000920699629773L;
   private static Logger logger = LoggerFactory.getLogger(TransportMessage.class);
-  @Deprecated
-  private final MessageType type;
+  @Deprecated private final MessageType type;
   private final int messageTypeValue;
   private final byte[] payload;
 

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
@@ -24,6 +24,8 @@ import java.nio.ByteBuffer;
 
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.InvalidProtocolBufferException;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,13 +99,11 @@ public class TransportMessage implements Serializable {
   }
 
   public ByteBuffer toByteBuffer() {
-    int totalBufferSize = payload.length + 4 + 4;
-    ByteBuffer buffer = ByteBuffer.allocate(totalBufferSize);
-    buffer.putInt(messageTypeValue);
-    buffer.putInt(payload.length);
-    buffer.put(payload);
-    buffer.flip();
-    return buffer;
+    CompositeByteBuf buffer = Unpooled.compositeBuffer();
+    buffer.writeInt(messageTypeValue);
+    buffer.writeInt(payload.length);
+    buffer.writeBytes(Unpooled.wrappedBuffer(payload));
+    return buffer.nioBuffer();
   }
 
   public static TransportMessage fromByteBuffer(ByteBuffer buffer) throws CelebornIOException {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
@@ -17,36 +17,25 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import static org.apache.celeborn.common.protocol.MessageType.*;
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.celeborn.common.exception.CelebornIOException;
+import org.apache.celeborn.common.protocol.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 
-import com.google.protobuf.GeneratedMessageV3;
-import com.google.protobuf.InvalidProtocolBufferException;
-import io.netty.buffer.CompositeByteBuf;
-import io.netty.buffer.Unpooled;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.apache.celeborn.common.exception.CelebornIOException;
-import org.apache.celeborn.common.protocol.MessageType;
-import org.apache.celeborn.common.protocol.PbBacklogAnnouncement;
-import org.apache.celeborn.common.protocol.PbBufferStreamEnd;
-import org.apache.celeborn.common.protocol.PbChunkFetchRequest;
-import org.apache.celeborn.common.protocol.PbOpenStream;
-import org.apache.celeborn.common.protocol.PbPushDataHandShake;
-import org.apache.celeborn.common.protocol.PbReadAddCredit;
-import org.apache.celeborn.common.protocol.PbRegionFinish;
-import org.apache.celeborn.common.protocol.PbRegionStart;
-import org.apache.celeborn.common.protocol.PbStreamChunkSlice;
-import org.apache.celeborn.common.protocol.PbStreamHandler;
-import org.apache.celeborn.common.protocol.PbTransportableError;
+import static org.apache.celeborn.common.protocol.MessageType.*;
 
 public class TransportMessage implements Serializable {
   private static final long serialVersionUID = -3259000920699629773L;
   private static Logger logger = LoggerFactory.getLogger(TransportMessage.class);
-  @Deprecated private final MessageType type;
+  @Deprecated
+  private final MessageType type;
   private final int messageTypeValue;
   private final byte[] payload;
 
@@ -99,10 +88,9 @@ public class TransportMessage implements Serializable {
   }
 
   public ByteBuffer toByteBuffer() {
-    CompositeByteBuf buffer = Unpooled.compositeBuffer();
-    buffer.writeInt(messageTypeValue);
-    buffer.writeInt(payload.length);
-    buffer.writeBytes(Unpooled.wrappedBuffer(payload));
+    ByteBuf headerBuf = Unpooled.buffer().writeInt(messageTypeValue).writeInt(payload.length);
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
+    ByteBuf buffer = Unpooled.wrappedBuffer(headerBuf, payloadBuf);
     return buffer.nioBuffer();
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
TransportMessage.toByteBuffer copies its payload byte array to a new dedicated byte array. Change to use Netty's CompositeByteBuf helps to reuse the payload array and skip redundant byte array copying and for less memory footprint. And also prevents manually shifting offset (+4 +4) for integers of the message header.

### Why are the changes needed?
To skip redundant byte array copying and for less memory footprint.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI tests.