### PR TITLE
[CELEBORN-1007][FOLLOWUP] Exclude unsupported prometheus gauge metrics for jvm thread state

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -67,7 +67,8 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
   val staticLabels: Map[String, String] = conf.metricsExtraLabels + roleLabel
   val staticLabelsString: String = MetricLabels.labelString(staticLabels)
 
-  protected val namedGauges: JList[NamedGauge[_]] = new JArrayList[NamedGauge[_]]()
+  // Visible for testing
+  protected[source] val namedGauges: JList[NamedGauge[_]] = new JArrayList[NamedGauge[_]]()
 
   def addGauge[T](
       name: String,

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/JVMSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/JVMSource.scala
@@ -87,8 +87,10 @@ class JVMSource(conf: CelebornConf, role: String) extends AbstractSource(conf, r
     })
 
   Seq(new ThreadStatesGaugeSet()).map(_.getMetrics.asScala.map {
-    case (name: String, metric: Gauge[_]) =>
+    case (name: String, metric: Gauge[_]) if metric.getValue.isInstanceOf[Number] =>
       addGauge(MetricRegistry.name(JVM_METRIC_THREAD_PREFIX, name), metric)
+    case (name: String, metric: Gauge[_]) =>
+      logWarning(s"Unsupported prometheus gauge type: $name: $metric")
     case (name, metric) => new IllegalArgumentException(s"Unknown metric type: $name: $metric")
   })
 

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/source/JVMSourceSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/source/JVMSourceSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.celeborn.common.metrics.source
 
+import scala.collection.JavaConverters._
+
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 
@@ -51,5 +53,7 @@ class JVMSourceSuite extends CelebornFunSuite {
     assert(memoryResult1._2 == Map.empty[String, String])
     assert(memoryResult2._1 == "jvm.memory.pools.init")
     assert(memoryResult2._2 == Map("name" -> "G1-Eden-Space"))
+
+    assert(!jvmSource.namedGauges.asScala.map(_.name).contains("jvm.thread.deadlocks"))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Since CELEBORN-1007, jvm thread state metrics involved.

For example:
```
metrics_jvm_thread_timed_waiting_count_Value{role="Worker"} 13 1698049548682
metrics_jvm_thread_deadlock_count_Value{role="Worker"} 0 1698049548683
metrics_jvm_thread_count_Value{role="Worker"} 86 1698049548683
metrics_jvm_thread_waiting_count_Value{role="Worker"} 27 1698049548683
metrics_jvm_thread_daemon_count_Value{role="Worker"} 83 1698049548683
metrics_jvm_thread_new_count_Value{role="Worker"} 0 1698049548683
metrics_jvm_thread_blocked_count_Value{role="Worker"} 0 1698049548683
metrics_jvm_thread_deadlocks_Value{role="Worker"} [] 1698049548683
metrics_jvm_thread_runnable_count_Value{role="Worker"} 48 1698049548683
metrics_jvm_thread_terminated_count_Value{role="Worker"} 0 1698049548684
```

But the format for prometheus is incorrect and I can not check the metrics in grafana.
FYI:
https://o11y.tools/metricslint/
<img width="1088" alt="image" src="https://github.com/apache/incubator-celeborn/assets/6757692/2b59247e-9c0d-4373-84e5-94a536376042">

So, in this pr, I exclude non-number gauge metrics for jvm thread state.

### Why are the changes needed?
Fix prometheus metrics format issue.


### Does this PR introduce _any_ user-facing change?
Yes, `metrics_jvm_thread_deadlocks_Value` was excluded since this pr.


### How was this patch tested?

UT.

After this pr:
<img width="1033" alt="image" src="https://github.com/apache/incubator-celeborn/assets/6757692/962e0608-2d80-4355-8d06-d0e38c6fcca3">
