### PR TITLE
[CELEBORN-1125][FOLLOW] Bump guava from 14.0.1 to 32.1.3-jre

### DIFF
--- a/client-spark/spark-2-shaded/pom.xml
+++ b/client-spark/spark-2-shaded/pom.xml
@@ -69,6 +69,7 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
+              <include>com.google.guava:failureaccess</include>
               <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
               <include>org.roaringbitmap:RoaringBitmap</include>

--- a/client-spark/spark-3-shaded/pom.xml
+++ b/client-spark/spark-3-shaded/pom.xml
@@ -69,6 +69,7 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
+              <include>com.google.guava:failureaccess</include>
               <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
               <include>org.roaringbitmap:RoaringBitmap</include>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <google.jsr305.version>1.3.9</google.jsr305.version>
     <grpc.version>1.44.0</grpc.version>
     <guava.version>32.1.3-jre</guava.version>
+    <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
     <junit.version>4.13.2</junit.version>
     <leveldb.version>1.8</leveldb.version>
@@ -333,6 +334,11 @@
             <artifactId>j2objc-annotations</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>failureaccess</artifactId>
+        <version>${guava.failureaccess.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -43,6 +43,7 @@ object Dependencies {
   val commonsLang3Version = "3.12.0"
   val findbugsVersion = "1.3.9"
   val guavaVersion = "32.1.3-jre"
+  val guavaFailureaccessVersion = "32.1.3-jre"
   val hadoopVersion = "3.2.4"
   val javaxServletVersion = "3.1.0"
   val junitInterfaceVersion = "0.13.3"
@@ -78,6 +79,7 @@ object Dependencies {
     ExclusionRule("com.google.errorprone", "error_prone_annotations"),
     ExclusionRule("com.google.guava", "listenablefuture"),
     ExclusionRule("com.google.j2objc", "j2objc-annotations"))
+  val guavaFailreaccess = "com.google.guava" % "failureaccess" % guavaFailureaccessVersion
   val hadoopClientApi = "org.apache.hadoop" % "hadoop-client-api" % hadoopVersion
   val hadoopClientRuntime = "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion
   val hadoopMapreduceClientApp = "org.apache.hadoop" % "hadoop-mapreduce-client-app" % hadoopVersion excludeAll(


### PR DESCRIPTION
### What changes were proposed in this pull request?
To fix class not found exception when using spark client.


### Why are the changes needed?

> 23/11/27 16:15:00 ERROR [celeborn-dispatcher-57] ThreadExceptionHandler: Uncaught exception in executor service celeborn-dispatcher, thread Thread[celeborn-dispatcher-57,5,main]
> java.lang.NoClassDefFoundError: org/apache/celeborn/shaded/com/google/common/util/concurrent/internal/InternalFutureFailureAccess
>         at org.apache.celeborn.shaded.com.google.common.cache.LocalCache$LoadingValueReference.<init>(LocalCache.java:3517) ~[celeborn-client-spark-3-shaded_2.12-0.4.0-SNAPSHOT.jar:?]
>         at org.apache.celeborn.shaded.com.google.common.cache.LocalCache$LoadingValueReference.<init>(LocalCache.java:3521) ~[celeborn-client-spark-3-shaded_2.12-0.4.0-SNAPSHOT.jar:?]
>         at org.apache.celeborn.shaded.com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2170) ~[celeborn-client-spark-3-shaded_2.12-0.4.0-SNAPSHOT.jar:?]
>         at org.apache.celeborn.shaded.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2081) ~[celeborn-client-spark-3-shaded_2.12-0.4.0-SNAPSHOT.jar:?]


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
Cluster
