### PR TITLE
[CELEBORN-1091] Update docs about how to use error-prone plugin in IDEA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,10 @@ There are already some further improvements on the schedule and welcome to conta
 ### Adding RPC Messages
 When you add new RPC message, it's recommended to follow raw PB message case, for example
 `RegisterWorker` and `RegisterWorkerResponse`. The RPC messages will be unified into raw PB messages eventually.
+
+### Using Error Prone
+Error Prone is a static analysis tool for Java that catches common programming mistakes at compile-time.
+
+To add the Error Prone plugin in IntelliJ IDEA, start the IDE and find the Plugins dialog. Browse Repositories, choose Category: Build, and find the Error-prone plugin. Right-click and choose 'Download and install'. The IDE will restart after you’ve exited these dialogs.
+
+Allows to build projects using Error Prone Java compiler to catch common Java mistakes at compile-time. To use the compiler, go to 'File | Settings/Preferences | Build, Execution, Deployment | Compiler | Java Compiler' and select 'Javac with error-prone' in 'Use compiler' box.


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CONTRIBUTING.md` introduces how to use Error Prone in IntelliJ IDEA.

### Why are the changes needed?

Error Prone is a static analysis tool for Java that catches common programming mistakes at compile-time. Starting from version 0.4.0, the Celeborn project supports augment the compiler’s type analysis using Error Prone. It's better to provide a detailed guide on how to eliminate classes of serious bugs from entering code in the Celeborn project using Error Prone plugin in IntelliJ IDEA.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.