### PR TITLE
[CELEBORN-1126] Set kubernetes resources field for master and worker init container for helm chart

### DIFF
--- a/charts/celeborn/templates/master-statefulset.yaml
+++ b/charts/celeborn/templates/master-statefulset.yaml
@@ -88,6 +88,8 @@ spec:
         - chown
         - {{ .Values.securityContext.runAsUser | default 10006 }}:{{ .Values.securityContext.runAsGroup | default 10006 }}
         - {{ (index $dirs 0).mountPath }}
+        resources:
+          {{- toYaml .Values.resources.master | nindent 12 }}
         volumeMounts:
           - name: {{ $.Release.Name }}-master-vol-0
             mountPath: {{ (index $dirs 0).mountPath }}

--- a/charts/celeborn/templates/worker-statefulset.yaml
+++ b/charts/celeborn/templates/worker-statefulset.yaml
@@ -90,6 +90,8 @@ spec:
         {{- range $dir := $dirs }}
         - {{ $dir.mountPath }}
         {{- end}}
+        resources:
+          {{- toYaml .Values.resources.worker | nindent 12 }}
         volumeMounts:
         {{- range $index, $dir := $dirs }}
         - name: {{ $.Release.Name }}-worker-vol-{{ $index }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
For the `helm` chart. I specified the resources field for the `initContainers` for `worker` and `master` statefulsets.
I used the same values which are specified for the "main" container


### Why are the changes needed?
For users that have a `ResourceQuota` (such as myself), worker and master pods do not start since the initContainers for the statefulsets do not specify the resources (cpu/ memory requests and limits).


### Does this PR introduce _any_ user-facing change?


### [Issue](https://github.com/apache/incubator-celeborn/issues/2094)



### How was this patch tested?
I installed the chart on my GKE cluster.
