### PR TITLE
[CELEBORN-1113][FOLLOWUP] Bump Hadoop client version from 3.2.4 to 3.3.6

### DIFF
--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -953,7 +953,8 @@ object MRClientProjects {
         copyDepsSettings,
         libraryDependencies ++= Seq(
           "org.apache.hadoop" % "hadoop-client-minicluster" % Dependencies.hadoopVersion % "test",
-          "org.apache.hadoop" % "hadoop-mapreduce-examples" % Dependencies.hadoopVersion % "test"
+          "org.apache.hadoop" % "hadoop-mapreduce-examples" % Dependencies.hadoopVersion % "test",
+          "org.bouncycastle" % "bcpkix-jdk15on" % "1.68" % "test"
         ) ++ commonUnitTestDependencies
       )
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
https://github.com/apache/incubator-celeborn/pull/2077#issuecomment-1835701576


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
