### PR TITLE
[CELEBORN-1124]Fix issue where excluding workers from the shuffle manager always removes workers with connection exception replicas

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -165,7 +165,7 @@ class WorkerStatusTracker(
                 StatusCode.RESERVE_SLOTS_FAILED |
                 StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_PRIMARY |
                 StatusCode.PUSH_DATA_CREATE_CONNECTION_FAIL_REPLICA |
-                StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_REPLICA |
+                StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_PRIMARY |
                 StatusCode.PUSH_DATA_CONNECTION_EXCEPTION_REPLICA |
                 StatusCode.PUSH_DATA_TIMEOUT_PRIMARY |
                 StatusCode.PUSH_DATA_TIMEOUT_REPLICA


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix issue where excludedWorkers match statusCode not correctly when remove worker
![image](https://github.com/apache/incubator-celeborn/assets/46274164/d04ce460-d3dd-4242-aebd-fcf51aef97f6)



### Why are the changes needed?
bug fix


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No
