### PR TITLE
[CELEBORN-1118] Cache files in memory

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/meta/Buffers.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/Buffers.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.meta;
+
+import org.apache.celeborn.common.network.buffer.ManagedBuffer;
+
+public interface Buffers {
+  int numChunks();
+
+  ManagedBuffer chunk(int chunkIndex, int offset, int len);
+}

--- a/common/src/main/java/org/apache/celeborn/common/util/MemCacheManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/MemCacheManager.java
@@ -1,0 +1,70 @@
+package org.apache.celeborn.common.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.netty.buffer.ByteBuf;
+
+import org.apache.celeborn.common.CelebornConf;
+
+public class MemCacheManager {
+  private static MemCacheManager memCacheManager;
+  private ConcurrentMap<String, ByteBuf> caches = new ConcurrentHashMap<>();
+  private CelebornConf conf;
+  private long maxCacheSize;
+  private boolean cacheEnable;
+  private AtomicLong currentCacheSize = new AtomicLong(0);
+
+  public MemCacheManager(CelebornConf conf) {
+    this.conf = conf;
+    maxCacheSize = this.conf.fileCacheMaxSize();
+    cacheEnable = this.conf.fileCacheEnable();
+  }
+
+  public void putCache(String key, ByteBuf cache) {
+    int cacheSize = cache.readableBytes();
+    caches.put(key, cache);
+    currentCacheSize.getAndAdd(cacheSize);
+  }
+
+  public boolean canCache(int cacheSize) {
+    return cacheEnable && (maxCacheSize > currentCacheSize.get() + cacheSize);
+  }
+
+  public void removeCache(String key) {
+    ByteBuf cache = caches.remove(key);
+    currentCacheSize.getAndAdd(-1 * cache.readableBytes());
+  }
+
+  public boolean contains(String key) {
+    if (!cacheEnable) return false;
+    return caches.containsKey(key);
+  }
+
+  public ByteBuf getCache(String key) {
+    return caches.get(key);
+  }
+
+  public static synchronized MemCacheManager getMemCacheManager(CelebornConf conf) {
+    if (memCacheManager == null) {
+      memCacheManager = new MemCacheManager(conf);
+    }
+    return memCacheManager;
+  }
+
+  public static synchronized MemCacheManager getMemCacheManager() {
+    if (memCacheManager == null) {
+      memCacheManager = new MemCacheManager(new CelebornConf());
+    }
+    return memCacheManager;
+  }
+
+  public long getCurrentCacheSize() {
+    return currentCacheSize.get();
+  }
+
+  public int getCacheFileNum() {
+    return caches.size();
+  }
+}

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -913,6 +913,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def partitionSplitMinimumSize: Long = get(WORKER_PARTITION_SPLIT_MIN_SIZE)
   def partitionSplitMaximumSize: Long = get(WORKER_PARTITION_SPLIT_MAX_SIZE)
 
