### PR TITLE
[CELEBORN-1074] Bump Guava from 14.0.1 to 32.1.3

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/FileSegmentManagedBuffer.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.io.ByteStreams;
 import io.netty.channel.DefaultFileRegion;
 
@@ -145,7 +145,7 @@ public final class FileSegmentManagedBuffer extends ManagedBuffer {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("file", file)
         .add("offset", offset)
         .add("length", length)

--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/NettyManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/NettyManagedBuffer.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
@@ -77,6 +77,6 @@ public class NettyManagedBuffer extends ManagedBuffer {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("buf", buf).toString();
+    return MoreObjects.toStringHelper(this).add("buf", buf).toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/NioManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/NioManagedBuffer.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
 
@@ -65,6 +65,6 @@ public class NioManagedBuffer extends ManagedBuffer {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("buf", buf).toString();
+    return MoreObjects.toStringHelper(this).add("buf", buf).toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.SettableFuture;
 import io.netty.channel.Channel;
@@ -314,7 +314,7 @@ public class TransportClient implements Closeable {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("remoteAddress", channel.remoteAddress())
         .add("isActive", isActive())
         .toString();

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -70,7 +71,7 @@ public final class ChunkFetchFailure extends ResponseMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("streamChunkId", streamChunkSlice)
         .add("errorString", errorString)
         .toString();

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import io.netty.buffer.ByteBuf;
 
 /**
@@ -67,6 +67,6 @@ public final class ChunkFetchRequest extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("streamChunkId", streamChunkSlice).toString();
+    return MoreObjects.toStringHelper(this).add("streamChunkId", streamChunkSlice).toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -90,7 +91,7 @@ public final class ChunkFetchSuccess extends ResponseMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("streamChunkId", streamChunkSlice)
         .add("buffer", body())
         .toString();

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/OneWayMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/OneWayMessage.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -80,6 +81,6 @@ public final class OneWayMessage extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("body", body()).toString();
+    return MoreObjects.toStringHelper(this).add("body", body()).toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
@@ -20,6 +20,7 @@ package org.apache.celeborn.common.network.protocol;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -99,7 +100,7 @@ public final class OpenStream extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("shuffleKey", new String(shuffleKey, StandardCharsets.UTF_8))
         .add("fileName", new String(fileName, StandardCharsets.UTF_8))
         .add("startMapIndex", startMapIndex)

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushData.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -104,7 +105,7 @@ public final class PushData extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("requestId", requestId)
         .add("mode", mode)
         .add("shuffleKey", shuffleKey)

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushDataHandShake.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushDataHandShake.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -104,7 +105,7 @@ public final class PushDataHandShake extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("mode", mode)
         .add("shuffleKey", shuffleKey)
         .add("partitionUniqueId", partitionUniqueId)

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushMergedData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushMergedData.java
@@ -19,6 +19,7 @@ package org.apache.celeborn.common.network.protocol;
 
 import java.util.Arrays;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -118,7 +119,7 @@ public final class PushMergedData extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("requestId", requestId)
         .add("mode", mode)
         .add("shuffleKey", shuffleKey)

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionFinish.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionFinish.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -86,7 +87,7 @@ public final class RegionFinish extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("mode", mode)
         .add("shuffleKey", shuffleKey)
         .add("partitionUniqueId", partitionUniqueId)

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionStart.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionStart.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -106,7 +107,7 @@ public final class RegionStart extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("mode", mode)
         .add("shuffleKey", shuffleKey)
         .add("partitionUniqueId", partitionUniqueId)

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcFailure.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -68,7 +69,7 @@ public final class RpcFailure extends ResponseMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("requestId", requestId)
         .add("errorString", errorString)
         .toString();

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcRequest.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -88,6 +89,9 @@ public final class RpcRequest extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("requestId", requestId).add("body", body()).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("requestId", requestId)
+        .add("body", body())
+        .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcResponse.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcResponse.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -88,6 +89,9 @@ public final class RpcResponse extends ResponseMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("requestId", requestId).add("body", body()).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("requestId", requestId)
+        .add("body", body())
+        .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamChunkSlice.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamChunkSlice.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -85,7 +86,7 @@ public final class StreamChunkSlice implements Encodable {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("streamId", streamId)
         .add("chunkIndex", chunkIndex)
         .add("offset", offset)

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamHandle.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamHandle.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
@@ -70,7 +71,7 @@ public final class StreamHandle extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("streamId", streamId)
         .add("numChunks", numChunks)
         .toString();

--- a/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
@@ -33,7 +33,7 @@ import org.apache.celeborn.common.internal.Logging
 object ThreadUtils {
 
   private val sameThreadExecutionContext =
-    ExecutionContext.fromExecutorService(MoreExecutors.sameThreadExecutor())
+    ExecutionContext.fromExecutorService(MoreExecutors.newDirectExecutorService())
 
   /**
    * An `ExecutionContextExecutor` that runs each task in the thread that invokes `execute/submit`.

--- a/dev/dependencies.sh
+++ b/dev/dependencies.sh
@@ -25,7 +25,7 @@ export LC_ALL=C
 
 PWD=$(cd "$(dirname "$0")"/.. || exit; pwd)
 
-MVN="mvn"
+MVN="${PWD}/build/mvn"
 SBT="${PWD}/build/sbt"
 
 SBT_ENABLED="false"

--- a/dev/dependencies.sh
+++ b/dev/dependencies.sh
@@ -25,7 +25,7 @@ export LC_ALL=C
 
 PWD=$(cd "$(dirname "$0")"/.. || exit; pwd)
 
-MVN="${PWD}/build/mvn"
+MVN="mvn"
 SBT="${PWD}/build/sbt"
 
 SBT_ENABLED="false"

--- a/dev/deps/dependencies-client-flink-1.14
+++ b/dev/deps/dependencies-client-flink-1.14
@@ -16,18 +16,23 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-client-flink-1.15
+++ b/dev/deps/dependencies-client-flink-1.15
@@ -16,18 +16,23 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-client-flink-1.17
+++ b/dev/deps/dependencies-client-flink-1.17
@@ -16,18 +16,23 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -22,6 +22,7 @@ aopalliance/1.0//aopalliance-1.0.jar
 asm/9.1//asm-9.1.jar
 audience-annotations/0.5.0//audience-annotations-0.5.0.jar
 avro/1.7.7//avro-1.7.7.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-beanutils/1.9.4//commons-beanutils-1.9.4.jar
 commons-cli/1.2//commons-cli-1.2.jar
 commons-codec/1.11//commons-codec-1.11.jar
@@ -41,9 +42,11 @@ curator-framework/2.13.0//curator-framework-2.13.0.jar
 curator-recipes/2.13.0//curator-recipes-2.13.0.jar
 dnsjava/2.1.7//dnsjava-2.1.7.jar
 ehcache/3.3.1//ehcache-3.3.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
 geronimo-jcache_1.0_spec/1.0-alpha-1//geronimo-jcache_1.0_spec-1.0-alpha-1.jar
 gson/2.9.0//gson-2.9.0.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 guice-servlet/4.0//guice-servlet-4.0.jar
 guice/4.0//guice-4.0.jar
 hadoop-annotations/3.2.4//hadoop-annotations-3.2.4.jar
@@ -66,6 +69,7 @@ hadoop-yarn-server-web-proxy/3.2.4//hadoop-yarn-server-web-proxy-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
 httpclient/4.5.13//httpclient-4.5.13.jar
 httpcore/4.4.13//httpcore-4.4.13.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.10.5//jackson-core-2.10.5.jar
 jackson-jaxrs-base/2.10.5//jackson-jaxrs-base-2.10.5.jar
@@ -120,6 +124,7 @@ kerby-pkix/1.0.1//kerby-pkix-1.0.1.jar
 kerby-util/1.0.1//kerby-util-1.0.1.jar
 kerby-xdr/1.0.1//kerby-xdr-1.0.1.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-client-spark-2.4
+++ b/dev/deps/dependencies-client-spark-2.4
@@ -16,18 +16,23 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.4.0//lz4-java-1.4.0.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -16,18 +16,23 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -16,18 +16,23 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -16,18 +16,23 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.7.1//lz4-java-1.7.1.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -16,18 +16,23 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -16,18 +16,23 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-client-spark-3.5
+++ b/dev/deps/dependencies-client-spark-3.5
@@ -16,18 +16,23 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/3.2.6//metrics-core-3.2.6.jar
 metrics-graphite/3.2.6//metrics-graphite-3.2.6.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -16,21 +16,26 @@
 #
 
 RoaringBitmap/0.9.32//RoaringBitmap-0.9.32.jar
+checker-qual/3.37.0//checker-qual-3.37.0.jar
 commons-cli/1.5.0//commons-cli-1.5.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+error_prone_annotations/2.21.1//error_prone_annotations-2.21.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 javassist/3.28.0-GA//javassist-3.28.0-GA.jar
 javax.servlet-api/3.1.0//javax.servlet-api-3.1.0.jar
 jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jsr305/1.3.9//jsr305-1.3.9.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 log4j-1.2-api/2.17.2//log4j-1.2-api-2.17.2.jar
 log4j-api/2.17.2//log4j-api-2.17.2.jar
 log4j-core/2.17.2//log4j-core-2.17.2.jar

--- a/dev/reformat
+++ b/dev/reformat
@@ -19,9 +19,9 @@
 set -x
 
 PROJECT_DIR="$(cd "`dirname "$0"`/.."; pwd)"
-mvn spotless:apply -Pflink-1.14
-mvn spotless:apply -Pflink-1.15
-mvn spotless:apply -Pflink-1.17
-mvn spotless:apply -Pspark-2.4
-mvn spotless:apply -Pspark-3.3
-mvn spotless:apply -Pmr
+${PROJECT_DIR}/build/mvn spotless:apply -Pflink-1.14
+${PROJECT_DIR}/build/mvn spotless:apply -Pflink-1.15
+${PROJECT_DIR}/build/mvn spotless:apply -Pflink-1.17
+${PROJECT_DIR}/build/mvn spotless:apply -Pspark-2.4
+${PROJECT_DIR}/build/mvn spotless:apply -Pspark-3.3
+${PROJECT_DIR}/build/mvn spotless:apply -Pmr

--- a/dev/reformat
+++ b/dev/reformat
@@ -19,9 +19,9 @@
 set -x
 
 PROJECT_DIR="$(cd "`dirname "$0"`/.."; pwd)"
-${PROJECT_DIR}/build/mvn spotless:apply -Pflink-1.14
-${PROJECT_DIR}/build/mvn spotless:apply -Pflink-1.15
-${PROJECT_DIR}/build/mvn spotless:apply -Pflink-1.17
-${PROJECT_DIR}/build/mvn spotless:apply -Pspark-2.4
-${PROJECT_DIR}/build/mvn spotless:apply -Pspark-3.3
-${PROJECT_DIR}/build/mvn spotless:apply -Pmr
+mvn spotless:apply -Pflink-1.14
+mvn spotless:apply -Pflink-1.15
+mvn spotless:apply -Pflink-1.17
+mvn spotless:apply -Pspark-2.4
+mvn spotless:apply -Pspark-3.3
+mvn spotless:apply -Pmr

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <commons-crypto.version>1.0.0</commons-crypto.version>
     <google.jsr305.version>1.3.9</google.jsr305.version>
     <grpc.version>1.44.0</grpc.version>
-    <guava.version>14.0.1</guava.version>
+    <guava.version>32.1.3-jre</guava.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
     <junit.version>4.13.2</junit.version>
     <leveldb.version>1.8</leveldb.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Bump Guava from 14.0.1 to 32.1.3, to :
- To modernize the API usage of Guava library.
- Previously unstable classes or APIs are removed `@Beta` marks, including
  - 'com.google.common.reflect.ClassPath'
  - 'com.google.common.util.concurrent.Uninterruptibles'
  - 'com.google.common.io.Files'
  - 'com.google.common.io.ByteStreams'


### Why are the changes needed?

As titled.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI tests.