### PR TITLE
[CELEBORN-247][FOLLOWUP] Add metrics for each user's quota usage of Celeborn Worker

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -73,10 +73,10 @@ Here is an example of Grafana dashboard importing.
 |             PartitionSize              |      master       |          The estimated partition size of last 20 flush window whose length is 15 seconds by defaults.           |
 |            PartitionWritten            |      master       |                                            The active shuffle size.                                             |
 |           PartitionFileCount           |      master       |                                       The active shuffle partition count.                                       |
-|             diskFileCount              |      master       |                                The count of disk files consumption by each user.                                |
-|            diskBytesWritten            |      master       |                               The amount of disk files consumption by each user.                                |
-|             hdfsFileCount              |      master       |                                The count of hdfs files consumption by each user.                                |
-|            hdfsBytesWritten            |      master       |                               The amount of hdfs files consumption by each user.                                |
+|             diskFileCount              | master and worker |                                The count of disk files consumption by each user.                                |
+|            diskBytesWritten            | master and worker |                               The amount of disk files consumption by each user.                                |
+|             hdfsFileCount              | master and worker |                                The count of hdfs files consumption by each user.                                |
+|            hdfsBytesWritten            | master and worker |                               The amount of hdfs files consumption by each user.                                |
 |         RegisteredShuffleCount         | master and worker |                                  The value means count of registered shuffle.                                   |
 |            CommitFilesTime             |      worker       |                           CommitFiles means flush and close a shuffle partition file.                           |
 |            ReserveSlotsTime            |      worker       |                     ReserveSlots means acquire a disk buffer and record partition location.                     |

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -521,6 +521,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def estimatedPartitionSizeForEstimationUpdateInterval: Long =
     get(ESTIMATED_PARTITION_SIZE_UPDATE_INTERVAL)
   def masterResourceConsumptionInterval: Long = get(MASTER_RESOURCE_CONSUMPTION_INTERVAL)
+  def workerResourceConsumptionInterval: Long = get(WORKER_RESOURCE_CONSUMPTION_INTERVAL)
 
   // //////////////////////////////////////////////////////
   //               Address && HA && RATIS                //
