### PR TITLE
[CELEBORN-1125] Bump guava from 14.0.1 to 32.1.3-jre

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/FileSegmentManagedBuffer.java
@@ -21,10 +21,11 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+
 import com.google.common.io.ByteStreams;
 import io.netty.channel.DefaultFileRegion;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.celeborn.common.network.util.LimitedInputStream;
 import org.apache.celeborn.common.network.util.TransportConf;

--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/FileSegmentManagedBuffer.java
@@ -21,8 +21,8 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
-
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import com.google.common.io.ByteStreams;
 import io.netty.channel.DefaultFileRegion;
 
@@ -145,10 +145,10 @@ public final class FileSegmentManagedBuffer extends ManagedBuffer {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("file", file)
-        .add("offset", offset)
-        .add("length", length)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("file", file)
+        .append("offset", offset)
+        .append("length", length)
         .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/NettyManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/NettyManagedBuffer.java
@@ -18,10 +18,11 @@
 package org.apache.celeborn.common.network.buffer;
 
 import java.io.IOException;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
@@ -77,6 +78,8 @@ public class NettyManagedBuffer extends ManagedBuffer {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("buf", buf).toString();
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+      .append("buf", buf)
+      .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/NettyManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/NettyManagedBuffer.java
@@ -18,14 +18,14 @@
 package org.apache.celeborn.common.network.buffer;
 
 import java.io.IOException;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 /** A {@link ManagedBuffer} backed by a Netty {@link ByteBuf}. */
 public class NettyManagedBuffer extends ManagedBuffer {
@@ -79,7 +79,7 @@ public class NettyManagedBuffer extends ManagedBuffer {
   @Override
   public String toString() {
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-      .append("buf", buf)
-      .toString();
+        .append("buf", buf)
+        .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/NioManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/NioManagedBuffer.java
@@ -18,10 +18,11 @@
 package org.apache.celeborn.common.network.buffer;
 
 import java.io.IOException;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import com.google.common.base.Objects;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
 
@@ -65,6 +66,8 @@ public class NioManagedBuffer extends ManagedBuffer {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("buf", buf).toString();
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("buf", buf)
+        .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/buffer/NioManagedBuffer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/buffer/NioManagedBuffer.java
@@ -18,13 +18,13 @@
 package org.apache.celeborn.common.network.buffer;
 
 import java.io.IOException;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 /** A {@link ManagedBuffer} backed by {@link ByteBuffer}. */
 public class NioManagedBuffer extends ManagedBuffer {

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -18,6 +18,8 @@
 package org.apache.celeborn.common.network.client;
 
 import java.io.Closeable;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -25,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.SettableFuture;
 import io.netty.channel.Channel;
@@ -314,10 +315,10 @@ public class TransportClient implements Closeable {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("remoteAddress", channel.remoteAddress())
-        .add("isActive", isActive())
-        .toString();
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+      .append("remoteAdress", channel.remoteAddress())
+      .append("isActive", isActive())
+      .toString();
   }
 
   private static final AtomicLong counter = new AtomicLong();

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -18,8 +18,6 @@
 package org.apache.celeborn.common.network.client;
 
 import java.io.Closeable;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -33,6 +31,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -316,9 +316,9 @@ public class TransportClient implements Closeable {
   @Override
   public String toString() {
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-      .append("remoteAdress", channel.remoteAddress())
-      .append("isActive", isActive())
-      .toString();
+        .append("remoteAdress", channel.remoteAddress())
+        .append("isActive", isActive())
+        .toString();
   }
 
   private static final AtomicLong counter = new AtomicLong();

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.protocol.PbChunkFetchRequest;
@@ -56,7 +58,7 @@ public final class ChunkFetchFailure extends ResponseMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(streamChunkSlice, errorString);
+    return Objects.hash(streamChunkSlice, errorString);
   }
 
   @Override
@@ -70,9 +72,9 @@ public final class ChunkFetchFailure extends ResponseMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("streamChunkId", streamChunkSlice)
-        .add("errorString", errorString)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("streamChunkId", streamChunkSlice)
+        .append("errorString", errorString)
         .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchFailure.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.protocol.PbChunkFetchRequest;
 

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchRequest.java
@@ -17,9 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import io.netty.buffer.ByteBuf;
 
 /**
  * Request to fetch a sequence of a single chunk of a stream. This will correspond to a single

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchRequest.java
@@ -17,7 +17,8 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import io.netty.buffer.ByteBuf;
 
 /**
@@ -67,6 +68,8 @@ public final class ChunkFetchRequest extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("streamChunkId", streamChunkSlice).toString();
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("streamChunkId", streamChunkSlice)
+        .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/ChunkFetchSuccess.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
@@ -76,7 +78,7 @@ public final class ChunkFetchSuccess extends ResponseMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(streamChunkSlice, body());
+    return Objects.hash(streamChunkSlice, body());
   }
 
   @Override
@@ -90,9 +92,9 @@ public final class ChunkFetchSuccess extends ResponseMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("streamChunkId", streamChunkSlice)
-        .add("buffer", body())
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("streamChunkId", streamChunkSlice)
+        .append("buffer", body())
         .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -19,7 +19,7 @@ package org.apache.celeborn.common.network.protocol;
 
 import java.nio.ByteBuffer;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
@@ -56,7 +56,7 @@ public abstract class Message implements Encodable {
   }
 
   protected boolean equals(Message other) {
-    return Objects.equal(body, other.body);
+    return Objects.equals(body, other.body);
   }
 
   public ByteBuffer toByteBuffer() {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/Message.java
@@ -18,8 +18,8 @@
 package org.apache.celeborn.common.network.protocol;
 
 import java.nio.ByteBuffer;
-
 import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/OneWayMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/OneWayMessage.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
@@ -66,7 +68,7 @@ public final class OneWayMessage extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(body());
+    return Objects.hash(body());
   }
 
   @Override
@@ -80,6 +82,8 @@ public final class OneWayMessage extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("body", body()).toString();
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("body", body())
+        .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/OneWayMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/OneWayMessage.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
@@ -19,11 +19,11 @@ package org.apache.celeborn.common.network.protocol;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Objects;
 
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 /**
  * Request to read a set of blocks. Returns {@link StreamHandle}. Use PbOpenStream instead of this

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/OpenStream.java
@@ -20,7 +20,9 @@ package org.apache.celeborn.common.network.protocol;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 /**
@@ -81,7 +83,7 @@ public final class OpenStream extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(
+    return Objects.hash(
         Arrays.hashCode(shuffleKey), Arrays.hashCode(fileName), startMapIndex, endMapIndex);
   }
 
@@ -99,11 +101,11 @@ public final class OpenStream extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("shuffleKey", new String(shuffleKey, StandardCharsets.UTF_8))
-        .add("fileName", new String(fileName, StandardCharsets.UTF_8))
-        .add("startMapIndex", startMapIndex)
-        .add("endMapIndex", endMapIndex)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("shuffleKey", new String(shuffleKey, StandardCharsets.UTF_8))
+        .append("fileName", new String(fileName, StandardCharsets.UTF_8))
+        .append("startMapIndex", startMapIndex)
+        .append("endMapIndex", endMapIndex)
         .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushData.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
@@ -86,7 +88,7 @@ public final class PushData extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(requestId, mode, shuffleKey, partitionUniqueId, body());
+    return Objects.hash(requestId, mode, shuffleKey, partitionUniqueId, body());
   }
 
   @Override
@@ -104,12 +106,12 @@ public final class PushData extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("requestId", requestId)
-        .add("mode", mode)
-        .add("shuffleKey", shuffleKey)
-        .add("partitionUniqueId", partitionUniqueId)
-        .add("body size", body().size())
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("requestId", requestId)
+        .append("mode", mode)
+        .append("shuffleKey", shuffleKey)
+        .append("partitionUniqueId", partitionUniqueId)
+        .append("body size", body().size())
         .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushData.java
@@ -18,9 +18,10 @@
 package org.apache.celeborn.common.network.protocol;
 
 import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushDataHandShake.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushDataHandShake.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 @Deprecated
 public final class PushDataHandShake extends RequestMessage {
@@ -85,8 +86,7 @@ public final class PushDataHandShake extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        mode, shuffleKey, partitionUniqueId, attemptId, numPartitions, bufferSize);
+    return Objects.hash(mode, shuffleKey, partitionUniqueId, attemptId, numPartitions, bufferSize);
   }
 
   @Override

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushDataHandShake.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushDataHandShake.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 @Deprecated
@@ -83,7 +85,7 @@ public final class PushDataHandShake extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(
+    return Objects.hash(
         mode, shuffleKey, partitionUniqueId, attemptId, numPartitions, bufferSize);
   }
 
@@ -104,13 +106,13 @@ public final class PushDataHandShake extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("mode", mode)
-        .add("shuffleKey", shuffleKey)
-        .add("partitionUniqueId", partitionUniqueId)
-        .add("attemptId", attemptId)
-        .add("numSubPartitions", numPartitions)
-        .add("bufferSize", bufferSize)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("mode", mode)
+        .append("shuffleKey", shuffleKey)
+        .append("partitionUniqueId", partitionUniqueId)
+        .append("attemptId", attemptId)
+        .append("numSubPartitions", numPartitions)
+        .append("bufferSize", bufferSize)
         .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushMergedData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushMergedData.java
@@ -18,11 +18,11 @@
 package org.apache.celeborn.common.network.protocol;
 
 import java.util.Arrays;
+import java.util.Objects;
 
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/PushMergedData.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/PushMergedData.java
@@ -19,7 +19,9 @@ package org.apache.celeborn.common.network.protocol;
 
 import java.util.Arrays;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
@@ -99,7 +101,7 @@ public final class PushMergedData extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(requestId, mode, shuffleKey);
+    return Objects.hash(requestId, mode, shuffleKey);
   }
 
   @Override
@@ -118,13 +120,13 @@ public final class PushMergedData extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("requestId", requestId)
-        .add("mode", mode)
-        .add("shuffleKey", shuffleKey)
-        .add("partitionIds", Arrays.toString(partitionUniqueIds))
-        .add("batchOffsets", Arrays.toString(batchOffsets))
-        .add("body size", body().size())
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("requestId", requestId)
+        .append("mode", mode)
+        .append("shuffleKey", shuffleKey)
+        .append("partitionIds", Arrays.toString(partitionUniqueIds))
+        .append("batchOffsets", Arrays.toString(batchOffsets))
+        .append("body size", body().size())
         .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionFinish.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionFinish.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 @Deprecated
 public final class RegionFinish extends RequestMessage {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionFinish.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionFinish.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 @Deprecated
@@ -68,7 +70,7 @@ public final class RegionFinish extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mode, shuffleKey, partitionUniqueId, attemptId);
+    return Objects.hash(mode, shuffleKey, partitionUniqueId, attemptId);
   }
 
   @Override
@@ -86,11 +88,11 @@ public final class RegionFinish extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("mode", mode)
-        .add("shuffleKey", shuffleKey)
-        .add("partitionUniqueId", partitionUniqueId)
-        .add("attemptId", attemptId)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("mode", mode)
+        .append("shuffleKey", shuffleKey)
+        .append("partitionUniqueId", partitionUniqueId)
+        .append("attemptId", attemptId)
         .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionStart.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionStart.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 @Deprecated
 public final class RegionStart extends RequestMessage {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionStart.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RegionStart.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 @Deprecated
@@ -85,7 +87,7 @@ public final class RegionStart extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(
+    return Objects.hash(
         mode, shuffleKey, partitionUniqueId, attemptId, currentRegionIndex, isBroadcast);
   }
 
@@ -106,13 +108,13 @@ public final class RegionStart extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("mode", mode)
-        .add("shuffleKey", shuffleKey)
-        .add("partitionUniqueId", partitionUniqueId)
-        .add("attemptId", attemptId)
-        .add("currentRegionIndex", currentRegionIndex)
-        .add("isBroadcast", isBroadcast)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("mode", mode)
+        .append("shuffleKey", shuffleKey)
+        .append("partitionUniqueId", partitionUniqueId)
+        .append("attemptId", attemptId)
+        .append("currentRegionIndex", currentRegionIndex)
+        .append("isBroadcast", isBroadcast)
         .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcFailure.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 /** Response to {@link RpcRequest} for a failed RPC. */
@@ -54,7 +56,7 @@ public final class RpcFailure extends ResponseMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(requestId, errorString);
+    return Objects.hash(requestId, errorString);
   }
 
   @Override
@@ -68,9 +70,9 @@ public final class RpcFailure extends ResponseMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("requestId", requestId)
-        .add("errorString", errorString)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("requestId", requestId)
+        .append("errorString", errorString)
         .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcFailure.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcFailure.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 /** Response to {@link RpcRequest} for a failed RPC. */
 public final class RpcFailure extends ResponseMessage {

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcRequest.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcRequest.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcRequest.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
@@ -74,7 +76,7 @@ public final class RpcRequest extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(requestId, body());
+    return Objects.hash(requestId, body());
   }
 
   @Override
@@ -88,6 +90,9 @@ public final class RpcRequest extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("requestId", requestId).add("body", body()).toString();
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("requestId", requestId)
+        .append("body", body())
+        .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcResponse.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcResponse.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
 import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcResponse.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/RpcResponse.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.network.buffer.ManagedBuffer;
@@ -74,7 +76,7 @@ public final class RpcResponse extends ResponseMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(requestId, body());
+    return Objects.hash(requestId, body());
   }
 
   @Override
@@ -88,6 +90,9 @@ public final class RpcResponse extends ResponseMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("requestId", requestId).add("body", body()).toString();
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("requestId", requestId)
+        .append("body", body())
+        .toString();
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamChunkSlice.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamChunkSlice.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.protocol.PbStreamChunkSlice;
@@ -68,7 +70,7 @@ public final class StreamChunkSlice implements Encodable {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(streamId, chunkIndex, offset, len);
+    return Objects.hash(streamId, chunkIndex, offset, len);
   }
 
   @Override
@@ -85,11 +87,11 @@ public final class StreamChunkSlice implements Encodable {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("streamId", streamId)
-        .add("chunkIndex", chunkIndex)
-        .add("offset", offset)
-        .add("len", len)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("streamId", streamId)
+        .append("chunkIndex", chunkIndex)
+        .append("offset", offset)
+        .append("len", len)
         .toString();
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamChunkSlice.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamChunkSlice.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 import org.apache.celeborn.common.protocol.PbStreamChunkSlice;
 

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamHandle.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamHandle.java
@@ -17,10 +17,11 @@
 
 package org.apache.celeborn.common.network.protocol;
 
+import java.util.Objects;
+
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import java.util.Objects;
-import io.netty.buffer.ByteBuf;
 
 /**
  * Identifier for a fixed number of chunks to read from a stream created by an "open blocks"

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamHandle.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/StreamHandle.java
@@ -17,7 +17,9 @@
 
 package org.apache.celeborn.common.network.protocol;
 
-import com.google.common.base.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 
 /**
@@ -56,7 +58,7 @@ public final class StreamHandle extends RequestMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(streamId, numChunks);
+    return Objects.hash(streamId, numChunks);
   }
 
   @Override
@@ -70,9 +72,9 @@ public final class StreamHandle extends RequestMessage {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("streamId", streamId)
-        .add("numChunks", numChunks)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("streamId", streamId)
+        .append("numChunks", numChunks)
         .toString();
   }
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
@@ -19,6 +19,7 @@ package org.apache.celeborn.common.util
 
 import java.util.concurrent._
 import java.util.concurrent.{ForkJoinPool => SForkJoinPool, ForkJoinWorkerThread => SForkJoinWorkerThread}
+import java.util.concurrent.locks.ReentrantLock
 
 import scala.concurrent.{Awaitable, ExecutionContext, ExecutionContextExecutor, Future}
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -26,14 +27,88 @@ import scala.language.higherKinds
 import scala.util.control.NonFatal
 
 import com.google.common.util.concurrent.{MoreExecutors, ThreadFactoryBuilder}
-
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
 
 object ThreadUtils {
 
   private val sameThreadExecutionContext =
-    ExecutionContext.fromExecutorService(MoreExecutors.sameThreadExecutor())
+    ExecutionContext.fromExecutorService(sameThreadExecutorService())
+
+  // Inspired by Guava MoreExecutors.sameThreadExecutor; inlined and converted
+  // to Scala here to avoid Guava version issues
+  def sameThreadExecutorService(): ExecutorService = new AbstractExecutorService {
+    private val lock = new ReentrantLock()
+    private val termination = lock.newCondition()
+    private var runningTasks = 0
+    private var serviceIsShutdown = false
+
+    override def shutdown(): Unit = {
+      lock.lock()
+      try {
+        serviceIsShutdown = true
+      } finally {
+        lock.unlock()
+      }
+    }
+
+    override def shutdownNow(): java.util.List[Runnable] = {
+      shutdown()
+      java.util.Collections.emptyList()
+    }
+
+    override def isShutdown: Boolean = {
+      lock.lock()
+      try {
+        serviceIsShutdown
+      } finally {
+        lock.unlock()
+      }
+    }
+
+    override def isTerminated: Boolean = synchronized {
+      lock.lock()
+      try {
+        serviceIsShutdown && runningTasks == 0
+      } finally {
+        lock.unlock()
+      }
+    }
+
+    override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
+      var nanos = unit.toNanos(timeout)
+      lock.lock()
+      try {
+        while (nanos > 0 && !isTerminated()) {
+          nanos = termination.awaitNanos(nanos)
+        }
+        isTerminated()
+      } finally {
+        lock.unlock()
+      }
+    }
+
+    override def execute(command: Runnable): Unit = {
+      lock.lock()
+      try {
+        if (isShutdown()) throw new RejectedExecutionException("Executor already shutdown")
+        runningTasks += 1
+      } finally {
+        lock.unlock()
+      }
+      try {
+        command.run()
+      } finally {
+        lock.lock()
+        try {
+          runningTasks -= 1
+          if (isTerminated()) termination.signalAll()
+        } finally {
+          lock.unlock()
+        }
+      }
+    }
+  }
 
   /**
    * An `ExecutionContextExecutor` that runs each task in the thread that invokes `execute/submit`.

--- a/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/ThreadUtils.scala
@@ -27,6 +27,7 @@ import scala.language.higherKinds
 import scala.util.control.NonFatal
 
 import com.google.common.util.concurrent.{MoreExecutors, ThreadFactoryBuilder}
+
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
 

--- a/dev/deps/dependencies-client-flink-1.14
+++ b/dev/deps/dependencies-client-flink-1.14
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-flink-1.14
+++ b/dev/deps/dependencies-client-flink-1.14
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-flink-1.15
+++ b/dev/deps/dependencies-client-flink-1.15
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-flink-1.15
+++ b/dev/deps/dependencies-client-flink-1.15
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-flink-1.17
+++ b/dev/deps/dependencies-client-flink-1.17
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-flink-1.17
+++ b/dev/deps/dependencies-client-flink-1.17
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-flink-1.18
+++ b/dev/deps/dependencies-client-flink-1.18
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-flink-1.18
+++ b/dev/deps/dependencies-client-flink-1.18
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -43,7 +43,7 @@ dnsjava/2.1.7//dnsjava-2.1.7.jar
 ehcache/3.3.1//ehcache-3.3.1.jar
 geronimo-jcache_1.0_spec/1.0-alpha-1//geronimo-jcache_1.0_spec-1.0-alpha-1.jar
 gson/2.9.0//gson-2.9.0.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 guice-servlet/4.0//guice-servlet-4.0.jar
 guice/4.0//guice-4.0.jar
 hadoop-annotations/3.2.4//hadoop-annotations-3.2.4.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -41,9 +41,10 @@ curator-framework/2.13.0//curator-framework-2.13.0.jar
 curator-recipes/2.13.0//curator-recipes-2.13.0.jar
 dnsjava/2.1.7//dnsjava-2.1.7.jar
 ehcache/3.3.1//ehcache-3.3.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
 geronimo-jcache_1.0_spec/1.0-alpha-1//geronimo-jcache_1.0_spec-1.0-alpha-1.jar
 gson/2.9.0//gson-2.9.0.jar
-guava/27.0-jre//guava-27.0-jre.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 guice-servlet/4.0//guice-servlet-4.0.jar
 guice/4.0//guice-4.0.jar
 hadoop-annotations/3.2.4//hadoop-annotations-3.2.4.jar

--- a/dev/deps/dependencies-client-spark-2.4
+++ b/dev/deps/dependencies-client-spark-2.4
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-2.4
+++ b/dev/deps/dependencies-client-spark-2.4
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.5
+++ b/dev/deps/dependencies-client-spark-3.5
@@ -20,7 +20,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-client-spark-3.5
+++ b/dev/deps/dependencies-client-spark-3.5
@@ -20,7 +20,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -21,7 +21,8 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/27.0-jre//guava-27.0-jre.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
+guava/32.1.3-jre//guava-32.1.3-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -21,7 +21,7 @@ commons-crypto/1.0.0//commons-crypto-1.0.0.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/27.0-jre//guava-27.0-jre.jar
 hadoop-client-api/3.2.4//hadoop-client-api-3.2.4.jar
 hadoop-client-runtime/3.2.4//hadoop-client-runtime-3.2.4.jar
 htrace-core4/4.1.0-incubating//htrace-core4-4.1.0-incubating.jar

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <error-prone.jdk8.javac.version>9+181-r4173-1</error-prone.jdk8.javac.version>
     <google.jsr305.version>1.3.9</google.jsr305.version>
     <grpc.version>1.44.0</grpc.version>
-    <guava.version>27.0-jre</guava.version>
+    <guava.version>32.1.3-jre</guava.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
     <junit.version>4.13.2</junit.version>
     <leveldb.version>1.8</leveldb.version>
@@ -323,10 +323,6 @@
           <exclusion>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.google.guava</groupId>
-            <artifactId>failureaccess</artifactId>
           </exclusion>
           <exclusion>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,32 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-annotations</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>listenablefuture</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.j2objc</groupId>
+            <artifactId>j2objc-annotations</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <error-prone.jdk8.javac.version>9+181-r4173-1</error-prone.jdk8.javac.version>
     <google.jsr305.version>1.3.9</google.jsr305.version>
     <grpc.version>1.44.0</grpc.version>
-    <guava.version>14.0.1</guava.version>
+    <guava.version>27.0-jre</guava.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
     <junit.version>4.13.2</junit.version>
     <leveldb.version>1.8</leveldb.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -42,7 +42,7 @@ object Dependencies {
   val commonsLoggingVersion = "1.1.3"
   val commonsLang3Version = "3.12.0"
   val findbugsVersion = "1.3.9"
-  val guavaVersion = "14.0.1"
+  val guavaVersion = "27.0-jre"
   val hadoopVersion = "3.2.4"
   val javaxServletVersion = "3.1.0"
   val junitInterfaceVersion = "0.13.3"

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -72,7 +72,13 @@ object Dependencies {
   val commonsLang3 = "org.apache.commons" % "commons-lang3" % commonsLang3Version
   val commonsLogging = "commons-logging" % "commons-logging" % commonsLoggingVersion
   val findbugsJsr305 = "com.google.code.findbugs" % "jsr305" % findbugsVersion
-  val guava = "com.google.guava" % "guava" % guavaVersion
+  val guava = "com.google.guava" % "guava" % guavaVersion excludeAll(
+    ExclusionRule("org.checkerframework", "checker-qual"),
+    ExclusionRule("org.codehaus.mojo", "animal-sniffer-annotations"),
+    ExclusionRule("com.google.errorprone", "error_prone_annotations"),
+    ExclusionRule("com.google.guava", "failureaccess"),
+    ExclusionRule("com.google.guava", "listenablefuture"),
+    ExclusionRule("com.google.j2objc", "j2objc-annotations"))
   val hadoopClientApi = "org.apache.hadoop" % "hadoop-client-api" % hadoopVersion
   val hadoopClientRuntime = "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion
   val hadoopMapreduceClientApp = "org.apache.hadoop" % "hadoop-mapreduce-client-app" % hadoopVersion excludeAll(

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -42,7 +42,7 @@ object Dependencies {
   val commonsLoggingVersion = "1.1.3"
   val commonsLang3Version = "3.12.0"
   val findbugsVersion = "1.3.9"
-  val guavaVersion = "27.0-jre"
+  val guavaVersion = "32.1.3-jre"
   val hadoopVersion = "3.2.4"
   val javaxServletVersion = "3.1.0"
   val junitInterfaceVersion = "0.13.3"
@@ -76,7 +76,6 @@ object Dependencies {
     ExclusionRule("org.checkerframework", "checker-qual"),
     ExclusionRule("org.codehaus.mojo", "animal-sniffer-annotations"),
     ExclusionRule("com.google.errorprone", "error_prone_annotations"),
-    ExclusionRule("com.google.guava", "failureaccess"),
     ExclusionRule("com.google.guava", "listenablefuture"),
     ExclusionRule("com.google.j2objc", "j2objc-annotations"))
   val hadoopClientApi = "org.apache.hadoop" % "hadoop-client-api" % hadoopVersion


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?

- bump guava from 14.0.1 to 32.1.3-jre
- refer to https://github.com/apache/spark/pull/26911, remove usages of Guava that no longer work in Guava 27/32, and replace with workalikes. After this PR, Celeborn no longer relies on a specific version of Guava, and is compatible with Guava 14/27/32. we have the ability to specify Guava to 27 when running MapReduce integration tests.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass GA
