### PR TITLE
[CELEBORN-1099] Check register when handleGetReducerFileGroup

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -270,21 +270,23 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
     val partitionType = lifecycleManager.getPartitionType(shuffleId)
     commitHandlers.computeIfAbsent(
       partitionType,
-      {
-        case PartitionType.REDUCE => new ReducePartitionCommitHandler(
-            appUniqueId,
-            conf,
-            lifecycleManager.shuffleAllocatedWorkers,
-            committedPartitionInfo,
-            lifecycleManager.workerStatusTracker)
-        case PartitionType.MAP => new MapPartitionCommitHandler(
-            appUniqueId,
-            conf,
-            lifecycleManager.shuffleAllocatedWorkers,
-            committedPartitionInfo,
-            lifecycleManager.workerStatusTracker)
-        case partitionType => throw new UnsupportedOperationException(
-            s"Unexpected ShufflePartitionType for CommitManager: $partitionType")
+      (partitionType: PartitionType) => {
+        partitionType match {
+          case PartitionType.REDUCE => new ReducePartitionCommitHandler(
+              appUniqueId,
+              conf,
+              lifecycleManager.shuffleAllocatedWorkers,
+              committedPartitionInfo,
+              lifecycleManager.workerStatusTracker)
+          case PartitionType.MAP => new MapPartitionCommitHandler(
+              appUniqueId,
+              conf,
+              lifecycleManager.shuffleAllocatedWorkers,
+              committedPartitionInfo,
+              lifecycleManager.workerStatusTracker)
+          case _ => throw new UnsupportedOperationException(
+              s"Unexpected ShufflePartitionType for CommitManager: $partitionType")
+        }
       })
   }
 

--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -268,30 +268,24 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
 
   private def getCommitHandler(shuffleId: Int): CommitHandler = {
     val partitionType = lifecycleManager.getPartitionType(shuffleId)
-    if (commitHandlers.containsKey(partitionType)) {
-      commitHandlers.get(partitionType)
-    } else {
-      commitHandlers.computeIfAbsent(
-        partitionType,
-        (partitionType: PartitionType) => {
-          partitionType match {
-            case PartitionType.REDUCE => new ReducePartitionCommitHandler(
-                appUniqueId,
-                conf,
-                lifecycleManager.shuffleAllocatedWorkers,
-                committedPartitionInfo,
-                lifecycleManager.workerStatusTracker)
-            case PartitionType.MAP => new MapPartitionCommitHandler(
-                appUniqueId,
-                conf,
-                lifecycleManager.shuffleAllocatedWorkers,
-                committedPartitionInfo,
-                lifecycleManager.workerStatusTracker)
-            case _ => throw new UnsupportedOperationException(
-                s"Unexpected ShufflePartitionType for CommitManager: $partitionType")
-          }
-        })
-    }
+    commitHandlers.computeIfAbsent(
+      partitionType,
+      {
+        case PartitionType.REDUCE => new ReducePartitionCommitHandler(
+            appUniqueId,
+            conf,
+            lifecycleManager.shuffleAllocatedWorkers,
+            committedPartitionInfo,
+            lifecycleManager.workerStatusTracker)
+        case PartitionType.MAP => new MapPartitionCommitHandler(
+            appUniqueId,
+            conf,
+            lifecycleManager.shuffleAllocatedWorkers,
+            committedPartitionInfo,
+            lifecycleManager.workerStatusTracker)
+        case partitionType => throw new UnsupportedOperationException(
+            s"Unexpected ShufflePartitionType for CommitManager: $partitionType")
+      })
   }
 
   def commitMetrics(): (Long, Long) = commitHandlers.asScala.values.foldLeft(0L -> 0L) {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -293,8 +293,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       }
 
     case GetReducerFileGroup(shuffleId: Int) =>
-      logDebug(s"Received GetShuffleFileGroup request," +
-        s"shuffleId $shuffleId.")
+      logDebug(s"Received GetShuffleFileGroup request for shuffleId $shuffleId.")
       handleGetReducerFileGroup(context, shuffleId)
   }
 
@@ -553,6 +552,14 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   private def handleGetReducerFileGroup(
       context: RpcCallContext,
       shuffleId: Int): Unit = {
+    if (!registeredShuffle.contains(shuffleId)) {
+      logWarning(s"[handleGetReducerFileGroup] shuffle $shuffleId not registered, maybe no shuffle data within this stage.")
+      context.reply(GetReducerFileGroupResponse(
+        StatusCode.SHUFFLE_NOT_REGISTERED,
+        JavaUtils.newConcurrentHashMap(),
+        Array.empty))
+      return
+    }
     commitManager.handleGetReducerFileGroup(context, shuffleId)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
For spark case, when stage outputPartitioning is satisfied and no longer needs shuffle exchange, there will be no shuffle write procedure, same goes for `RegisterShuffle`, currently the origin reduce stage will throw a NPE when LifeCycleManager `handleGetReducerFileGroup`.
```
ERROR [dispatcher-event-loop-11] Inbox: Ignoring error
java.lang.NullPointerException: null
    at org.apache.celeborn.client.commit.ReducePartitionCommitHandler.handleGetReducerFileGroup(ReducePartitionCommitHandler.scala:307)
    at org.apache.celeborn.client.CommitManager.handleGetReducerFileGroup(CommitManager.scala:266)
    at org.apache.celeborn.client.LifecycleManager.org$apache$celeborn$client$LifecycleManager$$handleGetReducerFileGroup(LifecycleManager.scala:556)
    at org.apache.celeborn.client.LifecycleManager$$anonfun$receiveAndReply$1.applyOrElse(LifecycleManager.scala:298) 
    at org.apache.celeborn.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:115)
    at org.apache.celeborn.common.rpc.netty.Inbox.safelyCall(Inbox.scala:222)
    at org.apache.celeborn.common.rpc.netty.Inbox.process(Inbox.scala:110)
    at org.apache.celeborn.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:227)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```
Reproduce example like: 
`select count(*) as cnt from tableA;`
And tableA is empty.

So here fix code to adapt to this normal situation. For Flink client, just follows the old behavior.

### Why are the changes needed?
Fix the probable NPE.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Cluster test.
