### PR TITLE
CELEBORN-1079: Fix use of GuardedBy in client-flink/common

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.flink.core.memory.MemorySegment;

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
@@ -63,7 +63,6 @@ public class PartitionSortedBuffer implements SortBuffer {
   private final BufferPool bufferPool;
 
   /** A segment list as a joint buffer which stores all records and index entries. */
-  @GuardedBy("lock")
   private final ArrayList<MemorySegment> buffers = new ArrayList<>();
 
   /** Addresses of the first record's index entry for each subpartition. */
@@ -92,7 +91,6 @@ public class PartitionSortedBuffer implements SortBuffer {
   // For writing
   // ---------------------------------------------------------------------------------------------
   /** Whether this sort buffer is released. A released sort buffer can not be used. */
-  @GuardedBy("lock")
   private boolean isReleased;
   /** Array index in the segment list of the current available buffer for writing. */
   private int writeSegmentIndex;

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/TransferBufferPool.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/TransferBufferPool.java
@@ -155,6 +155,7 @@ public class TransferBufferPool implements BufferRecycler {
     }
   }
 
+  @GuardedBy("lock")
   private int assignCredits(CreditListener creditListener) {
     assert Thread.holdsLock(lock);
 
@@ -176,6 +177,7 @@ public class TransferBufferPool implements BufferRecycler {
     return numCredits;
   }
 
+  @GuardedBy("lock")
   private List<CreditAssignment> dispatchReservedCredits() {
     assert Thread.holdsLock(lock);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

* Fix use of `GuardedBy` on nonexistant lock.
* Annotate methods, which are expected to be called with lock held, with `GuardedBy` so that error prone can analyze all invocations

### Why are the changes needed?
There is no functional change, but it helps errorprone analysis.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit tests
