### PR TITLE
[CELEBORN-1070] Add error-prone to pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
 
     <maven.plugin.antrun.version>3.0.0</maven.plugin.antrun.version>
     <maven.plugin.clean.version>3.2.0</maven.plugin.clean.version>
+    <maven.plugin.compiler.version>3.11.0</maven.plugin.compiler.version>
     <maven.plugin.dependency.version>3.1.1</maven.plugin.dependency.version>
     <maven.plugin.flatten.version>1.3.0</maven.plugin.flatten.version>
     <maven.plugin.jacoco.version>0.8.7</maven.plugin.jacoco.version>
@@ -870,7 +871,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>${maven.plugin.compiler.version}</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
@@ -886,11 +887,6 @@
                 <artifactId>error_prone_core</artifactId>
                 <version>${error-prone.version}</version>
               </path>
-              <!-- Other annotation processors go here.
-
-              If 'annotationProcessorPaths' is set, processors will no longer be
-              discovered on the regular -classpath; see also 'Using Error Prone
-              together with other annotation processors' below. -->
             </annotationProcessorPaths>
           </configuration>
         </plugin>
@@ -1140,6 +1136,7 @@
       </properties>
       <build>
         <plugins>
+          <!-- based on https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-8 -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
@@ -1201,11 +1198,6 @@
                   <artifactId>error_prone_core</artifactId>
                   <version>${error-prone.version}</version>
                 </path>
-                <!-- Other annotation processors go here.
-
-                If 'annotationProcessorPaths' is set, processors will no longer be
-                discovered on the regular -classpath; see also 'Using Error Prone
-                together with other annotation processors' below. -->
               </annotationProcessorPaths>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1174,7 +1174,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.11.0</version>
+            <version>${maven.plugin.compiler.version}</version>
             <configuration>
               <source>${java.version}</source>
               <target>${java.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,9 @@
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-io.version>2.13.0</commons-io.version>
     <commons-crypto.version>1.0.0</commons-crypto.version>
+    <!-- last version to support compilation in java 8 -->
+    <error-prone.version>2.10.0</error-prone.version>
+    <error-prone.jdk8.workaround.javac.version>9+181-r4173-1</error-prone.jdk8.workaround.javac.version>
     <google.jsr305.version>1.3.9</google.jsr305.version>
     <grpc.version>1.44.0</grpc.version>
     <guava.version>14.0.1</guava.version>
@@ -864,6 +867,32 @@
           </executions>
         </plugin>
 
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
+          <configuration>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
+            <encoding>UTF-8</encoding>
+            <compilerArgs>
+              <arg>-XDcompilePolicy=simple</arg>
+              <arg>-Xplugin:ErrorProne</arg>
+            </compilerArgs>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>${error-prone.version}</version>
+              </path>
+              <!-- Other annotation processors go here.
+
+              If 'annotationProcessorPaths' is set, processors will no longer be
+              discovered on the regular -classpath; see also 'Using Error Prone
+              together with other annotation processors' below. -->
+            </annotationProcessorPaths>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -1108,6 +1137,20 @@
       <properties>
         <java.version>8</java.version>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${error-prone.jdk8.workaround.javac.version}/javac-${error-prone.jdk8.workaround.javac.version}.jar</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <commons-crypto.version>1.0.0</commons-crypto.version>
     <!-- last version to support compilation in java 8. See https://errorprone.info/docs/installation#:~:text=you%20are%20using.-,JDK%208,-Error%20Prone%202.10.0 -->
     <error-prone.version>2.10.0</error-prone.version>
-    <error-prone.jdk8.workaround.javac.version>9+181-r4173-1</error-prone.jdk8.workaround.javac.version>
+    <error-prone.jdk8.javac.version>9+181-r4173-1</error-prone.jdk8.javac.version>
     <google.jsr305.version>1.3.9</google.jsr305.version>
     <grpc.version>1.44.0</grpc.version>
     <guava.version>14.0.1</guava.version>
@@ -1142,7 +1142,7 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
               <compilerArgs combine.children="append">
-                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${error-prone.jdk8.workaround.javac.version}/javac-${error-prone.jdk8.workaround.javac.version}.jar</arg>
+                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${error-prone.jdk8.javac.version}/javac-${error-prone.jdk8.javac.version}.jar</arg>
               </compilerArgs>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1136,7 +1136,7 @@
       </properties>
       <build>
         <plugins>
-          <!-- based on https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-8 -->
+          <!-- Based on https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-8 -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
@@ -1170,6 +1170,7 @@
       </properties>
       <build>
         <plugins>
+          <!-- Based on https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-io.version>2.13.0</commons-io.version>
     <commons-crypto.version>1.0.0</commons-crypto.version>
-    <!-- last version to support compilation in java 8 -->
+    <!-- last version to support compilation in java 8. See https://errorprone.info/docs/installation#:~:text=you%20are%20using.-,JDK%208,-Error%20Prone%202.10.0 -->
     <error-prone.version>2.10.0</error-prone.version>
     <error-prone.jdk8.workaround.javac.version>9+181-r4173-1</error-prone.jdk8.workaround.javac.version>
     <google.jsr305.version>1.3.9</google.jsr305.version>

--- a/pom.xml
+++ b/pom.xml
@@ -875,6 +875,7 @@
             <source>${java.version}</source>
             <target>${java.version}</target>
             <encoding>UTF-8</encoding>
+            <fork>true</fork>
             <compilerArgs>
               <arg>-XDcompilePolicy=simple</arg>
               <arg>-Xplugin:ErrorProne</arg>
@@ -1143,7 +1144,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <fork>true</fork>
               <compilerArgs combine.children="append">
                 <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${error-prone.jdk8.workaround.javac.version}/javac-${error-prone.jdk8.workaround.javac.version}.jar</arg>
               </compilerArgs>
@@ -1171,6 +1171,46 @@
       <properties>
         <java.version>17</java.version>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.11.0</version>
+            <configuration>
+              <source>${java.version}</source>
+              <target>${java.version}</target>
+              <encoding>UTF-8</encoding>
+              <compilerArgs>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xplugin:ErrorProne</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+              </compilerArgs>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${error-prone.version}</version>
+                </path>
+                <!-- Other annotation processors go here.
+
+                If 'annotationProcessorPaths' is set, processors will no longer be
+                discovered on the regular -classpath; see also 'Using Error Prone
+                together with other annotation processors' below. -->
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add [error prone](https://errorprone.info/) to the build.
Error Prone is a static analysis tool that cam catch common bugs and mistakes during compilation.


### Why are the changes needed?
Catch potential issues during build


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Local build
