### PR TITLE
[CELEBORN-1163] Upgrade protobuf from 3.19.2 to 3.21.7

### DIFF
--- a/dev/deps/dependencies-client-flink-1.14
+++ b/dev/deps/dependencies-client-flink-1.14
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-flink-1.15
+++ b/dev/deps/dependencies-client-flink-1.15
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-flink-1.17
+++ b/dev/deps/dependencies-client-flink-1.17
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-flink-1.18
+++ b/dev/deps/dependencies-client-flink-1.18
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -178,7 +178,7 @@ nimbus-jose-jwt/9.8.1//nimbus-jose-jwt-9.8.1.jar
 okhttp/4.9.3//okhttp-4.9.3.jar
 okio/2.8.0//okio-2.8.0.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-spark-2.4
+++ b/dev/deps/dependencies-client-spark-2.4
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-client-spark-3.5
+++ b/dev/deps/dependencies-client-spark-3.5
@@ -71,7 +71,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-proto/2.5.1//ratis-proto-2.5.1.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -78,7 +78,7 @@ netty-transport-sctp/4.1.93.Final//netty-transport-sctp-4.1.93.Final.jar
 netty-transport-udt/4.1.93.Final//netty-transport-udt-4.1.93.Final.jar
 netty-transport/4.1.93.Final//netty-transport-4.1.93.Final.jar
 paranamer/2.8//paranamer-2.8.jar
-protobuf-java/3.19.2//protobuf-java-3.19.2.jar
+protobuf-java/3.21.7//protobuf-java-3.21.7.jar
 ratis-client/2.5.1//ratis-client-2.5.1.jar
 ratis-common/2.5.1//ratis-common-2.5.1.jar
 ratis-grpc/2.5.1//ratis-grpc-2.5.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <mockito.version>4.11.0</mockito.version>
     <mockito-scalatest.version>1.17.14</mockito-scalatest.version>
     <netty.version>4.1.93.Final</netty.version>
-    <protobuf.version>3.19.2</protobuf.version>
+    <protobuf.version>3.21.7</protobuf.version>
     <ratis.version>2.5.1</ratis.version>
     <scalatest.version>3.2.16</scalatest.version>
     <slf4j.version>1.7.36</slf4j.version>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -65,8 +65,8 @@ object Dependencies {
   val snappyVersion = "1.1.10.5"
 
   // Versions for proto
-  val protocVersion = "3.19.2"
-  val protoVersion = "3.19.2"
+  val protocVersion = "3.21.7"
+  val protoVersion = "3.21.7"
   
   val commonsCompress = "org.apache.commons" % "commons-compress" % commonsCompressVersion
   val commonsCrypto = "org.apache.commons" % "commons-crypto" % commonsCryptoVersion excludeAll(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
upgrade protobuf from 3.19.2 to 3.21.7 reducing direct CVE vulnerabilities

### Why are the changes needed?

The protobuf version has the follow CVE vulnerabilities, see
https://scout.docker.com/vulnerabilities/id/CVE-2022-3510
https://scout.docker.com/vulnerabilities/id/CVE-2022-3509
https://scout.docker.com/vulnerabilities/id/CVE-2021-22570
https://scout.docker.com/vulnerabilities/id/CVE-2021-22569

### Does this PR introduce _any_ user-facing change?
No any user-facing change


### How was this patch tested?
`./build/make-distribution.sh` to package and run test on the local.

