### PR TITLE
[MINOR] Update log level of ChunkFetchSuccess failed for `FetchHandler#handleChunkFetchRequest` from error to warn

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -381,7 +381,7 @@ class FetchHandler(
                   s"Sending ChunkFetchSuccess operation succeeded, chunk $streamChunkSlice")
               }
             } else {
-              logError(
+              logWarning(
                 s"Sending ChunkFetchSuccess operation failed, chunk $streamChunkSlice",
                 future.cause())
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update log level of sending ChunkFetchSuccess operation failed for `FetchHandler#handleChunkFetchRequest` from error to warn.

### Why are the changes needed?

The log level of sending ChunkFetchSuccess operation failed for `FetchHandler#handleChunkFetchRequest` is warn enough, because sending ChunkFetchSuccess operation failed doen not take much effect.

```
| 2023-12-04 13:33:07.393 | - | 2023-12-04 13:33:07,375 [ERROR] [fetch-server-11-20] - org.apache.celeborn.service.deploy.worker.FetchHandler -Logging.scala(80) -Sending ChunkFetchSuccess operation failed, chunk StreamChunkSlice{streamId=578269344491, chunkIndex=2, offset=0, len=2147483647}

| 2023-12-04 13:23:48.546 | - | 2023-12-04 13:23:48,448 [ERROR] [fetch-server-11-34] - org.apache.celeborn.service.deploy.worker.FetchHandler -Logging.scala(80) -Sending ChunkFetchSuccess operation failed, chunk StreamChunkSlice{streamId=1211783796302, chunkIndex=22, offset=0, len=2147483647}

| 2023-12-04 13:14:23.164 | - | 2023-12-04 13:14:23,080 [ERROR] [fetch-server-11-31] - org.apache.celeborn.service.deploy.worker.FetchHandler -Logging.scala(80) -Sending ChunkFetchSuccess operation failed, chunk StreamChunkSlice{streamId=143400144965, chunkIndex=0, offset=0, len=2147483647}

| 2023-12-04 13:14:23.119 | - | 2023-12-04 13:14:23,079 [ERROR] [fetch-server-11-8] - org.apache.celeborn.service.deploy.worker.FetchHandler -Logging.scala(80) -Sending ChunkFetchSuccess operation failed, chunk StreamChunkSlice{streamId=2016474250418, chunkIndex=1, offset=0, len=2147483647}

| 2023-12-04 13:05:38.157 | - | 2023-12-04 13:05:38,145 [ERROR] [fetch-server-11-18] - org.apache.celeborn.service.deploy.worker.FetchHandler -Logging.scala(80) -Sending ChunkFetchSuccess operation failed, chunk StreamChunkSlice{streamId=786116367486, chunkIndex=2, offset=0, len=2147483647}

| 2023-12-04 13:05:34.162 | - | 2023-12-04 13:05:34,112 [ERROR] [fetch-server-11-3] - org.apache.celeborn.service.deploy.worker.FetchHandler -Logging.scala(80) -Sending ChunkFetchSuccess operation failed, chunk StreamChunkSlice{streamId=1942979937404, chunkIndex=1, offset=0, len=2147483647}

| 2023-12-04 13:03:53.660 | - | 2023-12-04 13:03:53,585 [ERROR] [fetch-server-11-24] - org.apache.celeborn.service.deploy.worker.FetchHandler -Logging.scala(80) -Sending ChunkFetchSuccess operation failed, chunk StreamChunkSlice{streamId=1897602579272, chunkIndex=3, offset=0, len=2147483647}

| 2023-12-04 12:46:28.090 | - | 2023-12-04 12:46:28,039 [ERROR] [fetch-server-11-42] - org.apache.celeborn.service.deploy.worker.FetchHandler -Logging.scala(80) -Sending ChunkFetchSuccess operation failed, chunk StreamChunkSlice{streamId=1018072081537, chunkIndex=1, offset=0, len=2147483647}
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.