+  def fileCacheMaxSize: Long = get(FILE_CACHE_MAX_SIZE)
+  def fileCacheEnable: Boolean = get(FILE_CACHE_ENABLE)
+
   def hdfsDir: String = {
     get(HDFS_DIR).map {
       hdfsDir =>
@@ -2056,6 +2059,22 @@ object CelebornConf extends Logging {
       .version("0.3.0")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("2g")
+
+  val FILE_CACHE_MAX_SIZE: ConfigEntry[Long] =
+    buildConf("celeborn.shuffle.cache.max")
+      .categories("worker")
+      .doc("Max size for shuffle file cache to memory")
+      .version("0.4.0")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("10g")
+
+  val FILE_CACHE_ENABLE: ConfigEntry[Boolean] =
+    buildConf("celeborn.shuffle.cache.enable")
+      .categories("worker")
+      .doc("memory cache enable")
+      .version("0.4.0")
+      .booleanConf
+      .createWithDefault(true)
 
   val WORKER_STORAGE_DIRS: OptionalConfigEntry[Seq[String]] =
     buildConf("celeborn.worker.storage.dirs")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -2064,17 +2064,17 @@ object CelebornConf extends Logging {
     buildConf("celeborn.shuffle.cache.max")
       .categories("worker")
       .doc("Max size for shuffle file cache to memory")
-      .version("0.4.0")
+      .version("0.3.2")
       .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("10g")
+      .createWithDefaultString("256m")
 
   val FILE_CACHE_ENABLE: ConfigEntry[Boolean] =
     buildConf("celeborn.shuffle.cache.enable")
       .categories("worker")
-      .doc("memory cache enable")
-      .version("0.4.0")
+      .doc("wether memory cache enable, it only effective when using local disk and should disable local shuffle read")
+      .version("0.3.2")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val WORKER_STORAGE_DIRS: OptionalConfigEntry[Seq[String]] =
     buildConf("celeborn.worker.storage.dirs")

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -21,6 +21,8 @@ license: |
 | --- | ------- | ----------- | ----- |
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
 | celeborn.master.estimatedPartitionSize.minSize | 8mb | Ignore partition size smaller than this configuration of partition size for estimation. | 0.3.0 | 
+| celeborn.shuffle.cache.enable | true | memory cache enable | 0.4.0 | 
+| celeborn.shuffle.cache.max | 10g | Max size for shuffle file cache to memory | 0.4.0 | 
 | celeborn.shuffle.chunk.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. | 0.2.0 | 
 | celeborn.storage.availableTypes | HDD | Enabled storages. Available options: MEMORY,HDD,SSD,HDFS. Note: HDD and SSD would be treated as identical. | 0.3.0 | 
 | celeborn.storage.hdfs.dir | &lt;undefined&gt; | HDFS base directory for Celeborn to store shuffle data. | 0.2.0 | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -21,8 +21,8 @@ license: |
 | --- | ------- | ----------- | ----- |
 | celeborn.master.endpoints | &lt;localhost&gt;:9097 | Endpoints of master nodes for celeborn client to connect, allowed pattern is: `<host1>:<port1>[,<host2>:<port2>]*`, e.g. `clb1:9097,clb2:9098,clb3:9099`. If the port is omitted, 9097 will be used. | 0.2.0 | 
 | celeborn.master.estimatedPartitionSize.minSize | 8mb | Ignore partition size smaller than this configuration of partition size for estimation. | 0.3.0 | 
-| celeborn.shuffle.cache.enable | true | memory cache enable | 0.4.0 | 
-| celeborn.shuffle.cache.max | 10g | Max size for shuffle file cache to memory | 0.4.0 | 
+| celeborn.shuffle.cache.enable | false | wether memory cache enable, it only effective when using local disk and should disable local shuffle read | 0.3.2 | 
+| celeborn.shuffle.cache.max | 256m | Max size for shuffle file cache to memory | 0.3.2 | 
 | celeborn.shuffle.chunk.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. | 0.2.0 | 
 | celeborn.storage.availableTypes | HDD | Enabled storages. Available options: MEMORY,HDD,SSD,HDFS. Note: HDD and SSD would be treated as identical. | 0.3.0 | 
 | celeborn.storage.hdfs.dir | &lt;undefined&gt; | HDFS base directory for Celeborn to store shuffle data. | 0.2.0 | 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
@@ -27,7 +27,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.celeborn.common.meta.FileManagedBuffers;
+import org.apache.celeborn.common.meta.Buffers;
 import org.apache.celeborn.common.meta.TimeWindow;
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.util.JavaUtils;
@@ -49,14 +49,14 @@ public class ChunkStreamManager {
 
   /** State of a single stream. */
   protected static class StreamState {
-    final FileManagedBuffers buffers;
+    final Buffers buffers;
     final String shuffleKey;
     final TimeWindow fetchTimeMetric;
 
     // Used to keep track of the number of chunks being transferred and not finished yet.
     volatile long chunksBeingTransferred = 0L;
 
-    StreamState(String shuffleKey, FileManagedBuffers buffers, TimeWindow fetchTimeMetric) {
+    StreamState(String shuffleKey, Buffers buffers, TimeWindow fetchTimeMetric) {
       this.buffers = Preconditions.checkNotNull(buffers);
       this.shuffleKey = shuffleKey;
       this.fetchTimeMetric = fetchTimeMetric;
@@ -82,7 +82,7 @@ public class ChunkStreamManager {
           String.format("Requested chunk index beyond end %s", chunkIndex));
     }
 
-    FileManagedBuffers buffers = state.buffers;
+    Buffers buffers = state.buffers;
     return buffers.chunk(chunkIndex, offset, len);
   }
 
@@ -127,8 +127,7 @@ public class ChunkStreamManager {
    * <p>This stream could be reused again when other channel of the client is reconnected. If a
    * stream is not properly closed, it will eventually be cleaned up by `cleanupExpiredShuffleKey`.
    */
-  public long registerStream(
-      String shuffleKey, FileManagedBuffers buffers, TimeWindow fetchTimeMetric) {
+  public long registerStream(String shuffleKey, Buffers buffers, TimeWindow fetchTimeMetric) {
     long myStreamId = nextStreamId.getAndIncrement();
     streams.put(myStreamId, new StreamState(shuffleKey, buffers, fetchTimeMetric));
     shuffleStreamIds.compute(

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/ChunkStreamManager.java
@@ -45,6 +45,8 @@ public class ChunkStreamManager {
   // ShuffleKey -> StreamId
   protected final ConcurrentHashMap<String, Set<Long>> shuffleStreamIds;
 
+  private AtomicLong chunksBeingTransferredNum = new AtomicLong(0);
+
   /** State of a single stream. */
   protected static class StreamState {
     final FileManagedBuffers buffers;
@@ -97,6 +99,7 @@ public class ChunkStreamManager {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
       streamState.chunksBeingTransferred++;
+      chunksBeingTransferredNum.incrementAndGet();
     }
   }
 
@@ -104,15 +107,12 @@ public class ChunkStreamManager {
     StreamState streamState = streams.get(streamId);
     if (streamState != null) {
       streamState.chunksBeingTransferred--;
+      chunksBeingTransferredNum.decrementAndGet();
     }
   }
 
   public long chunksBeingTransferred() {
-    long sum = 0L;
-    for (StreamState streamState : streams.values()) {
-      sum += streamState.chunksBeingTransferred;
-    }
-    return sum;
+    return chunksBeingTransferredNum.get();
   }
 
   /**

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -87,6 +87,7 @@ public abstract class FileWriter implements DeviceObserver {
   private String shuffleKey;
   private StorageManager storageManager;
   private boolean workerGracefulShutdown;
+  private MemCacheManager cacheManager;
 
   public FileWriter(
       FileInfo fileInfo,
@@ -130,6 +131,7 @@ public abstract class FileWriter implements DeviceObserver {
       }
     }
     source = workerSource;
+    cacheManager = MemCacheManager.getMemCacheManager(conf);
     logger.debug("FileWriter {} split threshold {} mode {}", this, splitThreshold, splitMode);
     if (rangeReadFilter) {
       this.mapIdBitMap = new RoaringBitmap();
@@ -155,7 +157,6 @@ public abstract class FileWriter implements DeviceObserver {
 
   @GuardedBy("flushLock")
   protected void flush(boolean finalFlush) throws IOException {
-    MemCacheManager cacheManager = MemCacheManager.getMemCacheManager();
     // flushBuffer == null here means writer already closed
     if (flushBuffer != null) {
       int numBytes = flushBuffer.readableBytes();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/FileWriter.java
@@ -42,6 +42,7 @@ import org.apache.celeborn.common.protocol.PartitionType;
 import org.apache.celeborn.common.protocol.StorageInfo;
 import org.apache.celeborn.common.unsafe.Platform;
 import org.apache.celeborn.common.util.FileChannelUtils;
+import org.apache.celeborn.common.util.MemCacheManager;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;
 import org.apache.celeborn.service.deploy.worker.congestcontrol.CongestionController;
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager;
@@ -154,19 +155,27 @@ public abstract class FileWriter implements DeviceObserver {
 
   @GuardedBy("flushLock")
   protected void flush(boolean finalFlush) throws IOException {
+    MemCacheManager cacheManager = MemCacheManager.getMemCacheManager();
     // flushBuffer == null here means writer already closed
     if (flushBuffer != null) {
       int numBytes = flushBuffer.readableBytes();
       if (numBytes != 0) {
         notifier.checkException();
-        notifier.numPendingFlushes.incrementAndGet();
-        FlushTask task = null;
-        if (channel != null) {
-          task = new LocalFlushTask(flushBuffer, channel, notifier);
-        } else if (fileInfo.isHdfs()) {
-          task = new HdfsFlushTask(flushBuffer, fileInfo.getHdfsPath(), notifier);
+        if (finalFlush && fileInfo.getFileLength() == 0 && cacheManager.canCache(numBytes)) {
+          cacheManager.putCache(fileInfo.getFilePath(), flushBuffer.copy());
+          flusher.returnBuffer(flushBuffer);
+          logger.debug(
+              "MemCache for " + fileInfo.getFilePath() + ", and total cache size is " + numBytes);
+        } else {
+          notifier.numPendingFlushes.incrementAndGet();
+          FlushTask task = null;
+          if (channel != null) {
+            task = new LocalFlushTask(flushBuffer, channel, notifier);
+          } else if (fileInfo.isHdfs()) {
+            task = new HdfsFlushTask(flushBuffer, fileInfo.getHdfsPath(), notifier);
+          }
+          addTask(task);
         }
-        addTask(task);
         flushBuffer = null;
         fileInfo.updateBytesFlushed(numBytes);
         if (!finalFlush) {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -90,6 +90,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
 
   private final ExecutorService fileSorterExecutors;
   private final Thread fileSorterSchedulerThread;
+  private MemCacheManager memCacheManager;
 
   public PartitionFilesSorter(
       MemoryManager memoryManager, CelebornConf conf, AbstractSource source) {
@@ -103,6 +104,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
     this.source = source;
     this.memoryManager = memoryManager;
     this.gracefulShutdown = conf.workerGracefulShutdown();
+    this.memCacheManager = MemCacheManager.getMemCacheManager(conf);
     // ShuffleClient can fetch shuffle data from a restarted worker only
     // when the worker's fetching port is stable and enables graceful shutdown.
     if (gracefulShutdown) {
@@ -611,7 +613,6 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
     }
 
     private void initializeFiles() throws IOException {
-      MemCacheManager memCacheManager = MemCacheManager.getMemCacheManager();
       if (isHdfs) {
         if (memCacheManager.contains(originFilePath)) {
           FSDataOutputStream hdfsOriginOutput =

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -339,7 +339,7 @@ private[celeborn] class Worker(
     memCacheManager.getCacheFileNum
   }
   workerSource.addGauge(WorkerSource.fileCacheHitRate) { () =>
-    FileManagedBuffers.getMemHitRate
+    fetchHandler.getMemCacheHitRate
   }
 
   private def highWorkload: Boolean = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/WorkerSource.scala
@@ -133,4 +133,12 @@ object WorkerSource {
   // active shuffle size
   val ACTIVE_SHUFFLE_SIZE = "ActiveShuffleSize"
   val ACTIVE_SHUFFLE_FILE_COUNT = "ActiveShuffleFileCount"
+  val RunningStreamTotalCount = "RunningStreamTotal"
+  val ChunksBeingTransferredNum = "ChunksBeingTransferred"
+  val pendingTotalReadFileSize = "pendingTotalReadFileSize"
+  val readTotalFileSize = "ReadTotalFileSize"
+  val totalChunkNum = "TotalChunk"
+  val fileCacheSize = "FileCacheSize"
+  val fileCacheNum = "FileCacheNum"
+  val fileCacheHitRate = "FileCacheHitRate"
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -131,6 +131,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
 
   deviceMonitor.startCheck()
 
+  val memCacheManager: MemCacheManager = MemCacheManager.getMemCacheManager(conf)
+
   val hdfsDir = conf.hdfsDir
   val hdfsPermission = new FsPermission("755")
   val hdfsWriters = JavaUtils.newConcurrentHashMap[String, FileWriter]()
@@ -550,7 +552,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   def cleanupExpiredShuffleKey(
       expiredShuffleKeys: util.HashSet[String],
       cleanDB: Boolean = true): Unit = {
-    val memCacheManager: MemCacheManager = MemCacheManager.getMemCacheManager
     expiredShuffleKeys.asScala.foreach { shuffleKey =>
       logInfo(s"Cleanup expired shuffle $shuffleKey.")
       if (fileInfos.containsKey(shuffleKey)) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Support for small file caching to improve shuffle performance,The architecture is as follows:
![image](https://github.com/apache/incubator-celeborn/assets/24331196/a4140acd-fcf5-4a30-8961-464b1f47d468)


### Why are the changes needed?

Support for small file caching to improve shuffle performance

### Does this PR introduce _any_ user-facing change?

None

### How was this patch tested?
The test resource used is as follows:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/11136313/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/11136313/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:middle;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



host memory | host cpu | disk | service heap memory | service off-heap memory | worker | master | spark total resource
-- | -- | -- | -- | -- | -- | -- | --
128G | 64 core | 11 * 7.1T | 12g | 40g | 5 | 3 | 25T/6400C



</body>

</html>

When turning off memory cache, test the performance as follows：
![image](https://github.com/apache/incubator-celeborn/assets/24331196/abb8242b-89c4-4db5-a1dd-296066230dc6)
Duration of application execution：
![image](https://github.com/apache/incubator-celeborn/assets/24331196/ae66ccc3-957b-4346-96eb-928b823775ac)
![image](https://github.com/apache/incubator-celeborn/assets/24331196/8bfb5833-016b-4657-9ba7-35b5ac8b5922)


The performance when I use memory for caching is as follows：
![image](https://github.com/apache/incubator-celeborn/assets/24331196/c82f1aa2-f9ce-4555-b08b-d66bfeb6dfa7)
![image](https://github.com/apache/incubator-celeborn/assets/24331196/fc069091-47ba-4de8-a0c7-78ac9a3393a9)
Duration of application execution：
![image](https://github.com/apache/incubator-celeborn/assets/24331196/69d50753-4bbe-442f-bf1f-88d2d10dfb1e)
![image](https://github.com/apache/incubator-celeborn/assets/24331196/49479f04-3707-45a1-a4d1-9dd89c1249c0)

The peak flow rate exceeds 20G, and the maximum time consumption is reduced to less than 2min,up to 4x performance improvement.

I think there are two aspects to improving performance:
1. Using memory reduces requests to obtain local disk data
2. Reduced file open consume and improved disk sequential read capability