### PR TITLE
[CELEBORN-1096] Avoid initializing SortShuffleManager when stop

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -167,8 +167,9 @@ public class SparkShuffleManager implements ShuffleManager {
     if (lifecycleManager != null) {
       lifecycleManager.stop();
     }
-    if (sortShuffleManager() != null) {
-      sortShuffleManager().stop();
+    if (_sortShuffleManager != null) {
+      _sortShuffleManager.stop();
+      _sortShuffleManager = null;
     }
   }
 

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -197,8 +197,8 @@ public class SparkShuffleManager implements ShuffleManager {
       lifecycleManager.stop();
       lifecycleManager = null;
     }
-    if (sortShuffleManager() != null) {
-      sortShuffleManager().stop();
+    if (_sortShuffleManager != null) {
+      _sortShuffleManager.stop();
       _sortShuffleManager = null;
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
If there is no fallback to the Spark SortShuffleManager, it will be initialized once when stopping, and then stopped again. This is not necessary.

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

