### PR TITLE
[CELEBORN-1156][BUILD] SBT publish support

### DIFF
--- a/docs/developers/sbt.md
+++ b/docs/developers/sbt.md
@@ -286,21 +286,19 @@ SBT supports publishing shade clients (Spark/Flink/MapReduce) to an internal Mav
 
 Before executing the publish command, ensure that the following environment variables are correctly set:
 
-| Environment Variable   | Description                                                                                                                      |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| SONATYPE_HOST          | Sonatype repository host address, default is "oss.sonatype.org"                                                                  |
-| SONATYPE_USERNAME      | Sonatype repository username                                                                                                     |
-| SONATYPE_PASSWORD      | Sonatype repository password                                                                                                     |
-| SONATYPE_SNAPSHOTS_URL | Sonatype repository URL for snapshot version releases, default is "https://oss.sonatype.org/content/repositories/snapshots"      |
-| SONATYPE_RELEASES_URL  | Sonatype repository URL for official release versions, default is "https://oss.sonatype.org/service/local/staging/deploy/maven2" |
+| Environment Variable   | Description                                                                                                                           |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| ASF_USERNAME           | Sonatype repository username                                                                                                          |
+| ASF_PASSWORD           | Sonatype repository password                                                                                                          |
+| SONATYPE_SNAPSHOTS_URL | Sonatype repository URL for snapshot version releases, default is "https://repository.apache.org/content/repositories/snapshots"      |
+| SONATYPE_RELEASES_URL  | Sonatype repository URL for official release versions, default is "https://repository.apache.org/service/local/staging/deploy/maven2" |
 
 For example:
 ```shell
 export SONATYPE_SNAPSHOTS_URL=http://192.168.3.46:8081/repository/maven-snapshots/
 export SONATYPE_RELEASES_URL=http://192.168.3.46:8081/repository/maven-releases/
-export SONATYPE_HOST=192.168.3.46
-export SONATYPE_USERNAME=admin
-export SONATYPE_PASSWORD=123456
+export ASF_USERNAME=admin
+export ASF_PASSWORD=123456
 ```
 
 Publish the shade client for Spark 3.5:

