### PR TITLE
[CELEBORN-1089] Seperate overHighWatermark check to a dedicated thread

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1012,6 +1012,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(WORKER_CONGESTION_CONTROL_HIGH_WATERMARK)
   def workerCongestionControlUserInactiveIntervalMs: Long =
     get(WORKER_CONGESTION_CONTROL_USER_INACTIVE_INTERVAL)
+  def workerCongestionControlCheckIntervalMs: Long = get(WORKER_CONGESTION_CONTROL_CHECK_INTERVAL)
 
   // //////////////////////////////////////////////////////
   //                 Columnar Shuffle                    //
@@ -2630,6 +2631,15 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("10min")
+
+  val WORKER_CONGESTION_CONTROL_CHECK_INTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.worker.congestionControl.check.interval")
+      .categories("worker")
+      .doc(
+        s"Interval of worker checks congestion if ${WORKER_CONGESTION_CONTROL_ENABLED.key} is true.")
+      .version("0.3.2")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("10ms")
 
   val WORKER_DECOMMISSION_CHECK_INTERVAL: ConfigEntry[Long] =
     buildConf("celeborn.worker.decommission.checkInterval")

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -29,6 +29,7 @@ license: |
 | celeborn.worker.closeIdleConnections | false | Whether worker will close idle connections. | 0.2.0 | 
 | celeborn.worker.commitFiles.threads | 32 | Thread number of worker to commit shuffle data files asynchronously. It's recommended to set at least `128` when `HDFS` is enabled in `celeborn.storage.activeTypes`. | 0.3.0 | 
 | celeborn.worker.commitFiles.timeout | 120s | Timeout for a Celeborn worker to commit files of a shuffle. It's recommended to set at least `240s` when `HDFS` is enabled in `celeborn.storage.activeTypes`. | 0.3.0 | 
+| celeborn.worker.congestionControl.check.interval | 10ms | Interval of worker checks congestion if celeborn.worker.congestionControl.enabled is true. | 0.3.2 | 
 | celeborn.worker.congestionControl.enabled | false | Whether to enable congestion control or not. | 0.3.0 | 
 | celeborn.worker.congestionControl.high.watermark | &lt;undefined&gt; | If the total bytes in disk buffer exceeds this configure, will start to congestusers whose produce rate is higher than the potential average consume rate. The congestion will stop if the produce rate is lower or equal to the average consume rate, or the total pending bytes lower than celeborn.worker.congestionControl.low.watermark | 0.3.0 | 
 | celeborn.worker.congestionControl.low.watermark | &lt;undefined&gt; | Will stop congest users if the total pending bytes of disk buffer is lower than this configuration | 0.3.0 | 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -128,7 +128,8 @@ private[celeborn] class Worker(
       conf.workerCongestionControlSampleTimeWindowSeconds.toInt,
       conf.workerCongestionControlHighWatermark.get,
       conf.workerCongestionControlLowWatermark.get,
-      conf.workerCongestionControlUserInactiveIntervalMs)
+      conf.workerCongestionControlUserInactiveIntervalMs,
+      conf.workerCongestionControlCheckIntervalMs)
   }
 
   var controller = new Controller(rpcEnv, conf, metricsSystem)
@@ -454,6 +455,7 @@ private[celeborn] class Worker(
       partitionsSorter.close(exitKind)
       storageManager.close(exitKind)
       memoryManager.close()
+      Option(CongestionController.instance()).foreach(_.close())
 
       masterClient.close()
       replicateServer.shutdown(exitKind)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Seperate `overHighWatermark` check to a dedicated thread, let this value can shared better and lighten `CongestionController#isUserCongested` logic.



### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual test and UT.
