### PR TITLE
[CELEBORN-1152] fix GetShuffleId RPC NPE for empty shuffle

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1629,6 +1629,10 @@ public class ShuffleClientImpl extends ShuffleClient {
       int endMapIndex,
       MetricsCallback metricsCallback)
       throws IOException {
+    if (partitionId == Utils$.MODULE$.UNKNOWN_APP_SHUFFLE_ID()) {
+      logger.warn("Shuffle data is empty for shuffle {}: UNKNOWN_APP_SHUFFLE_ID.", shuffleId);
+      return CelebornInputStream.empty();
+    }
     ReduceFileGroups fileGroups = loadFileGroup(shuffleId, partitionId);
 
     if (fileGroups.partitionGroups.isEmpty()

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -48,6 +48,7 @@ import org.apache.celeborn.common.rpc.netty.{LocalNettyRpcCallContext, RemoteNet
 import org.apache.celeborn.common.util.{JavaUtils, PbSerDeUtils, ThreadUtils, Utils}
 // Can Remove this if celeborn don't support scala211 in future
 import org.apache.celeborn.common.util.FunctionConverter._
+import org.apache.celeborn.common.util.Utils.UNKNOWN_APP_SHUFFLE_ID
 
 object LifecycleManager {
   // shuffle id -> partition id -> partition locations
@@ -82,7 +83,6 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     JavaUtils.newConcurrentHashMap[Int, ConcurrentHashMap[Int, PartitionLocation]]()
   private val userIdentifier: UserIdentifier = IdentityProvider.instantiate(conf).provide()
   private val availableStorageTypes = conf.availableStorageTypes
-  private val UNKNOWN_APP_SHUFFLE_ID = -1
   // app shuffle id -> LinkedHashMap of (app shuffle identifier, (shuffle id, fetch status))
   private val shuffleIdMapping = JavaUtils.newConcurrentHashMap[
     Int,

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -1020,6 +1020,8 @@ object Utils extends Logging {
   val SUFFIX_HDFS_WRITE_SUCCESS = ".success"
   val COMPATIBLE_HDFS_REGEX = "^[a-zA-Z0-9]+://.*"
 
+  val UNKNOWN_APP_SHUFFLE_ID = -1
+
   def isHdfsPath(path: String): Boolean = {
     path.matches(COMPATIBLE_HDFS_REGEX)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

In [celeborn-955](https://github.com/apache/incubator-celeborn/pull/1924),  GetShuffleId RPC was introduced to generate a celeborn shuffle id from app shuffle id to support spark stage rerun
GetShuffleId RPC assumes that Shuffle Write operation always happens before Shuffle Read operation, but this is not true for empty shuffle data in celeborn, which causes GetShuffleId RPC to throw NPE and fail the Job
This PR fixes this bug

### Why are the changes needed?
to avoid spark job failure with empty shuffle data


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
a new test case is included for empty shuffle data
