### PR TITLE
[CELEBORN-1077][METRICS] Support to apply base legend format for all grafana metrics

### DIFF
--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -153,6 +153,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_WorkerCount_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -243,6 +244,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_RegisteredShuffleCount_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -333,6 +335,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_ApplicationCount_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -438,6 +441,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_IsActiveMaster_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -530,6 +534,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PartitionSize_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -622,6 +627,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PartitionWritten_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -713,6 +719,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PartitionFileCount_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -803,6 +810,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_OfferSlotsTime_Mean",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -892,6 +900,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_OfferSlotsTime_Max",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -981,6 +990,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_ExcludedWorkerCount_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -1070,6 +1080,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_LostWorkers_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -1174,6 +1185,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_SlotsAllocated_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -1264,6 +1276,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_ReserveSlotsTime_Mean",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -1354,6 +1367,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_ReserveSlotsTime_Max",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -1443,6 +1457,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_PausePushData_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -1532,6 +1547,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_PausePushDataAndReplicate_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -1622,6 +1638,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_PausePushDataTime_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -1711,6 +1728,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_ActiveConnectionCount_Count{}",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -1828,6 +1846,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_ActiveShuffleSize_Value",
+              "legendFormat": "$baseLegend",
               "instant": false,
               "range": true,
               "refId": "A"
@@ -1946,6 +1965,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_ActiveShuffleFileCount_Value",
+              "legendFormat": "$baseLegend",
               "instant": false,
               "range": true,
               "refId": "A"
@@ -2051,6 +2071,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_PrimaryPushDataTime_Mean",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -2140,6 +2161,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_PrimaryPushDataTime_Max",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -2229,6 +2251,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_ReplicaPushDataTime_Mean",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -2318,6 +2341,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_ReplicaPushDataTime_Max",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -2407,6 +2431,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_WriteDataFailCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -2497,6 +2522,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicateDataWriteFailCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -2587,6 +2613,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicateDataFailCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -2677,6 +2704,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicateDataTimeoutCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -2767,6 +2795,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicateDataConnectionExceptionCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -2857,6 +2886,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicateDataCreateConnectionFailCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -2961,6 +2991,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_OpenStreamTime_Mean",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3050,6 +3081,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_OpenStreamTime_Max",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3139,6 +3171,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_FetchChunkTime_Mean",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3228,6 +3261,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_FetchChunkTime_Max",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3331,6 +3365,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_TakeBufferTime_Mean",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3420,6 +3455,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_TakeBufferTime_Max",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3509,6 +3545,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_FlushDataTime_Mean",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3598,6 +3635,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_FlushDataTime_Max",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3687,6 +3725,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_CommitFilesTime_Mean",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3776,6 +3815,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_CommitFilesTime_Max",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3879,6 +3919,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_NettyMemory_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -3968,6 +4009,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_DiskBuffer_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -4058,6 +4100,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_push_usedHeapMemory_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -4149,6 +4192,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_push_usedDirectMemory_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -4240,6 +4284,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_fetch_usedHeapMemory_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -4331,6 +4376,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_fetch_usedDirectMemory_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -4422,6 +4468,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_replicate_usedHeapMemory_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -4513,6 +4560,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_replicate_usedDirectMemory_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -4603,7 +4651,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_ReadBufferAllocatedCount_Value",
-              "legendFormat": "__auto",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -4695,7 +4743,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_BufferStreamReadBuffer_Value",
-              "legendFormat": "__auto",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -4786,7 +4834,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_ReadBufferDispatcherRequestsLength_Value",
-              "legendFormat": "__auto",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -4891,6 +4939,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_SortTime_Mean",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -4980,6 +5029,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_SortTime_Max",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -5068,6 +5118,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_SortingFiles_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -5156,6 +5207,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_SortedFiles_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -5245,6 +5297,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "expr": "metrics_SortMemory_Value",
+              "legendFormat": "$baseLegend",
               "refId": "A"
             }
           ],
