### PR TITLE
[CELEBORN-1124] Exclude workers of shuffle manager always remove worker of connect exception replica

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -165,7 +165,7 @@ class WorkerStatusTracker(
                 StatusCode.RESERVE_SLOTS_FAILED |
                 StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY |
                 StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_REPLICA |
-                StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_REPLICA |
+                StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_PRIMARY |
                 StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_REPLICA |
                 StatusCode.PUSH_DATA_TIMEOUT_PRIMARY |
                 StatusCode.PUSH_DATA_TIMEOUT_REPLICA


### PR DESCRIPTION
### What changes were proposed in this pull request?

Exclude workers of shuffle manager remove worker of connect exception primary and replica.

### Why are the changes needed?

Exclude workers of shuffle manager should not always remove worker of connect exception replica.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.