### PR TITLE
[CELEBORN-1153] Reuse thread pool for RPC in lifecycle manager

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/CommitManager.scala
@@ -119,7 +119,8 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
                         ThreadUtils.parmap(
                           workerToRequests,
                           "CommitFiles",
-                          parallelism) {
+                          parallelism,
+                          lifecycleManager.sharedRPCThreadPool) {
                           case (worker, requests) =>
                             val workerInfo =
                               lifecycleManager.shuffleAllocatedWorkers
@@ -277,13 +278,15 @@ class CommitManager(appUniqueId: String, val conf: CelebornConf, lifecycleManage
               conf,
               lifecycleManager.shuffleAllocatedWorkers,
               committedPartitionInfo,
-              lifecycleManager.workerStatusTracker)
+              lifecycleManager.workerStatusTracker,
+              lifecycleManager.sharedRPCThreadPool)
           case PartitionType.MAP => new MapPartitionCommitHandler(
               appUniqueId,
               conf,
               lifecycleManager.shuffleAllocatedWorkers,
               committedPartitionInfo,
-              lifecycleManager.workerStatusTracker)
+              lifecycleManager.workerStatusTracker,
+              lifecycleManager.sharedRPCThreadPool)
           case _ => throw new UnsupportedOperationException(
               s"Unexpected ShufflePartitionType for CommitManager: $partitionType")
         }

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -497,7 +497,11 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     // Second, for each worker, try to initialize the endpoint.
     val parallelism = Math.min(Math.max(1, slots.size()), conf.clientRpcMaxParallelism)
 