@@ -5334,6 +5387,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_SortedFileSize_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -5440,6 +5494,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PotentialConsumeSpeed_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -5532,6 +5587,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_WorkerConsumeSpeed_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -5624,6 +5680,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_UserProduceSpeed_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -5729,6 +5786,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PrimaryPushDataHandshakeTime_Mean",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -5820,6 +5878,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PrimaryPushDataHandshakeTime_Max",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -5911,6 +5970,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicaPushDataHandshakeTime_Mean",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6002,6 +6062,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicaPushDataHandshakeTime_Max",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6093,6 +6154,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PrimaryRegionStartTime_Mean",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6184,6 +6246,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PrimaryRegionStartTime_Max",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6275,6 +6338,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicaRegionStartTime_Mean",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6366,6 +6430,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicaRegionStartTime_Max",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6457,6 +6522,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PrimaryRegionFinishTime_Mean",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6548,6 +6614,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PrimaryRegionFinishTime_Max",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6639,6 +6706,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicaRegionFinishTime_Mean",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6730,6 +6798,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_ReplicaRegionFinishTime_Max",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6820,6 +6889,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_PushDataHandshakeFailCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -6910,6 +6980,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_RegionStartFailCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7000,6 +7071,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_RegionStartFailCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7104,7 +7176,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_CreditStreamCount_Value",
-              "legendFormat": "__auto",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7195,7 +7267,7 @@
               },
               "editorMode": "builder",
               "expr": "metrics_ActiveMapPartitionCount_Value",
-              "legendFormat": "__auto",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7301,7 +7373,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_JVMCPUTime_Value",
-              "legendFormat": "__auto",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7394,7 +7466,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_LastMinuteSystemLoad_Value",
-              "legendFormat": "__auto",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7487,7 +7559,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_DeviceOSFreeBytes_Value",
-              "legendFormat": "__auto",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7580,7 +7652,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_DeviceCelebornFreeBytes_Value",
-              "legendFormat": "__auto",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7673,7 +7745,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_AvailableProcessors_Value",
-              "legendFormat": "__auto",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7779,6 +7851,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_diskFileCount_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7871,6 +7944,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_diskBytesWritten_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -7962,6 +8036,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_hdfsFileCount_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -8054,6 +8129,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_hdfsBytesWritten_Value",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -8158,6 +8234,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_OutstandingFetchCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -8248,6 +8325,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_OutstandingRpcCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -8338,6 +8416,7 @@
               },
               "editorMode": "code",
               "expr": "metrics_OutstandingPushCount_Count",
+              "legendFormat": "$baseLegend",
               "range": true,
               "refId": "A"
             }
@@ -8363,12 +8442,12 @@
           "text": "__auto",
           "value": "__auto"
         },
-        "description": "The metrics legend format",
+        "description": "The base legend format to apply for all metrics",
         "hide": 0,
         "includeAll": false,
-        "label": "legend",
+        "label": "baseLegend",
         "multi": false,
-        "name": "legend",
+        "name": "baseLegend",
         "options": [
           {
             "selected": true,

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -8356,7 +8356,32 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "__auto",
+          "value": "__auto"
+        },
+        "description": "The metrics legend format",
+        "hide": 0,
+        "includeAll": false,
+        "label": "legend",
+        "multi": false,
+        "name": "legend",
+        "options": [
+          {
+            "selected": true,
+            "text": "__auto",
+            "value": "__auto"
+          }
+        ],
+        "query": "__auto",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
   },
   "time": {
     "from": "now-5m",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Apply base legend format for all grafana metrics.


### Why are the changes needed?

Before, the metrics dashboard is not readable easily.
<img width="836" alt="image" src="https://github.com/apache/incubator-celeborn/assets/6757692/4647834a-fa5b-42ca-8a98-3dad37c2cb13">

### Does this PR introduce _any_ user-facing change?
Yes. A variable introduced. 


### How was this patch tested?
Local Test.

Now, I can modify the variable value to `{{pod}}_{{cluster}}` and have a better insight.
<img width="853" alt="image" src="https://github.com/apache/incubator-celeborn/assets/6757692/a5cca8d9-37c3-4a18-9819-5a9861744cb9">

