### PR TITLE
[CELEBORN-1097] Optimize the retrieval of configuration in the internalCreateClient

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/FlinkTransportClientFactory.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/network/FlinkTransportClientFactory.java
@@ -42,6 +42,7 @@ public class FlinkTransportClientFactory extends TransportClientFactory {
     super(context);
     bufferSuppliers = JavaUtils.newConcurrentHashMap();
     this.fetchMaxRetries = fetchMaxRetries;
+    this.pooledAllocator = new UnpooledByteBufAllocator(true);
   }
 
   public TransportClient createClientWithRetry(String remoteHost, int remotePort)
@@ -73,11 +74,6 @@ public class FlinkTransportClientFactory extends TransportClientFactory {
       throws IOException, InterruptedException {
     return createClient(
         remoteHost, remotePort, -1, new TransportFrameDecoderWithBufferSupplier(bufferSuppliers));
-  }
-
-  @Override
-  protected void initializeMemoryAllocator() {
-    this.pooledAllocator = new UnpooledByteBufAllocator(true);
   }
 
   public void registerSupplier(long streamId, Supplier<ByteBuf> supplier) {

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -68,7 +68,6 @@ public class TransportClientFactory implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(TransportClientFactory.class);
 
   private final TransportContext context;
-  private final TransportConf conf;
   private final ConcurrentHashMap<SocketAddress, ClientPool> connectionPool;
 
   /** Random number generator for picking connections between peers. */
@@ -87,7 +86,7 @@ public class TransportClientFactory implements Closeable {
 
   public TransportClientFactory(TransportContext context) {
     this.context = Preconditions.checkNotNull(context);
-    this.conf = context.getConf();
+    TransportConf conf = context.getConf();
     this.connectionPool = JavaUtils.newConcurrentHashMap();
     this.numConnectionsPerPeer = conf.numConnectionsPerPeer();
     this.connectTimeoutMs = conf.connectTimeoutMs();
@@ -100,10 +99,6 @@ public class TransportClientFactory implements Closeable {
     logger.info("mode " + ioMode + " threads " + conf.clientThreads());
     this.workerGroup =
         NettyUtils.createEventLoop(ioMode, conf.clientThreads(), conf.getModuleName() + "-client");
-    initializeMemoryAllocator();
-  }
-
-  protected void initializeMemoryAllocator() {
     this.pooledAllocator = NettyUtils.getPooledByteBufAllocator(conf, null, false);
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -76,6 +76,11 @@ public class TransportClientFactory implements Closeable {
 
   private final int numConnectionsPerPeer;
 
+  private final int connectTimeoutMs;
+
+  private final int receiveBuf;
+
+  private final int sendBuf;
   private final Class<? extends Channel> socketChannelClass;
   private EventLoopGroup workerGroup;
   protected ByteBufAllocator pooledAllocator;
@@ -85,6 +90,9 @@ public class TransportClientFactory implements Closeable {
     this.conf = context.getConf();
     this.connectionPool = JavaUtils.newConcurrentHashMap();
     this.numConnectionsPerPeer = conf.numConnectionsPerPeer();
+    this.connectTimeoutMs = conf.connectTimeoutMs();
+    this.receiveBuf = conf.receiveBuf();
+    this.sendBuf = conf.sendBuf();
     this.rand = new Random();
 
     IOMode ioMode = IOMode.valueOf(conf.ioMode());
@@ -213,15 +221,15 @@ public class TransportClientFactory implements Closeable {
         // Disable Nagle's Algorithm since we don't want packets to wait
         .option(ChannelOption.TCP_NODELAY, true)
         .option(ChannelOption.SO_KEEPALIVE, true)
-        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, conf.connectTimeoutMs())
+        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs)
         .option(ChannelOption.ALLOCATOR, pooledAllocator);
 
-    if (conf.receiveBuf() > 0) {
-      bootstrap.option(ChannelOption.SO_RCVBUF, conf.receiveBuf());
+    if (receiveBuf > 0) {
+      bootstrap.option(ChannelOption.SO_RCVBUF, receiveBuf);
     }
 
-    if (conf.sendBuf() > 0) {
-      bootstrap.option(ChannelOption.SO_SNDBUF, conf.sendBuf());
+    if (sendBuf > 0) {
+      bootstrap.option(ChannelOption.SO_SNDBUF, sendBuf);
     }
 
     final AtomicReference<TransportClient> clientRef = new AtomicReference<>();
@@ -239,9 +247,9 @@ public class TransportClientFactory implements Closeable {
 
     // Connect to the remote server
     ChannelFuture cf = bootstrap.connect(address);
-    if (!cf.await(conf.connectTimeoutMs())) {
+    if (!cf.await(connectTimeoutMs)) {
       throw new CelebornIOException(
-          String.format("Connecting to %s timed out (%s ms)", address, conf.connectTimeoutMs()));
+          String.format("Connecting to %s timed out (%s ms)", address, connectTimeoutMs));
     } else if (cf.cause() != null) {
       throw new CelebornIOException(String.format("Failed to connect to %s", address), cf.cause());
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Optimize the retrieval of configuration in the internalCreateClient


### Why are the changes needed?
Directly accessing configuration information through 'conf.xx' in 'internalCreateClient' is time-consuming.
![image](https://github.com/apache/incubator-celeborn/assets/107825064/315a5013-5dfb-4a44-bf1b-109fc4ecc654)



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

