### PR TITLE
[CELEBORN-1149] Improve replica selection when rack aware

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -18,6 +18,7 @@
 package org.apache.celeborn.service.deploy.master;
 
 import java.util.*;
+import java.util.function.IntUnaryOperator;
 import java.util.stream.Collectors;
 
 import scala.Double;
@@ -235,11 +236,19 @@ public class SlotsAllocator {
   private static Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>>
       locateSlots(
           List<Integer> partitionIds,
-          List<WorkerInfo> workers,
+          List<WorkerInfo> workersList,
           Map<WorkerInfo, List<UsableDiskInfo>> slotRestrictions,
           boolean shouldReplicate,
           boolean shouldRackAware,
           int availableStorageTypes) {
+
+    List<WorkerInfo> workersFromSlotRestrictions = new ArrayList<>(slotRestrictions.keySet());
+    List<WorkerInfo> workers = workersList;
+    if (shouldReplicate && shouldRackAware) {
+      workersFromSlotRestrictions = generateRackAwareWorkers(workersFromSlotRestrictions);
+      workers = generateRackAwareWorkers(workers);
+    }
+
     Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
         new HashMap<>();
 
@@ -247,7 +256,7 @@ public class SlotsAllocator {
         roundRobin(
             slots,
             partitionIds,
-            new LinkedList<>(slotRestrictions.keySet()),
+            workersFromSlotRestrictions,
             slotRestrictions,
             shouldReplicate,
             shouldRackAware,
@@ -269,6 +278,51 @@ public class SlotsAllocator {
     return slots;
   }
 
+  /**
+   * The rack distribution of the input workers list is essentially random, and in degenerate cases
+   * the rack aware slot selection ends up skipping sub list's of hosts (in same rack) - which
+   * results in uneven distribution of replica selection. For example given worker list: [h1r1,
+   * h2r1, h3r1, h4r2, h5r2, h6r2] if primary is h3r1 and replica index is pointing to h1r1, it will
+   * skip both h2r1 and h3r1 in order to pick h4r2; and for the next slot, primary will be h4r2 and
+   * will skip all the r2 hosts in order to pick h1r1. This ends up being suboptimal where some
+   * hosts are picked a lot more than others (due to the worker and worker/rack distribution). In
+   * order to mitigate this, we reorder the worker list by redistributing the workers based on rack
+   * to increase the rack diversity between adjoining workers, so that we minimize skipping over
+   * consecutive hosts.
+   */
+  static List<WorkerInfo> generateRackAwareWorkers(List<WorkerInfo> workers) {
+
+    List<Map.Entry<String, LinkedList<WorkerInfo>>> sortedRackToHosts;
+    {
+      Map<String, LinkedList<WorkerInfo>> map = new HashMap<>();
+      for (WorkerInfo worker : workers) {
+        map.computeIfAbsent(worker.networkLocation(), key -> new LinkedList<>()).add(worker);
+      }
+      sortedRackToHosts = new ArrayList<>(map.entrySet());
+      // reverse sort by number of hosts per rack
+      sortedRackToHosts.sort(
+          (o1, o2) -> Integer.compare(o2.getValue().size(), o1.getValue().size()));
+    }
+
+    ArrayList<WorkerInfo> result = new ArrayList<>(workers.size());
+    int count = 0;
+    final int numWorkers = workers.size();
+    while (count < numWorkers) {
+      Iterator<Map.Entry<String, LinkedList<WorkerInfo>>> iter = sortedRackToHosts.iterator();
+      while (iter.hasNext()) {
+        LinkedList<WorkerInfo> workerList = iter.next().getValue();
+        result.add(workerList.removeFirst());
+        count++;
+        if (workerList.isEmpty()) {
+          iter.remove();
+        }
+      }
+    }
+    assert (sortedRackToHosts.isEmpty());
+
+    return Collections.unmodifiableList(result);
+  }
+
   private static List<Integer> roundRobin(
       Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots,
       List<Integer> partitionIds,
@@ -281,7 +335,12 @@ public class SlotsAllocator {
     Map<WorkerInfo, Integer> workerDiskIndexForPrimary = new HashMap<>();
     Map<WorkerInfo, Integer> workerDiskIndexForReplica = new HashMap<>();
     List<Integer> partitionIdList = new ArrayList<>(partitionIds);
-    int primaryIndex = rand.nextInt(workers.size());
+
+    final int workerSize = workers.size();
+    final IntUnaryOperator incrementIndex = v -> (v + 1) % workerSize;
+    int primaryIndex = rand.nextInt(workerSize);
+    int replicaIndex = rand.nextInt(workerSize);
+
     Iterator<Integer> iter = partitionIdList.iterator();
     outer:
     while (iter.hasNext()) {
@@ -292,7 +351,7 @@ public class SlotsAllocator {
       if (slotsRestrictions != null && !slotsRestrictions.isEmpty()) {
         // this means that we'll select a mount point
         while (!haveUsableSlots(slotsRestrictions, workers, nextPrimaryInd)) {
-          nextPrimaryInd = (nextPrimaryInd + 1) % workers.size();
+          nextPrimaryInd = incrementIndex.applyAsInt(nextPrimaryInd);
           if (nextPrimaryInd == primaryIndex) {
             break outer;
           }
@@ -307,7 +366,7 @@ public class SlotsAllocator {
       } else {
         if (StorageInfo.localDiskAvailable(availableStorageTypes)) {
           while (!workers.get(nextPrimaryInd).haveDisk()) {
-            nextPrimaryInd = (nextPrimaryInd + 1) % workers.size();
+            nextPrimaryInd = incrementIndex.applyAsInt(nextPrimaryInd);
             if (nextPrimaryInd == primaryIndex) {
               break outer;
             }
@@ -320,13 +379,14 @@ public class SlotsAllocator {
       PartitionLocation primaryPartition =
           createLocation(partitionId, workers.get(nextPrimaryInd), null, storageInfo, true);
 
+      int nextReplicaInd = replicaIndex;
       if (shouldReplicate) {
-        int nextReplicaInd = (nextPrimaryInd + 1) % workers.size();
         if (slotsRestrictions != null) {
-          while (!haveUsableSlots(slotsRestrictions, workers, nextReplicaInd)
+          while (nextReplicaInd == nextPrimaryInd
+              || !haveUsableSlots(slotsRestrictions, workers, nextReplicaInd)
               || !satisfyRackAware(shouldRackAware, workers, nextPrimaryInd, nextReplicaInd)) {
-            nextReplicaInd = (nextReplicaInd + 1) % workers.size();
-            if (nextReplicaInd == nextPrimaryInd) {
+            nextReplicaInd = incrementIndex.applyAsInt(nextReplicaInd);
+            if (nextReplicaInd == replicaIndex) {
               break outer;
             }
           }
@@ -338,17 +398,18 @@ public class SlotsAllocator {
                   workerDiskIndexForReplica,
                   availableStorageTypes);
         } else if (shouldRackAware) {
-          while (!satisfyRackAware(true, workers, nextPrimaryInd, nextReplicaInd)) {
-            nextReplicaInd = (nextReplicaInd + 1) % workers.size();
-            if (nextReplicaInd == nextPrimaryInd) {
+          while (nextReplicaInd == nextPrimaryInd
+              || !satisfyRackAware(true, workers, nextPrimaryInd, nextReplicaInd)) {
+            nextReplicaInd = incrementIndex.applyAsInt(nextReplicaInd);
+            if (nextReplicaInd == replicaIndex) {
               break outer;
             }
           }
         } else {
           if (StorageInfo.localDiskAvailable(availableStorageTypes)) {
-            while (!workers.get(nextPrimaryInd).haveDisk()) {
-              nextPrimaryInd = (nextPrimaryInd + 1) % workers.size();
-              if (nextPrimaryInd == primaryIndex) {
+            while (nextReplicaInd == nextPrimaryInd || !workers.get(nextReplicaInd).haveDisk()) {
+              nextReplicaInd = incrementIndex.applyAsInt(nextReplicaInd);
+              if (nextReplicaInd == replicaIndex) {
                 break outer;
               }
             }
@@ -366,13 +427,14 @@ public class SlotsAllocator {
                 workers.get(nextReplicaInd),
                 v -> new Tuple2<>(new ArrayList<>(), new ArrayList<>()));
         locations._2.add(replicaPartition);
+        replicaIndex = incrementIndex.applyAsInt(nextReplicaInd);
       }
 
       Tuple2<List<PartitionLocation>, List<PartitionLocation>> locations =
           slots.computeIfAbsent(
               workers.get(nextPrimaryInd), v -> new Tuple2<>(new ArrayList<>(), new ArrayList<>()));
       locations._1.add(primaryPartition);
-      primaryIndex = (nextPrimaryInd + 1) % workers.size();
+      primaryIndex = incrementIndex.applyAsInt(nextPrimaryInd);
       iter.remove();
     }
     return partitionIdList;

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -318,7 +318,6 @@ public class SlotsAllocator {
         }
       }
     }
-    assert (sortedRackToHosts.isEmpty());
 
     return Collections.unmodifiableList(result);
   }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/SlotsAllocator.java
@@ -379,8 +379,8 @@ public class SlotsAllocator {
       PartitionLocation primaryPartition =
           createLocation(partitionId, workers.get(nextPrimaryInd), null, storageInfo, true);
 
-      int nextReplicaInd = replicaIndex;
       if (shouldReplicate) {
+        int nextReplicaInd = replicaIndex;
         if (slotsRestrictions != null) {
           while (nextReplicaInd == nextPrimaryInd
               || !haveUsableSlots(slotsRestrictions, workers, nextReplicaInd)

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
@@ -150,12 +150,11 @@ public class SlotsAllocatorRackAwareSuiteJ {
   }
 
   @Test
-  public void testRoundRobinReplicationWithRackAwarenessPatterns() {
+  public void testRackAwareRoundRobinReplicaPatterns() {
     for (Tuple2<Integer, List<WorkerInfo>> tuple :
         Arrays.asList(
-            // This is a specific case we analyzed which results in degenerate behavior with
-            // replicas
-            // with the earlier implementation
+            // This is a specific case we analyzed which was resulting in degenerate
+            // behavior for replicas
             Tuple2.apply(
                 100,
                 Arrays.asList(
@@ -166,8 +165,8 @@ public class SlotsAllocatorRackAwareSuiteJ {
                     WorkersSupplier.initWorker("h4r2", "/rack/r2"),
                     WorkersSupplier.initWorker("h5r2", "/rack/r2"),
                     WorkersSupplier.initWorker("h6r2", "/rack/r2"))),
-            // This is a specific case we observed in production which resulted
-            // in suboptimal replica selection
+            // This is a specific case we observed in production which triggered
+            // suboptimal replica selection
             Tuple2.apply(
                 20,
                 Arrays.asList(
@@ -236,8 +235,6 @@ public class SlotsAllocatorRackAwareSuiteJ {
             SlotsAllocator.offerSlotsRoundRobin(
                 workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK);
 
-        // Ensure there is sufficient diversity of hosts. Earlier implementation would result in
-        // only picking h1r1 and h4r2 for the replica - except for the first few cases
         Map<String, Long> numReplicaPerHost =
             slots.entrySet().stream()
                 .flatMap(v -> v.getValue()._2.stream().map(PartitionLocation::getHost))
@@ -249,7 +246,6 @@ public class SlotsAllocatorRackAwareSuiteJ {
         Map.Entry<String, Long> maxEntry =
             Collections.max(numReplicaPerHost.entrySet(), entryComparator);
 
-        // expected
         assert (null != maxEntry);
 
         if (maxEntry.getValue() > maxValue) {
@@ -333,7 +329,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
 
     WorkersSupplier(int numHostsPerRack, int numRacks) {
       this(
-          String.format("Equals hosts(%d) per rack(%d)", numHostsPerRack, numRacks),
+          String.format("Equal hosts(%d) per rack(%d)", numHostsPerRack, numRacks),
           equalHostsPerRackWorkers(numHostsPerRack, numRacks));
     }
 

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
@@ -328,18 +328,21 @@ public class SlotsAllocatorRackAwareSuiteJ {
   private static class WorkersSupplier implements Supplier<List<WorkerInfo>> {
     private static final Random RAND = new Random(42);
 
+    private final String message;
     private final List<WorkerInfo> workerList;
 
     WorkersSupplier(int numHostsPerRack, int numRacks) {
-      this(false, equalHostsPerRackWorkers(numHostsPerRack, numRacks));
+      this(
+          String.format("Equals hosts(%d) per rack(%d)", numHostsPerRack, numRacks),
+          equalHostsPerRackWorkers(numHostsPerRack, numRacks));
     }
 
     WorkersSupplier(List<Integer> hostsPerRack) {
-      this(false, specifiedHostsPerRackWorkers(hostsPerRack));
+      this("Hosts per rack = " + hostsPerRack, specifiedHostsPerRackWorkers(hostsPerRack));
     }
 
-    @SuppressWarnings({"unused"})
-    private WorkersSupplier(boolean unused, List<WorkerInfo> workerList) {
+    WorkersSupplier(String message, List<WorkerInfo> workerList) {
+      this.message = message;
       this.workerList = Collections.unmodifiableList(workerList);
     }
 
@@ -380,10 +383,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
 
     @Override
     public String toString() {
-      return "WorkersSupplier{"
-          + "workerList="
-          + workerList.stream().map(WorkerInfo::host).collect(Collectors.toList())
-          + '}';
+      return "WorkersSupplier{" + message + "}";
     }
 
     private static WorkerInfo initWorker(String host, String rack) {
@@ -430,7 +430,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
                       + 1));
     }
 
-    private SlotReplicaAllocatorTestCase(
+    SlotReplicaAllocatorTestCase(
         Supplier<List<WorkerInfo>> workersSupplier,
         int numPartitions,
         int expectedMaxSlotsPerHost) {

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
@@ -199,13 +199,9 @@ public class SlotsAllocatorRackAwareSuiteJ {
 
       for (String host : workers.stream().map(WorkerInfo::host).collect(Collectors.toList())) {
         long numReplicas = numReplicaPerHost.getOrDefault(host, 0L);
-        assert numReplicas <= maxReplicaCount
-            : "host = "
-                + host
-                + ", numReplicaPerHost = "
-                + numReplicaPerHost
-                + ", slots = "
-                + slots;
+        Assert.assertTrue(
+            "host = " + host + ", numReplicaPerHost = " + numReplicaPerHost + ", slots = " + slots,
+            numReplicas <= maxReplicaCount);
       }
     }
   }
@@ -246,8 +242,6 @@ public class SlotsAllocatorRackAwareSuiteJ {
         Map.Entry<String, Long> maxEntry =
             Collections.max(numReplicaPerHost.entrySet(), entryComparator);
 
-        assert (null != maxEntry);
-
         if (maxEntry.getValue() > maxValue) {
           maxValue = maxEntry.getValue();
           maxValueWorkers = workers;
@@ -255,13 +249,13 @@ public class SlotsAllocatorRackAwareSuiteJ {
         }
       }
 
-      assert (null != maxValueWorkers);
+      Assert.assertNotNull(maxValueWorkers);
 
       for (String host :
           maxValueWorkers.stream().map(WorkerInfo::host).collect(Collectors.toList())) {
         long numReplicas = maxValueNumReplicaPerHost.getOrDefault(host, 0L);
-        assert numReplicas <= test.getExpectedMaxSlotsPerHost()
-            : "host = "
+        Assert.assertTrue(
+            "host = "
                 + host
                 + ", workerHosts = "
                 + maxValueWorkers.stream().map(WorkerInfo::host).collect(Collectors.toList())
@@ -272,7 +266,8 @@ public class SlotsAllocatorRackAwareSuiteJ {
                 + ", numReplicaPerHost = "
                 + maxValueNumReplicaPerHost
                 + ", test = "
-                + test;
+                + test,
+            numReplicas <= test.getExpectedMaxSlotsPerHost());
       }
     }
   }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
@@ -25,6 +25,10 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import scala.Tuple2;
 
@@ -34,12 +38,16 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
 import org.apache.celeborn.common.protocol.PartitionLocation;
 import org.apache.celeborn.common.protocol.StorageInfo;
 import org.apache.celeborn.service.deploy.master.network.CelebornRackResolver;
 
 public class SlotsAllocatorRackAwareSuiteJ {
+
+  private static final int NUM_ATTEMPTS =
+      Integer.getInteger("SlotsAllocatorRackAwareSuiteJ.NUM_ATTEMPTS", 100);
 
   @Test
   public void offerSlotsRoundRobinWithRackAware() throws IOException {
@@ -139,5 +147,321 @@ public class SlotsAllocatorRackAwareSuiteJ {
           }
         });
     return workers;
+  }
+
+  @Test
+  public void testRoundRobinReplicationWithRackAwarenessPatterns() {
+    for (Tuple2<Integer, List<WorkerInfo>> tuple :
+        Arrays.asList(
+            // This is a specific case we analyzed which results in degenerate behavior with
+            // replicas
+            // with the earlier implementation
+            Tuple2.apply(
+                100,
+                Arrays.asList(
+                    // h1r1, h2r1, h3r1, h4r2, h5r2, h6r2
+                    WorkersSupplier.initWorker("h1r1", "/rack/r1"),
+                    WorkersSupplier.initWorker("h2r1", "/rack/r1"),
+                    WorkersSupplier.initWorker("h3r1", "/rack/r1"),
+                    WorkersSupplier.initWorker("h4r2", "/rack/r2"),
+                    WorkersSupplier.initWorker("h5r2", "/rack/r2"),
+                    WorkersSupplier.initWorker("h6r2", "/rack/r2"))),
+            // This is a specific case we observed in production which resulted
+            // in suboptimal replica selection
+            Tuple2.apply(
+                20,
+                Arrays.asList(
+                    // h1r2, h4r2, h3r1, h1r1, h4r1, h2r1, h3r2, h2r2, h5r2, h5r1
+                    WorkersSupplier.initWorker("h1r2", "/rack/r2"),
+                    WorkersSupplier.initWorker("h4r2", "/rack/r2"),
+                    WorkersSupplier.initWorker("h3r1", "/rack/r1"),
+                    WorkersSupplier.initWorker("h1r1", "/rack/r1"),
+                    WorkersSupplier.initWorker("h4r1", "/rack/r1"),
+                    WorkersSupplier.initWorker("h2r1", "/rack/r1"),
+                    WorkersSupplier.initWorker("h3r2", "/rack/r2"),
+                    WorkersSupplier.initWorker("h2r2", "/rack/r2"),
+                    WorkersSupplier.initWorker("h5r2", "/rack/r2"),
+                    WorkersSupplier.initWorker("h5r1", "/rack/r1"))))) {
+
+      int numPartitions = tuple._1();
+      List<WorkerInfo> workers = tuple._2();
+      int maxReplicaCount = (numPartitions / workers.size()) + 1;
+      List<Integer> partitionIds =
+          IntStream.range(0, numPartitions).boxed().collect(Collectors.toList());
+
+      Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
+          SlotsAllocator.offerSlotsRoundRobin(
+              workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK);
+
+      Map<String, Long> numReplicaPerHost =
+          slots.entrySet().stream()
+              .flatMap(v -> v.getValue()._2.stream().map(PartitionLocation::getHost))
+              .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+      for (String host : workers.stream().map(WorkerInfo::host).collect(Collectors.toList())) {
+        long numReplicas = numReplicaPerHost.getOrDefault(host, 0L);
+        assert numReplicas <= maxReplicaCount
+            : "host = "
+                + host
+                + ", numReplicaPerHost = "
+                + numReplicaPerHost
+                + ", slots = "
+                + slots;
+      }
+    }
+  }
+
+  @Test
+  public void testRackAwareRoundRobinReplicaDistribution() {
+
+    List<SlotReplicaAllocatorTestCase> allTests = getSlotReplicaAllocatorTestCases();
+
+    for (final SlotReplicaAllocatorTestCase test : allTests) {
+
+      final int numPartitions = test.getNumPartitions();
+      long maxValue = Long.MIN_VALUE;
+      List<WorkerInfo> maxValueWorkers = null;
+      Map<String, Long> maxValueNumReplicaPerHost = null;
+      List<Integer> partitionIds =
+          Collections.unmodifiableList(
+              IntStream.range(0, numPartitions).boxed().collect(Collectors.toList()));
+
+      // For each test, run NUM_ATTEMPTS times and pick the worst case.
+      for (int attempt = 0; attempt < NUM_ATTEMPTS; attempt++) {
+
+        // workers will be randomized
+        List<WorkerInfo> workers = test.generateWorkers();
+
+        Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
+            SlotsAllocator.offerSlotsRoundRobin(
+                workers, partitionIds, true, true, StorageInfo.ALL_TYPES_AVAILABLE_MASK);
+
+        // Ensure there is sufficient diversity of hosts. Earlier implementation would result in
+        // only picking h1r1 and h4r2 for the replica - except for the first few cases
+        Map<String, Long> numReplicaPerHost =
+            slots.entrySet().stream()
+                .flatMap(v -> v.getValue()._2.stream().map(PartitionLocation::getHost))
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        Comparator<Map.Entry<String, Long>> entryComparator =
+            Comparator.comparingLong(Map.Entry::getValue);
+
+        Map.Entry<String, Long> maxEntry =
+            Collections.max(numReplicaPerHost.entrySet(), entryComparator);
+
+        // expected
+        assert (null != maxEntry);
+
+        if (maxEntry.getValue() > maxValue) {
+          maxValue = maxEntry.getValue();
+          maxValueWorkers = workers;
+          maxValueNumReplicaPerHost = numReplicaPerHost;
+        }
+      }
+
+      assert (null != maxValueWorkers);
+
+      for (String host :
+          maxValueWorkers.stream().map(WorkerInfo::host).collect(Collectors.toList())) {
+        long numReplicas = maxValueNumReplicaPerHost.getOrDefault(host, 0L);
+        assert numReplicas <= test.getExpectedMaxSlotsPerHost()
+            : "host = "
+                + host
+                + ", workerHosts = "
+                + maxValueWorkers.stream().map(WorkerInfo::host).collect(Collectors.toList())
+                + ", replicaHosts = "
+                + SlotsAllocator.generateWorkersListForRackAwareReplication(maxValueWorkers)
+                    .stream()
+                    .map(WorkerInfo::host)
+                    .collect(Collectors.toList())
+                + ", numReplicaPerHost = "
+                + maxValueNumReplicaPerHost
+                + ", test = "
+                + test;
+      }
+    }
+  }
+
+  private static List<SlotReplicaAllocatorTestCase> getSlotReplicaAllocatorTestCases() {
+    List<SlotReplicaAllocatorTestCase> equalHostsPerRackTests =
+        // equal number of hosts per rack
+        Arrays.asList(
+            new SlotReplicaAllocatorTestCase(5, 2, 50),
+            new SlotReplicaAllocatorTestCase(5, 2, 100),
+            new SlotReplicaAllocatorTestCase(5, 2, 200),
+            new SlotReplicaAllocatorTestCase(5, 2, 1000),
+            new SlotReplicaAllocatorTestCase(5, 2, 10000),
+            new SlotReplicaAllocatorTestCase(5, 2, 50000),
+            new SlotReplicaAllocatorTestCase(5, 3, 50),
+            new SlotReplicaAllocatorTestCase(5, 3, 100),
+            new SlotReplicaAllocatorTestCase(5, 3, 200),
+            new SlotReplicaAllocatorTestCase(5, 3, 1000),
+            new SlotReplicaAllocatorTestCase(5, 3, 10000),
+            new SlotReplicaAllocatorTestCase(5, 3, 50000),
+            new SlotReplicaAllocatorTestCase(10, 5, 200),
+            new SlotReplicaAllocatorTestCase(10, 5, 1000),
+            new SlotReplicaAllocatorTestCase(10, 5, 10000),
+            new SlotReplicaAllocatorTestCase(10, 5, 50000),
+            new SlotReplicaAllocatorTestCase(20, 10, 1000),
+            new SlotReplicaAllocatorTestCase(20, 10, 10000),
+            new SlotReplicaAllocatorTestCase(20, 10, 50000));
+
+    List<SlotReplicaAllocatorTestCase> unequalHostsPerRackTests =
+        Arrays.asList(
+            // specified number of hosts per rack
+            new SlotReplicaAllocatorTestCase(Arrays.asList(3, 7), 50),
+            new SlotReplicaAllocatorTestCase(Arrays.asList(3, 7), 100),
+            new SlotReplicaAllocatorTestCase(Arrays.asList(3, 7), 200),
+            new SlotReplicaAllocatorTestCase(Arrays.asList(3, 7), 1000),
+            new SlotReplicaAllocatorTestCase(Arrays.asList(3, 7), 10000),
+            new SlotReplicaAllocatorTestCase(Arrays.asList(3, 7), 50000),
+            new SlotReplicaAllocatorTestCase(Arrays.asList(2, 3, 5), 100),
+            new SlotReplicaAllocatorTestCase(Arrays.asList(2, 3, 5), 50000),
+            new SlotReplicaAllocatorTestCase(Arrays.asList(2, 3, 5, 5, 10), 100),
+            new SlotReplicaAllocatorTestCase(Arrays.asList(2, 3, 5, 5, 10), 50000));
+
+    List<SlotReplicaAllocatorTestCase> allTests = new ArrayList<>();
+    allTests.addAll(equalHostsPerRackTests);
+    allTests.addAll(unequalHostsPerRackTests);
+    return allTests;
+  }
+
+  private static class WorkersSupplier implements Supplier<List<WorkerInfo>> {
+    private static final Random RAND = new Random(42);
+
+    private final List<WorkerInfo> workerList;
+
+    WorkersSupplier(int numHostsPerRack, int numRacks) {
+      this(false, equalHostsPerRackWorkers(numHostsPerRack, numRacks));
+    }
+
+    WorkersSupplier(List<Integer> hostsPerRack) {
+      this(false, specifiedHostsPerRackWorkers(hostsPerRack));
+    }
+
+    @SuppressWarnings({"unused"})
+    private WorkersSupplier(boolean unused, List<WorkerInfo> workerList) {
+      this.workerList = Collections.unmodifiableList(workerList);
+    }
+
+    private static List<WorkerInfo> equalHostsPerRackWorkers(int numHostsPerRack, int numRacks) {
+      List<WorkerInfo> workers = new ArrayList<>(numRacks * numHostsPerRack);
+      for (int rack = 1; rack <= numRacks; rack++) {
+        final String rackName = "/rack/r" + rack;
+        for (int host = 1; host <= numHostsPerRack; host++) {
+          final String hostName = "h" + host + "r" + rack;
+          workers.add(initWorker(hostName, rackName));
+        }
+      }
+      return workers;
+    }
+
+    private static List<WorkerInfo> specifiedHostsPerRackWorkers(List<Integer> hostsPerRack) {
+      List<WorkerInfo> workers = new ArrayList<>();
+
+      int rack = 0;
+      for (int numHosts : hostsPerRack) {
+        rack++;
+        final String rackName = "/rack/r" + rack;
+        for (int host = 1; host <= numHosts; host++) {
+          final String hostName = "h" + host + "r" + rack;
+          workers.add(initWorker(hostName, rackName));
+        }
+      }
+
+      return workers;
+    }
+
+    @Override
+    public List<WorkerInfo> get() {
+      List<WorkerInfo> result = new ArrayList<>(workerList);
+      Collections.shuffle(result, RAND);
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return "WorkersSupplier{"
+          + "workerList="
+          + workerList.stream().map(WorkerInfo::host).collect(Collectors.toList())
+          + '}';
+    }
+
+    private static WorkerInfo initWorker(String host, String rack) {
+      long assumedPartitionSize = 64 * 1024 * 1024;
+      DiskInfo diskInfo = new DiskInfo("/mnt/a", 1024L * 1024L * 1024L * 1024L, 1, 1, 0);
+      diskInfo.maxSlots_$eq(diskInfo.actualUsableSpace() / assumedPartitionSize);
+
+      Map<String, DiskInfo> diskInfoMap = new HashMap<>(2);
+      diskInfoMap.put(diskInfo.mountPoint(), diskInfo);
+
+      WorkerInfo workerInfo =
+          new WorkerInfo(host, 1, 2, 3, 4, Collections.unmodifiableMap(diskInfoMap), null);
+      workerInfo.networkLocation_$eq(rack);
+      return workerInfo;
+    }
+  }
+
+  private static class SlotReplicaAllocatorTestCase {
+
+    private final Supplier<List<WorkerInfo>> workersSupplier;
+    // Total number of partitions
+    private final int numPartitions;
+
+    // The maximum number of slots per replica we are expecting
+    private final int expectedMaxSlotsPerHost;
+
+    SlotReplicaAllocatorTestCase(int numHostsPerRack, int numRacks, int numPartitions) {
+      this(
+          new WorkersSupplier(numHostsPerRack, numRacks),
+          numPartitions,
+          (int) Math.ceil(((double) numPartitions) / (numHostsPerRack * numRacks)));
+    }
+
+    SlotReplicaAllocatorTestCase(List<Integer> hostsPerRack, int numPartitions) {
+      this(
+          new WorkersSupplier(hostsPerRack),
+          numPartitions,
+          // 1 + (maxHostsPerRack * numPartitions) / (minHostsPerRack * totalHosts)
+          (int)
+              Math.ceil(
+                  ((double) Collections.max(hostsPerRack) * numPartitions)
+                          / (Collections.min(hostsPerRack)
+                              * hostsPerRack.stream().mapToInt(Integer::intValue).sum())
+                      + 1));
+    }
+
+    private SlotReplicaAllocatorTestCase(
+        Supplier<List<WorkerInfo>> workersSupplier,
+        int numPartitions,
+        int expectedMaxSlotsPerHost) {
+      this.workersSupplier = workersSupplier;
+      this.numPartitions = numPartitions;
+      this.expectedMaxSlotsPerHost = expectedMaxSlotsPerHost;
+    }
+
+    public int getNumPartitions() {
+      return numPartitions;
+    }
+
+    public int getExpectedMaxSlotsPerHost() {
+      return expectedMaxSlotsPerHost;
+    }
+
+    public List<WorkerInfo> generateWorkers() {
+      return workersSupplier.get();
+    }
+
+    @Override
+    public String toString() {
+      return "SlotReplicaAllocatorTestCase{"
+          + "workersSupplier="
+          + workersSupplier
+          + ", numPartitions="
+          + numPartitions
+          + ", expectedMaxSlotsPerHost="
+          + expectedMaxSlotsPerHost
+          + '}';
+    }
   }
 }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
@@ -270,8 +270,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
                 + ", workerHosts = "
                 + maxValueWorkers.stream().map(WorkerInfo::host).collect(Collectors.toList())
                 + ", replicaHosts = "
-                + SlotsAllocator.generateRackAwareWorkers(maxValueWorkers)
-                    .stream()
+                + SlotsAllocator.generateRackAwareWorkers(maxValueWorkers).stream()
                     .map(WorkerInfo::host)
                     .collect(Collectors.toList())
                 + ", numReplicaPerHost = "

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
@@ -409,16 +409,21 @@ public class SlotsAllocatorRackAwareSuiteJ {
     }
 
     SlotReplicaAllocatorTestCase(List<Integer> hostsPerRack, int numPartitions) {
-      this(
-          new WorkersSupplier(hostsPerRack),
-          numPartitions,
-          // 1 + (maxHostsPerRack * numPartitions) / (minHostsPerRack * totalHosts)
+      Collections.sort(hostsPerRack);
+      int maxHostsPerRack = hostsPerRack.get(hostsPerRack.size() - 1);
+      int secondMaxHostsPerRack = hostsPerRack.get(hostsPerRack.size() - 2);
+      int totalHosts = hostsPerRack.stream().mapToInt(Integer::intValue).sum();
+      int expected =
           (int)
               Math.ceil(
-                  ((double) Collections.max(hostsPerRack) * numPartitions)
-                          / (Collections.min(hostsPerRack)
-                              * hostsPerRack.stream().mapToInt(Integer::intValue).sum())
-                      + 1));
+                  ((double) (numPartitions)
+                      / totalHosts
+                      * (1
+                          + ((double) (maxHostsPerRack - secondMaxHostsPerRack + 1))
+                              / (totalHosts - maxHostsPerRack))));
+      this.workersSupplier = new WorkersSupplier(hostsPerRack);
+      this.numPartitions = numPartitions;
+      this.expectedMaxSlotsPerHost = expected;
     }
 
     SlotReplicaAllocatorTestCase(

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorRackAwareSuiteJ.java
@@ -270,7 +270,7 @@ public class SlotsAllocatorRackAwareSuiteJ {
                 + ", workerHosts = "
                 + maxValueWorkers.stream().map(WorkerInfo::host).collect(Collectors.toList())
                 + ", replicaHosts = "
-                + SlotsAllocator.generateWorkersListForRackAwareReplication(maxValueWorkers)
+                + SlotsAllocator.generateRackAwareWorkers(maxValueWorkers)
                     .stream()
                     .map(WorkerInfo::host)
                     .collect(Collectors.toList())


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As detailed in the jira, this improves replica selection when rack awareness is enabled.
There are primarily two changes:

* Change the distribution of workers in the input workers list so that there is maximum rack diversity between elements in the list.
* Change round robin implementation to independently select replica - instead of based on primary.


### Why are the changes needed?

In our productionization testing environment, we saw disproportionate amount of traffic to a small set of nodes when rack awareness was enabled - which resulted in bringing down the overall throughput of the entire deployment - as all celeborn traffic gets bottlenecked on a small set of nodes.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

This was extensively tested in our environment and validated to improve the overall performance. Note, this is againts a modified version of 0.3, but the specific changes touch parts of master which have not been updated since.
In addition unit tests pass as well.