@@ -2012,6 +2013,14 @@ object CelebornConf extends Logging {
       .categories("master")
       .doc("Time length for a window about compute user resource consumption.")
       .version("0.3.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("30s")
+
+  val WORKER_RESOURCE_CONSUMPTION_INTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.worker.userResourceConsumption.update.interval")
+      .categories("worker")
+      .doc("Time length for a window about compute user resource consumption.")
+      .version("0.3.2")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("30s")
 

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/ResourceConsumptionSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/ResourceConsumptionSource.scala
@@ -19,9 +19,18 @@ package org.apache.celeborn.common.metrics.source
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.metrics.MetricsSystem
 
-class ResourceConsumptionSource(conf: CelebornConf)
-  extends AbstractSource(conf, MetricsSystem.ROLE_MASTER) with Logging {
+class ResourceConsumptionSource(conf: CelebornConf, role: String)
+  extends AbstractSource(conf, role) with Logging {
   override val sourceName = "ResourceConsumption"
+}
+
+object ResourceConsumptionSource {
+  val DISK_FILE_COUNT = "diskFileCount"
+
+  val DISK_BYTES_WRITTEN = "diskBytesWritten"
+
+  val HDFS_FILE_COUNT = "hdfsFileCount"
+
+  val HDFS_BYTES_WRITTEN = "hdfsBytesWritten"
 }

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -104,6 +104,7 @@ license: |
 | celeborn.worker.storage.disk.reserve.size | 5G | Celeborn worker reserved space for each disk. | 0.3.0 | 
 | celeborn.worker.storage.expireDirs.timeout | 1h | The timeout for a expire dirs to be deleted on disk. | 0.3.2 | 
 | celeborn.worker.storage.workingDir | celeborn-worker/shuffle_data | Worker's working dir path name. | 0.3.0 | 
+| celeborn.worker.userResourceConsumption.update.interval | 30s | Time length for a window about compute user resource consumption. | 0.3.2 | 
 | celeborn.worker.writer.close.timeout | 120s | Timeout for a file writer to close | 0.2.0 | 
 | celeborn.worker.writer.create.maxAttempts | 3 | Retry count for a file writer to create if its creation was failed. | 0.2.0 | 
 <!--end-include-->

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -266,6 +266,14 @@ These metrics are exposed by Celeborn worker.
       [Dropwizard/Codahale Metric Sets for JVM instrumentation](https://metrics.dropwizard.io/4.2.0/manual/jvm.html)
       and in particular the metric sets BufferPoolMetricSet, GarbageCollectorMetricSet and MemoryUsageGaugeSet.
 
+  - namespace=ResourceConsumption
+    - **notes:**
+        - This metrics data is generated for each user and they are identified using a metric tag.
+    - diskFileCount
+    - diskBytesWritten
+    - hdfsFileCount
+    - hdfsBytesWritten
+
 **Note:**
 
 The Netty DirectArenaMetrics named like `push/fetch/replicate_server_numXX` are not exposed by default, nor in Grafana dashboard.

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -152,7 +152,8 @@ private[celeborn] class Master(
   private val slotsAssignPolicy = conf.masterSlotAssignPolicy
 
   // init and register master metrics
-  val resourceConsumptionSource = new ResourceConsumptionSource(conf)
+  private val resourceConsumptionSource =
+    new ResourceConsumptionSource(conf, MetricsSystem.ROLE_MASTER)
   private val masterSource = new MasterSource(conf)
   private var hadoopFs: FileSystem = _
   masterSource.addGauge(MasterSource.REGISTERED_SHUFFLE_COUNT) { () =>
@@ -840,16 +841,24 @@ private[celeborn] class Master(
       userIdentifier: UserIdentifier,
       context: RpcCallContext): Unit = {
 
-    resourceConsumptionSource.addGauge("diskFileCount", userIdentifier.toMap) { () =>
+    resourceConsumptionSource.addGauge(
+      ResourceConsumptionSource.DISK_FILE_COUNT,
+      userIdentifier.toMap) { () =>
       computeUserResourceConsumption(userIdentifier).diskFileCount
     }
-    resourceConsumptionSource.addGauge("diskBytesWritten", userIdentifier.toMap) { () =>
+    resourceConsumptionSource.addGauge(
+      ResourceConsumptionSource.DISK_BYTES_WRITTEN,
+      userIdentifier.toMap) { () =>
       computeUserResourceConsumption(userIdentifier).diskBytesWritten
     }
-    resourceConsumptionSource.addGauge("hdfsFileCount", userIdentifier.toMap) { () =>
+    resourceConsumptionSource.addGauge(
+      ResourceConsumptionSource.HDFS_FILE_COUNT,
+      userIdentifier.toMap) { () =>
       computeUserResourceConsumption(userIdentifier).hdfsFileCount
     }
-    resourceConsumptionSource.addGauge("hdfsBytesWritten", userIdentifier.toMap) { () =>
+    resourceConsumptionSource.addGauge(
+      ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
+      userIdentifier.toMap) { () =>
       computeUserResourceConsumption(userIdentifier).hdfsBytesWritten
     }
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
@@ -25,7 +25,7 @@ import org.apache.celeborn.service.deploy.master.MasterSource.OFFER_SLOTS_TIME
 
 class MasterSource(conf: CelebornConf)
   extends AbstractSource(conf, MetricsSystem.ROLE_MASTER) with Logging {
-  override val sourceName = s"master"
+  override val sourceName = "master"
 
   addTimer(OFFER_SLOTS_TIME)
   // start cleaner

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/MasterSource.scala
@@ -18,15 +18,14 @@
 package org.apache.celeborn.service.deploy.master
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.metrics.MetricsSystem
 import org.apache.celeborn.common.metrics.source.AbstractSource
-import org.apache.celeborn.service.deploy.master.MasterSource.OFFER_SLOTS_TIME
 
-class MasterSource(conf: CelebornConf)
-  extends AbstractSource(conf, MetricsSystem.ROLE_MASTER) with Logging {
+class MasterSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSystem.ROLE_MASTER) {
   override val sourceName = "master"
 
+  import MasterSource._
+  // add timers
   addTimer(OFFER_SLOTS_TIME)
   // start cleaner
   startCleaner()

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -19,6 +19,7 @@ package org.apache.celeborn.service.deploy.worker
 
 import java.io.File
 import java.lang.{Long => JLong}
+import java.util
 import java.util.{HashMap => JHashMap, HashSet => JHashSet, Map => JMap}
 import java.util.concurrent._
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicIntegerArray}
@@ -36,7 +37,7 @@ import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.meta.{DiskInfo, WorkerInfo, WorkerPartitionLocationInfo}
 import org.apache.celeborn.common.metrics.MetricsSystem
-import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, SystemMiscSource}
+import org.apache.celeborn.common.metrics.source.{JVMCPUSource, JVMSource, ResourceConsumptionSource, SystemMiscSource}
 import org.apache.celeborn.common.network.TransportContext
 import org.apache.celeborn.common.protocol.{PartitionType, PbRegisterWorkerResponse, PbWorkerLostResponse, RpcNameConstants, TransportModuleConstants}
 import org.apache.celeborn.common.protocol.message.ControlMessages._
@@ -104,7 +105,10 @@ private[celeborn] class Worker(
     }
   }
 
+  private val resourceConsumptionSource =
+    new ResourceConsumptionSource(conf, MetricsSystem.ROLE_WORKER)
   val workerSource = new WorkerSource(conf)
+  metricsSystem.registerSource(resourceConsumptionSource)
   metricsSystem.registerSource(workerSource)
   metricsSystem.registerSource(new JVMSource(conf, MetricsSystem.ROLE_WORKER))
   metricsSystem.registerSource(new JVMCPUSource(conf, MetricsSystem.ROLE_WORKER))
@@ -262,6 +266,10 @@ private[celeborn] class Worker(
   private val cleanTaskQueue = new LinkedBlockingQueue[JHashSet[String]]
   var cleaner: Thread = _
 
+  private val workerResourceConsumptionInterval = conf.workerResourceConsumptionInterval
+  private val userResourceConsumptions =
+    JavaUtils.newConcurrentHashMap[UserIdentifier, (ResourceConsumption, Long)]()
+
   workerSource.addGauge(WorkerSource.REGISTERED_SHUFFLE_COUNT) { () =>
     workerInfo.getShuffleKeySet.size
   }
@@ -334,9 +342,6 @@ private[celeborn] class Worker(
       workerInfo.updateThenGetDiskInfos(storageManager.disksSnapshot().map { disk =>
         disk.mountPoint -> disk
       }.toMap.asJava).values().asScala.toSeq
-    val resourceConsumption = workerInfo.updateThenGetUserResourceConsumption(
-      storageManager.userResourceConsumptionSnapshot().asJava)
-
     val response = masterClient.askSync[HeartbeatFromWorkerResponse](
       HeartbeatFromWorker(
         host,
@@ -345,7 +350,7 @@ private[celeborn] class Worker(
         fetchPort,
         replicatePort,
         diskInfos,
-        resourceConsumption,
+        handleResourceConsumption(),
         activeShuffleKeys,
         estimatedAppDiskUsage,
         highWorkload),
@@ -484,8 +489,7 @@ private[celeborn] class Worker(
               // Use WorkerInfo's diskInfo since re-register when heartbeat return not-registered,
               // StorageManager have update the disk info.
               workerInfo.diskInfos.asScala.toMap,
-              workerInfo.updateThenGetUserResourceConsumption(
-                storageManager.userResourceConsumptionSnapshot().asJava).asScala.toMap,
+              handleResourceConsumption().asScala.toMap,
               MasterClient.genRequestId()),
             classOf[PbRegisterWorkerResponse])
         } catch {
@@ -509,6 +513,52 @@ private[celeborn] class Worker(
     // If worker register still failed after retry, throw exception to stop worker process
     throw new CelebornException("Register worker failed.", exception)
   }
+
+  private def handleResourceConsumption(): util.Map[UserIdentifier, ResourceConsumption] = {
+    val resourceConsumptionSnapshot = storageManager.userResourceConsumptionSnapshot()
+    resourceConsumptionSnapshot.foreach { resourceConsumption =>
+      {
+        resourceConsumptionSource.addGauge(
+          ResourceConsumptionSource.DISK_FILE_COUNT,
+          resourceConsumption._1.toMap) { () =>
+          computeUserResourceConsumption(resourceConsumption).diskFileCount
+        }
+        resourceConsumptionSource.addGauge(
+          ResourceConsumptionSource.DISK_BYTES_WRITTEN,
+          resourceConsumption._1.toMap) { () =>
+          computeUserResourceConsumption(resourceConsumption).diskBytesWritten
+        }
+        resourceConsumptionSource.addGauge(
+          ResourceConsumptionSource.HDFS_FILE_COUNT,
+          resourceConsumption._1.toMap) { () =>
+          computeUserResourceConsumption(resourceConsumption).hdfsFileCount
+        }
+        resourceConsumptionSource.addGauge(
+          ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
+          resourceConsumption._1.toMap) { () =>
+          computeUserResourceConsumption(resourceConsumption).hdfsBytesWritten
+        }
+      }
+    }
+    workerInfo.updateThenGetUserResourceConsumption(resourceConsumptionSnapshot.asJava)
+  }
+
+  private def computeUserResourceConsumption(userResourceConsumption: (
+      UserIdentifier,
+      ResourceConsumption)): ResourceConsumption = {
+    val userIdentifier = userResourceConsumption._1
+    val resourceConsumption = userResourceConsumption._2
+    val current = System.currentTimeMillis()
+    if (userResourceConsumptions.containsKey(userIdentifier)) {
+      val resourceConsumptionAndUpdateTime = userResourceConsumptions.get(userIdentifier)
+      if (current - resourceConsumptionAndUpdateTime._2 <= workerResourceConsumptionInterval) {
+        return resourceConsumptionAndUpdateTime._1
+      }
+    }
+    userResourceConsumptions.put(userIdentifier, (resourceConsumption, current))
+    resourceConsumption
+  }
+
   @VisibleForTesting
   def cleanup(expiredShuffleKeys: JHashSet[String]): Unit = synchronized {
     expiredShuffleKeys.asScala.foreach { shuffleKey =>

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -18,13 +18,15 @@
 package org.apache.celeborn.service.deploy.worker
 
 import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.metrics.MetricsSystem
 import org.apache.celeborn.common.metrics.source.AbstractSource
+import org.apache.celeborn.service.deploy.worker.WorkerSource._
 
-class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSystem.ROLE_WORKER) {
+class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSystem.ROLE_WORKER)
+  with Logging {
   override val sourceName = "worker"
 
-  import WorkerSource._
   // add counters
   addCounter(WRITE_DATA_FAIL_COUNT)
   addCounter(REPLICATE_DATA_FAIL_COUNT)
@@ -38,7 +40,7 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSyste
   addCounter(REGION_FINISH_FAIL_COUNT)
   addCounter(ACTIVE_CONNECTION_COUNT)
 
-  // add Timers
+  // add timers
   addTimer(COMMIT_FILES_TIME)
   addTimer(RESERVE_SLOTS_TIME)
   addTimer(FLUSH_DATA_TIME)
@@ -130,7 +132,7 @@ object WorkerSource {
   val USER_PRODUCE_SPEED = "UserProduceSpeed"
   val WORKER_CONSUME_SPEED = "WorkerConsumeSpeed"
 
-  // active shuffle size
+  // active shuffle
   val ACTIVE_SHUFFLE_SIZE = "ActiveShuffleSize"
   val ACTIVE_SHUFFLE_FILE_COUNT = "ActiveShuffleFileCount"
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -18,15 +18,13 @@
 package org.apache.celeborn.service.deploy.worker
 
 import org.apache.celeborn.common.CelebornConf
-import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.metrics.MetricsSystem
 import org.apache.celeborn.common.metrics.source.AbstractSource
-import org.apache.celeborn.service.deploy.worker.WorkerSource._
 
-class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSystem.ROLE_WORKER)
-  with Logging {
+class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSystem.ROLE_WORKER) {
   override val sourceName = "worker"
 
+  import WorkerSource._
   // add counters
   addCounter(WRITE_DATA_FAIL_COUNT)
   addCounter(REPLICATE_DATA_FAIL_COUNT)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the metric `ResourceConsumption` to monitor each user's quota usage of Celeborn Worker.

### Why are the changes needed?

The metric `ResourceConsumption` supports to monitor each user's quota usage of Celeborn Master at present. The usage of Celeborn Worker also needs to monitor.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal tests.