### PR TITLE
[CELEBORN-1114] Remove allocationBuckets from WorkerInfo and refactor SLOTS_ALLOCATED metrics

### DIFF
--- a/assets/grafana/celeborn-dashboard.json
+++ b/assets/grafana/celeborn-dashboard.json
@@ -1184,12 +1184,12 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "metrics_SlotsAllocated_Value",
+              "expr": "metrics_SlotsAllocated_Count",
               "legendFormat": "${baseLegend}",
               "refId": "A"
             }
           ],
-          "title": "metrics_SlotsAllocated_Value",
+          "title": "metrics_SlotsAllocated_Count",
           "type": "timeseries"
         },
         {

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -59,14 +59,6 @@ class WorkerInfo(
       new util.HashMap[UserIdentifier, ResourceConsumption]())
   }
 
-  val allocationBuckets = new Array[Int](61)
-  var bucketIndex = 0
-  var bucketTime = System.currentTimeMillis()
-  var bucketAllocations = 0
-  0 until allocationBuckets.length foreach { case idx =>
-    allocationBuckets(idx) = 0
-  }
-
   def isActive: Boolean = {
     endpoint.asInstanceOf[NettyRpcEndpointRef].client.isActive
   }
@@ -76,27 +68,19 @@ class WorkerInfo(
     diskInfos.asScala.map(_._2.activeSlots).sum
   }
 
-  def allocateSlots(shuffleKey: String, slotsPerDisk: util.Map[String, Integer]): Unit =
+  def allocateSlots(shuffleKey: String, slotsPerDisk: util.Map[String, Integer]): Unit = {
+    logDebug(s"Shuffle $shuffleKey, allocations $slotsPerDisk")
     this.synchronized {
-      logDebug(s"shuffle $shuffleKey allocations $slotsPerDisk")
-      var totalSlots = 0
       slotsPerDisk.asScala.foreach { case (disk, slots) =>
-        if (!diskInfos.containsKey(disk)) {
-          logDebug(s"Unknown disk $disk")
+        val diskInfo = diskInfos.get(disk)
+        if (diskInfo == null) {
+          logDebug(s"Unknown disk $disk when allocateSlots")
         } else {
-          diskInfos.get(disk).allocateSlots(shuffleKey, slots)
+          diskInfo.allocateSlots(shuffleKey, slots)
         }
-        totalSlots += slots
       }
-
-      val current = System.currentTimeMillis()
-      if (current - bucketTime > 60 * 1000) {
-        bucketIndex = (bucketIndex + 1) % allocationBuckets.length
-        allocationBuckets(bucketIndex) = 0
-        bucketTime = current
-      }
-      allocationBuckets(bucketIndex) = allocationBuckets(bucketIndex) + totalSlots
     }
+  }
 
   def releaseSlots(shuffleKey: String, slots: util.Map[String, Integer]): Unit = this.synchronized {
     slots.asScala.foreach { case (disk, slot) =>
@@ -116,14 +100,6 @@ class WorkerInfo(
       shuffleKeySet.addAll(diskInfo.getShuffleKeySet())
     }
     shuffleKeySet
-  }
-
-  def allocationsInLastHour(): Int = this.synchronized {
-    var total = 0
-    1 to 60 foreach { case delta =>
-      total += allocationBuckets((bucketIndex + delta) % allocationBuckets.length)
-    }
-    total
   }
 
   def hasSameInfoWith(other: WorkerInfo): Boolean = {

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -815,7 +815,7 @@ object Utils extends Logging {
     val slotDistributions = new util.HashMap[String, Integer]()
     (masterLocations.asScala ++ workerLocations.asScala)
       .foreach {
-        case location =>
+        location =>
           val mountPoint = location.getStorageInfo.getMountPoint
           if (slotDistributions.containsKey(mountPoint)) {
             slotDistributions.put(mountPoint, slotDistributions.get(mountPoint) + 1)
@@ -823,10 +823,10 @@ object Utils extends Logging {
             slotDistributions.put(mountPoint, 1)
           }
       }
-    logDebug(s"locations to distribution ," +
-      s" ${masterLocations.asScala.map(_.toString).mkString(",")} " +
+    logDebug(s"locations to distribution, " +
+      s"${masterLocations.asScala.map(_.toString).mkString(",")} " +
       s"${workerLocations.asScala.map(_.toString).mkString(",")} " +
-      s"to ${slotDistributions} ")
+      s"to $slotDistributions ")
     slotDistributions
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -247,6 +247,7 @@ private[deploy] class Controller(
     workerInfo.allocateSlots(
       shuffleKey,
       Utils.getSlotsPerDisk(requestPrimaryLocs, requestReplicaLocs))
+    workerSource.incCounter(WorkerSource.SLOTS_ALLOCATED, primaryLocs.size() + replicaLocs.size())
 
     logInfo(s"Reserved ${primaryLocs.size()} primary location" +
       s" and ${replicaLocs.size()} replica location for $shuffleKey ")

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -278,9 +278,6 @@ private[celeborn] class Worker(
   workerSource.addGauge(WorkerSource.REGISTERED_SHUFFLE_COUNT) { () =>
     workerInfo.getShuffleKeySet.size
   }
-  workerSource.addGauge(WorkerSource.SLOTS_ALLOCATED) { () =>
-    workerInfo.allocationsInLastHour()
-  }
   workerSource.addGauge(WorkerSource.SORT_MEMORY) { () =>
     memoryManager.getSortMemoryCounter.get()
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -38,6 +38,8 @@ class WorkerSource(conf: CelebornConf) extends AbstractSource(conf, MetricsSyste
   addCounter(REGION_FINISH_FAIL_COUNT)
   addCounter(ACTIVE_CONNECTION_COUNT)
 
+  addCounter(SLOTS_ALLOCATED)
+
   // add timers
   addTimer(COMMIT_FILES_TIME)
   addTimer(RESERVE_SLOTS_TIME)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, `WorkerInfo` is used in many places, and allocationBuckets is only used when its own workers want to collect metrics `SLOTS_ALLOCATED`. If there are lots of workers in the RSS cluster, there may be a certain amount of memory waste, each `WorkerInfo` maintain a Array\[Int](61), so remove it from `WorkerInfo`. 
And refactor the metrics `SLOTS_ALLOCATED` from gauge to counter. Originally, this metrics is approximately one hour's total only if there are continuous tasks. Now refactoring it into a counter can reduce the cost of maintaining time windows, including storage and timely expiration data, etc. It can also be more flexibly transformed according to user needs on the prometheus side. 


### Why are the changes needed?
Ditto.


### Does this PR introduce _any_ user-facing change?
Yes. metrics_SlotsAllocated_Count metrics change from gauge for 1 hour to a increasing counter. 


### How was this patch tested?
Cluster test.
