### PR TITLE
[CELEBORN-1125][FOLLOWUP] Add failureaccess shade

### DIFF
--- a/client-flink/flink-1.14-shaded/pom.xml
+++ b/client-flink/flink-1.14-shaded/pom.xml
@@ -69,6 +69,7 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
+              <include>com.google.guava:failureaccess</include>
               <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
               <include>org.roaringbitmap:RoaringBitmap</include>

--- a/client-flink/flink-1.15-shaded/pom.xml
+++ b/client-flink/flink-1.15-shaded/pom.xml
@@ -69,6 +69,7 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
+              <include>com.google.guava:failureaccess</include>
               <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
               <include>org.roaringbitmap:RoaringBitmap</include>

--- a/client-flink/flink-1.17-shaded/pom.xml
+++ b/client-flink/flink-1.17-shaded/pom.xml
@@ -69,6 +69,7 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
+              <include>com.google.guava:failureaccess</include>
               <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
               <include>org.roaringbitmap:RoaringBitmap</include>

--- a/client-flink/flink-1.18-shaded/pom.xml
+++ b/client-flink/flink-1.18-shaded/pom.xml
@@ -69,6 +69,7 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
+              <include>com.google.guava:failureaccess</include>
               <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
               <include>org.roaringbitmap:RoaringBitmap</include>

--- a/client-mr/mr-shaded/pom.xml
+++ b/client-mr/mr-shaded/pom.xml
@@ -77,6 +77,7 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
+              <include>com.google.guava:failureaccess</include>
               <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
               <include>org.scala-lang:scala-library</include>

--- a/client-spark/spark-2-shaded/pom.xml
+++ b/client-spark/spark-2-shaded/pom.xml
@@ -69,6 +69,7 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
+              <include>com.google.guava:failureaccess</include>
               <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
               <include>org.roaringbitmap:RoaringBitmap</include>

--- a/client-spark/spark-3-shaded/pom.xml
+++ b/client-spark/spark-3-shaded/pom.xml
@@ -69,6 +69,7 @@
               <include>org.apache.celeborn:*</include>
               <include>com.google.protobuf:protobuf-java</include>
               <include>com.google.guava:guava</include>
+              <include>com.google.guava:failureaccess</include>
               <include>io.netty:*</include>
               <include>org.apache.commons:commons-lang3</include>
               <include>org.roaringbitmap:RoaringBitmap</include>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -680,6 +680,7 @@ trait SparkClientProjects {
             !(name.startsWith("celeborn-") ||
               name.startsWith("protobuf-java-") ||
               name.startsWith("guava-") ||
+              name.startsWith("failureaccess-") ||
               name.startsWith("netty-") ||
               name.startsWith("commons-lang3-") ||
               name.startsWith("RoaringBitmap-"))
@@ -883,6 +884,7 @@ trait FlinkClientProjects {
             !(name.startsWith("celeborn-") ||
                 name.startsWith("protobuf-java-") ||
                 name.startsWith("guava-") ||
+                name.startsWith("failureaccess-") ||
                 name.startsWith("netty-") ||
                 name.startsWith("commons-lang3-") ||
                 name.startsWith("RoaringBitmap-"))
@@ -977,6 +979,7 @@ object MRClientProjects {
             !(name.startsWith("celeborn-") ||
               name.startsWith("protobuf-java-") ||
               name.startsWith("guava-") ||
+              name.startsWith("failureaccess-") ||
               name.startsWith("netty-") ||
               name.startsWith("commons-lang3-") ||
               name.startsWith("RoaringBitmap-") ||


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add failureaccess shade.


### Why are the changes needed?
When test main branch, client got error like below:
```
Caused by: java.lang.NoClassDefFoundError: org/apache/celeborn/shaded/com/google/common/util/concurrent/internal/InternalFutureFailureAccess
	at org.apache.celeborn.shaded.com.google.common.cache.LocalCache$LoadingValueReference.<init>(LocalCache.java:3517)
	at org.apache.celeborn.shaded.com.google.common.cache.LocalCache$LoadingValueReference.<init>(LocalCache.java:3521)
	at org.apache.celeborn.shaded.com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2170)
	at org.apache.celeborn.shaded.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2081)
	at org.apache.celeborn.shaded.com.google.common.cache.LocalCache.get(LocalCache.java:4019)
	at org.apache.celeborn.shaded.com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4933)
	at org.apache.celeborn.client.commit.ReducePartitionCommitHandler.replyGetReducerFileGroup(ReducePartitionCommitHandler.scala:283)
	at org.apache.celeborn.client.commit.ReducePartitionCommitHandler.handleGetReducerFileGroup(ReducePartitionCommitHandler.scala:300)
	at org.apache.celeborn.client.CommitManager.handleGetReducerFileGroup(CommitManager.scala:266)
	at org.apache.celeborn.client.LifecycleManager.org$apache$celeborn$client$LifecycleManager$$handleGetReducerFileGroup(LifecycleManager.scala:628)
	at org.apache.celeborn.client.LifecycleManager$$anonfun$receiveAndReply$1.applyOrElse(LifecycleManager.scala:314)
	at org.apache.celeborn.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:115)
	at org.apache.celeborn.common.rpc.netty.Inbox.safelyCall(Inbox.scala:222)
	at org.apache.celeborn.common.rpc.netty.Inbox.process(Inbox.scala:110)
	at org.apache.celeborn.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:227)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test.
