### PR TITLE
[CELEBORN-1116] Read authentication configs from `HADOOP_CONF_DIR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ celeborn.rpc.askTimeout 240s
 celeborn.worker.flusher.hdfs.buffer.size 4m
 celeborn.storage.hdfs.dir hdfs://<namenode>/celeborn
 celeborn.worker.replicate.fastFail.duration 240s
-# If you HDFS is enabled with Kerberos.
-# You will need to set the following configs or use kinit to get valid TGT.
+# Either principal/keytab or valid TGT cache is required to access kerberized HDFS
 celeborn.storage.hdfs.kerberos.principal user@REALM
 celeborn.storage.hdfs.kerberos.keytab /path/to/user.keytab
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ celeborn.rpc.askTimeout 240s
 celeborn.worker.flusher.hdfs.buffer.size 4m
 celeborn.storage.hdfs.dir hdfs://<namenode>/celeborn
 celeborn.worker.replicate.fastFail.duration 240s
+# If you HDFS is enabled with Kerberos.
+# You will need to set the following configs or use kinit to get valid TGT.
+celeborn.storage.hdfs.kerberos.principal user@REALM
+celeborn.storage.hdfs.kerberos.keytab /path/to/user.keytab
 
 # If your hosts have disk raid or use lvm, set celeborn.worker.monitor.disk.enabled to false
 celeborn.worker.monitor.disk.enabled false

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1069,7 +1069,6 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   // //////////////////////////////////////////////////////
   //                    kerberos                         //
   // //////////////////////////////////////////////////////
-  def hdfsStorageKerberosEnabled = get(HDFS_STORAGE_TYPE_KERBEROS_ENABLED)
   def hdfsStorageKerberosPrincipal = get(HDFS_STORAGE_KERBEROS_PRINCIPAL)
   def hdfsStorageKerberosKeytab = get(HDFS_STORAGE_KERBEROS_KEYTAB)
 }
@@ -4016,14 +4015,6 @@ object CelebornConf extends Logging {
       .version("0.3.2")
       .intConf
       .createWithDefault(64)
-
-  val HDFS_STORAGE_TYPE_KERBEROS_ENABLED: ConfigEntry[Boolean] =
-    buildConf("celeborn.storage.hdfs.kerberos.enabled")
-      .categories("master", "worker")
-      .version("0.3.2")
-      .doc("Whether to enable kerberos authentication for HDFS storage connection.")
-      .booleanConf
-      .createWithDefault(false)
 
   val HDFS_STORAGE_KERBEROS_PRINCIPAL: OptionalConfigEntry[String] =
     buildConf("celeborn.storage.hdfs.kerberos.principal")

--- a/common/src/main/scala/org/apache/celeborn/common/util/CelebornHadoopUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/CelebornHadoopUtils.scala
@@ -77,8 +77,6 @@ object CelebornHadoopUtils extends Logging {
   }
 
   def initKerberos(conf: CelebornConf, hadoopConf: Configuration): Unit = {
-    // If we are accessing HDFS and it has Kerberos enabled, we have to login
-    // from a keytab file so that we can access HDFS beyond the kerberos ticket expiration.
     UserGroupInformation.setConfiguration(hadoopConf)
     if ("kerberos".equals(hadoopConf.get("hadoop.security.authentication").toLowerCase)) {
       val principalOpt = conf.hdfsStorageKerberosPrincipal

--- a/common/src/main/scala/org/apache/celeborn/common/util/CelebornHadoopUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/CelebornHadoopUtils.scala
@@ -81,8 +81,8 @@ object CelebornHadoopUtils extends Logging {
     if ("kerberos".equals(hadoopConf.get("hadoop.security.authentication").toLowerCase)) {
       (conf.hdfsStorageKerberosPrincipal, conf.hdfsStorageKerberosKeytab) match {
         case (Some(principal), Some(keytab)) =>
-          logInfo("Attempting to login to Kerberos " +
-            s"using principal: ${principal} and keytab: ${keytab}")
+          logInfo(
+            s"Attempting to login to Kerberos using principal: $principal and keytab: $keytab")
           if (!new File(keytab).exists()) {
             throw new CelebornException(s"Keytab file: ${keytab} does not exist")
           }

--- a/common/src/main/scala/org/apache/celeborn/common/util/CelebornHadoopUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/CelebornHadoopUtils.scala
@@ -84,7 +84,7 @@ object CelebornHadoopUtils extends Logging {
           logInfo(
             s"Attempting to login to Kerberos using principal: $principal and keytab: $keytab")
           if (!new File(keytab).exists()) {
-            throw new CelebornException(s"Keytab file: ${keytab} does not exist")
+            throw new CelebornException(s"Keytab file: $keytab does not exist")
           }
           UserGroupInformation.loginUserFromKeytab(principal, keytab)
         case _ =>

--- a/common/src/main/scala/org/apache/celeborn/common/util/CelebornHadoopUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/CelebornHadoopUtils.scala
@@ -79,9 +79,7 @@ object CelebornHadoopUtils extends Logging {
   def initKerberos(conf: CelebornConf, hadoopConf: Configuration): Unit = {
     UserGroupInformation.setConfiguration(hadoopConf)
     if ("kerberos".equals(hadoopConf.get("hadoop.security.authentication").toLowerCase)) {
-      val principalOpt = conf.hdfsStorageKerberosPrincipal
-      val keytabOpt = conf.hdfsStorageKerberosKeytab
-      (principalOpt, keytabOpt) match {
+      (conf.hdfsStorageKerberosPrincipal, conf.hdfsStorageKerberosKeytab) match {
         case (Some(principal), Some(keytab)) =>
           logInfo("Attempting to login to Kerberos " +
             s"using principal: ${principal} and keytab: ${keytab}")

--- a/docs/configuration/master.md
+++ b/docs/configuration/master.md
@@ -40,7 +40,6 @@ license: |
 | celeborn.master.workerUnavailableInfo.expireTimeout | 1800s | Worker unavailable info would be cleared when the retention period is expired | 0.3.1 | 
 | celeborn.storage.availableTypes | HDD | Enabled storages. Available options: MEMORY,HDD,SSD,HDFS. Note: HDD and SSD would be treated as identical. | 0.3.0 | 
 | celeborn.storage.hdfs.dir | &lt;undefined&gt; | HDFS base directory for Celeborn to store shuffle data. | 0.2.0 | 
-| celeborn.storage.hdfs.kerberos.enabled | false | Whether to enable kerberos authentication for HDFS storage connection. | 0.3.2 | 
 | celeborn.storage.hdfs.kerberos.keytab | &lt;undefined&gt; | Kerberos keytab file path for HDFS storage connection. | 0.3.2 | 
 | celeborn.storage.hdfs.kerberos.principal | &lt;undefined&gt; | Kerberos principal for HDFS storage connection. | 0.3.2 | 
 <!--end-include-->

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -24,7 +24,6 @@ license: |
 | celeborn.shuffle.chunk.size | 8m | Max chunk size of reducer's merged shuffle data. For example, if a reducer's shuffle data is 128M and the data will need 16 fetch chunk requests to fetch. | 0.2.0 | 
 | celeborn.storage.availableTypes | HDD | Enabled storages. Available options: MEMORY,HDD,SSD,HDFS. Note: HDD and SSD would be treated as identical. | 0.3.0 | 
 | celeborn.storage.hdfs.dir | &lt;undefined&gt; | HDFS base directory for Celeborn to store shuffle data. | 0.2.0 | 
-| celeborn.storage.hdfs.kerberos.enabled | false | Whether to enable kerberos authentication for HDFS storage connection. | 0.3.2 | 
 | celeborn.storage.hdfs.kerberos.keytab | &lt;undefined&gt; | Kerberos keytab file path for HDFS storage connection. | 0.3.2 | 
 | celeborn.storage.hdfs.kerberos.principal | &lt;undefined&gt; | Kerberos principal for HDFS storage connection. | 0.3.2 | 
 | celeborn.worker.activeConnection.max | &lt;undefined&gt; | If the number of active connections on a worker exceeds this configuration value, the worker will be marked as high-load in the heartbeat report, and the master will not include that node in the response of RequestSlots. | 0.3.1 | 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -58,8 +58,7 @@ celeborn.rpc.askTimeout 240s
 celeborn.worker.flusher.hdfs.buffer.size 4m
 celeborn.storage.hdfs.dir hdfs://<namenode>/celeborn
 celeborn.worker.replicate.fastFail.duration 240s
-# If you HDFS is enabled with Kerberos. 
-# You will need to set the following configs or use kinit to get valid TGT.
+# Either principal/keytab or valid TGT cache is required to access kerberized HDFS
 celeborn.storage.hdfs.kerberos.principal user@REALM
 celeborn.storage.hdfs.kerberos.keytab /path/to/user.keytab
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -58,6 +58,10 @@ celeborn.rpc.askTimeout 240s
 celeborn.worker.flusher.hdfs.buffer.size 4m
 celeborn.storage.hdfs.dir hdfs://<namenode>/celeborn
 celeborn.worker.replicate.fastFail.duration 240s
+# If you HDFS is enabled with Kerberos. 
+# You will need to set the following configs or use kinit to get valid TGT.
+celeborn.storage.hdfs.kerberos.principal user@REALM
+celeborn.storage.hdfs.kerberos.keytab /path/to/user.keytab
 
 # If your hosts have disk raid or use lvm, set celeborn.worker.monitor.disk.enabled to false
 celeborn.worker.monitor.disk.enabled false

--- a/sbin/load-celeborn-env.sh
+++ b/sbin/load-celeborn-env.sh
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 
-unset HADOOP_CONF_DIR
-
 # included in all the celeborn scripts with source command
 # should not be executable directly
 # also should not be passed any arguments, since we need original $*


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Make Celeborn read configs from HADOOP_COND_DIR.
2. Remove unnecessary Kerberos configs.


### Why are the changes needed?
To support HDFS with Kerberos.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA and cluster.
