### PR TITLE
[CELEBORN-1143][BUG] SortBasedPusher pushData should inc memory spill metrics

### DIFF
--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedPusherSuiteJ.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/celeborn/SortBasedPusherSuiteJ.java
@@ -82,6 +82,7 @@ public class SortBasedPusherSuiteJ {
         new SortBasedPusher(
             taskMemoryManager,
             /*shuffleClient=*/ client,
+            /*taskContext=*/ null,
             /*shuffleId=*/ 0,
             /*mapId=*/ 0,
             /*attemptNumber=*/ 0,

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -134,6 +134,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             new SortBasedPusher(
                 taskContext.taskMemoryManager(),
                 shuffleClient,
+                taskContext,
                 shuffleId,
                 mapId,
                 taskContext.attemptNumber(),
@@ -154,6 +155,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
           new SortBasedPusher(
               taskContext.taskMemoryManager(),
               shuffleClient,
+              taskContext,
               shuffleId,
               mapId,
               taskContext.attemptNumber(),

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -134,6 +134,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             new SortBasedPusher(
                 taskContext.taskMemoryManager(),
                 shuffleClient,
+                taskContext,
                 shuffleId,
                 mapId,
                 taskContext.attemptNumber(),
@@ -154,6 +155,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
           new SortBasedPusher(
               taskContext.taskMemoryManager(),
               shuffleClient,
+              taskContext,
               shuffleId,
               mapId,
               taskContext.attemptNumber(),


### PR DESCRIPTION
### What changes were proposed in this pull request?
SortBasedPusher `pushData` should inc memory spill metrics


### Why are the changes needed?
Make metrics more acurate


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

