### PR TITLE
open stream asynchronously

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/DfsPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/DfsPartitionReader.java
@@ -85,6 +85,7 @@ public class DfsPartitionReader implements PartitionReader {
     final List<Long> chunkOffsets = new ArrayList<>();
     if (endMapIndex != Integer.MAX_VALUE) {
       long fetchTimeoutMs = conf.clientFetchTimeoutMs();
+      long openStreamInterval = conf.clientOpenStreamRetryInterval();
       try {
         client = clientFactory.createClient(location.getHost(), location.getFetchPort());
         TransportMessage openStream =
@@ -97,7 +98,7 @@ public class DfsPartitionReader implements PartitionReader {
                     .setEndIndex(endMapIndex)
                     .build()
                     .toByteArray());
-        ByteBuffer response = client.sendRpcSync(openStream.toByteBuffer(), fetchTimeoutMs);
+        ByteBuffer response = client.openStream(openStream, fetchTimeoutMs, openStreamInterval);
         streamHandler = TransportMessage.fromByteBuffer(response).getParsedPayload();
         // Parse this message to ensure sort is done.
       } catch (IOException | InterruptedException e) {

--- a/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/LocalPartitionReader.java
@@ -92,6 +92,7 @@ public class LocalPartitionReader implements PartitionReader {
     this.location = location;
     this.metricsCallback = metricsCallback;
     long fetchTimeoutMs = conf.clientFetchTimeoutMs();
+    long openStreamInterval = conf.clientOpenStreamRetryInterval();
     try {
       client = clientFactory.createClient(location.getHost(), location.getFetchPort(), 0);
       TransportMessage openStreamMsg =
@@ -105,7 +106,7 @@ public class LocalPartitionReader implements PartitionReader {
                   .setReadLocalShuffle(true)
                   .build()
                   .toByteArray());
-      ByteBuffer response = client.sendRpcSync(openStreamMsg.toByteBuffer(), fetchTimeoutMs);
+      ByteBuffer response = client.openStream(openStreamMsg, fetchTimeoutMs, openStreamInterval);
       streamHandler = TransportMessage.fromByteBuffer(response).getParsedPayload();
     } catch (IOException | InterruptedException e) {
       throw new IOException(

--- a/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
@@ -62,6 +62,7 @@ public class WorkerPartitionReader implements PartitionReader {
   private final AtomicReference<IOException> exception = new AtomicReference<>();
   private final int fetchMaxReqsInFlight;
   private final long fetchTimeoutMs;
+  private final long openStreamRetryInterval;
   private boolean closed = false;
 
   // for test
@@ -83,6 +84,7 @@ public class WorkerPartitionReader implements PartitionReader {
     fetchMaxReqsInFlight = conf.clientFetchMaxReqsInFlight();
     results = new LinkedBlockingQueue<>();
     fetchTimeoutMs = conf.clientFetchTimeoutMs();
+    openStreamRetryInterval = conf.clientOpenStreamRetryInterval();
     this.metricsCallback = metricsCallback;
     // only add the buffer to results queue if this reader is not closed.
     callback =
@@ -123,7 +125,7 @@ public class WorkerPartitionReader implements PartitionReader {
                 .setEndIndex(endMapIndex)
                 .build()
                 .toByteArray());
-    ByteBuffer response = client.sendRpcSync(openStreamMsg.toByteBuffer(), fetchTimeoutMs);
+    ByteBuffer response = client.openStream(openStreamMsg, fetchTimeoutMs, openStreamRetryInterval);
     streamHandler = TransportMessage.fromByteBuffer(response).getParsedPayload();
 
     this.location = location;

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -794,6 +794,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   //               Shuffle Client Fetch                  //
   // //////////////////////////////////////////////////////
   def clientFetchTimeoutMs: Long = get(CLIENT_FETCH_TIMEOUT)
+  def clientOpenStreamRetryInterval = get(CLIENT_OPENSTREAM_RETRY_INTERVAL)
   def clientFetchBufferSize: Int = get(CLIENT_FETCH_BUFFER_SIZE).toInt
   def clientFetchMaxReqsInFlight: Int = get(CLIENT_FETCH_MAX_REQS_IN_FLIGHT)
   def clientFetchMaxRetriesForEachReplica: Int = get(CLIENT_FETCH_MAX_RETRIES_FOR_EACH_REPLICA)
@@ -3300,6 +3301,14 @@ object CelebornConf extends Logging {
       .doc("Timeout for a task to open stream and fetch chunk.")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("600s")
+
+  val CLIENT_OPENSTREAM_RETRY_INTERVAL: ConfigEntry[Long] =
+    buildConf("celeborn.client.openStream.retry.interval")
+      .categories("client")
+      .version("0.4.0")
+      .doc("open stream asynchronously")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("5s")
 
   val CLIENT_FETCH_BUFFER_SIZE: ConfigEntry[Long] =
     buildConf("celeborn.client.fetch.buffer.size")

--- a/common/src/main/scala/org/apache/celeborn/common/exception/FileUnderSortingException.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/exception/FileUnderSortingException.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.exception
+
+class FileUnderSortingException(message: String)
+  extends CelebornException(message)

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -42,6 +42,7 @@ license: |
 | celeborn.client.flink.resultPartition.minMemory | 8m | Min memory reserved for a result partition. | 0.3.0 | 
 | celeborn.client.flink.resultPartition.supportFloatingBuffer | true | Whether to support floating buffer for result partitions. | 0.3.0 | 
 | celeborn.client.mr.pushData.max | 32m | Max size for a push data sent from mr client. | 0.4.0 | 
+| celeborn.client.openStream.retry.interval | 5s | open stream asynchronously | 0.4.0 | 
 | celeborn.client.push.buffer.initial.size | 8k |  | 0.3.0 | 
 | celeborn.client.push.buffer.max.size | 64k | Max size of reducer partition buffer memory for shuffle hash writer. The pushed data will be buffered in memory before sending to Celeborn worker. For performance consideration keep this buffer size higher than 32K. Example: If reducer amount is 2000, buffer size is 64K, then each task will consume up to `64KiB * 2000 = 125MiB` heap memory. | 0.3.0 | 
 | celeborn.client.push.excludeWorkerOnFailure.enabled | false | Whether to enable shuffle client-side push exclude workers on failures. | 0.3.0 | 

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.exception.CelebornException;
+import org.apache.celeborn.common.exception.FileUnderSortingException;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.network.TransportContext;
@@ -136,7 +137,7 @@ public class FileWriterSuiteJ {
     MemoryManager.initialize(conf);
   }
 
-  public static void setupChunkServer(FileInfo info) throws IOException {
+  public static void setupChunkServer(FileInfo info) throws IOException, FileUnderSortingException {
     FetchHandler handler =
         new FetchHandler(transConf.getCelebornConf(), transConf, mock(WorkerSource.class)) {
           @Override

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/FileWriterSuiteJ.java
@@ -215,8 +215,20 @@ public class FileWriterSuiteJ {
     return message.toByteBuffer();
   }
 
+  public TransportMessage createOpenStreamMessage() {
+    return new TransportMessage(
+        MessageType.OPEN_STREAM,
+        PbOpenStream.newBuilder()
+            .setShuffleKey("shuffleKey")
+            .setFileName("location")
+            .setStartIndex(0)
+            .setEndIndex(Integer.MAX_VALUE)
+            .build()
+            .toByteArray());
+  }
+
   private void setUpConn(TransportClient client) throws IOException, CelebornException {
-    ByteBuffer resp = client.sendRpcSync(createOpenMessage(), 10000);
+    ByteBuffer resp = client.openStream(createOpenStreamMessage(), 10000, 5000);
     PbStreamHandler streamHandler = TransportMessage.fromByteBuffer(resp).getParsedPayload();
     streamId = streamHandler.getStreamId();
     numChunks = streamHandler.getNumChunks();

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorterSuiteJ.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.exception.FileUnderSortingException;
 import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.FileInfo;
 import org.apache.celeborn.common.unsafe.Platform;
@@ -132,7 +133,8 @@ public class PartitionFilesSorterSuiteJ {
     JavaUtils.deleteRecursively(new File(shuffleFile.getPath() + ".index"));
   }
 
-  private void check(int mapCount, int startMapIndex, int endMapIndex) throws IOException {
+  private void check(int mapCount, int startMapIndex, int endMapIndex)
+      throws IOException, FileUnderSortingException {
     try {
       long[] partitionSize = prepare(mapCount);
       CelebornConf conf = new CelebornConf();
@@ -160,14 +162,14 @@ public class PartitionFilesSorterSuiteJ {
   }
 
   @Test
-  public void testSmallFile() throws IOException {
+  public void testSmallFile() throws IOException, FileUnderSortingException {
     int startMapIndex = random.nextInt(5);
     int endMapIndex = startMapIndex + random.nextInt(5) + 5;
     check(1000, startMapIndex, endMapIndex);
   }
 
   @Test
-  public void testLargeFile() throws IOException {
+  public void testLargeFile() throws IOException, FileUnderSortingException {
     int startMapIndex = random.nextInt(5);
     int endMapIndex = startMapIndex + random.nextInt(5) + 5;
     check(15000, startMapIndex, endMapIndex);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
When there is a long-term file sorting operation in Woker, if many reducer will read this sorted files, the fetch thread will be occupied by a large number of openstream requests while it waiting sort operation finish, resulting in the fetch chunk request being blocked. This PR mainly modifies the openstream process to achieve asynchronous completion of openstream even file sorting occurs.


### Why are the changes needed?
both client and worker 


### Does this PR introduce _any_ user-facing change?

Prevent fetch threads from being occupied by openstream requests for a long time



