### PR TITLE
[CELEBORN-1133] Refactor fileinfo

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/FileInfo.java
@@ -17,257 +17,33 @@
 
 package org.apache.celeborn.common.meta;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.celeborn.common.identity.UserIdentifier;
-import org.apache.celeborn.common.protocol.PartitionType;
-import org.apache.celeborn.common.util.Utils;
 
-public class FileInfo {
-  private static Logger logger = LoggerFactory.getLogger(FileInfo.class);
-  private String mountPoint;
-  private final String filePath;
-  private final PartitionType partitionType;
-  private final UserIdentifier userIdentifier;
-
-  /**
-   * A flag used to indicate whether this FileInfo is sorted or not. Currently, it is only set for
-   * unsorted FileInfo instances.
-   */
-  private final AtomicBoolean sorted = new AtomicBoolean(false);
-
-  /** The set of stream IDs that are fetching this FileInfo. */
-  private final Set<Long> streams = ConcurrentHashMap.newKeySet();
-
-  // members for ReducePartition
-  private final List<Long> chunkOffsets;
-
-  // members for MapPartition
-  private int bufferSize;
-  private int numSubpartitions;
-
-  private volatile long bytesFlushed;
+public abstract class FileInfo {
+  private UserIdentifier userIdentifier;
   // whether to split is decided by client side.
   // now it's just used for mappartition to compatible with old client which can't support split
   private boolean partitionSplitEnabled;
+  protected FileMeta fileMeta;
 
-  public FileInfo(String filePath, List<Long> chunkOffsets, UserIdentifier userIdentifier) {
-    this(filePath, chunkOffsets, userIdentifier, PartitionType.REDUCE, true);
-  }
-
-  public FileInfo(
-      String filePath,
-      List<Long> chunkOffsets,
-      UserIdentifier userIdentifier,
-      PartitionType partitionType,
-      boolean partitionSplitEnabled) {
-    this.filePath = filePath;
-    this.chunkOffsets = chunkOffsets;
+  public FileInfo(UserIdentifier userIdentifier, boolean partitionSplitEnabled, FileMeta fileMeta) {
     this.userIdentifier = userIdentifier;
-    this.partitionType = partitionType;
     this.partitionSplitEnabled = partitionSplitEnabled;
+    this.fileMeta = fileMeta;
   }
 
-  public FileInfo(
-      String filePath,
-      List<Long> chunkOffsets,
-      UserIdentifier userIdentifier,
-      PartitionType partitionType,
-      int bufferSize,
-      int numSubpartitions,
-      long bytesFlushed,
-      boolean partitionSplitEnabled) {
-    this.filePath = filePath;
-    this.chunkOffsets = chunkOffsets;
-    this.userIdentifier = userIdentifier;
-    this.partitionType = partitionType;
-    this.bufferSize = bufferSize;
-    this.numSubpartitions = numSubpartitions;
-    this.bytesFlushed = bytesFlushed;
-    this.partitionSplitEnabled = partitionSplitEnabled;
+  public void replaceFileMeta(FileMeta meta) {
+    this.fileMeta = meta;
   }
 
-  public FileInfo(String filePath, UserIdentifier userIdentifier, PartitionType partitionType) {
-    this(filePath, new ArrayList(Arrays.asList(0L)), userIdentifier, partitionType, true);
+  public FileMeta getFileMeta() {
+    return fileMeta;
   }
 
-  public FileInfo(
-      String filePath,
-      UserIdentifier userIdentifier,
-      PartitionType partitionType,
-      boolean partitionSplitEnabled) {
-    this(
-        filePath,
-        new ArrayList(Arrays.asList(0L)),
-        userIdentifier,
-        partitionType,
-        partitionSplitEnabled);
-  }
-
-  @VisibleForTesting
-  public FileInfo(File file, UserIdentifier userIdentifier) {
-    this(
-        file.getAbsolutePath(),
-        new ArrayList(Arrays.asList(0L)),
-        userIdentifier,
-        PartitionType.REDUCE,
-        true);
-  }
-
-  public synchronized void addChunkOffset(long bytesFlushed) {
-    chunkOffsets.add(bytesFlushed);
-  }
-
-  public synchronized int numChunks() {
-    if (!chunkOffsets.isEmpty()) {
-      return chunkOffsets.size() - 1;
-    } else {
-      return 0;
-    }
-  }
-
-  public synchronized long getLastChunkOffset() {
-    return chunkOffsets.get(chunkOffsets.size() - 1);
-  }
-
-  public long getFileLength() {
-    return bytesFlushed;
-  }
-
-  public long updateBytesFlushed(long numBytes) {
-    bytesFlushed += numBytes;
-    return bytesFlushed;
-  }
-
-  public File getFile() {
-    return new File(filePath);
-  }
-
-  public String getFilePath() {
-    return filePath;
-  }
-
-  public String getSortedPath() {
-    return Utils.getSortedFilePath(filePath);
-  }
-
-  public String getIndexPath() {
-    return Utils.getIndexFilePath(filePath);
-  }
-
-  public Path getHdfsPath() {
-    return new Path(filePath);
-  }
-
-  public Path getHdfsIndexPath() {
-    return new Path(Utils.getIndexFilePath(filePath));
-  }
-
-  public Path getHdfsSortedPath() {
-    return new Path(Utils.getSortedFilePath(filePath));
-  }
-
-  public Path getHdfsWriterSuccessPath() {
-    return new Path(Utils.getWriteSuccessFilePath(filePath));
-  }
-
-  public Path getHdfsPeerWriterSuccessPath() {
-    return new Path(Utils.getWriteSuccessFilePath(Utils.getPeerPath(filePath)));
-  }
+  public abstract long getFileLength();
 
   public UserIdentifier getUserIdentifier() {
     return userIdentifier;
-  }
-
-  public void deleteAllFiles(FileSystem hdfsFs) {
-    if (isHdfs()) {
-      try {
-        hdfsFs.delete(getHdfsPath(), false);
-        hdfsFs.delete(getHdfsWriterSuccessPath(), false);
-        hdfsFs.delete(getHdfsIndexPath(), false);
-        hdfsFs.delete(getHdfsSortedPath(), false);
-      } catch (Exception e) {
-        // ignore delete exceptions because some other workers might be deleting the directory
-        logger.debug(
-            "delete HDFS file {},{},{},{} failed {}",
-            getHdfsPath(),
-            getHdfsWriterSuccessPath(),
-            getHdfsIndexPath(),
-            getHdfsSortedPath(),
-            e);
-      }
-    } else {
-      getFile().delete();
-      new File(getIndexPath()).delete();
-      new File(getSortedPath()).delete();
-    }
-  }
-
-  public boolean isHdfs() {
-    return Utils.isHdfsPath(filePath);
-  }
-
-  public synchronized List<Long> getChunkOffsets() {
-    return chunkOffsets;
-  }
-
-  public PartitionType getPartitionType() {
-    return partitionType;
-  }
-
-  @Override
-  public String toString() {
-    return "FileInfo{"
-        + "file="
-        + filePath
-        + ", chunkOffsets="
-        + StringUtils.join(this.chunkOffsets, ",")
-        + ", userIdentifier="
-        + userIdentifier.toString()
-        + ", partitionType="
-        + partitionType
-        + '}';
-  }
-
-  public void setBufferSize(int bufferSize) {
-    this.bufferSize = bufferSize;
-  }
-
-  public int getBufferSize() {
-    return bufferSize;
-  }
-
-  public int getNumSubpartitions() {
-    return numSubpartitions;
-  }
-
-  public void setNumSubpartitions(int numSubpartitions) {
-    this.numSubpartitions = numSubpartitions;
-  }
-
-  public String getMountPoint() {
-    return mountPoint;
-  }
-
-  public void setMountPoint(String mountPoint) {
-    this.mountPoint = mountPoint;
-  }
-
-  public long getBytesFlushed() {
-    return bytesFlushed;
   }
 
   public boolean isPartitionSplitEnabled() {
@@ -276,34 +52,5 @@ public class FileInfo {
 
   public void setPartitionSplitEnabled(boolean partitionSplitEnabled) {
     this.partitionSplitEnabled = partitionSplitEnabled;
-  }
-
-  public void setSorted() {
-    synchronized (sorted) {
-      sorted.set(true);
-    }
-  }
-
-  public boolean addStream(long streamId) {
-    synchronized (sorted) {
-      if (sorted.get()) {
-        return false;
-      } else {
-        streams.add(streamId);
-        return true;
-      }
-    }
-  }
-
-  public void closeStream(long streamId) {
-    synchronized (sorted) {
-      streams.remove(streamId);
-    }
-  }
-
-  public boolean isStreamsEmpty() {
-    synchronized (sorted) {
-      return streams.isEmpty();
-    }
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/meta/FileManagedBuffers.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/FileManagedBuffers.java
@@ -31,7 +31,7 @@ public class FileManagedBuffers {
 
   private final TransportConf conf;
 
-  public FileManagedBuffers(FileInfo fileInfo, TransportConf conf) {
+  public FileManagedBuffers(NonMemoryFileInfo fileInfo, TransportConf conf) {
     file = fileInfo.getFile();
     numChunks = fileInfo.numChunks();
     if (numChunks > 0) {

--- a/common/src/main/java/org/apache/celeborn/common/meta/FileMeta.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/FileMeta.java
@@ -1,0 +1,67 @@
+package org.apache.celeborn.common.meta;
+
+import java.util.List;
+
+import org.apache.commons.lang3.NotImplementedException;
+
+public interface FileMeta {
+  default List<Long> getChunkOffsets() {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default void setBufferSize(int bufferSize) {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default void setNumSubpartitions(int numSubpartitions) {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default int getBufferSize() {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default int getNumSubPartitions() {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default void addChunkOffset(long offset) {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default void setSorted() {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default boolean getSorted() {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default void setMountPoint(String mountPoint) {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default String getMountPoint() {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default int getNumSubpartitions() {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+
+  default long getLastChunkOffset() {
+    throw new NotImplementedException(
+        this.getClass().getSimpleName() + " did not implement this method");
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/meta/MapFileMeta.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/MapFileMeta.java
@@ -1,0 +1,61 @@
+package org.apache.celeborn.common.meta;
+
+import java.util.List;
+
+import org.apache.commons.lang3.NotImplementedException;
+
+public class MapFileMeta implements FileMeta {
+  int bufferSize;
+  int numSubPartitions;
+  String mountPoint;
+
+  public MapFileMeta(int bufferSize, int numSubPartitions) {
+    this.bufferSize = bufferSize;
+    this.numSubPartitions = numSubPartitions;
+  }
+
+  @Override
+  public List<Long> getChunkOffsets() {
+    throw new NotImplementedException("Map file meta did not implement this method");
+  }
+
+  @Override
+  public int getBufferSize() {
+    return bufferSize;
+  }
+
+  @Override
+  public int getNumSubPartitions() {
+    return numSubPartitions;
+  }
+
+  @Override
+  public void addChunkOffset(long offset) {
+    throw new NotImplementedException("Map file meta did not implement this method");
+  }
+
+  @Override
+  public void setSorted() {
+    throw new NotImplementedException("Map file meta did not implement this method");
+  }
+
+  @Override
+  public boolean getSorted() {
+    throw new NotImplementedException("Map file meta did not implement this method");
+  }
+
+  @Override
+  public void setMountPoint(String mountPoint) {
+    this.mountPoint = mountPoint;
+  }
+
+  @Override
+  public String getMountPoint() {
+    return mountPoint;
+  }
+
+  @Override
+  public int getNumSubpartitions() {
+    return numSubPartitions;
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/meta/MemoryFileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/MemoryFileInfo.java
@@ -15,21 +15,35 @@
  * limitations under the License.
  */
 
-package org.apache.celeborn.service.deploy.worker;
+package org.apache.celeborn.common.meta;
 
-import org.apache.celeborn.common.protocol.PartitionLocation;
-import org.apache.celeborn.service.deploy.worker.storage.PartitionDataWriter;
+import io.netty.buffer.CompositeByteBuf;
 
-public class WorkingPartition extends PartitionLocation {
-  private final transient PartitionDataWriter partitionDataWriter;
+import org.apache.celeborn.common.identity.UserIdentifier;
 
-  public WorkingPartition(
-      PartitionLocation partitionLocation, PartitionDataWriter partitionDataWriter) {
-    super(partitionLocation);
-    this.partitionDataWriter = partitionDataWriter;
+public class MemoryFileInfo extends FileInfo {
+  private CompositeByteBuf buffer;
+  private long length;
+
+  public MemoryFileInfo(
+      UserIdentifier userIdentifier, boolean partitionSplitEnabled, FileMeta fileMeta) {
+    super(userIdentifier, partitionSplitEnabled, fileMeta);
   }
 
-  public PartitionDataWriter getFileWriter() {
-    return partitionDataWriter;
+  public CompositeByteBuf getBuffer() {
+    return buffer;
+  }
+
+  public void setBuffer(CompositeByteBuf buffer) {
+    this.buffer = buffer;
+  }
+
+  public void setBufferSize(int bufferSize) {
+    this.length = bufferSize;
+  }
+
+  @Override
+  public long getFileLength() {
+    return length;
   }
 }

--- a/common/src/main/java/org/apache/celeborn/common/meta/NonMemoryFileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/NonMemoryFileInfo.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.meta;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.identity.UserIdentifier;
+import org.apache.celeborn.common.protocol.StorageInfo;
+import org.apache.celeborn.common.util.Utils;
+
+public class NonMemoryFileInfo extends FileInfo {
+  private static Logger logger = LoggerFactory.getLogger(NonMemoryFileInfo.class);
+  private final Set<Long> streams = ConcurrentHashMap.newKeySet();
+  private String filePath;
+  private StorageInfo.Type storageType;
+  private volatile long bytesFlushed;
+
+  public NonMemoryFileInfo(
+      UserIdentifier userIdentifier,
+      boolean partitionSplitEnabled,
+      FileMeta fileMeta,
+      String filePath,
+      StorageInfo.Type storageType) {
+    super(userIdentifier, partitionSplitEnabled, fileMeta);
+    this.filePath = filePath;
+    this.storageType = storageType;
+  }
+
+  public NonMemoryFileInfo(
+      UserIdentifier userIdentifier,
+      boolean partitionSplitEnabled,
+      FileMeta fileMeta,
+      String filePath) {
+    super(userIdentifier, partitionSplitEnabled, fileMeta);
+    this.filePath = filePath;
+    // assume that a fileinfo reloaded from pb is local file
+    this.storageType = StorageInfo.Type.HDD;
+  }
+
+  public NonMemoryFileInfo(File file, UserIdentifier userIdentifier) {
+    this(
+        userIdentifier,
+        true,
+        new ReduceFileMeta(new ArrayList(Arrays.asList(0L))),
+        file.getAbsolutePath(),
+        StorageInfo.Type.HDD);
+  }
+
+  public boolean addStream(long streamId) {
+    synchronized (fileMeta) {
+      if (fileMeta.getSorted()) {
+        return false;
+      } else {
+        streams.add(streamId);
+        return true;
+      }
+    }
+  }
+
+  public void closeStream(long streamId) {
+    synchronized (fileMeta) {
+      streams.remove(streamId);
+    }
+  }
+
+  public boolean isStreamsEmpty() {
+    synchronized (fileMeta) {
+      return streams.isEmpty();
+    }
+  }
+
+  public synchronized void addChunkOffset(long bytesFlushed) {
+    fileMeta.getChunkOffsets().add(bytesFlushed);
+  }
+
+  public synchronized int numChunks() {
+    if (!fileMeta.getChunkOffsets().isEmpty()) {
+      return fileMeta.getChunkOffsets().size() - 1;
+    } else {
+      return 0;
+    }
+  }
+
+  public synchronized long getLastChunkOffset() {
+    return fileMeta.getChunkOffsets().get(fileMeta.getChunkOffsets().size() - 1);
+  }
+
+  public long getFileLength() {
+    return bytesFlushed;
+  }
+
+  public long updateBytesFlushed(long numBytes) {
+    bytesFlushed += numBytes;
+    return bytesFlushed;
+  }
+
+  public File getFile() {
+    return new File(filePath);
+  }
+
+  public String getFilePath() {
+    return filePath;
+  }
+
+  public String getSortedPath() {
+    return Utils.getSortedFilePath(filePath);
+  }
+
+  public String getIndexPath() {
+    return Utils.getIndexFilePath(filePath);
+  }
+
+  public Path getHdfsPath() {
+    return new Path(filePath);
+  }
+
+  public Path getHdfsIndexPath() {
+    return new Path(Utils.getIndexFilePath(filePath));
+  }
+
+  public Path getHdfsSortedPath() {
+    return new Path(Utils.getSortedFilePath(filePath));
+  }
+
+  public Path getHdfsWriterSuccessPath() {
+    return new Path(Utils.getWriteSuccessFilePath(filePath));
+  }
+
+  public Path getHdfsPeerWriterSuccessPath() {
+    return new Path(Utils.getWriteSuccessFilePath(Utils.getPeerPath(filePath)));
+  }
+
+  public void deleteAllFiles(FileSystem hdfsFs) {
+    if (isHdfs()) {
+      try {
+        hdfsFs.delete(getHdfsPath(), false);
+        hdfsFs.delete(getHdfsWriterSuccessPath(), false);
+        hdfsFs.delete(getHdfsIndexPath(), false);
+        hdfsFs.delete(getHdfsSortedPath(), false);
+      } catch (Exception e) {
+        // ignore delete exceptions because some other workers might be deleting the directory
+        logger.debug(
+            "delete HDFS file {},{},{},{} failed {}",
+            getHdfsPath(),
+            getHdfsWriterSuccessPath(),
+            getHdfsIndexPath(),
+            getHdfsSortedPath(),
+            e);
+      }
+    } else {
+      getFile().delete();
+      new File(getIndexPath()).delete();
+      new File(getSortedPath()).delete();
+    }
+  }
+
+  public String getMountPoint() {
+    return fileMeta.getMountPoint();
+  }
+
+  public void setMountPoint(String mountPoint) {
+    fileMeta.setMountPoint(mountPoint);
+  }
+
+  public long getBytesFlushed() {
+    return bytesFlushed;
+  }
+
+  public boolean isHdfs() {
+    return Utils.isHdfsPath(filePath);
+  }
+
+  public synchronized List<Long> getChunkOffsets() {
+    return fileMeta.getChunkOffsets();
+  }
+}

--- a/common/src/main/java/org/apache/celeborn/common/meta/ReduceFileMeta.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/ReduceFileMeta.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.meta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.lang3.NotImplementedException;
+
+public class ReduceFileMeta implements FileMeta {
+  List<Long> chunkOffsets;
+  AtomicBoolean sorted;
+
+  public ReduceFileMeta() {
+    this.chunkOffsets = new ArrayList<>();
+    sorted = new AtomicBoolean(false);
+  }
+
+  public ReduceFileMeta(List<Long> chunkOffsets) {
+    this.chunkOffsets = chunkOffsets;
+  }
+
+  @Override
+  public List<Long> getChunkOffsets() {
+    return chunkOffsets;
+  }
+
+  @Override
+  public int getBufferSize() {
+    throw new NotImplementedException("Reduce file meta did not implement this method");
+  }
+
+  @Override
+  public int getNumSubPartitions() {
+    throw new NotImplementedException("Reduce file meta did not implement this method");
+  }
+
+  @Override
+  public void addChunkOffset(long offset) {
+    chunkOffsets.add(offset);
+  }
+
+  public synchronized long getLastChunkOffset() {
+    return chunkOffsets.get(chunkOffsets.size() - 1);
+  }
+
+  @Override
+  public void setSorted() {
+    sorted.set(true);
+  }
+
+  @Override
+  public boolean getSorted() {
+    return sorted.get();
+  }
+
+  public synchronized int numChunks() {
+    if (!chunkOffsets.isEmpty()) {
+      return chunkOffsets.size() - 1;
+    } else {
+      return 0;
+    }
+  }
+}

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -494,6 +494,26 @@ message PbFileInfo {
   bool partitionSplitEnabled = 8;
 }
 
+message PbMapFileMeta{
+  int32 bufferSize = 1;
+  int32 numSubPartitions = 2;
+}
+
+message PbReduceFileMeta {
+  repeated int64 chunkOffsets = 1;
+  bool sorted = 2;
+}
+
+message PbNonMemoryFile{
+  PbUserIdentifier userIdentifier = 1;
+  bool partitionSplitEnabled = 2;
+  PbMapFileMeta mapFileMeta = 3;
+  PbReduceFileMeta reduceFileMeta = 4;
+  string filePath = 5;
+  PbStorageInfo storageInfo = 6;
+  int64 bytesFlusher = 7;
+}
+
 message PbFileInfoMap {
   map<string, PbFileInfo> values = 1;
 }

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 import com.google.protobuf.InvalidProtocolBufferException
 
 import org.apache.celeborn.common.identity.UserIdentifier
-import org.apache.celeborn.common.meta.{AppDiskUsage, AppDiskUsageSnapShot, DiskInfo, FileInfo, WorkerInfo}
+import org.apache.celeborn.common.meta.{AppDiskUsage, AppDiskUsageSnapShot, DiskInfo, FileInfo, MapFileMeta, NonMemoryFileInfo, ReduceFileMeta, WorkerInfo}
 import org.apache.celeborn.common.protocol._
 import org.apache.celeborn.common.protocol.PartitionLocation.Mode
 import org.apache.celeborn.common.protocol.message.ControlMessages.WorkerResource
@@ -86,38 +86,47 @@ object PbSerDeUtils {
       .setStorageType(diskInfo.storageType.getValue)
       .build
 
-  def fromPbFileInfo(pbFileInfo: PbFileInfo): FileInfo =
+  def fromPbFileInfo(pbFileInfo: PbFileInfo): NonMemoryFileInfo =
     fromPbFileInfo(pbFileInfo, fromPbUserIdentifier(pbFileInfo.getUserIdentifier))
 
-  def fromPbFileInfo(pbFileInfo: PbFileInfo, userIdentifier: UserIdentifier) =
-    new FileInfo(
-      pbFileInfo.getFilePath,
-      pbFileInfo.getChunkOffsetsList,
+  def fromPbFileInfo(pbFileInfo: PbFileInfo, userIdentifier: UserIdentifier) = {
+    val meta = Utils.toPartitionType(pbFileInfo.getPartitionType) match {
+      case PartitionType.REDUCE =>
+        new ReduceFileMeta(pbFileInfo.getChunkOffsetsList)
+      case PartitionType.MAP =>
+        new MapFileMeta(pbFileInfo.getBufferSize, pbFileInfo.getNumSubpartitions)
+    }
+    new NonMemoryFileInfo(
       userIdentifier,
-      Utils.toPartitionType(pbFileInfo.getPartitionType),
-      pbFileInfo.getBufferSize,
-      pbFileInfo.getNumSubpartitions,
-      pbFileInfo.getBytesFlushed,
-      pbFileInfo.getPartitionSplitEnabled)
+      pbFileInfo.getPartitionSplitEnabled,
+      meta,
+      pbFileInfo.getFilePath)
+  }
 
-  def toPbFileInfo(fileInfo: FileInfo): PbFileInfo =
-    PbFileInfo.newBuilder
+  def toPbFileInfo(fileInfo: NonMemoryFileInfo): PbFileInfo = {
+    val builder = PbFileInfo.newBuilder
       .setFilePath(fileInfo.getFilePath)
       .addAllChunkOffsets(fileInfo.getChunkOffsets)
       .setUserIdentifier(toPbUserIdentifier(fileInfo.getUserIdentifier))
-      .setPartitionType(fileInfo.getPartitionType.getValue)
-      .setBufferSize(fileInfo.getBufferSize)
-      .setNumSubpartitions(fileInfo.getNumSubpartitions)
+      .setBufferSize(fileInfo.getFileMeta.getBufferSize)
+      .setNumSubpartitions(fileInfo.getFileMeta.getNumSubpartitions)
       .setBytesFlushed(fileInfo.getFileLength)
       .setPartitionSplitEnabled(fileInfo.isPartitionSplitEnabled)
-      .build
+    if (fileInfo.getFileMeta.isInstanceOf[MapFileMeta]) {
+      builder.setPartitionType(PartitionType.MAP.getValue)
+    } else {
+      builder.setPartitionType(PartitionType.REDUCE.getValue)
+    }
+    builder.build
+  }
 
   @throws[InvalidProtocolBufferException]
   def fromPbFileInfoMap(
       data: Array[Byte],
-      cache: ConcurrentHashMap[String, UserIdentifier]): ConcurrentHashMap[String, FileInfo] = {
+      cache: ConcurrentHashMap[String, UserIdentifier])
+      : ConcurrentHashMap[String, NonMemoryFileInfo] = {
     val pbFileInfoMap = PbFileInfoMap.parseFrom(data)
-    val fileInfoMap = JavaUtils.newConcurrentHashMap[String, FileInfo]
+    val fileInfoMap = JavaUtils.newConcurrentHashMap[String, NonMemoryFileInfo]
     pbFileInfoMap.getValuesMap.entrySet().asScala.foreach { entry =>
       val fileName = entry.getKey
       val pbFileInfo = entry.getValue
@@ -138,7 +147,7 @@ object PbSerDeUtils {
   def toPbFileInfoMap(fileInfoMap: ConcurrentHashMap[String, FileInfo]): Array[Byte] = {
     val pbFileInfoMap = JavaUtils.newConcurrentHashMap[String, PbFileInfo]()
     fileInfoMap.entrySet().asScala.foreach { entry =>
-      pbFileInfoMap.put(entry.getKey, toPbFileInfo(entry.getValue))
+      pbFileInfoMap.put(entry.getKey, toPbFileInfo(entry.getValue.asInstanceOf[NonMemoryFileInfo]))
     }
     PbFileInfoMap.newBuilder.putAllValues(pbFileInfoMap).build.toByteArray
   }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -44,7 +44,7 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.CelebornConf.PORT_MAX_RETRY
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{DiskStatus, FileInfo, WorkerInfo}
+import org.apache.celeborn.common.meta.{DiskStatus, FileInfo, NonMemoryFileInfo, WorkerInfo}
 import org.apache.celeborn.common.network.protocol.TransportMessage
 import org.apache.celeborn.common.network.util.TransportConf
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType, TransportModuleConstants}
@@ -1078,10 +1078,10 @@ object Utils extends Logging {
   }
 
   def getShortFormattedFileName(fileInfo: FileInfo): String = {
-    val parentFile = fileInfo.getFile.getParent
+    val parentFile = fileInfo.asInstanceOf[NonMemoryFileInfo].getFile.getParent
     parentFile.substring(
       parentFile.lastIndexOf("/"),
-      parentFile.length) + "/" + fileInfo.getFile.getName
+      parentFile.length) + "/" + fileInfo.asInstanceOf[NonMemoryFileInfo].getFile.getName
   }
 
   def parseMetricLabels(label: String): (String, String) = {

--- a/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
@@ -22,7 +22,7 @@ import java.util
 
 import org.apache.celeborn.CelebornFunSuite
 import org.apache.celeborn.common.identity.UserIdentifier
-import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, FileInfo, WorkerInfo}
+import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, FileInfo, NonMemoryFileInfo, ReduceFileMeta, WorkerInfo}
 import org.apache.celeborn.common.protocol.{PartitionLocation, StorageInfo}
 import org.apache.celeborn.common.protocol.message.ControlMessages.WorkerResource
 import org.apache.celeborn.common.quota.ResourceConsumption
@@ -54,8 +54,19 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
   val chunkOffsets1 = util.Arrays.asList[java.lang.Long](1000L, 2000L, 3000L)
   val chunkOffsets2 = util.Arrays.asList[java.lang.Long](2000L, 4000L, 6000L)
 
-  val fileInfo1 = new FileInfo("/tmp/1", chunkOffsets1, userIdentifier1)
-  val fileInfo2 = new FileInfo("/tmp/2", chunkOffsets2, userIdentifier2)
+  val fileInfo1 = new NonMemoryFileInfo(
+    userIdentifier1,
+    true,
+    new ReduceFileMeta(chunkOffsets1),
+    file1.getAbsolutePath)
+  // "/tmp/1", chunkOffsets1, userIdentifier1)
+  //  val fileInfo1 = new FileInfo("/tmp/1", chunkOffsets1, userIdentifier1)
+  val fileInfo2 = new NonMemoryFileInfo(
+    userIdentifier2,
+    true,
+    new ReduceFileMeta(chunkOffsets2),
+    file2.getAbsolutePath)
+  // "/tmp/2", chunkOffsets2, userIdentifier2)
   val fileInfoMap = JavaUtils.newConcurrentHashMap[String, FileInfo]()
   fileInfoMap.put("file1", fileInfo1)
   fileInfoMap.put("file2", fileInfo2)
@@ -138,10 +149,12 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
     val pbFileInfo = PbSerDeUtils.toPbFileInfo(fileInfo1)
     val restoredFileInfo = PbSerDeUtils.fromPbFileInfo(pbFileInfo)
 
-    assert(restoredFileInfo.getFilePath.equals(fileInfo1.getFilePath))
-    assert(restoredFileInfo.getChunkOffsets.equals(fileInfo1.getChunkOffsets))
+    assert(
+      restoredFileInfo.asInstanceOf[NonMemoryFileInfo].getFilePath.equals(fileInfo1.getFilePath))
+    assert(restoredFileInfo.asInstanceOf[NonMemoryFileInfo].getChunkOffsets.equals(
+      fileInfo1.getChunkOffsets))
     assert(restoredFileInfo.getUserIdentifier.equals(fileInfo1.getUserIdentifier))
-    assert(restoredFileInfo.getPartitionType.equals(fileInfo1.getPartitionType))
+//    assert(restoredFileInfo.asInstanceOf[NonMemoryFileInfo].getPartitionType.equals(fileInfo1.getPartitionType))
   }
 
   test("fromAndToPbFileInfoMap") {
@@ -151,11 +164,15 @@ class PbSerDeUtilsTest extends CelebornFunSuite {
     val restoredFileInfo2 = restoredFileInfoMap.get("file2")
 
     assert(restoredFileInfoMap.size().equals(fileInfoMap.size()))
-    assert(restoredFileInfo1.getFilePath.equals(fileInfo1.getFilePath))
-    assert(restoredFileInfo1.getChunkOffsets.equals(fileInfo1.getChunkOffsets))
+    assert(
+      restoredFileInfo1.asInstanceOf[NonMemoryFileInfo].getFilePath.equals(fileInfo1.getFilePath))
+    assert(restoredFileInfo1.asInstanceOf[NonMemoryFileInfo].getChunkOffsets.equals(
+      fileInfo1.getChunkOffsets))
     assert(restoredFileInfo1.getUserIdentifier.equals(fileInfo1.getUserIdentifier))
-    assert(restoredFileInfo2.getFilePath.equals(fileInfo2.getFilePath))
-    assert(restoredFileInfo2.getChunkOffsets.equals(fileInfo2.getChunkOffsets))
+    assert(
+      restoredFileInfo2.asInstanceOf[NonMemoryFileInfo].getFilePath.equals(fileInfo2.getFilePath))
+    assert(restoredFileInfo2.asInstanceOf[NonMemoryFileInfo].getChunkOffsets.equals(
+      fileInfo2.getChunkOffsets))
     assert(restoredFileInfo2.getUserIdentifier.equals(fileInfo2.getUserIdentifier))
   }
 

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManager.java
@@ -132,7 +132,8 @@ public class CreditStreamManager {
       FileInfo fileInfo,
       long streamId,
       MapDataPartition mapDataPartition) {
-    StreamState streamState = new StreamState(channel, fileInfo.getBufferSize(), mapDataPartition);
+    StreamState streamState =
+        new StreamState(channel, fileInfo.getFileMeta().getBufferSize(), mapDataPartition);
     streams.put(streamId, streamState);
     mapDataPartition.setupDataPartitionReader(startSubIndex, endSubIndex, streamId, channel);
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
@@ -36,6 +36,7 @@ import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.exception.AlreadyClosedException;
 import org.apache.celeborn.common.meta.DiskStatus;
 import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.meta.NonMemoryFileInfo;
 import org.apache.celeborn.common.metrics.source.AbstractSource;
 import org.apache.celeborn.common.protocol.PartitionSplitMode;
 import org.apache.celeborn.common.protocol.PartitionType;
@@ -50,8 +51,8 @@ import org.apache.celeborn.service.deploy.worker.memory.MemoryManager;
  * Note: Once FlushNotifier.exception is set, the whole file is not available.
  *       That's fine some of the internal state(e.g. bytesFlushed) may be inaccurate.
  */
-public abstract class FileWriter implements DeviceObserver {
-  private static final Logger logger = LoggerFactory.getLogger(FileWriter.class);
+public abstract class PartitionDataWriter implements DeviceObserver {
+  private static final Logger logger = LoggerFactory.getLogger(PartitionDataWriter.class);
   private static final long WAIT_INTERVAL_MS = 5;
 
   protected final FileInfo fileInfo;
@@ -87,9 +88,9 @@ public abstract class FileWriter implements DeviceObserver {
   private StorageManager storageManager;
   private boolean workerGracefulShutdown;
 
-  public FileWriter(
-      FileInfo fileInfo,
-      Flusher flusher,
+  public PartitionDataWriter(
+      StorageManager storageManager,
+      CreateFileContext createFileContext,
       AbstractSource workerSource,
       CelebornConf conf,
       DeviceMonitor deviceMonitor,
@@ -98,9 +99,11 @@ public abstract class FileWriter implements DeviceObserver {
       PartitionType partitionType,
       boolean rangeReadFilter)
       throws IOException {
-    this.fileInfo = fileInfo;
-    this.flusher = flusher;
-    this.flushWorkerIndex = flusher.getWorkerIndex();
+    this.storageManager = storageManager;
+    CreateFileResult createFileResult = storageManager.createFile(createFileContext);
+    fileInfo = createFileResult.fileInfo();
+    flusher = createFileResult.flusher();
+    this.flushWorkerIndex = createFileResult.flusher().getWorkerIndex();
     this.writerCloseTimeoutMs = conf.workerWriterCloseTimeoutMs();
     this.workerGracefulShutdown = conf.workerGracefulShutdown();
     this.splitThreshold = splitThreshold;
@@ -108,16 +111,19 @@ public abstract class FileWriter implements DeviceObserver {
     this.splitMode = splitMode;
     this.partitionType = partitionType;
     this.rangeReadFilter = rangeReadFilter;
-    if (!fileInfo.isHdfs()) {
+    if (!((NonMemoryFileInfo) fileInfo).isHdfs()) {
       this.flusherBufferSize = conf.workerFlusherBufferSize();
-      channel = FileChannelUtils.createWritableFileChannel(fileInfo.getFilePath());
+      channel =
+          FileChannelUtils.createWritableFileChannel(((NonMemoryFileInfo) fileInfo).getFilePath());
     } else {
       this.flusherBufferSize = conf.workerHdfsFlusherBufferSize();
       // We open the stream and close immediately because HDFS output stream will
       // create a DataStreamer that is a thread.
       // If we reuse HDFS output stream, we will exhaust the memory soon.
       try {
-        StorageManager.hadoopFs().create(fileInfo.getHdfsPath(), true).close();
+        StorageManager.hadoopFs()
+            .create(((NonMemoryFileInfo) fileInfo).getHdfsPath(), true)
+            .close();
       } catch (IOException e) {
         try {
           // If create file failed, wait 10 ms and retry
@@ -125,7 +131,9 @@ public abstract class FileWriter implements DeviceObserver {
         } catch (InterruptedException ex) {
           throw new RuntimeException(ex);
         }
-        StorageManager.hadoopFs().create(fileInfo.getHdfsPath(), true).close();
+        StorageManager.hadoopFs()
+            .create(((NonMemoryFileInfo) fileInfo).getHdfsPath(), true)
+            .close();
       }
     }
     source = workerSource;
@@ -141,7 +149,7 @@ public abstract class FileWriter implements DeviceObserver {
   }
 
   public File getFile() {
-    return fileInfo.getFile();
+    return ((NonMemoryFileInfo) fileInfo).getFile();
   }
 
   public void incrementPendingWrites() {
@@ -163,12 +171,14 @@ public abstract class FileWriter implements DeviceObserver {
           FlushTask task = null;
           if (channel != null) {
             task = new LocalFlushTask(flushBuffer, channel, notifier);
-          } else if (fileInfo.isHdfs()) {
-            task = new HdfsFlushTask(flushBuffer, fileInfo.getHdfsPath(), notifier);
+          } else if (((NonMemoryFileInfo) fileInfo).isHdfs()) {
+            task =
+                new HdfsFlushTask(
+                    flushBuffer, ((NonMemoryFileInfo) fileInfo).getHdfsPath(), notifier);
           }
           addTask(task);
           flushBuffer = null;
-          fileInfo.updateBytesFlushed(numBytes);
+          ((NonMemoryFileInfo) fileInfo).updateBytesFlushed(numBytes);
           if (!finalFlush) {
             takeBuffer();
           }
@@ -180,7 +190,9 @@ public abstract class FileWriter implements DeviceObserver {
   /** assume data size is less than chunk capacity */
   public void write(ByteBuf data) throws IOException {
     if (closed) {
-      String msg = "FileWriter has already closed!, fileName " + fileInfo.getFilePath();
+      String msg =
+          "FileWriter has already closed!, fileName "
+              + ((NonMemoryFileInfo) fileInfo).getFilePath();
       logger.warn(msg);
       throw new AlreadyClosedException(msg);
     }
@@ -208,7 +220,9 @@ public abstract class FileWriter implements DeviceObserver {
 
     synchronized (flushLock) {
       if (closed) {
-        String msg = "FileWriter has already closed!, fileName " + fileInfo.getFilePath();
+        String msg =
+            "FileWriter has already closed!, fileName "
+                + ((NonMemoryFileInfo) fileInfo).getFilePath();
         logger.warn(msg);
         throw new AlreadyClosedException(msg);
       }
@@ -240,7 +254,8 @@ public abstract class FileWriter implements DeviceObserver {
       if (deleted) {
         return null;
       } else {
-        return new StorageInfo(StorageInfo.Type.HDFS, true, fileInfo.getFilePath());
+        return new StorageInfo(
+            StorageInfo.Type.HDFS, true, ((NonMemoryFileInfo) fileInfo).getFilePath());
       }
     }
   }
@@ -262,7 +277,8 @@ public abstract class FileWriter implements DeviceObserver {
       RunnableWithIOException finalClose)
       throws IOException {
     if (closed) {
-      String msg = "FileWriter has already closed! fileName " + fileInfo.getFilePath();
+      String msg =
+          "FileWriter has already closed! fileName " + ((NonMemoryFileInfo) fileInfo).getFilePath();
       logger.error(msg);
       throw new AlreadyClosedException(msg);
     }
@@ -293,7 +309,7 @@ public abstract class FileWriter implements DeviceObserver {
       finalClose.run();
 
       // unregister from DeviceMonitor
-      if (!fileInfo.isHdfs()) {
+      if (!((NonMemoryFileInfo) fileInfo).isHdfs()) {
         logger.debug("file info {} unregister from device monitor", fileInfo);
         deviceMonitor.unregisterFileWriter(this);
       }
@@ -318,17 +334,17 @@ public abstract class FileWriter implements DeviceObserver {
       } catch (IOException e) {
         logger.warn(
             "Close channel failed for file {} caused by {}.",
-            fileInfo.getFilePath(),
+            ((NonMemoryFileInfo) fileInfo).getFilePath(),
             e.getMessage());
       }
     }
 
     if (!destroyed) {
       destroyed = true;
-      fileInfo.deleteAllFiles(StorageManager.hadoopFs());
+      ((NonMemoryFileInfo) fileInfo).deleteAllFiles(StorageManager.hadoopFs());
 
       // unregister from DeviceMonitor
-      if (!fileInfo.isHdfs()) {
+      if (!((NonMemoryFileInfo) fileInfo).isHdfs()) {
         deviceMonitor.unregisterFileWriter(this);
       }
     }
@@ -369,7 +385,7 @@ public abstract class FileWriter implements DeviceObserver {
     String fileAbsPath = null;
     if (source.metricsCollectCriticalEnabled()) {
       metricsName = WorkerSource.TAKE_BUFFER_TIME();
-      fileAbsPath = fileInfo.getFilePath();
+      fileAbsPath = ((NonMemoryFileInfo) fileInfo).getFilePath();
       source.startTimer(metricsName, fileAbsPath);
     }
 
@@ -402,16 +418,18 @@ public abstract class FileWriter implements DeviceObserver {
   }
 
   public int hashCode() {
-    return fileInfo.getFilePath().hashCode();
+    return ((NonMemoryFileInfo) fileInfo).getFilePath().hashCode();
   }
 
   public boolean equals(Object obj) {
-    return (obj instanceof FileWriter)
-        && fileInfo.getFilePath().equals(((FileWriter) obj).fileInfo.getFilePath());
+    return (obj instanceof PartitionDataWriter)
+        && ((NonMemoryFileInfo) fileInfo)
+            .getFilePath()
+            .equals(((NonMemoryFileInfo) ((PartitionDataWriter) obj).fileInfo).getFilePath());
   }
 
   public String toString() {
-    return fileInfo.getFilePath();
+    return ((NonMemoryFileInfo) fileInfo).getFilePath();
   }
 
   public void flushOnMemoryPressure() throws IOException {
@@ -458,9 +476,5 @@ public abstract class FileWriter implements DeviceObserver {
 
   public void setShuffleKey(String shuffleKey) {
     this.shuffleKey = shuffleKey;
-  }
-
-  public void setStorageManager(StorageManager storageManager) {
-    this.storageManager = storageManager;
   }
 }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -32,7 +32,7 @@ import io.netty.buffer.ByteBuf
 
 import org.apache.celeborn.common.exception.{AlreadyClosedException, CelebornIOException}
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{DiskStatus, WorkerInfo, WorkerPartitionLocationInfo}
+import org.apache.celeborn.common.meta.{DiskStatus, NonMemoryFileInfo, WorkerInfo, WorkerPartitionLocationInfo}
 import org.apache.celeborn.common.metrics.source.Source
 import org.apache.celeborn.common.network.buffer.{NettyManagedBuffer, NioManagedBuffer}
 import org.apache.celeborn.common.network.client.{RpcResponseCallback, TransportClient, TransportClientFactory}
@@ -45,7 +45,7 @@ import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.unsafe.Platform
 import org.apache.celeborn.common.util.{DiskUtils, Utils}
 import org.apache.celeborn.service.deploy.worker.congestcontrol.CongestionController
-import org.apache.celeborn.service.deploy.worker.storage.{FileWriter, HdfsFlusher, LocalFlusher, MapPartitionFileWriter, StorageManager}
+import org.apache.celeborn.service.deploy.worker.storage.{HdfsFlusher, LocalFlusher, MapPartitionPartitionDataWriter, PartitionDataWriter, StorageManager}
 
 class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler with Logging {
 
@@ -252,7 +252,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
 
     if (fileWriter.isClosed) {
       logWarning(
-        s"[handlePushData] FileWriter is already closed! File path ${fileWriter.getFileInfo.getFilePath}")
+        s"[handlePushData] FileWriter is already closed! File path ${fileWriter.getFileInfo.asInstanceOf[NonMemoryFileInfo].getFilePath}")
       callbackWithTimer.onFailure(new CelebornIOException("File already closed!"))
       fileWriter.decrementPendingWrites()
       return;
@@ -517,7 +517,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     val closedFileWriter = fileWriters.find(_.isClosed)
     if (closedFileWriter.isDefined) {
       logWarning(
-        s"[handlePushMergedData] FileWriter is already closed! File path ${closedFileWriter.get.getFileInfo.getFilePath}")
+        s"[handlePushMergedData] FileWriter is already closed! File path ${closedFileWriter.get.getFileInfo.asInstanceOf[NonMemoryFileInfo].getFilePath}")
       callbackWithTimer.onFailure(new CelebornIOException("File already closed!"))
       fileWriters.foreach(_.decrementPendingWrites())
       return
@@ -660,8 +660,8 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
    */
   private def getFileWriters(
       partitionIdToLocations: Array[(String, PartitionLocation)])
-      : (Array[FileWriter], Option[Int]) = {
-    val fileWriters = new Array[FileWriter](partitionIdToLocations.length)
+      : (Array[PartitionDataWriter], Option[Int]) = {
+    val fileWriters = new Array[PartitionDataWriter](partitionIdToLocations.length)
     var i = 0
     var exceptionFileWriterIndex: Option[Int] = None
     while (i < partitionIdToLocations.length) {
@@ -781,7 +781,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     val fileWriter =
       getFileWriterAndCheck(pushData.`type`(), location, isPrimary, callback) match {
         case (true, _) => return
-        case (false, f: FileWriter) => f
+        case (false, f: PartitionDataWriter) => f
       }
 
     // for mappartition we will not check whether disk full or split partition
@@ -790,7 +790,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
 
     if (fileWriter.isClosed) {
       logWarning(
-        s"[handleMapPartitionPushData] FileWriter is already closed! File path ${fileWriter.getFileInfo.getFilePath}")
+        s"[handleMapPartitionPushData] FileWriter is already closed! File path ${fileWriter.getFileInfo.asInstanceOf[NonMemoryFileInfo].getFilePath}")
       callback.onFailure(new CelebornIOException("File already closed!"))
       fileWriter.decrementPendingWrites()
       return;
@@ -969,13 +969,13 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     val fileWriter =
       getFileWriterAndCheck(messageType, location, isPrimary, callback) match {
         case (true, _) => return
-        case (false, f: FileWriter) => f
+        case (false, f: PartitionDataWriter) => f
       }
 
     // During worker shutdown, worker will return HARD_SPLIT for all existed partition.
     // This should before return exception to make current push request revive and retry.
     val isPartitionSplitEnabled = fileWriter.asInstanceOf[
-      MapPartitionFileWriter].getFileInfo.isPartitionSplitEnabled
+      MapPartitionPartitionDataWriter].getFileInfo.isPartitionSplitEnabled
 
     if (shutdown.get() && (messageType == Type.REGION_START || messageType ==
         Type.PUSH_DATA_HAND_SHAKE) && isPartitionSplitEnabled) {
@@ -1003,7 +1003,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
               (
                 pbMsg.asInstanceOf[PbPushDataHandShake].getNumPartitions,
                 pbMsg.asInstanceOf[PbPushDataHandShake].getBufferSize)
-          fileWriter.asInstanceOf[MapPartitionFileWriter].pushDataHandShake(
+          fileWriter.asInstanceOf[MapPartitionPartitionDataWriter].pushDataHandShake(
             numPartitions,
             bufferSize)
         case Type.REGION_START =>
@@ -1016,11 +1016,11 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
               (
                 pbMsg.asInstanceOf[PbRegionStart].getCurrentRegionIndex,
                 pbMsg.asInstanceOf[PbRegionStart].getIsBroadcast)
-          fileWriter.asInstanceOf[MapPartitionFileWriter].regionStart(
+          fileWriter.asInstanceOf[MapPartitionPartitionDataWriter].regionStart(
             currentRegionIndex,
             isBroadcast)
         case Type.REGION_FINISH =>
-          fileWriter.asInstanceOf[MapPartitionFileWriter].regionFinish()
+          fileWriter.asInstanceOf[MapPartitionPartitionDataWriter].regionFinish()
         case _ => throw new IllegalArgumentException(s"Not support $messageType yet")
       }
       // for primary , send data to replica
@@ -1113,7 +1113,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
   private def checkFileWriterException(
       messageType: Message.Type,
       isPrimary: Boolean,
-      fileWriter: FileWriter,
+      fileWriter: PartitionDataWriter,
       callback: RpcResponseCallback): Unit = {
     logWarning(
       s"[handle$messageType] fileWriter $fileWriter has Exception ${fileWriter.getException}")
@@ -1144,7 +1144,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
       messageType: Message.Type,
       location: PartitionLocation,
       isPrimary: Boolean,
-      callback: RpcResponseCallback): (Boolean, FileWriter) = {
+      callback: RpcResponseCallback): (Boolean, PartitionDataWriter) = {
     val fileWriter = location.asInstanceOf[WorkingPartition].getFileWriter
     val exception = fileWriter.getException
     if (exception != null) {
@@ -1154,7 +1154,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     (false, fileWriter)
   }
 
-  private def checkDiskFull(fileWriter: FileWriter): Boolean = {
+  private def checkDiskFull(fileWriter: PartitionDataWriter): Boolean = {
     if (fileWriter.flusher.isInstanceOf[HdfsFlusher]) {
       return false
     }
@@ -1166,7 +1166,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
   }
 
   private def checkDiskFullAndSplit(
-      fileWriter: FileWriter,
+      fileWriter: PartitionDataWriter,
       isPrimary: Boolean,
       softSplit: AtomicBoolean,
       callback: RpcResponseCallback): Boolean = {
@@ -1178,7 +1178,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
          |partitionSplitMinimumSize:$partitionSplitMinimumSize,
          |splitThreshold:${fileWriter.getSplitThreshold()},
          |fileLength:${fileWriter.getFileInfo.getFileLength}
-         |fileName:${fileWriter.getFileInfo.getFilePath}
+         |fileName:${fileWriter.getFileInfo.asInstanceOf[NonMemoryFileInfo].getFilePath}
          |""".stripMargin)
     if (workerPartitionSplitEnabled && ((diskFull && fileWriter.getFileInfo.getFileLength > partitionSplitMinimumSize) ||
         (isPrimary && fileWriter.getFileInfo.getFileLength > fileWriter.getSplitThreshold()))) {
@@ -1194,7 +1194,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
              |partitionSplitMinimumSize:$partitionSplitMinimumSize,
              |splitThreshold:${fileWriter.getSplitThreshold()},
              |fileLength:${fileWriter.getFileInfo.getFileLength},
-             |fileName:${fileWriter.getFileInfo.getFilePath}
+             |fileName:${fileWriter.getFileInfo.asInstanceOf[NonMemoryFileInfo].getFilePath}
              |""".stripMargin)
         return true
       }
@@ -1211,13 +1211,13 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
   }
 
   private def writeLocalData(
-      fileWriters: Seq[FileWriter],
+      fileWriters: Seq[PartitionDataWriter],
       body: ByteBuf,
       shuffleKey: String,
       isPrimary: Boolean,
       batchOffsets: Option[Array[Int]],
       writePromise: Promise[Unit]): Unit = {
-    def writeData(fileWriter: FileWriter, body: ByteBuf, shuffleKey: String): Unit = {
+    def writeData(fileWriter: PartitionDataWriter, body: ByteBuf, shuffleKey: String): Unit = {
       try {
         fileWriter.write(body)
       } catch {
@@ -1247,7 +1247,7 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
     batchOffsets match {
       case Some(batchOffsets) =>
         var index = 0
-        var fileWriter: FileWriter = null
+        var fileWriter: PartitionDataWriter = null
         while (index < fileWriters.length) {
           if (!writePromise.isCompleted) {
             fileWriter = fileWriters(index)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -37,8 +37,8 @@ import org.apache.celeborn.service.deploy.worker.WorkerSource
 
 trait DeviceMonitor {
   def startCheck() {}
-  def registerFileWriter(fileWriter: FileWriter): Unit = {}
-  def unregisterFileWriter(fileWriter: FileWriter): Unit = {}
+  def registerFileWriter(fileWriter: PartitionDataWriter): Unit = {}
+  def unregisterFileWriter(fileWriter: PartitionDataWriter): Unit = {}
   // Only local flush needs device monitor.
   def registerFlusher(flusher: LocalFlusher): Unit = {}
   def unregisterFlusher(flusher: LocalFlusher): Unit = {}
@@ -163,12 +163,12 @@ class LocalDeviceMonitor(
       TimeUnit.MILLISECONDS)
   }
 
-  override def registerFileWriter(fileWriter: FileWriter): Unit = {
+  override def registerFileWriter(fileWriter: PartitionDataWriter): Unit = {
     val mountPoint = DeviceInfo.getMountPoint(fileWriter.getFile.getAbsolutePath, diskInfos)
     observedDevices.get(diskInfos.get(mountPoint).deviceInfo).addObserver(fileWriter)
   }
 
-  override def unregisterFileWriter(fileWriter: FileWriter): Unit = {
+  override def unregisterFileWriter(fileWriter: PartitionDataWriter): Unit = {
     val mountPoint = DeviceInfo.getMountPoint(fileWriter.getFile.getAbsolutePath, diskInfos)
     observedDevices.get(diskInfos.get(mountPoint).deviceInfo).removeObserver(fileWriter)
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -37,7 +37,7 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.exception.CelebornException
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus, FileInfo, TimeWindow}
+import org.apache.celeborn.common.meta.{DeviceInfo, DiskInfo, DiskStatus, FileInfo, NonMemoryFileInfo, ReduceFileMeta, TimeWindow}
 import org.apache.celeborn.common.metrics.source.AbstractSource
 import org.apache.celeborn.common.network.util.{NettyUtils, TransportConf}
 import org.apache.celeborn.common.protocol.{PartitionLocation, PartitionSplitMode, PartitionType, StorageInfo}
@@ -48,11 +48,26 @@ import org.apache.celeborn.service.deploy.worker.memory.MemoryManager.MemoryPres
 import org.apache.celeborn.service.deploy.worker.shuffledb.{DB, DBBackend, DBProvider}
 import org.apache.celeborn.service.deploy.worker.storage.StorageManager.hadoopFs
 
+class CreateFileContext(
+    val location: PartitionLocation,
+    val appId: String,
+    val shuffleId: Int,
+    val fileName: String,
+    val userIdentifier: UserIdentifier,
+    val partitionType: PartitionType,
+    val partitionSplitEnabled: Boolean)
+
+class CreateFileResult(
+    val filePath: String,
+    val mountPointFile: File,
+    val flusher: Flusher,
+    val fileInfo: NonMemoryFileInfo)
+
 final private[worker] class StorageManager(conf: CelebornConf, workerSource: AbstractSource)
   extends ShuffleRecoverHelper with DeviceObserver with Logging with MemoryPressureListener {
   // mount point -> file writer
   val workingDirWriters =
-    JavaUtils.newConcurrentHashMap[File, ConcurrentHashMap[String, FileWriter]]()
+    JavaUtils.newConcurrentHashMap[File, ConcurrentHashMap[String, PartitionDataWriter]]()
 
   val hasHDFSStorage = conf.hasHDFSStorage
 
@@ -137,7 +152,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
 
   val hdfsDir = conf.hdfsDir
   val hdfsPermission = new FsPermission("755")
-  val hdfsWriters = JavaUtils.newConcurrentHashMap[String, FileWriter]()
+  val hdfsWriters = JavaUtils.newConcurrentHashMap[String, PartitionDataWriter]()
   val (hdfsFlusher, _totalHdfsFlusherThread) =
     if (hasHDFSStorage) {
       logInfo(s"Initialize HDFS support with path ${hdfsDir}")
@@ -192,8 +207,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   }
 
   // shuffleKey -> (fileName -> file info)
-  private val fileInfos =
-    JavaUtils.newConcurrentHashMap[String, ConcurrentHashMap[String, FileInfo]]()
+  private val nonMemoryFileInfos =
+    JavaUtils.newConcurrentHashMap[String, ConcurrentHashMap[String, NonMemoryFileInfo]]()
   private val RECOVERY_FILE_NAME_PREFIX = "recovery"
   private var RECOVERY_FILE_NAME = "recovery.ldb"
   private var db: DB = null
@@ -264,7 +279,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           try {
             val files = PbSerDeUtils.fromPbFileInfoMap(entry.getValue, cache)
             logDebug(s"Reload DB: $shuffleKey -> $files")
-            fileInfos.put(shuffleKey, files)
+            nonMemoryFileInfos.put(shuffleKey, files)
             db.delete(entry.getKey)
           } catch {
             case exception: Exception =>
@@ -306,13 +321,13 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
     }
 
   private val workingDirWriterListFunc =
-    new java.util.function.Function[File, ConcurrentHashMap[String, FileWriter]]() {
-      override def apply(t: File): ConcurrentHashMap[String, FileWriter] =
-        JavaUtils.newConcurrentHashMap[String, FileWriter]()
+    new java.util.function.Function[File, ConcurrentHashMap[String, PartitionDataWriter]]() {
+      override def apply(t: File): ConcurrentHashMap[String, PartitionDataWriter] =
+        JavaUtils.newConcurrentHashMap[String, PartitionDataWriter]()
     }
 
   @throws[IOException]
-  def createWriter(
+  def createPartitionDataWriter(
       appId: String,
       shuffleId: Int,
       location: PartitionLocation,
@@ -320,8 +335,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       splitMode: PartitionSplitMode,
       partitionType: PartitionType,
       rangeReadFilter: Boolean,
-      userIdentifier: UserIdentifier): FileWriter = {
-    createWriter(
+      userIdentifier: UserIdentifier): PartitionDataWriter = {
+    createPartitionDataWriter(
       appId,
       shuffleId,
       location,
@@ -334,7 +349,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   }
 
   @throws[IOException]
-  def createWriter(
+  def createPartitionDataWriter(
       appId: String,
       shuffleId: Int,
       location: PartitionLocation,
@@ -343,149 +358,55 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       partitionType: PartitionType,
       rangeReadFilter: Boolean,
       userIdentifier: UserIdentifier,
-      partitionSplitEnabled: Boolean): FileWriter = {
+      partitionSplitEnabled: Boolean): PartitionDataWriter = {
     if (healthyWorkingDirs().size <= 0 && !hasHDFSStorage) {
       throw new IOException("No available working dirs!")
     }
-
-    val fileName = location.getFileName
-    var retryCount = 0
-    var exception: IOException = null
-    val suggestedMountPoint = location.getStorageInfo.getMountPoint
-    while (retryCount < conf.workerCreateWriterMaxAttempts) {
-      val diskInfo = diskInfos.get(suggestedMountPoint)
-      val dirs =
-        if (diskInfo != null && diskInfo.status.equals(DiskStatus.HEALTHY)) {
-          diskInfo.dirs
-        } else {
-          logDebug(s"Disk unavailable for $suggestedMountPoint, return all healthy" +
-            s" working dirs. diskInfo $diskInfo")
-          healthyWorkingDirs()
-        }
-      if (dirs.isEmpty && hdfsFlusher.isEmpty) {
-        throw new IOException(s"No available disks! suggested mountPoint $suggestedMountPoint")
-      }
-      val shuffleKey = Utils.makeShuffleKey(appId, shuffleId)
-      if ((dirs.isEmpty && location.getStorageInfo.HDFSAvailable()) || location.getStorageInfo.HDFSOnly()) {
-        val shuffleDir =
-          new Path(new Path(hdfsDir, conf.workerWorkingDir), s"$appId/$shuffleId")
-        val fileInfo =
-          new FileInfo(
-            new Path(shuffleDir, fileName).toString,
-            userIdentifier,
-            partitionType,
-            partitionSplitEnabled)
-        fileInfos.computeIfAbsent(shuffleKey, newMapFunc).put(fileName, fileInfo)
-        FileSystem.mkdirs(StorageManager.hadoopFs, shuffleDir, hdfsPermission)
-        val hdfsWriter = partitionType match {
-          case PartitionType.MAP => new MapPartitionFileWriter(
-              fileInfo,
-              hdfsFlusher.get,
-              workerSource,
-              conf,
-              deviceMonitor,
-              splitThreshold,
-              splitMode,
-              rangeReadFilter)
-          case PartitionType.REDUCE => new ReducePartitionFileWriter(
-              fileInfo,
-              hdfsFlusher.get,
-              workerSource,
-              conf,
-              deviceMonitor,
-              splitThreshold,
-              splitMode,
-              rangeReadFilter)
-          case _ => throw new UnsupportedOperationException(s"Not support $partitionType yet")
-        }
-        if (workerGracefulShutdown) {
-          hdfsWriter.setStorageManager(this)
-          hdfsWriter.setShuffleKey(shuffleKey)
-        }
-        hdfsWriters.put(fileInfo.getFilePath, hdfsWriter)
-        return hdfsWriter
-      } else if (dirs.nonEmpty && location.getStorageInfo.localDiskAvailable()) {
-        val dir = dirs(getNextIndex() % dirs.size)
-        val mountPoint = DeviceInfo.getMountPoint(dir.getAbsolutePath, mountPoints)
-        val shuffleDir = new File(dir, s"$appId/$shuffleId")
-        val file = new File(shuffleDir, fileName)
-        try {
-          val fileInfo =
-            new FileInfo(
-              file.getAbsolutePath,
+    try {
+      partitionType match {
+        case PartitionType.MAP => new MapPartitionPartitionDataWriter(
+            this,
+            new CreateFileContext(
+              location,
+              appId,
+              shuffleId,
+              location.getFileName,
               userIdentifier,
               partitionType,
-              partitionSplitEnabled)
-          fileInfo.setMountPoint(mountPoint)
-          fileInfos.computeIfAbsent(shuffleKey, newMapFunc).put(fileName, fileInfo)
-          shuffleDir.mkdirs()
-          if (file.exists()) {
-            throw new FileAlreadyExistsException(
-              s"Shuffle data file ${file.getAbsolutePath} already exists.")
-          } else {
-            val createFileSuccess = file.createNewFile()
-            if (!createFileSuccess) {
-              throw new CelebornException(
-                s"Create shuffle data file ${file.getAbsolutePath} failed!")
-            }
-          }
-          val fileWriter = partitionType match {
-            case PartitionType.MAP => new MapPartitionFileWriter(
-                fileInfo,
-                localFlushers.get(mountPoint),
-                workerSource,
-                conf,
-                deviceMonitor,
-                splitThreshold,
-                splitMode,
-                rangeReadFilter)
-            case PartitionType.REDUCE => new ReducePartitionFileWriter(
-                fileInfo,
-                localFlushers.get(mountPoint),
-                workerSource,
-                conf,
-                deviceMonitor,
-                splitThreshold,
-                splitMode,
-                rangeReadFilter)
-            case _ => throw new UnsupportedOperationException(s"Not support $partitionType yet")
-          }
-          if (workerGracefulShutdown) {
-            fileWriter.setStorageManager(this)
-            fileWriter.setShuffleKey(shuffleKey)
-          }
-          deviceMonitor.registerFileWriter(fileWriter)
-          val map = workingDirWriters.computeIfAbsent(dir, workingDirWriterListFunc)
-          map.put(fileInfo.getFilePath, fileWriter)
-          location.getStorageInfo.setMountPoint(mountPoint)
-          logDebug(s"location $location set disk hint to ${location.getStorageInfo} ")
-          return fileWriter
-        } catch {
-          case fe: FileAlreadyExistsException =>
-            logError("Failed to create fileWriter because of existed file", fe)
-            throw fe
-          case t: Throwable =>
-            logError(
-              s"Create FileWriter for ${file.getAbsolutePath} of mount $mountPoint " +
-                s"failed, report to DeviceMonitor",
-              t)
-            exception = new IOException(t)
-            deviceMonitor.reportNonCriticalError(
-              mountPoint,
-              exception,
-              DiskStatus.READ_OR_WRITE_FAILURE)
-        }
-      } else {
-        exception = new IOException("No storage available for location:" + location.toString)
+              partitionSplitEnabled),
+            workerSource,
+            conf,
+            deviceMonitor,
+            splitThreshold,
+            splitMode,
+            rangeReadFilter)
+        case PartitionType.REDUCE => new ReducePartitionPartitionDataWriter(
+            this,
+            new CreateFileContext(
+              location,
+              appId,
+              shuffleId,
+              location.getFileName,
+              userIdentifier,
+              partitionType,
+              partitionSplitEnabled),
+            workerSource,
+            conf,
+            deviceMonitor,
+            splitThreshold,
+            splitMode,
+            rangeReadFilter)
+        case _ => throw new UnsupportedOperationException(s"Not support $partitionType yet")
       }
-      retryCount += 1
+    } catch {
+      case e: Exception =>
+        logError("Create partition data writer failed", e)
+        throw e
     }
-
-    throw exception
   }
 
   def getFileInfo(shuffleKey: String, fileName: String): FileInfo = {
-    val shuffleMap = fileInfos.get(shuffleKey)
+    val shuffleMap = nonMemoryFileInfos.get(shuffleKey)
     if (shuffleMap ne null) {
       shuffleMap.get(fileName)
     } else {
@@ -504,12 +425,12 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
 
   def shuffleKeySet(): util.HashSet[String] = {
     val hashSet = new util.HashSet[String]()
-    hashSet.addAll(fileInfos.keySet())
+    hashSet.addAll(nonMemoryFileInfos.keySet())
     hashSet
   }
 
   def topAppDiskUsage: util.Map[String, Long] = {
-    fileInfos.asScala.map { keyedWriters =>
+    nonMemoryFileInfos.asScala.map { keyedWriters =>
       {
         keyedWriters._1 -> keyedWriters._2.values().asScala.map(_.getFileLength).sum
       }
@@ -523,11 +444,11 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   def cleanFile(shuffleKey: String, fileName: String): Unit = {
     val fileInfo = getFileInfo(shuffleKey, fileName)
     if (fileInfo != null) {
-      cleanFileInternal(shuffleKey, fileInfo)
+      cleanFileInternal(shuffleKey, fileInfo.asInstanceOf[NonMemoryFileInfo])
     }
   }
 
-  def cleanFileInternal(shuffleKey: String, fileInfo: FileInfo): Boolean = {
+  def cleanFileInternal(shuffleKey: String, fileInfo: NonMemoryFileInfo): Boolean = {
     var isHdfsExpired = false
     if (fileInfo.isHdfs) {
       isHdfsExpired = true
@@ -559,8 +480,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       cleanDB: Boolean = true): Unit = {
     expiredShuffleKeys.asScala.foreach { shuffleKey =>
       logInfo(s"Cleanup expired shuffle $shuffleKey.")
-      if (fileInfos.containsKey(shuffleKey)) {
-        val removedFileInfos = fileInfos.remove(shuffleKey)
+      if (nonMemoryFileInfos.containsKey(shuffleKey)) {
+        val removedFileInfos = nonMemoryFileInfos.remove(shuffleKey)
         var isHdfsExpired = false
         if (removedFileInfos != null) {
           removedFileInfos.asScala.foreach {
@@ -741,10 +662,12 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   }
 
   private def flushFileWriters(): Unit = {
-    workingDirWriters.forEach(new BiConsumer[File, ConcurrentHashMap[String, FileWriter]] {
-      override def accept(t: File, writers: ConcurrentHashMap[String, FileWriter]): Unit = {
-        writers.forEach(new BiConsumer[String, FileWriter] {
-          override def accept(file: String, writer: FileWriter): Unit = {
+    workingDirWriters.forEach(new BiConsumer[File, ConcurrentHashMap[String, PartitionDataWriter]] {
+      override def accept(
+          t: File,
+          writers: ConcurrentHashMap[String, PartitionDataWriter]): Unit = {
+        writers.forEach(new BiConsumer[String, PartitionDataWriter] {
+          override def accept(file: String, writer: PartitionDataWriter): Unit = {
             if (writer.getException == null) {
               try {
                 writer.flushOnMemoryPressure()
@@ -762,8 +685,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         })
       }
     })
-    hdfsWriters.forEach(new BiConsumer[String, FileWriter] {
-      override def accept(t: String, u: FileWriter): Unit = {
+    hdfsWriters.forEach(new BiConsumer[String, PartitionDataWriter] {
+      override def accept(t: String, u: PartitionDataWriter): Unit = {
         u.flushOnMemoryPressure()
       }
     })
@@ -808,9 +731,9 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   }
 
   def userResourceConsumptionSnapshot(): Map[UserIdentifier, ResourceConsumption] = {
-    fileInfos.synchronized {
+    nonMemoryFileInfos.synchronized {
       // shuffleId -> (fileName -> fileInfo)
-      fileInfos
+      nonMemoryFileInfos
         .asScala
         .toList
         .flatMap { case (_, fileInfoMaps) =>
@@ -847,12 +770,103 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   }
 
   def getActiveShuffleSize(): Long = {
-    fileInfos.values().asScala.map(_.values().asScala.map(_.getBytesFlushed).sum).sum
+    nonMemoryFileInfos.values().asScala.map(_.values().asScala.map(_.getBytesFlushed).sum).sum
   }
 
   def getActiveShuffleFileCount(): Long = {
-    fileInfos.asScala.values.map(_.size()).sum
+    nonMemoryFileInfos.asScala.values.map(_.size()).sum
   }
+
+  def createFile(
+      createFileContext: CreateFileContext): CreateFileResult = {
+    val (location, appId, shuffleId, fileName) = (
+      createFileContext.location,
+      createFileContext.appId,
+      createFileContext.shuffleId,
+      createFileContext.fileName)
+    val suggestedMountPoint = location.getStorageInfo.getMountPoint
+    var retryCount = 0
+    var exception: IOException = null
+    while (retryCount < conf.workerCreateWriterMaxAttempts) {
+      val diskInfo = diskInfos.get(suggestedMountPoint)
+      val dirs =
+        if (diskInfo != null && diskInfo.status.equals(DiskStatus.HEALTHY)) {
+          diskInfo.dirs
+        } else {
+          logDebug(s"Disk unavailable for $suggestedMountPoint, return all healthy" +
+            s" working dirs. diskInfo $diskInfo")
+          healthyWorkingDirs()
+        }
+      if (dirs.isEmpty && hdfsFlusher.isEmpty) {
+        throw new IOException(s"No available disks! suggested mountPoint $suggestedMountPoint")
+      }
+
+      if (dirs.isEmpty && location.getStorageInfo.HDFSAvailable()) {
+        val shuffleDir =
+          new Path(new Path(hdfsDir, conf.workerWorkingDir), s"$appId/$shuffleId")
+        FileSystem.mkdirs(StorageManager.hadoopFs, shuffleDir, hdfsPermission)
+        val hdfsFilePath = new Path(shuffleDir, fileName).toString
+        return new CreateFileResult(
+          hdfsFilePath,
+          null,
+          hdfsFlusher.get,
+          new NonMemoryFileInfo(
+            createFileContext.userIdentifier,
+            createFileContext.partitionSplitEnabled,
+            new ReduceFileMeta(),
+            hdfsFilePath,
+            StorageInfo.Type.HDFS))
+        // (hdfsFilePath, createFileContext.userIdentifier, createFileContext.partitionType, createFileContext.partitionSplitEnabled))
+      } else if (dirs.nonEmpty && location.getStorageInfo.localDiskAvailable()) {
+        val dir = dirs(getNextIndex() % dirs.size)
+        val mountPoint = DeviceInfo.getMountPoint(dir.getAbsolutePath, mountPoints)
+        val shuffleDir = new File(dir, s"$appId/$shuffleId")
+        shuffleDir.mkdirs()
+        val file = new File(shuffleDir, fileName)
+        try {
+          if (file.exists()) {
+            throw new FileAlreadyExistsException(
+              s"Shuffle data file ${file.getAbsolutePath} already exists.")
+          } else {
+            val createFileSuccess = file.createNewFile()
+            if (!createFileSuccess) {
+              throw new CelebornException(
+                s"Create shuffle data file ${file.getAbsolutePath} failed!")
+            }
+          }
+          val filePath = file.getAbsolutePath
+          return new CreateFileResult(
+            filePath,
+            dir,
+            localFlushers.get(mountPoint),
+            new NonMemoryFileInfo(
+              createFileContext.userIdentifier,
+              createFileContext.partitionSplitEnabled,
+              new ReduceFileMeta(),
+              filePath,
+              StorageInfo.Type.HDD))
+        } catch {
+          case fe: FileAlreadyExistsException =>
+            logError("Failed to create fileWriter because of existed file", fe)
+            throw fe
+          case t: Throwable =>
+            logError(
+              s"Create FileWriter for ${file.getAbsolutePath} of mount $mountPoint " +
+                s"failed, report to DeviceMonitor",
+              t)
+            deviceMonitor.reportNonCriticalError(
+              mountPoint,
+              new IOException(t),
+              DiskStatus.READ_OR_WRITE_FAILURE)
+            throw t
+        }
+      } else {
+        exception = new IOException("No storage available for location:" + location.toString)
+      }
+    }
+    throw exception
+  }
+
 }
 
 object StorageManager {

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/FetchHandlerSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/FetchHandlerSuiteJ.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.meta.NonMemoryFileInfo;
 import org.apache.celeborn.common.network.buffer.NioManagedBuffer;
 import org.apache.celeborn.common.network.client.TransportClient;
 import org.apache.celeborn.common.network.client.TransportResponseHandler;
@@ -87,7 +88,7 @@ public class FetchHandlerSuiteJ {
     byte[] batchHeader = new byte[16];
     File shuffleFile = File.createTempFile("celeborn", UUID.randomUUID().toString());
 
-    FileInfo fileInfo = new FileInfo(shuffleFile, userIdentifier);
+    FileInfo fileInfo = new NonMemoryFileInfo(shuffleFile, userIdentifier);
     FileOutputStream fileOutputStream = new FileOutputStream(shuffleFile);
     FileChannel channel = fileOutputStream.getChannel();
     Map<Integer, Integer> batchIds = new HashMap<>();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManagerSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManagerSuiteJ.java
@@ -37,6 +37,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.meta.MapFileMeta;
+import org.apache.celeborn.common.meta.NonMemoryFileInfo;
 import org.apache.celeborn.common.util.JavaUtils;
 import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager;
@@ -75,9 +77,10 @@ public class CreditStreamManagerSuiteJ {
     CreditStreamManager creditStreamManager = new CreditStreamManager(10, 10, 1, 32);
     Channel channel = Mockito.mock(Channel.class);
     FileInfo fileInfo =
-        new FileInfo(createTemporaryFileWithIndexFile(), new UserIdentifier("default", "default"));
-    fileInfo.setNumSubpartitions(10);
-    fileInfo.setBufferSize(1024);
+        new NonMemoryFileInfo(
+            createTemporaryFileWithIndexFile(), new UserIdentifier("default", "default"));
+    MapFileMeta mapFileMeta = new MapFileMeta(1024, 10);
+    fileInfo.replaceFileMeta(mapFileMeta);
     Consumer<Long> streamIdConsumer = streamId -> Assert.assertTrue(streamId > 0);
 
     long registerStream1 =

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriterSuiteJ.java
@@ -25,11 +25,11 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
 import scala.Function0;
+import scala.Tuple3;
 import scala.collection.mutable.ListBuffer;
 
 import io.netty.buffer.Unpooled;
@@ -52,9 +52,9 @@ import org.apache.celeborn.common.util.Utils;
 import org.apache.celeborn.service.deploy.worker.WorkerSource;
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager;
 
-public class MapPartitionFileWriterSuiteJ {
+public class MapPartitionDataWriterSuiteJ {
 
-  private static final Logger LOG = LoggerFactory.getLogger(MapPartitionFileWriterSuiteJ.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MapPartitionDataWriterSuiteJ.class);
 
   private static final CelebornConf CONF = new CelebornConf();
   public static final Long SPLIT_THRESHOLD = 256 * 1024 * 1024L;
@@ -118,12 +118,17 @@ public class MapPartitionFileWriterSuiteJ {
   }
 
   @Test
-  public void testMultiThreadWrite() throws IOException, ExecutionException, InterruptedException {
-    File file = getTemporaryFile();
-    MapPartitionFileWriter fileWriter =
-        new MapPartitionFileWriter(
-            new FileInfo(file, userIdentifier),
+  public void testMultiThreadWrite() throws IOException {
+    Tuple3<StorageManager, CreateFileContext, FileInfo> context =
+        PartitionDataWriterSuiteUtils.prepareTestFileContext(
+            PartitionDataWriterSuiteUtils.getTemporaryFile(tempDir),
+            userIdentifier,
             localFlusher,
+            true);
+    MapPartitionPartitionDataWriter fileWriter =
+        new MapPartitionPartitionDataWriter(
+            context._1(),
+            context._2(),
             source,
             CONF,
             DeviceMonitor$.MODULE$.EmptyMonitor(),

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterSuiteUtils.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterSuiteUtils.java
@@ -1,0 +1,40 @@
+package org.apache.celeborn.service.deploy.worker.storage;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import scala.Tuple3;
+
+import org.mockito.Mockito;
+
+import org.apache.celeborn.common.identity.UserIdentifier;
+import org.apache.celeborn.common.meta.FileInfo;
+import org.apache.celeborn.common.meta.NonMemoryFileInfo;
+
+public class PartitionDataWriterSuiteUtils {
+  public static File getTemporaryFile(File tempDir) throws IOException {
+    String filename = UUID.randomUUID().toString();
+    File temporaryFile = new File(tempDir, filename);
+    temporaryFile.createNewFile();
+    return temporaryFile;
+  }
+
+  public static Tuple3<StorageManager, CreateFileContext, FileInfo> prepareTestFileContext(
+      File tempDir, UserIdentifier userIdentifier, Flusher flusher, boolean reduceMeta)
+      throws IOException {
+    File file = getTemporaryFile(tempDir);
+    FileInfo fileInfo = new NonMemoryFileInfo(file, userIdentifier);
+    if (!reduceMeta) {
+      //      fileInfo.replaceFileMeta(new MapFileMeta());
+    }
+
+    StorageManager storageManager = Mockito.mock(StorageManager.class);
+    CreateFileContext createFileContext = Mockito.mock(CreateFileContext.class);
+    Mockito.doAnswer(
+            invocation -> new CreateFileResult(file.getAbsolutePath(), null, flusher, fileInfo))
+        .when(storageManager)
+        .createFile(Mockito.any());
+    return new Tuple3<>(storageManager, createFileContext, fileInfo);
+  }
+}

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitorSuite.scala
@@ -230,10 +230,10 @@ class DeviceMonitorSuite extends AnyFunSuite {
 
         deviceMonitor.init()
 
-        val fw1 = mock[FileWriter]
-        val fw2 = mock[FileWriter]
-        val fw3 = mock[FileWriter]
-        val fw4 = mock[FileWriter]
+        val fw1 = mock[PartitionDataWriter]
+        val fw2 = mock[PartitionDataWriter]
+        val fw3 = mock[PartitionDataWriter]
+        val fw4 = mock[PartitionDataWriter]
 
         val f1 = new File("/mnt/disk1/data1/f1")
         val f2 = new File("/mnt/disk1/data2/f2")

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/WorkerSuite.scala
@@ -58,7 +58,7 @@ class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach {
     val pl1 = new PartitionLocation(0, 0, "12", 0, 0, 0, 0, PartitionLocation.Mode.PRIMARY)
     val pl2 = new PartitionLocation(1, 0, "12", 0, 0, 0, 0, PartitionLocation.Mode.REPLICA)
 
-    worker.storageManager.createWriter(
+    worker.storageManager.createPartitionDataWriter(
       "1",
       1,
       pl1,
@@ -67,7 +67,7 @@ class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach {
       PartitionType.REDUCE,
       true,
       new UserIdentifier("1", "2"))
-    worker.storageManager.createWriter(
+    worker.storageManager.createPartitionDataWriter(
       "2",
       2,
       pl2,
@@ -96,8 +96,8 @@ class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach {
     conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, "/tmp")
     worker = new Worker(conf, workerArgs)
     val dir = new File("/tmp")
-    val allWriters = new util.HashSet[FileWriter]()
-    val map = JavaUtils.newConcurrentHashMap[String, FileWriter]()
+    val allWriters = new util.HashSet[PartitionDataWriter]()
+    val map = JavaUtils.newConcurrentHashMap[String, PartitionDataWriter]()
     worker.storageManager.workingDirWriters.put(dir, map)
     worker.storageManager.workingDirWriters.asScala.foreach { case (_, writers) =>
       writers.synchronized {
@@ -107,7 +107,7 @@ class WorkerSuite extends AnyFunSuite with BeforeAndAfterEach {
     }
     Assert.assertEquals(0, allWriters.size())
 
-    val fileWriter = mock[FileWriter]
+    val fileWriter = mock[PartitionDataWriter]
     when(fileWriter.getException).thenReturn(null)
     map.put("1", fileWriter)
     worker.storageManager.workingDirWriters.asScala.foreach { case (_, writers) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Rename FileWriter to PartitionLocationDataWriter,add storageManager,delete fileinfo,flusher in constructor.
2. FileInfo:
FileInfo(userIdentifier,partitionSplitEnabled,fileMeta)
– NonMemoryFileInfo(streams,filePath,storageType,bytesFlushed)
– MemoryFileInfo(length,buffer)

FileMeta
– reduceFileMeta(chunkOffsets,sorted)
– mapFileMeta(bufferSize,numSubPartitions)


### Why are the changes needed?
1. To make concepts more clear.
2. To support memory storage and HDFS slot management.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
GA
