### PR TITLE
[CELEBORN-255][FOLLOWUP] Add counter of outstandingFetches, outstandingRpcs and outstandingPushes to metrics

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -104,6 +104,9 @@ Here is an example of Grafana dashboard importing.
 |       PausePushDataAndReplicate        |      worker       |    PausePushDataAndReplicate means the count of worker stopped receiving data from client and other workers.    |
 |           ActiveShuffleSize            |      worker       |                 The active shuffle size of a worker including master replica and slave replica.                 |
 |         ActiveShuffleFileCount         |      worker       |              The active shuffle file count of a worker including master replica and slave replica.              |
+|         OutstandingFetchCount          |      worker       |                         The count of outstanding fetch request received in peer worker.                         |
+|          OutstandingRpcCount           |      worker       |                          The count of outstanding rpc request received in peer worker.                          |
+|          OutstandingPushCount          |      worker       |                         The count of outstanding push request received in peer worker.                          |
 |              jvm_gc_count              |        JVM        |                                     The GC count of each garbage collector.                                     |
 |              jvm_gc_time               |        JVM        |                                   The GC cost time of each garbage collector.                                   |
 |          jvm_memory_heap_init          |        JVM        |                                         The amount of heap init memory.                                         |

--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -1847,7 +1847,6 @@
               "editorMode": "builder",
               "expr": "metrics_ActiveShuffleSize_Value",
               "legendFormat": "${baseLegend}",
-              "instant": false,
               "range": true,
               "refId": "A"
             }
@@ -1966,7 +1965,6 @@
               "editorMode": "builder",
               "expr": "metrics_ActiveShuffleFileCount_Value",
               "legendFormat": "${baseLegend}",
-              "instant": false,
               "range": true,
               "refId": "A"
             }
@@ -8139,6 +8137,293 @@
         }
       ],
       "title": "UserConsumption",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 183,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 81
+          },
+          "id": 184,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_OutstandingFetchCount_Count",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_OutstandingFetchCount_Count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 81
+          },
+          "id": 185,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_OutstandingRpcCount_Count",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_OutstandingRpcCount_Count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 81
+          },
+          "id": 186,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "metrics_OutstandingPushCount_Count",
+              "legendFormat": "${baseLegend}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "metrics_OutstandingPushCount_Count",
+          "type": "timeseries"
+        }
+      ],
+      "title": "OutstandingRequest",
       "type": "row"
     }
   ],

