### PR TITLE
[CELEBORN-665][FOLLOWUP] Skip empty app snapshot logs

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/AppDiskUsageMetric.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/AppDiskUsageMetric.scala
@@ -143,7 +143,13 @@ class AppDiskUsageMetric(conf: CelebornConf) extends Logging {
           currentSnapShot.get().commit()
         }
         currentSnapShot.set(getNewSnapShot())
-        logInfo(s"App Disk Usage Top$usageCount Report ${summary()}")
+        val summaryStr = Some(summary()).map(str =>
+          if (str != null && str.nonEmpty) {
+            "\n" + str
+          } else {
+            str
+          }).getOrElse("")
+        logInfo(s"App Disk Usage Top$usageCount Report $summaryStr")
       }
     },
     60,
@@ -161,7 +167,7 @@ class AppDiskUsageMetric(conf: CelebornConf) extends Logging {
   def summary(): String = {
     val stringBuilder = new StringBuilder()
     for (i <- 0 until snapshotCount) {
-      if (snapShots(i) != null && snapShots(i).topNItems.length != 0) {
+      if (snapShots(i) != null && snapShots(i).topNItems.exists(_ != null)) {
         stringBuilder.append(snapShots(i))
         stringBuilder.append("    \n")
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
`topNItems` is never empty, but may be all null.

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

