### PR TITLE
Celeborn 1131: Adds support for Sasl Authentication in Celeborn's Transport layer

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/TransportContext.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/TransportContext.java
@@ -17,6 +17,9 @@
 
 package org.apache.celeborn.common.network;
 
+import java.util.Collections;
+import java.util.List;
+
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -27,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.common.network.client.TransportClient;
+import org.apache.celeborn.common.network.client.TransportClientBootstrap;
 import org.apache.celeborn.common.network.client.TransportClientFactory;
 import org.apache.celeborn.common.network.client.TransportResponseHandler;
 import org.apache.celeborn.common.network.protocol.MessageEncoder;
@@ -93,35 +97,60 @@ public class TransportContext {
     this(conf, msgHandler, false, false, null);
   }
 
+  public TransportClientFactory createClientFactory(List<TransportClientBootstrap> bootstraps) {
+    return new TransportClientFactory(this, bootstraps);
+  }
+
   public TransportClientFactory createClientFactory() {
-    return new TransportClientFactory(this);
+    return createClientFactory(Collections.emptyList());
   }
 
   /** Create a server which will attempt to bind to a specific host and port. */
   public TransportServer createServer(String host, int port) {
-    return new TransportServer(this, host, port, source);
+    return new TransportServer(this, host, port, source, msgHandler, Collections.emptyList());
+  }
+
+  public TransportServer createServer(
+      String host, int port, List<TransportServerBootstrap> bootstraps) {
+    return new TransportServer(this, host, port, source, msgHandler, bootstraps);
   }
 
   public TransportServer createServer(int port) {
-    return createServer(null, port);
+    return createServer(null, port, Collections.emptyList());
+  }
+
+  public TransportServer createServer(int port, List<TransportServerBootstrap> bootstraps) {
+    return createServer(null, port, bootstraps);
+  }
+
+  public TransportServer createServer(List<TransportServerBootstrap> bootstraps) {
+    return createServer(0, bootstraps);
   }
 
   /** For Suite only */
   public TransportServer createServer() {
-    return createServer(null, 0);
-  }
-
-  public TransportChannelHandler initializePipeline(SocketChannel channel) {
-    return initializePipeline(channel, new TransportFrameDecoder());
+    return createServer(null, 0, Collections.emptyList());
   }
 
   public TransportChannelHandler initializePipeline(
       SocketChannel channel, ChannelInboundHandlerAdapter decoder) {
+    return initializePipeline(channel, decoder, msgHandler);
+  }
+
+  public TransportChannelHandler initializePipeline(
+      SocketChannel channel, BaseMessageHandler resolvedMsgHandler) {
+    return initializePipeline(channel, new TransportFrameDecoder(), resolvedMsgHandler);
+  }
+
+  public TransportChannelHandler initializePipeline(
+      SocketChannel channel,
+      ChannelInboundHandlerAdapter decoder,
+      BaseMessageHandler resolvedMsgHandler) {
     try {
       if (channelsLimiter != null) {
         channel.pipeline().addLast("limiter", channelsLimiter);
       }
-      TransportChannelHandler channelHandler = createChannelHandler(channel, msgHandler);
+      TransportChannelHandler channelHandler = createChannelHandler(channel, resolvedMsgHandler);
       channel
           .pipeline()
           .addLast("encoder", ENCODER)

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientBootstrap.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientBootstrap.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.client;
+
+import io.netty.channel.Channel;
+
+/**
+ * A bootstrap which is executed on a TransportClient before it is returned to the user. This
+ * enables an initial exchange of information (e.g., SASL authentication tokens) on a once-per-
+ * connection basis.
+ *
+ * <p>Since connections (and TransportClients) are reused as much as possible, it is generally
+ * reasonable to perform an expensive bootstrapping operation, as they often share a lifespan with
+ * the JVM itself.
+ */
+public interface TransportClientBootstrap {
+  /** Performs the bootstrapping operation, throwing an exception on failure. */
+  void doBootstrap(TransportClient client, Channel channel) throws RuntimeException;
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClientFactory.java
@@ -21,12 +21,16 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.time.Duration;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.*;
@@ -68,6 +72,7 @@ public class TransportClientFactory implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(TransportClientFactory.class);
 
   private final TransportContext context;
+  private final List<TransportClientBootstrap> clientBootstraps;
   private final ConcurrentHashMap<SocketAddress, ClientPool> connectionPool;
 
   /** Random number generator for picking connections between peers. */
@@ -84,9 +89,11 @@ public class TransportClientFactory implements Closeable {
   private EventLoopGroup workerGroup;
   protected ByteBufAllocator pooledAllocator;
 
-  public TransportClientFactory(TransportContext context) {
+  public TransportClientFactory(
+      TransportContext context, List<TransportClientBootstrap> clientBootstraps) {
     this.context = Preconditions.checkNotNull(context);
     TransportConf conf = context.getConf();
+    this.clientBootstraps = Lists.newArrayList(Preconditions.checkNotNull(clientBootstraps));
     this.connectionPool = JavaUtils.newConcurrentHashMap();
     this.numConnectionsPerPeer = conf.numConnectionsPerPeer();
     this.connectTimeoutMs = conf.connectTimeoutMs();
@@ -241,6 +248,7 @@ public class TransportClientFactory implements Closeable {
         });
 
     // Connect to the remote server
+    long preConnect = System.nanoTime();
     ChannelFuture cf = bootstrap.connect(address);
     if (!cf.await(connectTimeoutMs)) {
       throw new CelebornIOException(
@@ -250,7 +258,28 @@ public class TransportClientFactory implements Closeable {
     }
 
     TransportClient client = clientRef.get();
+    Channel channel = channelRef.get();
     assert client != null : "Channel future completed successfully with null client";
+
+    // Execute any client bootstraps synchronously before marking the Client as successful.
+    long preBootstrap = System.nanoTime();
+    logger.debug("Connection to {} successful, running bootstraps...", address);
+    try {
+      for (TransportClientBootstrap clientBootstrap : clientBootstraps) {
+        clientBootstrap.doBootstrap(client, channel);
+      }
+    } catch (Exception e) { // catch non-RuntimeExceptions too as bootstrap may be written in Scala
+      long bootstrapTimeMs = Duration.ofNanos(System.nanoTime() - preBootstrap).toMillis();
+      logger.error("Exception while bootstrapping client after " + bootstrapTimeMs + " ms", e);
+      client.close();
+      throw Throwables.propagate(e);
+    }
+    long postBootstrap = System.nanoTime();
+    logger.info(
+        "Successfully created connection to {} after {} ms ({} ms spent in bootstraps)",
+        address,
+        (postBootstrap - preConnect) / 1000000,
+        (postBootstrap - preBootstrap) / 1000000);
 
     logger.debug(
         "Connection from {} to {} successful", client.getChannel().localAddress(), address);

--- a/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/protocol/TransportMessage.java
@@ -37,6 +37,8 @@ import org.apache.celeborn.common.protocol.PbPushDataHandShake;
 import org.apache.celeborn.common.protocol.PbReadAddCredit;
 import org.apache.celeborn.common.protocol.PbRegionFinish;
 import org.apache.celeborn.common.protocol.PbRegionStart;
+import org.apache.celeborn.common.protocol.PbSaslRequest;
+import org.apache.celeborn.common.protocol.PbSaslResponse;
 import org.apache.celeborn.common.protocol.PbStreamChunkSlice;
 import org.apache.celeborn.common.protocol.PbStreamHandler;
 import org.apache.celeborn.common.protocol.PbTransportableError;
@@ -90,6 +92,10 @@ public class TransportMessage implements Serializable {
         return (T) PbChunkFetchRequest.parseFrom(payload);
       case TRANSPORTABLE_ERROR_VALUE:
         return (T) PbTransportableError.parseFrom(payload);
+      case SASL_REQUEST_VALUE:
+        return (T) PbSaslRequest.parseFrom(payload);
+      case SASL_RESPONSE_VALUE:
+        return (T) PbSaslResponse.parseFrom(payload);
       default:
         logger.error("Unexpected type {}", type);
     }

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/AppRegistrationFetcher.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/AppRegistrationFetcher.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+/** Fetches registration information for an application. */
+public class AppRegistrationFetcher {
+  public void fetchRegistrationInfoFor(String appId) {
+    // Do nothing.
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslClient.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+import static org.apache.celeborn.common.network.sasl.CelebornSaslServer.*;
+import static org.apache.celeborn.common.network.sasl.SaslConstants.*;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+import javax.security.sasl.RealmChoiceCallback;
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslException;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.network.sasl.anonymous.AnonymousSaslProvider;
+
+/**
+ * A SASL Client for Celeborn which simply keeps track of the state of a single SASL session, from
+ * the initial state to the "authenticated" state. This client initializes the protocol via a
+ * firstToken, which is then followed by a set of challenges and responses.
+ */
+public class CelebornSaslClient {
+  private static final Logger logger = LoggerFactory.getLogger(CelebornSaslClient.class);
+
+  private SaslClient saslClient;
+
+  public CelebornSaslClient(
+      String saslMechanism,
+      @Nullable Map<String, String> saslProps,
+      @Nullable CallbackHandler authCallbackHandler) {
+    AnonymousSaslProvider.initializeIfNeeded();
+    Preconditions.checkNotNull(saslMechanism);
+    try {
+      this.saslClient =
+          Sasl.createSaslClient(
+              new String[] {saslMechanism},
+              null,
+              null,
+              DEFAULT_REALM,
+              saslProps,
+              authCallbackHandler);
+    } catch (SaslException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /** Used to initiate SASL handshake with server. */
+  public synchronized byte[] firstToken() {
+    if (saslClient != null && saslClient.hasInitialResponse()) {
+      try {
+        return saslClient.evaluateChallenge(new byte[0]);
+      } catch (SaslException e) {
+        throw Throwables.propagate(e);
+      }
+    } else {
+      return new byte[0];
+    }
+  }
+
+  /** Determines whether the authentication exchange has completed. */
+  public synchronized boolean isComplete() {
+    return saslClient != null && saslClient.isComplete();
+  }
+
+  /** Returns the value of a negotiated property. */
+  public Object getNegotiatedProperty(String name) {
+    return saslClient.getNegotiatedProperty(name);
+  }
+
+  /**
+   * Respond to server's SASL token.
+   *
+   * @param token contains server's SASL token
+   * @return client's response SASL token
+   */
+  public synchronized byte[] response(byte[] token) {
+    try {
+      return saslClient != null ? saslClient.evaluateChallenge(token) : new byte[0];
+    } catch (SaslException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * Disposes of any system resources or security-sensitive information the SaslClient might be
+   * using.
+   */
+  public synchronized void dispose() {
+    if (saslClient != null) {
+      try {
+        saslClient.dispose();
+      } catch (SaslException e) {
+        // ignore
+      } finally {
+        saslClient = null;
+      }
+    }
+  }
+
+  /**
+   * Implementation of javax.security.auth.callback.CallbackHandler that works with share secrets.
+   */
+  public static class ClientCallbackHandler implements CallbackHandler {
+
+    private final String id;
+    private final String password;
+
+    public ClientCallbackHandler(String id, String password) {
+      this.id = Preconditions.checkNotNull(id, "id");
+      this.password = Preconditions.checkNotNull(password, "password");
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+
+      for (Callback callback : callbacks) {
+        if (callback instanceof NameCallback) {
+          logger.trace("SASL client callback: setting username");
+          NameCallback nc = (NameCallback) callback;
+          nc.setName(encodeIdentifier(id));
+        } else if (callback instanceof PasswordCallback) {
+          logger.trace("SASL client callback: setting password");
+          PasswordCallback pc = (PasswordCallback) callback;
+          pc.setPassword(encodePassword(password));
+        } else if (callback instanceof RealmCallback) {
+          logger.trace("SASL client callback: setting realm");
+          RealmCallback rc = (RealmCallback) callback;
+          rc.setText(rc.getDefaultText());
+        } else if (callback instanceof RealmChoiceCallback) {
+          // ignore (?)
+        } else {
+          throw new UnsupportedCallbackException(callback, "Unrecognized SASL DIGEST-MD5 Callback");
+        }
+      }
+    }
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslServer.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+import static org.apache.celeborn.common.network.sasl.SaslConstants.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
+import javax.security.sasl.RealmCallback;
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.base64.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.network.sasl.anonymous.AnonymousSaslProvider;
+
+/**
+ * A SASL Server for Celeborn which simply keeps track of the state of a single SASL session, from
+ * the initial state to the "authenticated" state. (It is not a server in the sense of accepting
+ * connections on some socket.)
+ */
+public class CelebornSaslServer {
+  private static final Logger logger = LoggerFactory.getLogger(CelebornSaslServer.class);
+
+  private SaslServer saslServer;
+
+  public CelebornSaslServer(
+      String saslMechanism,
+      @Nullable Map<String, String> saslProps,
+      @Nullable CallbackHandler callbackHandler) {
+    AnonymousSaslProvider.initializeIfNeeded();
+    Preconditions.checkNotNull(saslMechanism);
+    try {
+      this.saslServer =
+          Sasl.createSaslServer(saslMechanism, null, DEFAULT_REALM, saslProps, callbackHandler);
+    } catch (SaslException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /** Determines whether the authentication exchange has completed successfully. */
+  public synchronized boolean isComplete() {
+    return saslServer != null && saslServer.isComplete();
+  }
+
+  /** Returns the value of a negotiated property. */
+  public Object getNegotiatedProperty(String name) {
+    return saslServer.getNegotiatedProperty(name);
+  }
+
+  /**
+   * Used to respond to server SASL tokens.
+   *
+   * @param token Server's SASL token
+   * @return response to send back to the server.
+   */
+  public synchronized byte[] response(byte[] token) {
+    try {
+      return saslServer != null ? saslServer.evaluateResponse(token) : new byte[0];
+    } catch (SaslException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * Disposes of any system resources or security-sensitive information the SaslServer might be
+   * using.
+   */
+  public synchronized void dispose() {
+    if (saslServer != null) {
+      try {
+        saslServer.dispose();
+      } catch (SaslException e) {
+        // ignore
+      } finally {
+        saslServer = null;
+      }
+    }
+  }
+
+  /**
+   * Implementation of javax.security.auth.callback.CallbackHandler for SASL DIGEST-MD5 mechanism.
+   */
+  static class DigestCallbackHandler implements CallbackHandler {
+    private final String secretKeyId;
+    private final SecretRegistry secretKeyHolder;
+
+    DigestCallbackHandler(String secretKeyId, SecretRegistry secretRegistry) {
+      this.secretKeyId = Preconditions.checkNotNull(secretKeyId);
+      this.secretKeyHolder = Preconditions.checkNotNull(secretRegistry);
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+      for (Callback callback : callbacks) {
+        if (callback instanceof NameCallback) {
+          logger.trace("SASL server callback: setting username");
+          NameCallback nc = (NameCallback) callback;
+          nc.setName(encodeIdentifier(secretKeyHolder.getSaslUser(secretKeyId)));
+        } else if (callback instanceof PasswordCallback) {
+          logger.trace("SASL server callback: setting password");
+          PasswordCallback pc = (PasswordCallback) callback;
+          pc.setPassword(encodePassword(secretKeyHolder.getSecretKey(secretKeyId)));
+        } else if (callback instanceof RealmCallback) {
+          logger.trace("SASL server callback: setting realm");
+          RealmCallback rc = (RealmCallback) callback;
+          rc.setText(rc.getDefaultText());
+        } else if (callback instanceof AuthorizeCallback) {
+          AuthorizeCallback ac = (AuthorizeCallback) callback;
+          String authId = ac.getAuthenticationID();
+          String authzId = ac.getAuthorizationID();
+          ac.setAuthorized(authId.equals(authzId));
+          if (ac.isAuthorized()) {
+            ac.setAuthorizedID(authzId);
+          }
+          logger.debug("SASL Authorization complete, authorized set to {}", ac.isAuthorized());
+        } else {
+          throw new UnsupportedCallbackException(callback, "Unrecognized SASL DIGEST-MD5 Callback");
+        }
+      }
+    }
+  }
+
+  /* Encode a byte[] identifier as a Base64-encoded string. */
+  public static String encodeIdentifier(String identifier) {
+    Preconditions.checkNotNull(identifier, "User cannot be null if SASL is enabled");
+    return getBase64EncodedString(identifier);
+  }
+
+  /** Encode a password as a base64-encoded char[] array. */
+  public static char[] encodePassword(String password) {
+    Preconditions.checkNotNull(password, "Password cannot be null if SASL is enabled");
+    return getBase64EncodedString(password).toCharArray();
+  }
+
+  /** Return a Base64-encoded string. */
+  private static String getBase64EncodedString(String str) {
+    ByteBuf byteBuf = null;
+    ByteBuf encodedByteBuf = null;
+    try {
+      byteBuf = Unpooled.wrappedBuffer(str.getBytes(StandardCharsets.UTF_8));
+      encodedByteBuf = Base64.encode(byteBuf);
+      return encodedByteBuf.toString(StandardCharsets.UTF_8);
+    } finally {
+      // The release is called to suppress the memory leak error messages raised by netty.
+      if (byteBuf != null) {
+        byteBuf.release();
+        if (encodedByteBuf != null) {
+          encodedByteBuf.release();
+        }
+      }
+    }
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslClientBootstrap.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslClientBootstrap.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+import static org.apache.celeborn.common.network.sasl.SaslConstants.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeoutException;
+
+import com.google.common.base.Preconditions;
+import com.google.protobuf.ByteString;
+import io.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.network.client.TransportClient;
+import org.apache.celeborn.common.network.client.TransportClientBootstrap;
+import org.apache.celeborn.common.network.protocol.TransportMessage;
+import org.apache.celeborn.common.network.util.TransportConf;
+import org.apache.celeborn.common.protocol.MessageType;
+import org.apache.celeborn.common.protocol.PbAuthType;
+import org.apache.celeborn.common.protocol.PbSaslRequest;
+import org.apache.celeborn.common.protocol.PbSaslResponse;
+
+/**
+ * Bootstraps a {@link TransportClient} by performing SASL authentication on the connection. The
+ * server should be setup with a {@link SaslRpcHandler} with matching keys for the given appId.
+ */
+public class SaslClientBootstrap implements TransportClientBootstrap {
+  private static final Logger logger = LoggerFactory.getLogger(SaslClientBootstrap.class);
+
+  private final TransportConf conf;
+  private final String appId;
+  private final SaslCredentials saslCredentials;
+
+  public SaslClientBootstrap(TransportConf conf, String appId, SaslCredentials saslCredentials) {
+    this.conf = conf;
+    this.appId = appId;
+    this.saslCredentials = Preconditions.checkNotNull(saslCredentials);
+  }
+
+  /**
+   * Performs SASL authentication by sending a token, and then proceeding with the SASL
+   * challenge-response tokens until we either successfully authenticate or throw an exception due
+   * to mismatch.
+   */
+  @Override
+  public void doBootstrap(TransportClient client, Channel channel) {
+    // TODO: Hardcoding the the SASL mechanism to DIGEST-MD5 for Connection Authentication. This
+    // should
+    // be configurable in the future.
+    CelebornSaslClient saslClient =
+        new CelebornSaslClient(
+            DIGEST,
+            DEFAULT_SASL_CLIENT_PROPS,
+            new CelebornSaslClient.ClientCallbackHandler(
+                saslCredentials.getUserId(), saslCredentials.getPassword()));
+    try {
+      byte[] payload = saslClient.firstToken();
+
+      while (!saslClient.isComplete()) {
+        TransportMessage msg =
+            new TransportMessage(
+                MessageType.SASL_REQUEST,
+                PbSaslRequest.newBuilder()
+                    .setAppId(appId)
+                    .setMethod(DIGEST)
+                    .setAuthType(PbAuthType.CONNECTION_AUTH)
+                    .setPayload(ByteString.copyFrom(payload))
+                    .build()
+                    .toByteArray());
+        ByteBuffer response;
+        try {
+          response = client.sendRpcSync(msg.toByteBuffer(), conf.saslTimeoutMs());
+        } catch (RuntimeException ex) {
+          // We know it is a Sasl timeout here if it is a TimeoutException.
+          if (ex.getCause() instanceof TimeoutException) {
+            throw new SaslTimeoutException(ex.getCause());
+          } else {
+            throw ex;
+          }
+        }
+        PbSaslResponse saslResponse = TransportMessage.fromByteBuffer(response).getParsedPayload();
+        payload = saslClient.response(saslResponse.getPayload().toByteArray());
+      }
+      client.setClientId(appId);
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    } finally {
+      try {
+        // Once authentication is complete, the server will trust all remaining communication.
+        saslClient.dispose();
+      } catch (RuntimeException e) {
+        logger.error("Error while disposing SASL client", e);
+      }
+    }
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslConstants.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslConstants.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+import java.util.Map;
+
+import javax.security.sasl.Sasl;
+
+import com.google.common.collect.ImmutableMap;
+
+public interface SaslConstants {
+  /** Sasl Mechanisms */
+  String ANONYMOUS = "ANONYMOUS";
+
+  String DIGEST = "DIGEST-MD5";
+
+  /** Quality of protection value that includes encryption. */
+  String QOP_AUTH_CONF = "auth-conf";
+  /** Quality of protection value that does not include encryption. */
+  String QOP_AUTH = "auth";
+
+  String DEFAULT_REALM = "default";
+
+  Map<String, String> DEFAULT_SASL_CLIENT_PROPS =
+      ImmutableMap.<String, String>builder().put(Sasl.QOP, QOP_AUTH).build();
+
+  Map<String, String> DEFAULT_SASL_SERVER_PROPS =
+      ImmutableMap.<String, String>builder()
+          .put(Sasl.SERVER_AUTH, "true")
+          .put(Sasl.QOP, String.format("%s,%s", QOP_AUTH_CONF, QOP_AUTH))
+          .build();
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslCredentials.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslCredentials.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+import com.google.common.base.Preconditions;
+
+public class SaslCredentials {
+  private final String userId;
+  private final String password;
+
+  public SaslCredentials(String userId, String password) {
+    this.userId = Preconditions.checkNotNull(userId);
+    this.password = Preconditions.checkNotNull(password);
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslRpcHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslRpcHandler.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+import static org.apache.celeborn.common.network.sasl.SaslConstants.*;
+
+import java.io.IOException;
+
+import com.google.common.base.Throwables;
+import com.google.protobuf.ByteString;
+import io.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.network.client.RpcResponseCallback;
+import org.apache.celeborn.common.network.client.TransportClient;
+import org.apache.celeborn.common.network.protocol.RequestMessage;
+import org.apache.celeborn.common.network.protocol.RpcFailure;
+import org.apache.celeborn.common.network.protocol.RpcRequest;
+import org.apache.celeborn.common.network.protocol.TransportMessage;
+import org.apache.celeborn.common.network.server.AbstractAuthRpcHandler;
+import org.apache.celeborn.common.network.server.BaseMessageHandler;
+import org.apache.celeborn.common.network.util.TransportConf;
+import org.apache.celeborn.common.protocol.MessageType;
+import org.apache.celeborn.common.protocol.PbSaslRequest;
+import org.apache.celeborn.common.protocol.PbSaslResponse;
+
+/**
+ * RPC Handler which performs SASL authentication before delegating to a child RPC handler. The
+ * delegate will only receive messages if the given connection has been successfully authenticated.
+ * A connection may be authenticated at most once.
+ *
+ * <p>Note that the authentication process consists of multiple challenge-response pairs, each of
+ * which are individual RPCs.
+ */
+public class SaslRpcHandler extends AbstractAuthRpcHandler {
+  private static final Logger logger = LoggerFactory.getLogger(SaslRpcHandler.class);
+
+  /** Transport configuration. */
+  private final TransportConf conf;
+
+  /** The client channel. */
+  private final Channel channel;
+
+  /** Class which provides secret keys which are shared by server and client on a per-app basis. */
+  private final SecretRegistry secretRegistry;
+
+  private CelebornSaslServer saslServer;
+  private AppRegistrationFetcher _appRegistrationFetcher;
+
+  public SaslRpcHandler(
+      TransportConf conf,
+      Channel channel,
+      BaseMessageHandler delegate,
+      SecretRegistry secretRegistry,
+      AppRegistrationFetcher appRegistrationFetcher) {
+    super(delegate);
+    this.conf = conf;
+    this.channel = channel;
+    this.secretRegistry = secretRegistry;
+    this.saslServer = null;
+    this._appRegistrationFetcher = appRegistrationFetcher;
+  }
+
+  @Override
+  public boolean checkRegistered() {
+    return delegate.checkRegistered();
+  }
+
+  @Override
+  public boolean doAuthChallenge(
+      TransportClient client, RequestMessage message, RpcResponseCallback callback) {
+    if (saslServer == null || !saslServer.isComplete()) {
+      RpcRequest rpcRequest = (RpcRequest) message;
+      PbSaslRequest saslMessage = null;
+      try {
+        TransportMessage pbMsg = TransportMessage.fromByteBuffer(message.body().nioByteBuffer());
+        saslMessage = pbMsg.getParsedPayload();
+      } catch (IOException e) {
+        logger.error(
+            "Error while invoking RpcHandler#receive() on RPC id " + rpcRequest.requestId, e);
+        client
+            .getChannel()
+            .writeAndFlush(
+                new RpcFailure(rpcRequest.requestId, Throwables.getStackTraceAsString(e)));
+      }
+      assert saslMessage != null;
+      if (saslServer == null) {
+        // Check if the application is registered or not. If it isn't then we need to pull
+        // the information from the Celeborn coordinator. For the Celeborn coordinator,
+        // the application information should always be registered at this point.
+        if (!secretRegistry.isRegistered(saslMessage.getAppId())) {
+          logger.info("Application registration missing for {}", saslMessage.getAppId());
+          // Pull the registration information from the coordinator.
+          if (_appRegistrationFetcher != null) {
+            _appRegistrationFetcher.fetchRegistrationInfoFor(saslMessage.getAppId());
+          }
+        }
+        if (!secretRegistry.isRegistered(saslMessage.getAppId())) {
+          throw new RuntimeException("Application has not registered " + saslMessage.getAppId());
+        }
+
+        // First message in the handshake, setup the necessary state.
+        client.setClientId(saslMessage.getAppId());
+        saslServer =
+            new CelebornSaslServer(
+                DIGEST,
+                DEFAULT_SASL_SERVER_PROPS,
+                new CelebornSaslServer.DigestCallbackHandler(
+                    saslMessage.getAppId(), secretRegistry));
+      }
+
+      byte[] response = saslServer.response(saslMessage.getPayload().toByteArray());
+      PbSaslResponse saslResponse =
+          PbSaslResponse.newBuilder().setPayload(ByteString.copyFrom(response)).build();
+      TransportMessage transportMessage =
+          new TransportMessage(MessageType.SASL_RESPONSE, saslResponse.toByteArray());
+      callback.onSuccess(transportMessage.toByteBuffer());
+    }
+
+    // Setup encryption after the SASL response is sent, otherwise the client can't parse the
+    // response. It's ok to change the channel pipeline here since we are processing an incoming
+    // message, so the pipeline is busy and no new incoming messages will be fed to it before this
+    // method returns. This assumes that the code ensures, through other means, that no outbound
+    // messages are being written to the channel while negotiation is still going on.
+    if (saslServer.isComplete()) {
+      logger.debug("SASL authentication successful for channel {}", client);
+      complete(true);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public void channelInactive(TransportClient client) {
+    try {
+      super.channelInactive(client);
+    } finally {
+      if (saslServer != null) {
+        saslServer.dispose();
+      }
+    }
+  }
+
+  private void complete(boolean dispose) {
+    if (dispose) {
+      try {
+        saslServer.dispose();
+      } catch (RuntimeException e) {
+        logger.error("Error while disposing SASL server", e);
+      }
+    }
+    saslServer = null;
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslServerBootstrap.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslServerBootstrap.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+import io.netty.channel.Channel;
+
+import org.apache.celeborn.common.network.server.BaseMessageHandler;
+import org.apache.celeborn.common.network.server.TransportServerBootstrap;
+import org.apache.celeborn.common.network.util.TransportConf;
+
+/**
+ * A bootstrap which is executed on a TransportServer's client channel once a client connects to the
+ * server. This allows customizing the client channel to allow for things such as SASL
+ * authentication.
+ */
+public class SaslServerBootstrap implements TransportServerBootstrap {
+
+  private final TransportConf conf;
+  private final SecretRegistry secretKeyHolder;
+  private final AppRegistrationFetcher _appRegistrationFetcher;
+
+  public SaslServerBootstrap(
+      TransportConf conf,
+      SecretRegistry secretRegistry,
+      AppRegistrationFetcher appRegistrationFetcher) {
+    this.conf = conf;
+    this.secretKeyHolder = secretRegistry;
+    this._appRegistrationFetcher = appRegistrationFetcher;
+  }
+
+  /**
+   * Wrap the given application handler in a SaslRpcHandler that will handle the initial SASL
+   * negotiation.
+   */
+  @Override
+  public BaseMessageHandler doBootstrap(Channel channel, BaseMessageHandler rpcHandler) {
+    return new SaslRpcHandler(conf, channel, rpcHandler, secretKeyHolder, _appRegistrationFetcher);
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslTimeoutException.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/SaslTimeoutException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+/** An exception thrown if there is a SASL timeout. */
+public class SaslTimeoutException extends RuntimeException {
+  public SaslTimeoutException(Throwable cause) {
+    super(cause);
+  }
+
+  public SaslTimeoutException(String message) {
+    super(message);
+  }
+
+  public SaslTimeoutException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/SecretRegistry.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/SecretRegistry.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+/** Interface for getting a secret key associated with some application. */
+public interface SecretRegistry {
+  /**
+   * Gets an appropriate SASL User for the given appId.
+   *
+   * @throws IllegalArgumentException if the given appId is not associated with a SASL user.
+   */
+  String getSaslUser(String appId);
+
+  /**
+   * Gets an appropriate SASL secret key for the given appId.
+   *
+   * @throws IllegalArgumentException if the given appId is not associated with a SASL secret key.
+   */
+  String getSecretKey(String appId);
+
+  boolean isRegistered(String appId);
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/SecretRegistryImpl.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/SecretRegistryImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.google.common.collect.Lists;
+
+public class SecretRegistryImpl implements SecretRegistry {
+
+  private static final SecretRegistryImpl INSTANCE = new SecretRegistryImpl();
+
+  public static SecretRegistryImpl getInstance() {
+    return INSTANCE;
+  }
+
+  private final ConcurrentHashMap<String, String> secrets = new ConcurrentHashMap<>();
+
+  public void registerApplication(String appId, String secret) {
+    secrets.put(appId, secret);
+  }
+
+  public void unregisterApplication(String appId) {
+    secrets.remove(appId);
+  }
+
+  public String getSecret(String appId) {
+    return secrets.get(appId);
+  }
+
+  public boolean isRegistered(String appId) {
+    return secrets.containsKey(appId);
+  }
+
+  public List<String> getAllRegisteredApps() {
+    return Lists.newArrayList(secrets.keySet());
+  }
+
+  /**
+   * Gets an appropriate SASL User for the given appId.
+   *
+   * @throws IllegalArgumentException if the given appId is not associated with a SASL user.
+   */
+  @Override
+  public String getSaslUser(String appId) {
+    return appId;
+  }
+
+  /**
+   * Gets an appropriate SASL secret key for the given appId.
+   *
+   * @throws IllegalArgumentException if the given appId is not associated with a SASL secret key.
+   */
+  @Override
+  public String getSecretKey(String appId) {
+    return secrets.get(appId);
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslClientFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslClientFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl.anonymous;
+
+import static org.apache.celeborn.common.network.sasl.SaslConstants.*;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
+
+public class AnonymousSaslClientFactory implements SaslClientFactory {
+
+  @Override
+  public SaslClient createSaslClient(
+      String[] mechanisms,
+      String authorizationId,
+      String protocol,
+      String serverName,
+      Map<String, ?> props,
+      CallbackHandler cbh)
+      throws SaslException {
+    for (String mech : mechanisms) {
+      if (mech.equals(ANONYMOUS)) {
+        return new CelebornAnonymousSaslClient();
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String[] getMechanismNames(Map<String, ?> props) {
+    return new String[] {ANONYMOUS};
+  }
+
+  class CelebornAnonymousSaslClient implements SaslClient {
+
+    private boolean isCompleted = false;
+
+    @Override
+    public String getMechanismName() {
+      return ANONYMOUS;
+    }
+
+    @Override
+    public boolean hasInitialResponse() {
+      return false;
+    }
+
+    @Override
+    public byte[] evaluateChallenge(byte[] challenge) throws SaslException {
+      if (isCompleted) {
+        throw new IllegalStateException("Authentication has already completed.");
+      }
+      isCompleted = true;
+      return ANONYMOUS.getBytes();
+    }
+
+    @Override
+    public boolean isComplete() {
+      return isCompleted;
+    }
+
+    @Override
+    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+      throw new IllegalStateException("ANONYMOUS mechanism does not support wrap/unwrap");
+    }
+
+    @Override
+    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+      throw new IllegalStateException("ANONYMOUS mechanism does not support wrap/unwrap");
+    }
+
+    @Override
+    public Object getNegotiatedProperty(String propName) {
+      return null;
+    }
+
+    @Override
+    public void dispose() throws SaslException {
+      // Cleanup resources if any
+    }
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslProvider.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl.anonymous;
+
+import static org.apache.celeborn.common.network.sasl.SaslConstants.*;
+
+import java.security.Provider;
+import java.security.Security;
+
+public final class AnonymousSaslProvider extends Provider {
+
+  private static boolean init = false;
+
+  private AnonymousSaslProvider() {
+    super("AnonymousSasl", 1.0, "ANONYMOUS SASL MECHANISM PROVIDER");
+    put("SaslClientFactory." + ANONYMOUS, AnonymousSaslClientFactory.class.getName());
+    put("SaslServerFactory." + ANONYMOUS, AnonymousSaslServerFactory.class.getName());
+  }
+
+  public static synchronized void initializeIfNeeded() {
+    if (!init) {
+      AnonymousSaslProvider provider = new AnonymousSaslProvider();
+      Security.addProvider(provider);
+      init = true;
+    }
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslServerFactory.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/anonymous/AnonymousSaslServerFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl.anonymous;
+
+import static org.apache.celeborn.common.network.sasl.SaslConstants.*;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+public class AnonymousSaslServerFactory implements SaslServerFactory {
+  @Override
+  public SaslServer createSaslServer(
+      String mechanism,
+      String protocol,
+      String serverName,
+      Map<String, ?> props,
+      CallbackHandler cbh)
+      throws SaslException {
+    if (mechanism.equals(ANONYMOUS)) {
+      return new CelebornAnonymousSaslServer();
+    }
+    return null;
+  }
+
+  @Override
+  public String[] getMechanismNames(Map<String, ?> props) {
+    return new String[] {ANONYMOUS};
+  }
+
+  class CelebornAnonymousSaslServer implements SaslServer {
+    private boolean isCompleted = false;
+
+    @Override
+    public String getMechanismName() {
+      return ANONYMOUS;
+    }
+
+    @Override
+    public byte[] evaluateResponse(byte[] response) throws SaslException {
+      if (isCompleted) {
+        throw new IllegalStateException("Authentication has already completed.");
+      }
+      // Typically, we would process the response here. For ANONYMOUS, we just accept it.
+      isCompleted = true;
+      return new byte[0]; // No challenge is expected for ANONYMOUS.
+    }
+
+    @Override
+    public boolean isComplete() {
+      return isCompleted;
+    }
+
+    @Override
+    public String getAuthorizationID() {
+      return ANONYMOUS;
+    }
+
+    @Override
+    public byte[] unwrap(byte[] incoming, int offset, int len) {
+      throw new IllegalStateException("ANONYMOUS mechanism does not support wrap/unwrap");
+    }
+
+    @Override
+    public byte[] wrap(byte[] outgoing, int offset, int len) {
+      throw new IllegalStateException("ANONYMOUS mechanism does not support wrap/unwrap");
+    }
+
+    @Override
+    public Object getNegotiatedProperty(String propName) {
+      return null;
+    }
+
+    @Override
+    public void dispose() {
+      // Cleanup resources if any.
+    }
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/server/AbstractAuthRpcHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/AbstractAuthRpcHandler.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.server;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.network.client.RpcResponseCallback;
+import org.apache.celeborn.common.network.client.TransportClient;
+import org.apache.celeborn.common.network.protocol.RequestMessage;
+
+/**
+ * RPC Handler which performs authentication, and when it's successful, delegates further calls to
+ * another RPC handler. The authentication handshake itself should be implemented by subclasses.
+ */
+public abstract class AbstractAuthRpcHandler extends BaseMessageHandler {
+  /** RpcHandler we will delegate to for authenticated connections. */
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractAuthRpcHandler.class);
+
+  protected final BaseMessageHandler delegate;
+
+  private boolean isAuthenticated;
+
+  protected AbstractAuthRpcHandler(BaseMessageHandler delegate) {
+    this.delegate = delegate;
+  }
+
+  /**
+   * Responds to an authentication challenge.
+   *
+   * @return Whether the client is authenticated.
+   */
+  protected abstract boolean doAuthChallenge(
+      TransportClient client, RequestMessage message, RpcResponseCallback callback);
+
+  @Override
+  public final void receive(
+      TransportClient client, RequestMessage message, RpcResponseCallback callback) {
+    if (isAuthenticated) {
+      LOG.trace("Already authenticated. Delegating {}", client.getClientId());
+      delegate.receive(client, message, callback);
+    } else {
+      isAuthenticated = doAuthChallenge(client, message, callback);
+    }
+  }
+
+  @Override
+  public final void receive(TransportClient client, RequestMessage message) {
+    if (isAuthenticated) {
+      delegate.receive(client, message);
+    } else {
+      throw new SecurityException("Unauthenticated call to receive().");
+    }
+  }
+
+  @Override
+  public void channelActive(TransportClient client) {
+    delegate.channelActive(client);
+  }
+
+  @Override
+  public void channelInactive(TransportClient client) {
+    delegate.channelInactive(client);
+  }
+
+  @Override
+  public void exceptionCaught(Throwable cause, TransportClient client) {
+    delegate.exceptionCaught(cause, client);
+  }
+
+  public boolean isAuthenticated() {
+    return isAuthenticated;
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/server/BaseMessageHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/BaseMessageHandler.java
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.common.network.server;
 
+import org.apache.celeborn.common.network.client.RpcResponseCallback;
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.protocol.RequestMessage;
 
@@ -24,6 +25,10 @@ import org.apache.celeborn.common.network.protocol.RequestMessage;
 public class BaseMessageHandler {
 
   public void receive(TransportClient client, RequestMessage msg) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void receive(TransportClient client, RequestMessage msg, RpcResponseCallback callback) {
     throw new UnsupportedOperationException();
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportServerBootstrap.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportServerBootstrap.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.server;
+
+import io.netty.channel.Channel;
+
+/**
+ * A bootstrap which is executed on a TransportServer's client channel once a client connects to the
+ * server. This allows customizing the client channel to allow for things such as SASL
+ * authentication.
+ */
+public interface TransportServerBootstrap {
+  /**
+   * Customizes the channel to include new features, if needed.
+   *
+   * @param channel The connected channel opened by the client.
+   * @param baseMessageHandler The RPC handler for the server.
+   * @return The base message handler to use for the channel.
+   */
+  BaseMessageHandler doBootstrap(Channel channel, BaseMessageHandler baseMessageHandler);
+}

--- a/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/TransportConf.java
@@ -153,4 +153,9 @@ public class TransportConf {
   public long clientHeartbeatInterval() {
     return celebornConf.clientHeartbeatInterval(module);
   }
+
+  /** Timeout for a single round trip of sasl message exchange, in milliseconds. */
+  public int saslTimeoutMs() {
+    return celebornConf.networkIoSaslTimoutMs(module);
+  }
 }

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -87,6 +87,8 @@ enum MessageType {
   TRANSPORTABLE_ERROR = 64;
   WORKER_EXCLUDE = 65;
   WORKER_EXCLUDE_RESPONSE = 66;
+  SASL_REQUEST = 67;
+  SASL_RESPONSE = 68;
 }
 
 enum StreamType {
@@ -585,4 +587,25 @@ message PbChunkFetchRequest {
 message PbTransportableError {
   int64 streamId = 1;
   string message = 2;
+}
+
+enum PbAuthType {
+  CLIENT_AUTH = 0;
+  CONNECTION_AUTH = 1;
+}
+
+message PbSaslMechanism {
+  string mechanism = 1;
+  repeated PbAuthType authTypes = 2;
+}
+
+message PbSaslRequest {
+  string appId = 1;
+  string method = 2;
+  PbAuthType authType = 3;
+  bytes payload = 4;
+}
+
+message PbSaslResponse {
+  bytes payload = 1;
 }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -509,6 +509,11 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
 
   def maxDefaultNettyThreads: Int = get(MAX_DEFAULT_NETTY_THREADS)
 
+  def networkIoSaslTimoutMs(module: String): Int = {
+    val key = NETWORK_IO_SASL_TIMEOUT.key.replace("<module>", module)
+    getTimeAsMs(key, s"${networkTimeout.duration.toMillis}ms").toInt
+  }
+
   // //////////////////////////////////////////////////////
   //                      Master                         //
   // //////////////////////////////////////////////////////
@@ -4053,4 +4058,12 @@ object CelebornConf extends Logging {
       .doc("Kerberos keytab file path for HDFS storage connection.")
       .stringConf
       .createOptional
+
+  val NETWORK_IO_SASL_TIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.<module>.io.saslTimeout")
+      .categories("network")
+      .doc("Timeout for a single round trip of auth message exchange, in milliseconds.")
+      .version("0.3.2")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("30s")
 }

--- a/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/rpc/netty/NettyRpcEnv.scala
@@ -36,7 +36,7 @@ import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.network.TransportContext
 import org.apache.celeborn.common.network.buffer.NioManagedBuffer
 import org.apache.celeborn.common.network.client._
-import org.apache.celeborn.common.network.protocol.{OneWayMessage => NOneWayMessage, RequestMessage => NRequestMessage, RpcFailure => NRpcFailure, RpcRequest, RpcResponse}
+import org.apache.celeborn.common.network.protocol.{RequestMessage => NRequestMessage, RpcFailure => NRpcFailure, RpcRequest}
 import org.apache.celeborn.common.network.server._
 import org.apache.celeborn.common.protocol.{RpcNameConstants, TransportModuleConstants}
 import org.apache.celeborn.common.rpc._
@@ -530,53 +530,31 @@ private[celeborn] class NettyRpcHandler(
   override def receive(
       client: TransportClient,
       requestMessage: NRequestMessage): Unit = {
-    requestMessage match {
-      case r: RpcRequest =>
-        processRpc(client, r)
-      case r: NOneWayMessage =>
-        processOnewayMessage(client, r)
-    }
-  }
-
-  private def processRpc(client: TransportClient, r: RpcRequest): Unit = {
-    val callback = new RpcResponseCallback {
-      override def onSuccess(response: ByteBuffer): Unit = {
-        client.getChannel.writeAndFlush(new RpcResponse(
-          r.requestId,
-          new NioManagedBuffer(response)))
-      }
-
-      override def onFailure(e: Throwable): Unit = {
-        client.getChannel.writeAndFlush(new NRpcFailure(
-          r.requestId,
-          Throwables.getStackTraceAsString(e)))
-      }
-    }
     try {
-      val message = r.body().nioByteBuffer()
-      val messageToDispatch = internalReceive(client, message)
-      dispatcher.postRemoteMessage(messageToDispatch, callback)
-    } catch {
-      case e: Exception =>
-        logError("Error while invoking RpcHandler#receive() on RPC id " + r.requestId, e)
-        client.getChannel.writeAndFlush(new NRpcFailure(
-          r.requestId,
-          Throwables.getStackTraceAsString(e)))
-    } finally {
-      r.body().release()
-    }
-  }
-
-  private def processOnewayMessage(client: TransportClient, r: NOneWayMessage): Unit = {
-    try {
-      val message = r.body().nioByteBuffer()
+      val message = requestMessage.body().nioByteBuffer()
       val messageToDispatch = internalReceive(client, message)
       dispatcher.postOneWayMessage(messageToDispatch)
     } catch {
       case e: Exception =>
         logError("Error while invoking RpcHandler#receive() for one-way message.", e)
-    } finally {
-      r.body().release()
+    }
+  }
+
+  override def receive(
+      client: TransportClient,
+      requestMessage: NRequestMessage,
+      callback: RpcResponseCallback): Unit = {
+    try {
+      val message = requestMessage.body().nioByteBuffer()
+      val messageToDispatch = internalReceive(client, message)
+      dispatcher.postRemoteMessage(messageToDispatch, callback)
+    } catch {
+      case e: Exception =>
+        val rpcReq = requestMessage.asInstanceOf[RpcRequest]
+        logError("Error while invoking RpcHandler#receive() on RPC id " + rpcReq.requestId, e)
+        client.getChannel.writeAndFlush(new NRpcFailure(
+          rpcReq.requestId,
+          Throwables.getStackTraceAsString(e)))
     }
   }
 

--- a/common/src/test/java/org/apache/celeborn/common/network/sasl/CelebornSaslSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/sasl/CelebornSaslSuiteJ.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.network.sasl;
+
+import static org.apache.celeborn.common.network.sasl.SaslConstants.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.network.TransportContext;
+import org.apache.celeborn.common.network.client.RpcResponseCallback;
+import org.apache.celeborn.common.network.client.TransportClient;
+import org.apache.celeborn.common.network.client.TransportClientBootstrap;
+import org.apache.celeborn.common.network.protocol.RequestMessage;
+import org.apache.celeborn.common.network.server.BaseMessageHandler;
+import org.apache.celeborn.common.network.server.TransportServer;
+import org.apache.celeborn.common.network.util.TransportConf;
+import org.apache.celeborn.common.util.JavaUtils;
+
+/**
+ * Jointly tests {@link CelebornSaslClient} and {@link CelebornSaslServer}, as both are black boxes.
+ */
+public class CelebornSaslSuiteJ {
+
+  private static final String TEST_APP = "appId";
+  private static final String TEST_SECRET = "secret";
+
+  @BeforeClass
+  public static void setup() {
+    SecretRegistryImpl.getInstance().registerApplication(TEST_APP, TEST_SECRET);
+  }
+
+  @Test
+  public void testAnonymous() {
+    Security.addProvider(new sun.security.provider.Sun());
+    CelebornSaslClient client = new CelebornSaslClient(ANONYMOUS, null, null);
+    CelebornSaslServer server = new CelebornSaslServer(ANONYMOUS, null, null);
+
+    assertFalse(client.isComplete());
+    assertFalse(server.isComplete());
+
+    byte[] clientMessage = client.firstToken();
+    while (!client.isComplete()) {
+      clientMessage = client.response(server.response(clientMessage));
+    }
+    assertTrue(server.isComplete());
+
+    // Disposal should invalidate
+    server.dispose();
+    assertFalse(server.isComplete());
+    client.dispose();
+    assertFalse(client.isComplete());
+  }
+
+  @Test
+  public void testDigestMatching() {
+    CelebornSaslClient client =
+        new CelebornSaslClient(
+            SaslConstants.DIGEST,
+            DEFAULT_SASL_CLIENT_PROPS,
+            new CelebornSaslClient.ClientCallbackHandler(TEST_APP, TEST_SECRET));
+    CelebornSaslServer server =
+        new CelebornSaslServer(
+            SaslConstants.DIGEST,
+            DEFAULT_SASL_SERVER_PROPS,
+            new CelebornSaslServer.DigestCallbackHandler(
+                TEST_APP, SecretRegistryImpl.getInstance()));
+
+    assertFalse(client.isComplete());
+    assertFalse(server.isComplete());
+
+    byte[] clientMessage = client.firstToken();
+
+    while (!client.isComplete()) {
+      clientMessage = client.response(server.response(clientMessage));
+    }
+    assertTrue(server.isComplete());
+
+    // Disposal should invalidate
+    server.dispose();
+    assertFalse(server.isComplete());
+    client.dispose();
+    assertFalse(client.isComplete());
+  }
+
+  @Test
+  public void testDigestNonMatching() {
+    CelebornSaslClient client =
+        new CelebornSaslClient(
+            SaslConstants.DIGEST,
+            DEFAULT_SASL_CLIENT_PROPS,
+            new CelebornSaslClient.ClientCallbackHandler(TEST_APP, "my-secret"));
+    CelebornSaslServer server =
+        new CelebornSaslServer(
+            SaslConstants.DIGEST,
+            DEFAULT_SASL_SERVER_PROPS,
+            new CelebornSaslServer.DigestCallbackHandler(
+                TEST_APP, SecretRegistryImpl.getInstance()));
+
+    assertFalse(client.isComplete());
+    assertFalse(server.isComplete());
+
+    byte[] clientMessage = client.firstToken();
+
+    try {
+      while (!client.isComplete()) {
+        clientMessage = client.response(server.response(clientMessage));
+      }
+      fail("Should not have completed");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("Mismatched response"));
+      assertFalse(client.isComplete());
+      assertFalse(server.isComplete());
+    }
+  }
+
+  @Test
+  public void testBasicSaslAuthentication() throws Throwable {
+    BaseMessageHandler rpcHandler = mock(BaseMessageHandler.class);
+    doAnswer(
+            invocation -> {
+              RequestMessage message = (RequestMessage) invocation.getArguments()[1];
+              RpcResponseCallback cb = (RpcResponseCallback) invocation.getArguments()[2];
+              assertEquals("Ping", JavaUtils.bytesToString(message.body().nioByteBuffer()));
+              cb.onSuccess(JavaUtils.stringToBytes("Pong"));
+              return null;
+            })
+        .when(rpcHandler)
+        .receive(
+            any(TransportClient.class), any(RequestMessage.class), any(RpcResponseCallback.class));
+
+    doReturn(true).when(rpcHandler).checkRegistered();
+
+    try (SaslTestCtx ctx = new SaslTestCtx(rpcHandler)) {
+      ByteBuffer response =
+          ctx.client.sendRpcSync(JavaUtils.stringToBytes("Ping"), TimeUnit.SECONDS.toMillis(10));
+      assertEquals("Pong", JavaUtils.bytesToString(response));
+    } finally {
+      // There should be 2 terminated events; one for the client, one for the server.
+      Throwable error = null;
+      long deadline = System.nanoTime() + TimeUnit.NANOSECONDS.convert(10, TimeUnit.SECONDS);
+      while (deadline > System.nanoTime()) {
+        try {
+          verify(rpcHandler, times(2)).channelInactive(any(TransportClient.class));
+          error = null;
+          break;
+        } catch (Throwable t) {
+          error = t;
+          TimeUnit.MILLISECONDS.sleep(10);
+        }
+      }
+      if (error != null) {
+        throw error;
+      }
+    }
+  }
+
+  @Test
+  public void testRpcHandlerDelegate() throws Exception {
+    // Tests all delegates exception for receive(), which is more complicated and already handled
+    // by all other tests.
+    BaseMessageHandler handler = mock(BaseMessageHandler.class);
+    BaseMessageHandler saslHandler = new SaslRpcHandler(null, null, handler, null, null);
+
+    saslHandler.channelInactive(null);
+    verify(handler).channelInactive(isNull());
+
+    saslHandler.exceptionCaught(null, null);
+    verify(handler).exceptionCaught(isNull(), isNull());
+  }
+
+  @Test
+  public void testDelegates() throws Exception {
+    Method[] rpcHandlerMethods = BaseMessageHandler.class.getDeclaredMethods();
+    for (Method m : rpcHandlerMethods) {
+      Method delegate = SaslRpcHandler.class.getMethod(m.getName(), m.getParameterTypes());
+      assertNotEquals(delegate.getDeclaringClass(), BaseMessageHandler.class);
+    }
+  }
+
+  private static class SaslTestCtx implements AutoCloseable {
+
+    final TransportClient client;
+    final TransportServer server;
+    final TransportContext ctx;
+
+    SaslTestCtx(BaseMessageHandler rpcHandler) throws Exception {
+      TransportConf conf = new TransportConf("shuffle", new CelebornConf());
+
+      this.ctx = new TransportContext(conf, rpcHandler);
+      this.server =
+          ctx.createServer(
+              Collections.singletonList(
+                  new SaslServerBootstrap(conf, SecretRegistryImpl.getInstance(), null)));
+      try {
+        List<TransportClientBootstrap> clientBootstraps = new ArrayList<>();
+        clientBootstraps.add(
+            new SaslClientBootstrap(conf, "appId", new SaslCredentials(TEST_APP, TEST_SECRET)));
+        this.client =
+            ctx.createClientFactory(clientBootstraps)
+                .createClient(JavaUtils.getLocalHost(), server.getPort());
+      } catch (Exception e) {
+        close();
+        throw e;
+      }
+    }
+
+    public void close() {
+      if (client != null) {
+        client.close();
+      }
+      if (server != null) {
+        server.close();
+      }
+    }
+  }
+}

--- a/common/src/test/java/org/apache/celeborn/common/network/server/TransportRequestHandlerSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/server/TransportRequestHandlerSuiteJ.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.celeborn.common.network.server;
 
 import static org.mockito.Mockito.*;

--- a/common/src/test/java/org/apache/celeborn/common/network/server/TransportRequestHandlerSuiteJ.java
+++ b/common/src/test/java/org/apache/celeborn/common/network/server/TransportRequestHandlerSuiteJ.java
@@ -1,0 +1,55 @@
+package org.apache.celeborn.common.network.server;
+
+import static org.mockito.Mockito.*;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.apache.celeborn.common.network.buffer.NettyManagedBuffer;
+import org.apache.celeborn.common.network.client.TransportClient;
+import org.apache.celeborn.common.network.protocol.OneWayMessage;
+import org.apache.celeborn.common.network.protocol.RpcRequest;
+
+public class TransportRequestHandlerSuiteJ {
+
+  @Mock private Channel channel;
+
+  @Mock private TransportClient reverseClient;
+
+  @Mock private BaseMessageHandler msgHandler;
+
+  private TransportRequestHandler requestHandler;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    when(msgHandler.checkRegistered()).thenReturn(true);
+    requestHandler = new TransportRequestHandler(channel, reverseClient, msgHandler);
+  }
+
+  @Test
+  public void testHandleRpcRequest() {
+    ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] {1});
+    RpcRequest rpcRequest = new RpcRequest(1, new NettyManagedBuffer(buffer));
+    requestHandler.handle(rpcRequest);
+    verify(msgHandler).receive(eq(reverseClient), eq(rpcRequest), any());
+    verify(msgHandler, times(0)).receive(eq(reverseClient), eq(rpcRequest));
+    assert buffer.refCnt() == 0;
+  }
+
+  @Test
+  public void testHandleOneWayMessage() {
+    when(msgHandler.checkRegistered()).thenReturn(true);
+    ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] {1});
+    OneWayMessage oneWayMessage = new OneWayMessage(new NettyManagedBuffer(buffer));
+    requestHandler.handle(oneWayMessage);
+    verify(msgHandler).receive(eq(reverseClient), eq(oneWayMessage));
+    verify(msgHandler, times(0)).receive(eq(reverseClient), eq(oneWayMessage), any());
+    assert buffer.refCnt() == 0;
+  }
+}

--- a/docs/configuration/network.md
+++ b/docs/configuration/network.md
@@ -34,6 +34,7 @@ license: |
 | celeborn.&lt;module&gt;.io.preferDirectBufs | true | If true, we will prefer allocating off-heap byte buffers within Netty. |  | 
 | celeborn.&lt;module&gt;.io.receiveBuffer | 0b | Receive buffer size (SO_RCVBUF). Note: the optimal size for receive buffer and send buffer should be latency * network_bandwidth. Assuming latency = 1ms, network_bandwidth = 10Gbps buffer size should be ~ 1.25MB. | 0.2.0 | 
 | celeborn.&lt;module&gt;.io.retryWait | 5s | Time that we will wait in order to perform a retry after an IOException. Only relevant if maxIORetries > 0. | 0.2.0 | 
+| celeborn.&lt;module&gt;.io.saslTimeout | 30s | Timeout for a single round trip of auth message exchange, in milliseconds. | 0.3.2 | 
 | celeborn.&lt;module&gt;.io.sendBuffer | 0b | Send buffer size (SO_SNDBUF). | 0.2.0 | 
 | celeborn.&lt;module&gt;.io.serverThreads | 0 | Number of threads used in the server thread pool. Default to 0, which is 2x#cores. |  | 
 | celeborn.&lt;module&gt;.push.timeoutCheck.interval | 5s | Interval for checking push data timeout. If setting <module> to `data`, it works for shuffle client push data and should be configured on client side. If setting <module> to `replicate`, it works for worker replicate data to peer worker and should be configured on worker side. | 0.3.0 | 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds foundation for Sasl authentication in Celeborn's Transport client/server. This is part of the epic: https://issues.apache.org/jira/browse/CELEBORN-1011.
Most of the Sasl code is taken from Apache Spark.

### Why are the changes needed?
The changes are needed for adding authentication to Celeborn. See CELEBORN-1011.

### Does this PR introduce _any_ user-facing change?
Yes, it adds a configuration.

### How was this patch tested?
This is part of a much bigger change which I have tested manually. For this specific change, I have added UTs. 
