### PR TITLE
[CELEBORN-1137] Correct suggested leader of exception message for MasterNotLeaderException

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterNotLeaderException.java
@@ -35,9 +35,11 @@ public class MasterNotLeaderException extends IOException {
       String currentPeer, String suggestedLeaderPeer, @Nullable Throwable cause) {
     super(
         String.format(
-            "Master:%s is not the leader. Suggested leader is Master:%s.%s",
+            "Master:%s is not the leader.%s%s",
             currentPeer,
-            suggestedLeaderPeer,
+            currentPeer.equals(suggestedLeaderPeer)
+                ? StringUtils.EMPTY
+                : String.format(" Suggested leader is Master:%s.", suggestedLeaderPeer),
             cause == null
                 ? StringUtils.EMPTY
                 : String.format(" Exception:%s.", cause.getMessage())),


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MasterNotLeaderException` corrects the suggested leader of exception message.

### Why are the changes needed?

When current peer isn't the leader of master and the leader is switching which cache isn't expired, the suggested leader of exception message in MasterNotLeaderException is confusing that the suggested leader is current peer. It's recommened to correct suggested leader of exception message for MasterNotLeaderException if current peer is equal to the suggested leader.
```
Caused by: org.apache.celeborn.common.haclient.MasterNotLeaderException: Master:xx.xx.xx.xx:9099 is not the leader. Suggested leader is Master:xx.xx.xx.xx:9099. Exception:bound must be positive.
    at org.apache.celeborn.service.deploy.master.clustermeta.ha.HAHelper.sendFailure(HAHelper.java:58)
    at org.apache.celeborn.service.deploy.master.Master.executeWithLeaderChecker(Master.scala:236)
    at org.apache.celeborn.service.deploy.master.Master$$anonfun$receiveAndReply$1.applyOrElse(Master.scala:314)
    ... 7 more
Caused by: java.lang.IllegalArgumentException: bound must be positive
    at java.util.Random.nextInt(Random.java:388)
    at org.apache.celeborn.service.deploy.master.SlotsAllocator.roundRobin(SlotsAllocator.java:202)
    at org.apache.celeborn.service.deploy.master.SlotsAllocator.offerSlotsLoadAware(SlotsAllocator.java:151)
    at org.apache.celeborn.service.deploy.master.Master.$anonfun$handleRequestSlots$1(Master.scala:598)
    at org.apache.celeborn.common.metrics.source.AbstractSource.sample(AbstractSource.scala:199)
    at org.apache.celeborn.common.metrics.source.AbstractSource.sample(AbstractSource.scala:189)
    at org.apache.celeborn.service.deploy.master.Master.handleRequestSlots(Master.scala:587)
    at org.apache.celeborn.service.deploy.master.Master$$anonfun$receiveAndReply$1.$anonfun$applyOrElse$12(Master.scala:314)
    at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
    at org.apache.celeborn.service.deploy.master.Master.executeWithLeaderChecker(Master.scala:233)
    ... 8 more  
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.