### PR TITLE
[CELEBORN-1128] Fix miseuse of ConcurrentHashMap.contains to ConcurrentHashMap.containsKey

### DIFF
--- a/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/WorkerStatusTrackerSuite.scala
@@ -61,13 +61,13 @@ class WorkerStatusTrackerSuite extends CelebornFunSuite {
     // test new added workers
     Assert.assertTrue(statusTracker.excludedWorkers.containsKey(mock("host0")))
     Assert.assertTrue(statusTracker.excludedWorkers.containsKey(mock("host3")))
-    Assert.assertTrue(!statusTracker.excludedWorkers.contains(mock("host4")))
+    Assert.assertTrue(!statusTracker.excludedWorkers.containsKey(mock("host4")))
     Assert.assertTrue(statusTracker.shuttingWorkers.contains(mock("host4")))
 
     // test re heartbeat with shutdown workers
     val response3 = buildResponse(Array.empty, Array.empty, Array("host4"))
     statusTracker.handleHeartbeatResponse(response3)
-    Assert.assertTrue(!statusTracker.excludedWorkers.contains(mock("host4")))
+    Assert.assertTrue(!statusTracker.excludedWorkers.containsKey(mock("host4")))
     Assert.assertTrue(statusTracker.shuttingWorkers.contains(mock("host4")))
 
     // test remove

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -353,7 +353,7 @@ private[deploy] class Controller(
       epoch: Long): Unit = {
 
     def alreadyCommitted(shuffleKey: String, epoch: Long): Boolean = {
-      shuffleCommitInfos.contains(shuffleKey) && shuffleCommitInfos.get(shuffleKey).contains(epoch)
+      shuffleCommitInfos.containsKey(shuffleKey) && shuffleCommitInfos.get(shuffleKey).containsKey(epoch)
     }
 
     // Reply SHUFFLE_NOT_REGISTERED if shuffleKey does not exist AND the shuffle is not committed.

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -353,7 +353,8 @@ private[deploy] class Controller(
       epoch: Long): Unit = {
 
     def alreadyCommitted(shuffleKey: String, epoch: Long): Boolean = {
-      shuffleCommitInfos.containsKey(shuffleKey) && shuffleCommitInfos.get(shuffleKey).containsKey(epoch)
+      shuffleCommitInfos.containsKey(shuffleKey) && shuffleCommitInfos.get(shuffleKey).containsKey(
+        epoch)
     }
 
     // Reply SHUFFLE_NOT_REGISTERED if shuffleKey does not exist AND the shuffle is not committed.


### PR DESCRIPTION


### What changes were proposed in this pull request?
ConcurrentHashMap.contains main containsValue ,not containsKey. In the current codebase, there is a misuse of the contains method in the ConcurrentHashMap class.

### Why are the changes needed?
ConcurrentHashMap.contains misuse


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No