-    ThreadUtils.parmap(slots.asScala.filter(_._1.endpoint == null), "InitWorkerRef", parallelism) {
+    ThreadUtils.parmap(
+      slots.asScala.filter(_._1.endpoint == null),
+      "InitWorkerRef",
+      parallelism,
+      sharedRPCThreadPool) {
       case (workerInfo, _) =>
         try {
           workerInfo.endpoint =

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -20,7 +20,7 @@ package org.apache.celeborn.client
 import java.nio.ByteBuffer
 import java.util
 import java.util.{function, List => JList}
-import java.util.concurrent.{Callable, ConcurrentHashMap, ScheduledFuture, TimeUnit}
+import java.util.concurrent.{Callable, ConcurrentHashMap, ScheduledFuture, ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Consumer
 
@@ -93,7 +93,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     .maximumSize(rpcCacheSize)
     .build().asInstanceOf[Cache[Int, ByteBuffer]]
 
-  private val sharedRPCThreadPool =
+  val sharedRPCThreadPool: Option[ThreadPoolExecutor] =
     if (conf.clientRPCThreadPoolShare) {
       Option.apply(ThreadUtils.newDaemonCachedThreadPool(
         "LifecycleManager-shared-reserveSlot-pool",

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -93,12 +93,12 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     .maximumSize(rpcCacheSize)
     .build().asInstanceOf[Cache[Int, ByteBuffer]]
 
-  private val reserveSlotThreadPool =
-    if (conf.clientReserveSlotsThreadPoolShare) {
+  private val sharedRPCThreadPool =
+    if (conf.clientRPCThreadPoolShare) {
       Option.apply(ThreadUtils.newDaemonCachedThreadPool(
         "LifecycleManager-shared-reserveSlot-pool",
-        conf.clientReserveSlotsThreadPoolMax,
-        conf.clientReserveSlotsThreadPoolIdleTime.asInstanceOf[Int]))
+        conf.clientRPCThreadPoolMax,
+        conf.clientRPCThreadPoolIdleTime.asInstanceOf[Int]))
     } else {
       Option.empty
     }
@@ -741,7 +741,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       workerPartitionLocations,
       "ReserveSlot",
       parallelism,
-      reserveSlotThreadPool) {
+      sharedRPCThreadPool) {
       case (workerInfo, (primaryLocations, replicaLocations)) =>
         val res =
           if (workerInfo.endpoint == null) {

--- a/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/MapPartitionCommitHandler.scala
@@ -19,7 +19,7 @@ package org.apache.celeborn.client.commit
 
 import java.util
 import java.util.Collections
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.{ConcurrentHashMap, ThreadPoolExecutor}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
@@ -52,8 +52,14 @@ class MapPartitionCommitHandler(
     conf: CelebornConf,
     shuffleAllocatedWorkers: ShuffleAllocatedWorkers,
     committedPartitionInfo: CommittedPartitionInfo,
-    workerStatusTracker: WorkerStatusTracker)
-  extends CommitHandler(appId, conf, committedPartitionInfo, workerStatusTracker)
+    workerStatusTracker: WorkerStatusTracker,
+    sharedRPCThreadPool: Option[ThreadPoolExecutor])
+  extends CommitHandler(
+    appId,
+    conf,
+    committedPartitionInfo,
+    workerStatusTracker,
+    sharedRPCThreadPool)
   with Logging {
 
   private val shuffleSucceedPartitionIds = JavaUtils.newConcurrentHashMap[Int, util.Set[Integer]]()

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -19,7 +19,7 @@ package org.apache.celeborn.client.commit
 
 import java.nio.ByteBuffer
 import java.util
-import java.util.concurrent.{Callable, ConcurrentHashMap, TimeUnit}
+import java.util.concurrent.{Callable, ConcurrentHashMap, ThreadPoolExecutor, TimeUnit}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -51,8 +51,14 @@ class ReducePartitionCommitHandler(
     conf: CelebornConf,
     shuffleAllocatedWorkers: ShuffleAllocatedWorkers,
     committedPartitionInfo: CommittedPartitionInfo,
-    workerStatusTracker: WorkerStatusTracker)
-  extends CommitHandler(appUniqueId, conf, committedPartitionInfo, workerStatusTracker)
+    workerStatusTracker: WorkerStatusTracker,
+    sharedRPCThreadPool: Option[ThreadPoolExecutor])
+  extends CommitHandler(
+    appUniqueId,
+    conf,
+    committedPartitionInfo,
+    workerStatusTracker,
+    sharedRPCThreadPool)
   with Logging {
 
   private val getReducerFileGroupRequest =

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -4037,7 +4037,7 @@ object CelebornConf extends Logging {
     buildConf("celeborn.client.rpc.threadPool.share")
       .categories("client")
       .doc("" +
-        "whether to share thread pool for processing RPCs in lifecycle manager.")
+        "whether to share thread pool for processing RPC in lifecycle manager.")
       .version("0.3.2")
       .booleanConf
       .createWithDefault(true)
@@ -4045,7 +4045,7 @@ object CelebornConf extends Logging {
   val CLIENT_RPC_THREADPOOL_MAX: ConfigEntry[Int] =
     buildConf("celeborn.client.rpc.threadPool.max")
       .categories("client")
-      .doc("The max thread number for thread pool to reserve slots.")
+      .doc("The max thread number for thread pool to process RPC.")
       .version("0.3.2")
       .intConf
       .createWithDefault(256)
@@ -4053,7 +4053,7 @@ object CelebornConf extends Logging {
   val CLIENT_RPC_THREADPOOL_IDLETIME: ConfigEntry[Long] =
     buildConf("celeborn.client.rpc.threadPool.idleTime")
       .categories("client")
-      .doc("The max idle time for a thread in thread pool to be freed.")
+      .doc("The max idle time for a thread in the shared RPC thread pool to be freed.")
       .version("0.3.2")
       .timeConf(TimeUnit.SECONDS)
       .createWithDefaultString("30s")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1068,6 +1068,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(CLIENT_RESULT_PARTITION_SUPPORT_FLOATING_BUFFER)
   def clientFlinkDataCompressionEnabled: Boolean = get(CLIENT_DATA_COMPRESSION_ENABLED)
   def clientShuffleMapPartitionSplitEnabled = get(CLIENT_SHUFFLE_MAPPARTITION_SPLIT_ENABLED)
+  def clientReserveSlotsThreadPoolShare = get(CLIENT_RESERVESLOTS_THREADPOOL_SHARE)
+  def clientReserveSlotsThreadPoolMax = get(CLIENT_RESERVESLOTS_THREADPOOL_MAX)
+  def clientReserveSlotsThreadPoolIdleTime = get(CLIENT_RESERVESLOTS_THREADPOOL_IDLETIME)
 
   // //////////////////////////////////////////////////////
   //                    kerberos                         //
@@ -4029,6 +4032,31 @@ object CelebornConf extends Logging {
       .version("0.3.1")
       .booleanConf
       .createWithDefault(false)
+
+  val CLIENT_RESERVESLOTS_THREADPOOL_SHARE: ConfigEntry[Boolean] =
+    buildConf("celeborn.client.reserveSlots.threadPool.share")
+      .categories("client")
+      .doc("" +
+        "whther to share thread pool in reserve slots.")
+      .version("0.3.2")
+      .booleanConf
+      .createWithDefault(false)
+
+  val CLIENT_RESERVESLOTS_THREADPOOL_MAX: ConfigEntry[Int] =
+    buildConf("celeborn.client.reserveSlots.threadPool.max")
+      .categories("client")
+      .doc("The max thread number for thread pool to reserve slots.")
+      .version("0.3.2")
+      .intConf
+      .createWithDefault(512)
+
+  val CLIENT_RESERVESLOTS_THREADPOOL_IDLETIME: ConfigEntry[Long] =
+    buildConf("celeborn.client.reserveSlots.threadPool.idleTime")
+      .categories("client")
+      .doc("The max idle time for a thread in thread pool to be freeed.")
+      .version("0.3.2")
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefaultString("30s")
 
   val MAX_DEFAULT_NETTY_THREADS: ConfigEntry[Int] =
     buildConf("celeborn.io.maxDefaultNettyThreads")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1068,9 +1068,9 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(CLIENT_RESULT_PARTITION_SUPPORT_FLOATING_BUFFER)
   def clientFlinkDataCompressionEnabled: Boolean = get(CLIENT_DATA_COMPRESSION_ENABLED)
   def clientShuffleMapPartitionSplitEnabled = get(CLIENT_SHUFFLE_MAPPARTITION_SPLIT_ENABLED)
-  def clientReserveSlotsThreadPoolShare = get(CLIENT_RESERVESLOTS_THREADPOOL_SHARE)
-  def clientReserveSlotsThreadPoolMax = get(CLIENT_RESERVESLOTS_THREADPOOL_MAX)
-  def clientReserveSlotsThreadPoolIdleTime = get(CLIENT_RESERVESLOTS_THREADPOOL_IDLETIME)
+  def clientRPCThreadPoolShare = get(CLIENT_RPC_THREADPOOL_SHARE)
+  def clientRPCThreadPoolMax = get(CLIENT_RPC_THREADPOOL_MAX)
+  def clientRPCThreadPoolIdleTime = get(CLIENT_RPC_THREADPOOL_IDLETIME)
 
   // //////////////////////////////////////////////////////
   //                    kerberos                         //
@@ -4033,27 +4033,27 @@ object CelebornConf extends Logging {
       .booleanConf
       .createWithDefault(false)
 
-  val CLIENT_RESERVESLOTS_THREADPOOL_SHARE: ConfigEntry[Boolean] =
-    buildConf("celeborn.client.reserveSlots.threadPool.share")
+  val CLIENT_RPC_THREADPOOL_SHARE: ConfigEntry[Boolean] =
+    buildConf("celeborn.client.rpc.threadPool.share")
       .categories("client")
       .doc("" +
-        "whther to share thread pool in reserve slots.")
+        "whether to share thread pool for processing RPCs in lifecycle manager.")
       .version("0.3.2")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
-  val CLIENT_RESERVESLOTS_THREADPOOL_MAX: ConfigEntry[Int] =
-    buildConf("celeborn.client.reserveSlots.threadPool.max")
+  val CLIENT_RPC_THREADPOOL_MAX: ConfigEntry[Int] =
+    buildConf("celeborn.client.rpc.threadPool.max")
       .categories("client")
       .doc("The max thread number for thread pool to reserve slots.")
       .version("0.3.2")
       .intConf
-      .createWithDefault(512)
+      .createWithDefault(256)
 
-  val CLIENT_RESERVESLOTS_THREADPOOL_IDLETIME: ConfigEntry[Long] =
-    buildConf("celeborn.client.reserveSlots.threadPool.idleTime")
+  val CLIENT_RPC_THREADPOOL_IDLETIME: ConfigEntry[Long] =
+    buildConf("celeborn.client.rpc.threadPool.idleTime")
       .categories("client")
-      .doc("The max idle time for a thread in thread pool to be freeed.")
+      .doc("The max idle time for a thread in thread pool to be freed.")
       .version("0.3.2")
       .timeConf(TimeUnit.SECONDS)
       .createWithDefaultString("30s")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -73,9 +73,6 @@ license: |
 | celeborn.client.reserveSlots.maxRetries | 3 | Max retry times for client to reserve slots. | 0.3.0 | 
 | celeborn.client.reserveSlots.rackaware.enabled | false | Whether need to place different replicates on different racks when allocating slots. | 0.3.1 | 
 | celeborn.client.reserveSlots.retryWait | 3s | Wait time before next retry if reserve slots failed. | 0.3.0 | 
-| celeborn.client.reserveSlots.threadPool.idleTime | 30s | The max idle time for a thread in thread pool to be freeed. | 0.3.2 | 
-| celeborn.client.reserveSlots.threadPool.max | 512 | The max thread number for thread pool to reserve slots. | 0.3.2 | 
-| celeborn.client.reserveSlots.threadPool.share | false | whther to share thread pool in reserve slots. | 0.3.2 | 
 | celeborn.client.rpc.cache.concurrencyLevel | 32 | The number of write locks to update rpc cache. | 0.3.0 | 
 | celeborn.client.rpc.cache.expireTime | 15s | The time before a cache item is removed. | 0.3.0 | 
 | celeborn.client.rpc.cache.size | 256 | The max cache items count for rpc cache. | 0.3.0 | 
@@ -84,6 +81,9 @@ license: |
 | celeborn.client.rpc.registerShuffle.askTimeout | &lt;value of celeborn.&lt;module&gt;.io.connectionTimeout&gt; | Timeout for ask operations during register shuffle. During this process, there are two times for retry opportunities for requesting slots, one request for establishing a connection with Worker and `celeborn.client.reserveSlots.maxRetries` times for retry opportunities for reserving slots. User can customize this value according to your setting. By default, the value is the max timeout value `celeborn.<module>.io.connectionTimeout`. | 0.3.0 | 
 | celeborn.client.rpc.requestPartition.askTimeout | &lt;value of celeborn.&lt;module&gt;.io.connectionTimeout&gt; | Timeout for ask operations during requesting change partition location, such as reviving or splitting partition. During this process, there are `celeborn.client.reserveSlots.maxRetries` times for retry opportunities for reserving slots. User can customize this value according to your setting. By default, the value is the max timeout value `celeborn.<module>.io.connectionTimeout`. | 0.2.0 | 
 | celeborn.client.rpc.reserveSlots.askTimeout | &lt;value of celeborn.rpc.askTimeout&gt; | Timeout for LifecycleManager request reserve slots. | 0.3.0 | 
+| celeborn.client.rpc.threadPool.idleTime | 30s | The max idle time for a thread in thread pool to be freed. | 0.3.2 | 
+| celeborn.client.rpc.threadPool.max | 256 | The max thread number for thread pool to reserve slots. | 0.3.2 | 
+| celeborn.client.rpc.threadPool.share | true | whether to share thread pool for processing RPCs in lifecycle manager. | 0.3.2 | 
 | celeborn.client.shuffle.batchHandleChangePartition.interval | 100ms | Interval for LifecycleManager to schedule handling change partition requests in batch. | 0.3.0 | 
 | celeborn.client.shuffle.batchHandleChangePartition.threads | 8 | Threads number for LifecycleManager to handle change partition request in batch. | 0.3.0 | 
 | celeborn.client.shuffle.batchHandleCommitPartition.interval | 5s | Interval for LifecycleManager to schedule handling commit partition requests in batch. | 0.3.0 | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -73,6 +73,9 @@ license: |
 | celeborn.client.reserveSlots.maxRetries | 3 | Max retry times for client to reserve slots. | 0.3.0 | 
 | celeborn.client.reserveSlots.rackaware.enabled | false | Whether need to place different replicates on different racks when allocating slots. | 0.3.1 | 
 | celeborn.client.reserveSlots.retryWait | 3s | Wait time before next retry if reserve slots failed. | 0.3.0 | 
+| celeborn.client.reserveSlots.threadPool.idleTime | 30s | The max idle time for a thread in thread pool to be freeed. | 0.3.2 | 
+| celeborn.client.reserveSlots.threadPool.max | 512 | The max thread number for thread pool to reserve slots. | 0.3.2 | 
+| celeborn.client.reserveSlots.threadPool.share | false | whther to share thread pool in reserve slots. | 0.3.2 | 
 | celeborn.client.rpc.cache.concurrencyLevel | 32 | The number of write locks to update rpc cache. | 0.3.0 | 
 | celeborn.client.rpc.cache.expireTime | 15s | The time before a cache item is removed. | 0.3.0 | 
 | celeborn.client.rpc.cache.size | 256 | The max cache items count for rpc cache. | 0.3.0 | 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -81,9 +81,9 @@ license: |
 | celeborn.client.rpc.registerShuffle.askTimeout | &lt;value of celeborn.&lt;module&gt;.io.connectionTimeout&gt; | Timeout for ask operations during register shuffle. During this process, there are two times for retry opportunities for requesting slots, one request for establishing a connection with Worker and `celeborn.client.reserveSlots.maxRetries` times for retry opportunities for reserving slots. User can customize this value according to your setting. By default, the value is the max timeout value `celeborn.<module>.io.connectionTimeout`. | 0.3.0 | 
 | celeborn.client.rpc.requestPartition.askTimeout | &lt;value of celeborn.&lt;module&gt;.io.connectionTimeout&gt; | Timeout for ask operations during requesting change partition location, such as reviving or splitting partition. During this process, there are `celeborn.client.reserveSlots.maxRetries` times for retry opportunities for reserving slots. User can customize this value according to your setting. By default, the value is the max timeout value `celeborn.<module>.io.connectionTimeout`. | 0.2.0 | 
 | celeborn.client.rpc.reserveSlots.askTimeout | &lt;value of celeborn.rpc.askTimeout&gt; | Timeout for LifecycleManager request reserve slots. | 0.3.0 | 
-| celeborn.client.rpc.threadPool.idleTime | 30s | The max idle time for a thread in thread pool to be freed. | 0.3.2 | 
-| celeborn.client.rpc.threadPool.max | 256 | The max thread number for thread pool to reserve slots. | 0.3.2 | 
-| celeborn.client.rpc.threadPool.share | true | whether to share thread pool for processing RPCs in lifecycle manager. | 0.3.2 | 
+| celeborn.client.rpc.threadPool.idleTime | 30s | The max idle time for a thread in the shared RPC thread pool to be freed. | 0.3.2 | 
+| celeborn.client.rpc.threadPool.max | 256 | The max thread number for thread pool to process RPC. | 0.3.2 | 
+| celeborn.client.rpc.threadPool.share | true | whether to share thread pool for processing RPC in lifecycle manager. | 0.3.2 | 
 | celeborn.client.shuffle.batchHandleChangePartition.interval | 100ms | Interval for LifecycleManager to schedule handling change partition requests in batch. | 0.3.0 | 
 | celeborn.client.shuffle.batchHandleChangePartition.threads | 8 | Threads number for LifecycleManager to handle change partition request in batch. | 0.3.0 | 
 | celeborn.client.shuffle.batchHandleCommitPartition.interval | 5s | Interval for LifecycleManager to schedule handling commit partition requests in batch. | 0.3.0 | 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reuse thread pool in lifecycle manager to reduce total thread number.


### Why are the changes needed?
Too many threads may exhaust the lifecycle manager's memory.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA.