--- a/common/src/main/java/org/apache/celeborn/common/network/TransportContext.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/TransportContext.java
@@ -121,7 +121,7 @@ public class TransportContext {
       if (channelsLimiter != null) {
         channel.pipeline().addLast("limiter", channelsLimiter);
       }
-      TransportChannelHandler channelHandler = createChannelHandler(channel, msgHandler);
+      TransportChannelHandler channelHandler = createChannelHandler(channel, msgHandler, source);
       channel
           .pipeline()
           .addLast("encoder", ENCODER)
@@ -140,8 +140,8 @@ public class TransportContext {
   }
 
   private TransportChannelHandler createChannelHandler(
-      Channel channel, BaseMessageHandler msgHandler) {
-    TransportResponseHandler responseHandler = new TransportResponseHandler(conf, channel);
+      Channel channel, BaseMessageHandler msgHandler, AbstractSource source) {
+    TransportResponseHandler responseHandler = new TransportResponseHandler(conf, channel, source);
     TransportClient client = new TransportClient(channel, responseHandler);
     TransportRequestHandler requestHandler =
         new TransportRequestHandler(channel, client, msgHandler);

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportResponseHandler.java
@@ -26,11 +26,14 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.exception.CelebornIOException;
+import org.apache.celeborn.common.metrics.source.AbstractSource;
+import org.apache.celeborn.common.metrics.source.NamedGauge;
 import org.apache.celeborn.common.network.protocol.*;
 import org.apache.celeborn.common.network.server.MessageHandler;
 import org.apache.celeborn.common.network.util.NettyUtils;
@@ -62,23 +65,24 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
   /** Records the time (in system nanoseconds) that the last fetch or RPC request was sent. */
   private final AtomicLong timeOfLastRequestNs;
 
-  private final long pushTimeoutCheckerInterval;
+  private final AbstractSource source;
+
   private static ScheduledExecutorService pushTimeoutChecker = null;
-  private ScheduledFuture pushCheckerScheduleFuture;
+  private ScheduledFuture<?> pushCheckerScheduleFuture;
 
-  private final long fetchTimeoutCheckerInterval;
   private static ScheduledExecutorService fetchTimeoutChecker = null;
-  private ScheduledFuture fetchCheckerScheduleFuture;
+  private ScheduledFuture<?> fetchCheckerScheduleFuture;
 
-  public TransportResponseHandler(TransportConf conf, Channel channel) {
+  public TransportResponseHandler(TransportConf conf, Channel channel, AbstractSource source) {
     this.conf = conf;
     this.channel = channel;
     this.outstandingFetches = JavaUtils.newConcurrentHashMap();
     this.outstandingRpcs = JavaUtils.newConcurrentHashMap();
     this.outstandingPushes = JavaUtils.newConcurrentHashMap();
     this.timeOfLastRequestNs = new AtomicLong(0);
-    this.pushTimeoutCheckerInterval = conf.pushDataTimeoutCheckIntervalMs();
-    this.fetchTimeoutCheckerInterval = conf.fetchDataTimeoutCheckIntervalMs();
+    this.source = source;
+    long pushTimeoutCheckerInterval = conf.pushDataTimeoutCheckIntervalMs();
+    long fetchTimeoutCheckerInterval = conf.fetchDataTimeoutCheckIntervalMs();
 
     String module = conf.getModuleName();
     boolean checkPushTimeout = false;
@@ -110,7 +114,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
     if (checkPushTimeout) {
       pushCheckerScheduleFuture =
           pushTimeoutChecker.scheduleWithFixedDelay(
-              () -> failExpiredPushRequest(),
+              this::failExpiredPushRequest,
               pushTimeoutCheckerInterval,
               pushTimeoutCheckerInterval,
               TimeUnit.MILLISECONDS);
@@ -119,11 +123,13 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
     if (checkFetchTimeout) {
       fetchCheckerScheduleFuture =
           fetchTimeoutChecker.scheduleWithFixedDelay(
-              () -> failExpiredFetchRequest(),
+              this::failExpiredFetchRequest,
               fetchTimeoutCheckerInterval,
               fetchTimeoutCheckerInterval,
               TimeUnit.MILLISECONDS);
     }
+
+    monitorOutstandingRequests();
   }
 
   public void failExpiredPushRequest() {
@@ -175,6 +181,25 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
           info.callback = null;
         }
       }
+    }
+  }
+
+  private void monitorOutstandingRequests() {
+    if (source != null) {
+      gauge("OutstandingFetchCount", outstandingFetches);
+      gauge("OutstandingRpcCount", outstandingRpcs);
+      gauge("OutstandingPushCount", outstandingPushes);
+    }
+  }
+
+  private void gauge(String name, Map<?, ?> outstandingRequests) {
+    if (source.getGauge(name) == null) {
+      source.addGauge(name, outstandingRequests::size);
+    } else {
+      NamedGauge<?> namedGauge = source.getGauge(name);
+      source.removeGauge(name);
+      source.addGauge(
+          name, () -> (Integer) namedGauge.gauge().getValue() + outstandingRequests.size());
     }
   }
 
@@ -267,7 +292,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
     if (numOutstandingRequests() > 0) {
       // show the details of outstanding Fetches
       if (logger.isDebugEnabled()) {
-        if (outstandingFetches.size() > 0) {
+        if (!outstandingFetches.isEmpty()) {
           for (Map.Entry<StreamChunkSlice, FetchRequestInfo> e : outstandingFetches.entrySet()) {
             StreamChunkSlice key = e.getKey();
             logger.debug("The channel is closed, but there is still outstanding Fetch {}", key);
@@ -454,5 +479,10 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
           "FetchRequestInfo ({}) not found/already addressed when listener handles fetch request failure",
           streamChunkSlice);
     }
+  }
+
+  @VisibleForTesting
+  public AbstractSource source() {
+    return source;
   }
 }

--- a/common/src/test/java/org/apache/celeborn/common/network/TransportResponseHandlerSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/TransportResponseHandlerSuiteJ.java
@@ -27,6 +27,7 @@ import io.netty.channel.local.LocalChannel;
 import org.junit.Test;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.common.network.buffer.NioManagedBuffer;
 import org.apache.celeborn.common.network.client.ChunkReceivedCallback;
 import org.apache.celeborn.common.network.client.RpcResponseCallback;
@@ -41,50 +42,38 @@ public class TransportResponseHandlerSuiteJ {
   @Test
   public void handleSuccessfulFetch() throws Exception {
     StreamChunkSlice streamChunkSlice = new StreamChunkSlice(1, 0);
-
-    TransportResponseHandler handler =
-        new TransportResponseHandler(
-            Utils.fromCelebornConf(new CelebornConf(), TransportModuleConstants.FETCH_MODULE, 8),
-            new LocalChannel());
+    TransportResponseHandler handler = createResponseHandler(TransportModuleConstants.FETCH_MODULE);
     ChunkReceivedCallback callback = mock(ChunkReceivedCallback.class);
-    FetchRequestInfo info = new FetchRequestInfo(System.currentTimeMillis() + 30000, callback);
-    handler.addFetchRequest(streamChunkSlice, info);
-    assertEquals(1, handler.numOutstandingRequests());
+    handleFetchRequest(streamChunkSlice, handler, callback, 1, 1);
 
     handler.handle(new ChunkFetchSuccess(streamChunkSlice, new TestManagedBuffer(123)));
     verify(callback, times(1)).onSuccess(eq(0), any());
-    assertEquals(0, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingFetchCount", 0);
   }
 
   @Test
   public void handleFailedFetch() throws Exception {
     StreamChunkSlice streamChunkSlice = new StreamChunkSlice(1, 0);
-    TransportResponseHandler handler =
-        new TransportResponseHandler(
-            Utils.fromCelebornConf(new CelebornConf(), TransportModuleConstants.FETCH_MODULE, 8),
-            new LocalChannel());
+    TransportResponseHandler handler = createResponseHandler(TransportModuleConstants.FETCH_MODULE);
     ChunkReceivedCallback callback = mock(ChunkReceivedCallback.class);
     FetchRequestInfo info = new FetchRequestInfo(System.currentTimeMillis() + 30000, callback);
     handler.addFetchRequest(streamChunkSlice, info);
-    assertEquals(1, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingFetchCount", 1);
 
     handler.handle(new ChunkFetchFailure(streamChunkSlice, "some error msg"));
     verify(callback, times(1)).onFailure(eq(0), any());
-    assertEquals(0, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingFetchCount", 0);
   }
 
   @Test
   public void clearAllOutstandingRequests() throws Exception {
-    TransportResponseHandler handler =
-        new TransportResponseHandler(
-            Utils.fromCelebornConf(new CelebornConf(), TransportModuleConstants.DATA_MODULE, 8),
-            new LocalChannel());
+    TransportResponseHandler handler = createResponseHandler(TransportModuleConstants.DATA_MODULE);
     ChunkReceivedCallback callback = mock(ChunkReceivedCallback.class);
     FetchRequestInfo info = new FetchRequestInfo(System.currentTimeMillis() + 30000, callback);
     handler.addFetchRequest(new StreamChunkSlice(1, 0), info);
     handler.addFetchRequest(new StreamChunkSlice(1, 1), info);
     handler.addFetchRequest(new StreamChunkSlice(1, 2), info);
-    assertEquals(3, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingFetchCount", 3);
 
     handler.handle(new ChunkFetchSuccess(new StreamChunkSlice(1, 0), new TestManagedBuffer(12)));
     handler.exceptionCaught(new Exception("duh duh duhhhh"));
@@ -93,58 +82,49 @@ public class TransportResponseHandlerSuiteJ {
     verify(callback, times(1)).onSuccess(eq(0), any());
     verify(callback, times(1)).onFailure(eq(1), any());
     verify(callback, times(1)).onFailure(eq(2), any());
-    assertEquals(0, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingFetchCount", 0);
   }
 
   @Test
   public void handleSuccessfulRPC() throws Exception {
-    TransportResponseHandler handler =
-        new TransportResponseHandler(
-            Utils.fromCelebornConf(new CelebornConf(), TransportModuleConstants.RPC_MODULE, 8),
-            new LocalChannel());
+    TransportResponseHandler handler = createResponseHandler(TransportModuleConstants.RPC_MODULE);
     RpcResponseCallback callback = mock(RpcResponseCallback.class);
     handler.addRpcRequest(12345, callback);
-    assertEquals(1, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingRpcCount", 1);
 
     // This response should be ignored.
     handler.handle(new RpcResponse(54321, new NioManagedBuffer(ByteBuffer.allocate(7))));
-    assertEquals(1, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingRpcCount", 1);
 
     ByteBuffer resp = ByteBuffer.allocate(10);
     handler.handle(new RpcResponse(12345, new NioManagedBuffer(resp)));
     verify(callback, times(1)).onSuccess(eq(ByteBuffer.allocate(10)));
-    assertEquals(0, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingRpcCount", 0);
   }
 
   @Test
   public void handleFailedRPC() throws Exception {
-    TransportResponseHandler handler =
-        new TransportResponseHandler(
-            Utils.fromCelebornConf(new CelebornConf(), TransportModuleConstants.RPC_MODULE, 8),
-            new LocalChannel());
+    TransportResponseHandler handler = createResponseHandler(TransportModuleConstants.RPC_MODULE);
     RpcResponseCallback callback = mock(RpcResponseCallback.class);
     handler.addRpcRequest(12345, callback);
-    assertEquals(1, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingRpcCount", 1);
 
     handler.handle(new RpcFailure(54321, "uh-oh!")); // should be ignored
-    assertEquals(1, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingRpcCount", 1);
 
     handler.handle(new RpcFailure(12345, "oh no"));
     verify(callback, times(1)).onFailure(any());
-    assertEquals(0, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingRpcCount", 0);
   }
 
   @Test
   public void handleSuccessfulPush() throws Exception {
-    TransportResponseHandler handler =
-        new TransportResponseHandler(
-            Utils.fromCelebornConf(new CelebornConf(), TransportModuleConstants.DATA_MODULE, 8),
-            new LocalChannel());
+    TransportResponseHandler handler = createResponseHandler(TransportModuleConstants.DATA_MODULE);
     RpcResponseCallback callback = mock(RpcResponseCallback.class);
     PushRequestInfo info = new PushRequestInfo(System.currentTimeMillis() + 30000, callback);
     info.setChannelFuture(mock(ChannelFuture.class));
     handler.addPushRequest(12345, info);
-    assertEquals(1, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingPushCount", 1);
 
     // This response should be ignored.
     handler.handle(new RpcResponse(54321, new NioManagedBuffer(ByteBuffer.allocate(7))));
@@ -153,26 +133,86 @@ public class TransportResponseHandlerSuiteJ {
     ByteBuffer resp = ByteBuffer.allocate(10);
     handler.handle(new RpcResponse(12345, new NioManagedBuffer(resp)));
     verify(callback, times(1)).onSuccess(eq(ByteBuffer.allocate(10)));
-    assertEquals(0, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingPushCount", 0);
   }
 
   @Test
   public void handleFailedPush() throws Exception {
-    TransportResponseHandler handler =
-        new TransportResponseHandler(
-            Utils.fromCelebornConf(new CelebornConf(), TransportModuleConstants.DATA_MODULE, 8),
-            new LocalChannel());
+    TransportResponseHandler handler = createResponseHandler(TransportModuleConstants.DATA_MODULE);
     RpcResponseCallback callback = mock(RpcResponseCallback.class);
     PushRequestInfo info = new PushRequestInfo(System.currentTimeMillis() + 30000L, callback);
     info.setChannelFuture(mock(ChannelFuture.class));
     handler.addPushRequest(12345, info);
-    assertEquals(1, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingPushCount", 1);
 
     handler.handle(new RpcFailure(54321, "uh-oh!")); // should be ignored
-    assertEquals(1, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingPushCount", 1);
 
     handler.handle(new RpcFailure(12345, "oh no"));
     verify(callback, times(1)).onFailure(any());
-    assertEquals(0, handler.numOutstandingRequests());
+    assertOutstandingRequests(handler, "OutstandingPushCount", 0);
+  }
+
+  @Test
+  public void multipleHandleFetchRequest() {
+    StreamChunkSlice streamChunkSlice1 = new StreamChunkSlice(1, 0);
+    CelebornConf celebornConf = new CelebornConf();
+    AbstractSource source = createSource(celebornConf);
+    TransportResponseHandler handler1 =
+        createResponseHandler(TransportModuleConstants.FETCH_MODULE, celebornConf, source);
+    ChunkReceivedCallback callback = mock(ChunkReceivedCallback.class);
+    handleFetchRequest(streamChunkSlice1, handler1, callback, 1, 1);
+
+    TransportResponseHandler handler2 =
+        createResponseHandler(TransportModuleConstants.FETCH_MODULE, celebornConf, source);
+    handleFetchRequest(streamChunkSlice1, handler2, callback, 1, 2);
+
+    StreamChunkSlice streamChunkSlice2 = new StreamChunkSlice(1, 1);
+    handleFetchRequest(streamChunkSlice2, handler1, callback, 2, 3);
+    handleFetchRequest(streamChunkSlice2, handler2, callback, 2, 4);
+  }
+
+  private AbstractSource createSource(CelebornConf celebornConf) {
+    return new AbstractSource(celebornConf, "Worker") {
+      @Override
+      public String sourceName() {
+        return "worker";
+      }
+    };
+  }
+
+  private TransportResponseHandler createResponseHandler(String module) {
+    CelebornConf celebornConf = new CelebornConf();
+    return createResponseHandler(module, celebornConf, createSource(celebornConf));
+  }
+
+  private TransportResponseHandler createResponseHandler(
+      String module, CelebornConf celebornConf, AbstractSource source) {
+    return new TransportResponseHandler(
+        Utils.fromCelebornConf(celebornConf, module, 8), new LocalChannel(), source);
+  }
+
+  private void assertOutstandingRequests(
+      TransportResponseHandler handler, String name, int expected) {
+    assertEquals(expected, handler.numOutstandingRequests());
+    assertEquals(expected, handler.source().getGauge(name).gauge().getValue());
+  }
+
+  private void handleFetchRequest(
+      StreamChunkSlice streamChunkSlice,
+      TransportResponseHandler handler,
+      ChunkReceivedCallback callback,
+      int expectedRequests,
+      int expectedGauge) {
+    FetchRequestInfo info = new FetchRequestInfo(System.currentTimeMillis() + 30000, callback);
+    handler.addFetchRequest(streamChunkSlice, info);
+    assertFetchRequests(handler, expectedRequests, expectedGauge);
+  }
+
+  private void assertFetchRequests(
+      TransportResponseHandler handler, int expectedRequests, int expectedGauge) {
+    assertEquals(expectedRequests, handler.numOutstandingRequests());
+    assertEquals(
+        expectedGauge, handler.source().getGauge("OutstandingFetchCount").gauge().getValue());
   }
 }

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -198,6 +198,12 @@ These metrics are exposed by Celeborn worker.
         - The active shuffle size of a worker including master replica and slave replica.
     - ActiveShuffleFileCount
         - The active shuffle file count of a worker including master replica and slave replica.
+    - OutstandingFetchCount
+        - The count of outstanding fetch request.
+    - OutstandingRpcCount
+        - The count of outstanding rpc request.
+    - OutstandingPushCount
+        - The count of outstanding push request.
     - push_server_usedHeapMemory 
     - push_server_usedDirectMemory
     - push_server_numAllocations 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add counter of `outstandingFetches`, `outstandingRpcs` and `outstandingPushes` of `TransportResponseHandler` to metrics of Celeborn Worker.

### Why are the changes needed?

The counter of `outstandingFetches`, `outstandingRpcs` and `outstandingPushes` of `TransportResponseHandler` could be added to metrics to monitor `outstandingFetches`, `outstandingRpcs` and `outstandingPushes`. 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`TransportResponseHandlerSuiteJ`