--- a/docs/developers/sbt.md
+++ b/docs/developers/sbt.md
@@ -279,3 +279,43 @@ Similarly, if your objective involves compiling and packaging within an intranet
 ```
 
 For more details on sbt repository configuration, please refer to the [SBT documentation](https://www.scala-sbt.org/1.x/docs/Proxy-Repositories.html).
+
+## Publish
+
+SBT supports publishing shade clients (Spark/Flink/MapReduce) to an internal Maven private repository, such as [Sonatype Nexus](https://www.sonatype.com/) or [JFrog](https://jfrog.com/help/r/jfrog-artifactory-documentation/maven-repository).
+
+Before executing the publish command, ensure that the following environment variables are correctly set:
+
+| Environment Variable   | Description                                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| SONATYPE_HOST          | Sonatype repository host address, default is "oss.sonatype.org"                                                                  |
+| SONATYPE_USERNAME      | Sonatype repository username                                                                                                     |
+| SONATYPE_PASSWORD      | Sonatype repository password                                                                                                     |
+| SONATYPE_SNAPSHOTS_URL | Sonatype repository URL for snapshot version releases, default is "https://oss.sonatype.org/content/repositories/snapshots"      |
+| SONATYPE_RELEASES_URL  | Sonatype repository URL for official release versions, default is "https://oss.sonatype.org/service/local/staging/deploy/maven2" |
+
+For example:
+```shell
+export SONATYPE_SNAPSHOTS_URL=http://192.168.3.46:8081/repository/maven-snapshots/
+export SONATYPE_RELEASES_URL=http://192.168.3.46:8081/repository/maven-releases/
+export SONATYPE_HOST=192.168.3.46
+export SONATYPE_USERNAME=admin
+export SONATYPE_PASSWORD=123456
+```
+
+Publish the shade client for Spark 3.5:
+```shell
+$ ./build/sbt -Pspark-3.5 celeborn-client-spark-3-shaded/publish
+```
+
+Publish the shade client for Flink 1.18:
+```shell
+$ ./build/sbt -Pflink-1.18 celeborn-client-flink-1_18-shaded/publish
+```
+
+Publish the shade client for MapReduce:
+```shell
+$ ./build/sbt -Pmr celeborn-client-mr-shaded/publish
+```
+
+Make sure to complete the necessary build and testing before executing the publish commands.

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -350,8 +350,6 @@ object Utils {
     require(ALL_SCALA_VERSIONS.contains(v), s"found not allow scala version: $v")
     v
   }
-
-
 }
 
 object CelebornCommon {

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -218,6 +218,39 @@ object CelebornCommonSettings {
     Test / envVars += ("IS_TESTING", "1")
   )
 
+  /*
+   ********************
+   * Release settings *
+   ********************
+   */
+
+  lazy val releaseSettings = Seq(
+    publishMavenStyle := true,
+    publishArtifact := true,
+    Test / publishArtifact := false,
+    credentials += Credentials(
+      "Sonatype Nexus Repository Manager",
+      sys.env.getOrElse("SONATYPE_HOST", ""),
+      sys.env.getOrElse("SONATYPE_USERNAME", ""),
+      sys.env.getOrElse("SONATYPE_PASSWORD", "")
+    ),
+    publishTo := {
+      // val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value) {
+        Some(("snapshots" at sys.env.getOrElse("SONATYPE_SNAPSHOTS_URL", "")).withAllowInsecureProtocol(true))
+      } else {
+        Some(("releases"  at sys.env.getOrElse("SONATYPE_RELEASES_URL", "")).withAllowInsecureProtocol(true))
+      }
+    },
+    licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
+      pomExtra :=
+        <url>https://celeborn.apache.org/</url>
+        <scm>
+          <url>git@github.com:apache/incubator-celeborn.git</url>
+          <connection>scm:git:git@github.com:apache/incubator-celeborn.git</connection>
+        </scm>
+  )
+
   lazy val protoSettings = Seq(
     // Setting version for the protobuf compiler
     PB.protocVersion := Dependencies.protocVersion,
@@ -675,6 +708,7 @@ trait SparkClientProjects {
       .dependsOn(sparkClient)
       .settings (
         commonSettings,
+        releaseSettings,
 
         // align final shaded jar name with maven.
         (assembly / assemblyJarName) := {
@@ -879,6 +913,7 @@ trait FlinkClientProjects {
       .dependsOn(flinkClient)
       .settings (
         commonSettings,
+        releaseSettings,
 
         (assembly / test) := { },
 
@@ -975,6 +1010,7 @@ object MRClientProjects {
       .dependsOn(mrClient)
       .settings(
         commonSettings,
+        releaseSettings,
 
         // align final shaded jar name with maven.
         (assembly / assemblyJarName) := {

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -230,7 +230,7 @@ object CelebornCommonSettings {
     Test / publishArtifact := false,
     credentials += Credentials(
       "Sonatype Nexus Repository Manager",
-      sys.env.getOrElse("SONATYPE_HOST", ""),
+      sys.env.getOrElse("SONATYPE_HOST", "oss.sonatype.org"),
       sys.env.getOrElse("SONATYPE_USERNAME", ""),
       sys.env.getOrElse("SONATYPE_PASSWORD", "")
     ),

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -218,11 +218,9 @@ object CelebornCommonSettings {
     Test / envVars += ("IS_TESTING", "1")
   )
 
-  /*
-   ********************
-   * Release settings *
-   ********************
-   */
+  ////////////////////////////////////////////////////////
+  //                 Release settings                   //
+  ////////////////////////////////////////////////////////
 
   lazy val releaseSettings = Seq(
     publishMavenStyle := true,
@@ -845,13 +843,6 @@ trait FlinkClientProjects {
   //   1.14.6 -> 1.14
   lazy val flinkMajorVersion: String = flinkVersion.split("\\.").take(2).reduce(_ + "." + _)
 
-  // the output would be something like: celeborn-client-flink-1.17_2.12-0.4.0-SNAPSHOT.jar
-  def flinkClientJarName(
-      module: ModuleID,
-      artifact: Artifact,
-      scalaBinaryVersionString: String): String =
-    s"celeborn-client-flink-${flinkMajorVersion}_$scalaBinaryVersionString" + "-" + module.revision + "." + artifact.extension
-
   // the output would be something like: celeborn-client-flink-1.17-shaded_2.12-0.4.0-SNAPSHOT.jar
   def flinkClientShadeJarName(
       revision: String,
@@ -876,12 +867,7 @@ trait FlinkClientProjects {
       .settings (
         commonSettings,
 
-        // 1. reference for modifying the jar name.
-        // https://stackoverflow.com/questions/52771831/how-to-modify-jar-name-generate-by-cmd-sbt-package
-        // 2. since SBT doesn't allow using `.` in the project name, explicitly setting the artifact Name
-        artifactName := { (sv: ScalaVersion, module: ModuleID, artifact: Artifact) =>
-          flinkClientJarName(module, artifact, scalaBinaryVersion.value)
-        },
+        moduleName := s"celeborn-client-flink-$flinkMajorVersion",
 
         libraryDependencies ++= Seq(
           "org.apache.flink" % "flink-runtime" % flinkVersion % "provided",

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -760,7 +760,8 @@ trait SparkClientProjects {
           case "META-INF/native/libnetty_transport_native_epoll_x86_64.so" => CustomMergeStrategy.rename( _ => "META-INF/native/liborg_apache_celeborn_shaded_netty_transport_native_epoll_x86_64.so" )
           case "META-INF/native/libnetty_transport_native_epoll_aarch_64.so" => CustomMergeStrategy.rename( _ => "META-INF/native/liborg_apache_celeborn_shaded_netty_transport_native_epoll_aarch_64.so" )
           case _ => MergeStrategy.first
-        }
+        },
+        addArtifact(assembly / artifact, assembly)
       )
     if (includeColumnarShuffle) {
         p.dependsOn(sparkColumnarShuffle)
@@ -917,6 +918,8 @@ trait FlinkClientProjects {
         commonSettings,
         releaseSettings,
 
+        moduleName := s"celeborn-client-flink-$flinkMajorVersion-shaded",
+
         (assembly / test) := { },
 
         (assembly / assemblyJarName) := {
@@ -965,7 +968,8 @@ trait FlinkClientProjects {
           case "META-INF/native/libnetty_transport_native_epoll_x86_64.so" => CustomMergeStrategy.rename( _ => "META-INF/native/liborg_apache_celeborn_shaded_netty_transport_native_epoll_x86_64.so" )
           case "META-INF/native/libnetty_transport_native_epoll_aarch_64.so" => CustomMergeStrategy.rename( _ => "META-INF/native/liborg_apache_celeborn_shaded_netty_transport_native_epoll_aarch_64.so" )
           case _ => MergeStrategy.first
-        }
+        },
+        addArtifact(assembly / artifact, assembly)
       )
   }
 }
@@ -1067,7 +1071,8 @@ object MRClientProjects {
           case "META-INF/native/libnetty_transport_native_epoll_x86_64.so" => CustomMergeStrategy.rename(_ => "META-INF/native/liborg_apache_celeborn_shaded_netty_transport_native_epoll_x86_64.so")
           case "META-INF/native/libnetty_transport_native_epoll_aarch_64.so" => CustomMergeStrategy.rename(_ => "META-INF/native/liborg_apache_celeborn_shaded_netty_transport_native_epoll_aarch_64.so")
           case _ => MergeStrategy.first
-        }
+        },
+        addArtifact(assembly / artifact, assembly)
       )
   }
 

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -235,8 +235,8 @@ object CelebornCommonSettings {
       Credentials(
         "Sonatype Nexus Repository Manager",
         host,
-        sys.env.getOrElse("SONATYPE_USERNAME", ""),
-        sys.env.getOrElse("SONATYPE_PASSWORD", "")),
+        sys.env.getOrElse("ASF_USERNAME", ""),
+        sys.env.getOrElse("ASF_PASSWORD", "")),
     },
     publishTo := {
       if (isSnapshot.value) {

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -235,11 +235,13 @@ object CelebornCommonSettings {
       sys.env.getOrElse("SONATYPE_PASSWORD", "")
     ),
     publishTo := {
-      // val nexus = "https://oss.sonatype.org/"
+      val nexus = "https://oss.sonatype.org/"
       if (isSnapshot.value) {
-        Some(("snapshots" at sys.env.getOrElse("SONATYPE_SNAPSHOTS_URL", "")).withAllowInsecureProtocol(true))
+        val snapshotUrl = sys.env.getOrElse("SONATYPE_SNAPSHOTS_URL", nexus + "content/repositories/snapshots")
+        Some(("snapshots" at snapshotUrl).withAllowInsecureProtocol(true))
       } else {
-        Some(("releases"  at sys.env.getOrElse("SONATYPE_RELEASES_URL", "")).withAllowInsecureProtocol(true))
+        val releaseUrl = sys.env.getOrElse("SONATYPE_RELEASES_URL", nexus + "service/local/staging/deploy/maven2")
+        Some(("releases" at releaseUrl).withAllowInsecureProtocol(true))
       }
     },
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -247,7 +247,7 @@ object CelebornCommonSettings {
         Some(("releases" at publishUrl).withAllowInsecureProtocol(true))
       }
     },
-    licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
+    licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0")),
       pomExtra :=
         <url>https://celeborn.apache.org/</url>
         <scm>

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=1.9.7
+sbt.version=1.9.4

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=1.9.4
+sbt.version=1.9.7


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?

As title

### Does this PR introduce _any_ user-facing change?

Yes, the user can publish shade clients via SBT

### How was this patch tested?

```shell
docker run -d -p 8081:8081 sonatype/nexus3
```

```shell
export SONATYPE_SNAPSHOTS_URL=http://192.168.3.46:8081/repository/maven-snapshots/
export SONATYPE_RELEASES_URL=http://192.168.3.46:8081/repository/maven-releases/
export ASF_USERNAME=admin
export ASF_PASSWORD=123456
```

- Publish the shade client for Spark 3.5:
```shell
./build/sbt -Pspark-3.4 celeborn-client-spark-3-shaded/publish
```

<img width="1673" alt="截屏2023-12-08 下午10 22 07" src="https://github.com/apache/incubator-celeborn/assets/8537877/1e87e7e2-cf3b-4bc0-8272-0f5b03ee65bf">

- Publish the shade client for Flink 1.18:

```shell
$ ./build/sbt -Pflink-1.18 celeborn-client-flink-1_18-shaded/publish
```
<img width="1676" alt="截屏2023-12-08 下午10 25 28" src="https://github.com/apache/incubator-celeborn/assets/8537877/62d0c3c4-e105-4e8a-8d8d-e78650a2eb09">

- Publish the shade client for MapReduce:
```shell
$ ./build/sbt -Pmr celeborn-client-mr-shaded/publish
```
<img width="1672" alt="截屏2023-12-08 下午10 25 47" src="https://github.com/apache/incubator-celeborn/assets/8537877/563d5ad5-fa6d-46fc-9465-8279ef96385a">


