### PR TITLE
[CELEBORN-1110] Support celeborn.worker.storage.disk.reserve.ratio to configure worker reserved ratio for each disk

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/util/CollectionUtils.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/CollectionUtils.java
@@ -37,5 +37,4 @@ public class CollectionUtils {
   public static boolean isNotEmpty(Map map) {
     return !isEmpty(map);
   }
-
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -988,6 +988,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def workerDiskTimeSlidingWindowMinFetchCount: Int =
     get(WORKER_DISKTIME_SLIDINGWINDOW_MINFETCHCOUNT)
   def workerDiskReserveSize: Long = get(WORKER_DISK_RESERVE_SIZE)
+  def workerDiskReserveRatio: Option[Double] = get(WORKER_DISK_RESERVE_RATIO)
   def workerDiskCleanThreads: Int = get(WORKER_DISK_CLEAN_THREADS)
   def workerDiskMonitorEnabled: Boolean = get(WORKER_DISK_MONITOR_ENABLED)
   def workerDiskMonitorCheckList: Seq[String] = get(WORKER_DISK_MONITOR_CHECKLIST)
@@ -2168,6 +2169,16 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("5G")
+
+  val WORKER_DISK_RESERVE_RATIO: OptionalConfigEntry[Double] =
+    buildConf("celeborn.worker.storage.disk.reserve.ratio")
+      .categories("worker")
+      .doc("Celeborn worker reserved ratio for each disk. The minimum usable size for each disk is the max space " +
+        "between the reserved space and the space calculate via reserved ratio.")
+      .version("0.3.2")
+      .doubleConf
+      .checkValue(v => v > 0.0 && v < 1.0, "Should be in (0.0, 1.0).")
+      .createOptional
 
   val WORKER_DISK_CLEAN_THREADS: ConfigEntry[Int] =
     buildConf("celeborn.worker.disk.clean.threads")

--- a/common/src/main/scala/org/apache/celeborn/common/util/DiskUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/DiskUtils.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.util
+
+import java.nio.file.{Files, Paths}
+
+import org.apache.celeborn.common.meta.DiskInfo
+
+/**
+ * Disk utilities provide detail of disk info including disk statistics etc.
+ */
+object DiskUtils {
+
+  /**
+   * Gets the minimum usable size for each disk, which size is the max space between the reserved space
+   * and the space calculate via reserved ratio.
+   *
+   * @param diskInfo The reserved disk info.
+   * @param diskReserveSize The reserved space for each disk.
+   * @param diskReserveRatio The reserved ratio for each disk.
+   * @return the minimum usable space.
+   */
+  def getMinimumUsableSize(
+      diskInfo: DiskInfo,
+      diskReserveSize: Long,
+      diskReserveRatio: Option[Double]): Long = {
+    var minimumUsableSize = diskReserveSize
+    if (diskReserveRatio.isDefined) {
+      try {
+        val totalSpace = Files.getFileStore(Paths.get(diskInfo.mountPoint)).getTotalSpace
+        minimumUsableSize =
+          BigDecimal(totalSpace * diskReserveRatio.get).longValue.max(minimumUsableSize)
+      } catch {
+        case _: Exception => // Do nothing
+      }
+    }
+    minimumUsableSize
+  }
+}

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -107,6 +107,7 @@ license: |
 | celeborn.worker.storage.checkDirsEmpty.maxRetries | 3 | The number of retries for a worker to check if the working directory is cleaned up before registering with the master. | 0.3.0 | 
 | celeborn.worker.storage.checkDirsEmpty.timeout | 1000ms | The wait time per retry for a worker to check if the working directory is cleaned up before registering with the master. | 0.3.0 | 
 | celeborn.worker.storage.dirs | &lt;undefined&gt; | Directory list to store shuffle data. It's recommended to configure one directory on each disk. Storage size limit can be set for each directory. For the sake of performance, there should be no more than 2 flush threads on the same disk partition if you are using HDD, and should be 8 or more flush threads on the same disk partition if you are using SSD. For example: `dir1[:capacity=][:disktype=][:flushthread=],dir2[:capacity=][:disktype=][:flushthread=]` | 0.2.0 | 
+| celeborn.worker.storage.disk.reserve.ratio | &lt;undefined&gt; | Celeborn worker reserved ratio for each disk. The minimum usable size for each disk is the max space between the reserved space and the space calculate via reserved ratio. | 0.3.2 | 
 | celeborn.worker.storage.disk.reserve.size | 5G | Celeborn worker reserved space for each disk. | 0.3.0 | 
 | celeborn.worker.storage.expireDirs.timeout | 1h | The timeout for a expire dirs to be deleted on disk. | 0.3.2 | 
 | celeborn.worker.storage.workingDir | celeborn-worker/shuffle_data | Worker's working dir path name. | 0.3.0 | 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -121,15 +121,7 @@ private[celeborn] class Master(
   private def shutdownWorkerSnapshot: util.List[WorkerInfo] =
     statusSystem.workers.synchronized(new util.ArrayList[WorkerInfo](statusSystem.shutdownWorkers))
 
-  private def diskReserveSize = conf.workerDiskReserveSize
-
   private val slotsAssignMaxWorkers = conf.masterSlotAssignMaxWorkers
-  private val slotsAssignLoadAwareDiskGroupNum = conf.masterSlotAssignLoadAwareDiskGroupNum
-  private val slotsAssignLoadAwareDiskGroupGradient =
-    conf.masterSlotAssignLoadAwareDiskGroupGradient
-  private val loadAwareFlushTimeWeight = conf.masterSlotAssignLoadAwareFlushTimeWeight
-  private val loadAwareFetchTimeWeight = conf.masterSlotAssignLoadAwareFetchTimeWeight
-
   private val estimatedPartitionSizeUpdaterInitialDelay =
     conf.estimatedPartitionSizeUpdaterInitialDelay
   private val estimatedPartitionSizeForEstimationUpdateInterval =
@@ -664,11 +656,7 @@ private[celeborn] class Master(
               requestSlots.partitionIdList,
               requestSlots.shouldReplicate,
               requestSlots.shouldRackAware,
-              diskReserveSize,
-              slotsAssignLoadAwareDiskGroupNum,
-              slotsAssignLoadAwareDiskGroupGradient,
-              loadAwareFlushTimeWeight,
-              loadAwareFetchTimeWeight,
+              conf,
               requestSlots.availableStorageTypes)
           } else {
             SlotsAllocator.offerSlotsRoundRobin(

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -121,7 +121,16 @@ private[celeborn] class Master(
   private def shutdownWorkerSnapshot: util.List[WorkerInfo] =
     statusSystem.workers.synchronized(new util.ArrayList[WorkerInfo](statusSystem.shutdownWorkers))
 
+  private def diskReserveSize = conf.workerDiskReserveSize
+  private def diskReserveRatio = conf.workerDiskReserveRatio
+
   private val slotsAssignMaxWorkers = conf.masterSlotAssignMaxWorkers
+  private val slotsAssignLoadAwareDiskGroupNum = conf.masterSlotAssignLoadAwareDiskGroupNum
+  private val slotsAssignLoadAwareDiskGroupGradient =
+    conf.masterSlotAssignLoadAwareDiskGroupGradient
+  private val loadAwareFlushTimeWeight = conf.masterSlotAssignLoadAwareFlushTimeWeight
+  private val loadAwareFetchTimeWeight = conf.masterSlotAssignLoadAwareFetchTimeWeight
+
   private val estimatedPartitionSizeUpdaterInitialDelay =
     conf.estimatedPartitionSizeUpdaterInitialDelay
   private val estimatedPartitionSizeForEstimationUpdateInterval =
@@ -656,7 +665,12 @@ private[celeborn] class Master(
               requestSlots.partitionIdList,
               requestSlots.shouldReplicate,
               requestSlots.shouldRackAware,
-              conf,
+              diskReserveSize,
+              diskReserveRatio,
+              slotsAssignLoadAwareDiskGroupNum,
+              slotsAssignLoadAwareDiskGroupGradient,
+              loadAwareFlushTimeWeight,
+              loadAwareFetchTimeWeight,
               requestSlots.availableStorageTypes)
           } else {
             SlotsAllocator.offerSlotsRoundRobin(

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
+import scala.Option;
 import scala.Tuple2;
 
 import org.junit.Assert;
@@ -228,17 +229,20 @@ public class SlotsAllocatorSuiteJ {
       boolean expectSuccess) {
     String shuffleKey = "appId-1";
     CelebornConf conf = new CelebornConf();
-    conf.set(CelebornConf.MASTER_SLOT_ASSIGN_LOADAWARE_DISKGROUP_NUM(), 2);
-    conf.set(CelebornConf.MASTER_SLOT_ASSIGN_LOADAWARE_DISKGROUP_GRADIENT(), 1.0);
-    conf.set(CelebornConf.WORKER_DISK_RESERVE_SIZE(), 10 * 1024 * 1024 * 1024L);
-    conf.set(CelebornConf.WORKER_DISK_RESERVE_RATIO(), 0.1);
+    conf.set(CelebornConf.MASTER_SLOT_ASSIGN_LOADAWARE_DISKGROUP_NUM().key(), "2");
+    conf.set(CelebornConf.MASTER_SLOT_ASSIGN_LOADAWARE_DISKGROUP_GRADIENT().key(), "1");
     Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
         SlotsAllocator.offerSlotsLoadAware(
             workers,
             partitionIds,
             shouldReplicate,
             false,
-            conf,
+            10 * 1024 * 1024 * 1024L,
+            Option.empty(),
+            conf.masterSlotAssignLoadAwareDiskGroupNum(),
+            conf.masterSlotAssignLoadAwareDiskGroupGradient(),
+            conf.masterSlotAssignLoadAwareFlushTimeWeight(),
+            conf.masterSlotAssignLoadAwareFetchTimeWeight(),
             StorageInfo.ALL_TYPES_AVAILABLE_MASK);
     if (expectSuccess) {
       if (shouldReplicate) {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -228,19 +228,17 @@ public class SlotsAllocatorSuiteJ {
       boolean expectSuccess) {
     String shuffleKey = "appId-1";
     CelebornConf conf = new CelebornConf();
-    conf.set(CelebornConf.MASTER_SLOT_ASSIGN_LOADAWARE_DISKGROUP_NUM().key(), "2");
-    conf.set(CelebornConf.MASTER_SLOT_ASSIGN_LOADAWARE_DISKGROUP_GRADIENT().key(), "1");
+    conf.set(CelebornConf.MASTER_SLOT_ASSIGN_LOADAWARE_DISKGROUP_NUM(), 2);
+    conf.set(CelebornConf.MASTER_SLOT_ASSIGN_LOADAWARE_DISKGROUP_GRADIENT(), 1.0);
+    conf.set(CelebornConf.WORKER_DISK_RESERVE_SIZE(), 10 * 1024 * 1024 * 1024L);
+    conf.set(CelebornConf.WORKER_DISK_RESERVE_RATIO(), 0.1);
     Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
         SlotsAllocator.offerSlotsLoadAware(
             workers,
             partitionIds,
             shouldReplicate,
             false,
-            10 * 1024 * 1024 * 1024L,
-            conf.masterSlotAssignLoadAwareDiskGroupNum(),
-            conf.masterSlotAssignLoadAwareDiskGroupGradient(),
-            conf.masterSlotAssignLoadAwareFlushTimeWeight(),
-            conf.masterSlotAssignLoadAwareFetchTimeWeight(),
+            conf,
             StorageInfo.ALL_TYPES_AVAILABLE_MASK);
     if (expectSuccess) {
       if (shouldReplicate) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support `celeborn.worker.storage.disk.reserve.ratio` to configure worker reserved ratio for each disk.

### Why are the changes needed?

`CelebornConf` supports to configure celeborn worker reserved space for each disk, which space is absolute. `CelebornConf` could support `celeborn.worker.storage.disk.reserve.ratio` to configure worker reserved ratio for each disk. The minimum usable size for each disk should be the max space between the reserved space and the space calculate via reserved ratio.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`SlotsAllocatorSuiteJ`