### PR TITLE
[CELEBORN-1121] Improve WorkerInfo#hashCode method

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -47,6 +47,8 @@ class WorkerInfo(
       JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption](_userResourceConsumption)
     else null
   var endpoint: RpcEndpointRef = null
+  // Cache the hash code for WorkerInfo
+  var hash = 0
 
   def this(host: String, rpcPort: Int, pushPort: Int, fetchPort: Int, replicatePort: Int) {
     this(
@@ -232,8 +234,17 @@ class WorkerInfo(
   }
 
   override def hashCode(): Int = {
-    val state = Seq(host, rpcPort, pushPort, fetchPort, replicatePort)
-    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+    var h = hash
+    if (h == 0) {
+      val state = Seq(host, rpcPort, pushPort, fetchPort, replicatePort)
+      var i = 0
+      while (i < state.size) {
+        h = 31 * h + state(i).hashCode()
+        i = i + 1
+      }
+      hash = h
+    }
+    h
   }
 }
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -48,7 +48,7 @@ class WorkerInfo(
     else null
   var endpoint: RpcEndpointRef = null
   // Cache the hash code for WorkerInfo
-  var hash = 0
+  private var hash = 0
 
   def this(host: String, rpcPort: Int, pushPort: Int, fetchPort: Int, replicatePort: Int) {
     this(

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -235,21 +235,12 @@ class WorkerInfo(
   }
 
   override def hashCode(): Int = {
-    var h = hash
-    if (h == 0 || isZeroHash) {
-      val state = Array(host, rpcPort, pushPort, fetchPort, replicatePort)
-      var i = 0
-      while (i < state.length) {
-        h = 31 * h + state(i).hashCode()
-        i = i + 1
-      }
-      if (h == 0) {
-        isZeroHash = true
-      } else {
-        hash = h
-      }
-    }
-    h
+    var result = host.hashCode()
+    result = 31 * result + rpcPort.hashCode()
+    result = 31 * result + pushPort.hashCode()
+    result = 31 * result + fetchPort.hashCode()
+    result = 31 * result + replicatePort.hashCode()
+    result
   }
 }
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -47,9 +47,6 @@ class WorkerInfo(
       JavaUtils.newConcurrentHashMap[UserIdentifier, ResourceConsumption](_userResourceConsumption)
     else null
   var endpoint: RpcEndpointRef = null
-  // Cache the hash code for WorkerInfo
-  private var hash = 0
-  private var isZeroHash = false
 
   def this(host: String, rpcPort: Int, pushPort: Int, fetchPort: Int, replicatePort: Int) {
     this(

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -49,6 +49,7 @@ class WorkerInfo(
   var endpoint: RpcEndpointRef = null
   // Cache the hash code for WorkerInfo
   private var hash = 0
+  private var isZeroHash = false
 
   def this(host: String, rpcPort: Int, pushPort: Int, fetchPort: Int, replicatePort: Int) {
     this(
@@ -235,14 +236,18 @@ class WorkerInfo(
 
   override def hashCode(): Int = {
     var h = hash
-    if (h == 0) {
-      val state = Seq(host, rpcPort, pushPort, fetchPort, replicatePort)
+    if (h == 0 || isZeroHash) {
+      val state = Array(host, rpcPort, pushPort, fetchPort, replicatePort)
       var i = 0
-      while (i < state.size) {
+      while (i < state.length) {
         h = 31 * h + state(i).hashCode()
         i = i + 1
       }
-      hash = h
+      if (h == 0) {
+        isZeroHash = true
+      } else {
+        hash = h
+      }
     }
     h
   }

--- a/common/src/test/scala/org/apache/celeborn/common/ComputeIfAbsentBenchmark.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/ComputeIfAbsentBenchmark.scala
@@ -30,9 +30,9 @@ import org.apache.celeborn.benchmark.{Benchmark, BenchmarkBase}
  * ComputeIfAbsent benchmark.
  * To run this benchmark:
  * {{{
- *   1. build/sbt "common/test:runMain <this class>"
+ *   1. build/sbt "celeborn-common/test:runMain <this class>"
  *   2. generate result:
- *      CELEBORN_GENERATE_BENCHMARK_FILES=1 build/sbt "common/test:runMain <this class>"
+ *      CELEBORN_GENERATE_BENCHMARK_FILES=1 build/sbt "celeborn-common/test:runMain <this class>"
  *      Results will be written to "benchmarks/ComputeIfAbsentBenchmark-results.txt".
  * }}}
  */

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -314,10 +314,10 @@ class WorkerInfoSuite extends CelebornFunSuite {
 
   test("Test WorkerInfo hashcode") {
     val host = generateRandomIPv4Address
-    val rpcPort = Random.nextInt(65535)
-    val pushPort = Random.nextInt(65535)
-    val fetchPort = Random.nextInt(65535)
-    val replicatePort = Random.nextInt(65535)
+    val rpcPort = Random.nextInt(65536)
+    val pushPort = Random.nextInt(65536)
+    val fetchPort = Random.nextInt(65536)
+    val replicatePort = Random.nextInt(65536)
     val workerInfo = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort)
 
     // origin hashCode() logic

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
-import scala.reflect.ClassTag
+import scala.util.Random
 
 import org.junit.Assert.{assertEquals, assertNotEquals, assertNotNull}
 
@@ -32,8 +32,7 @@ import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.quota.ResourceConsumption
-import org.apache.celeborn.common.rpc.{RpcAddress, RpcEndpointAddress, RpcEndpointRef, RpcEnv, RpcTimeout}
-import org.apache.celeborn.common.rpc.netty.{NettyRpcEndpointRef, NettyRpcEnv}
+import org.apache.celeborn.common.rpc.{RpcAddress, RpcEndpointAddress, RpcEnv}
 import org.apache.celeborn.common.util.{JavaUtils, ThreadUtils}
 
 class WorkerInfoSuite extends CelebornFunSuite {
@@ -304,12 +303,21 @@ class WorkerInfoSuite extends CelebornFunSuite {
     }
   }
 
+  def generateRandomIPv4Address: String = {
+    val ipAddress = new StringBuilder
+    for (i <- 0 until 4) {
+      ipAddress.append(Random.nextInt(256))
+      if (i < 3) ipAddress.append(".")
+    }
+    ipAddress.toString
+  }
+
   test("Test WorkerInfo hashcode") {
-    val host = "127.0.0.1"
-    val rpcPort = 9082
-    val pushPort = 9092
-    val fetchPort = 9093
-    val replicatePort = 9094
+    val host = generateRandomIPv4Address
+    val rpcPort = Random.nextInt(65535)
+    val pushPort = Random.nextInt(65535)
+    val fetchPort = Random.nextInt(65535)
+    val replicatePort = Random.nextInt(65535)
     val workerInfo = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort)
 
     // origin hashCode() logic

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -324,11 +324,9 @@ class WorkerInfoSuite extends CelebornFunSuite {
     val state = Seq(host, rpcPort, pushPort, fetchPort, replicatePort)
     val originHash = state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
 
-    // hashCode() with while loop
     val hashCode1 = workerInfo.hashCode()
     assert(originHash === hashCode1)
 
-    // hashCode() with cache
     val hashCode2 = workerInfo.hashCode()
     assert(hashCode1 === hashCode2)
   }

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -303,4 +303,34 @@ class WorkerInfoSuite extends CelebornFunSuite {
       }
     }
   }
+
+  test("Test WorkerInfo hashcode") {
+    val host = "127.0.0.1"
+    val rpcPort = 9082
+    val pushPort = 9092
+    val fetchPort = 9093
+    val replicatePort = 9094
+    val workerInfo = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort)
+
+    // origin hashCode()
+    var now = System.nanoTime()
+    val state = Seq(host, rpcPort, pushPort, fetchPort, replicatePort)
+    val originHash = state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+    var after = System.nanoTime()
+    println("WorkerInfo origin hash result = " + originHash + ", costs " + (after - now))
+
+    // hashCode() with while loop
+    now = System.nanoTime()
+    val hashCode1 = workerInfo.hashCode()
+    after = System.nanoTime()
+    println("WorkerInfo hashCode1 hash result = " + hashCode1 + ", costs " + (after - now))
+    assert(originHash === hashCode1)
+
+    // hashCode() with cache
+    now = System.nanoTime()
+    val hashCode2 = workerInfo.hashCode()
+    after = System.nanoTime()
+    println("WorkerInfo hashCode2 hash result = " + hashCode2 + ", costs " + (after - now))
+    assert(hashCode1 === hashCode2)
+  }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/meta/WorkerInfoSuite.scala
@@ -312,25 +312,16 @@ class WorkerInfoSuite extends CelebornFunSuite {
     val replicatePort = 9094
     val workerInfo = new WorkerInfo(host, rpcPort, pushPort, fetchPort, replicatePort)
 
-    // origin hashCode()
-    var now = System.nanoTime()
+    // origin hashCode() logic
     val state = Seq(host, rpcPort, pushPort, fetchPort, replicatePort)
     val originHash = state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
-    var after = System.nanoTime()
-    println("WorkerInfo origin hash result = " + originHash + ", costs " + (after - now))
 
     // hashCode() with while loop
-    now = System.nanoTime()
     val hashCode1 = workerInfo.hashCode()
-    after = System.nanoTime()
-    println("WorkerInfo hashCode1 hash result = " + hashCode1 + ", costs " + (after - now))
     assert(originHash === hashCode1)
 
     // hashCode() with cache
-    now = System.nanoTime()
     val hashCode2 = workerInfo.hashCode()
-    after = System.nanoTime()
-    println("WorkerInfo hashCode2 hash result = " + hashCode2 + ", costs " + (after - now))
     assert(hashCode1 === hashCode2)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change WorkerInfo#hashCode() from map+foldLeft to while and cache.

Test the each way to calculate, code and result show as below:
```
val state = Seq(host, rpcPort, pushPort, fetchPort, replicatePort)
// origin
val originHash = state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)

// for
var forHash = 0
for (i <- state) {
  forHash = 31 * forHash + i.hashCode()
}

// while
var whileHash = 0
var i = 0
while (i < state.size) {
  whileHash = 31 * whileHash + state(i).hashCode()
  i = i + 1
}
```
Result:
```
java version "1.8.0_261"
origin hash result = -831724440, costs 1103914 ns
for hash result = -831724440, costs 444588 ns (2.5x)
while hash result = -831724440, costs 46510 ns (23x)
```


### Why are the changes needed?
The current WorkerInfo's hashCode() is a little time-consuming. Since it is widely used in lots of hash maps, it needs to be improved.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added UT.
