### PR TITLE
[CELEBORN-1084][FOLLOWUP][0.3] Import `mock` method to recover CI

### DIFF
--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -20,6 +20,7 @@ package org.apache.celeborn.service.deploy.worker.storage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?

The branch-0.3 CI process encountered a compiler error as follows:

```
Error:  /home/runner/work/incubator-celeborn/incubator-celeborn/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java:140:65:  error: cannot find symbol
Warning:  javac exited with exit code 1
```

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass GA