### PR TITLE
upgrade snappy-java from 1.1.8.2 to 1.1.10.5

### DIFF
--- a/dev/deps/dependencies-client-flink-1.14
+++ b/dev/deps/dependencies-client-flink-1.14
@@ -81,5 +81,5 @@ scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar

--- a/dev/deps/dependencies-client-flink-1.15
+++ b/dev/deps/dependencies-client-flink-1.15
@@ -81,5 +81,5 @@ scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar

--- a/dev/deps/dependencies-client-flink-1.17
+++ b/dev/deps/dependencies-client-flink-1.17
@@ -81,5 +81,5 @@ scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar

--- a/dev/deps/dependencies-client-flink-1.18
+++ b/dev/deps/dependencies-client-flink-1.18
@@ -81,5 +81,5 @@ scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar

--- a/dev/deps/dependencies-client-mr
+++ b/dev/deps/dependencies-client-mr
@@ -191,7 +191,7 @@ shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 slf4j-reload4j/1.7.36//slf4j-reload4j-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 stax2-api/4.2.1//stax2-api-4.2.1.jar
 token-provider/1.0.1//token-provider-1.0.1.jar
 websocket-api/9.4.51.v20230217//websocket-api-9.4.51.v20230217.jar

--- a/dev/deps/dependencies-client-spark-2.4
+++ b/dev/deps/dependencies-client-spark-2.4
@@ -81,5 +81,5 @@ scala-reflect/2.11.12//scala-reflect-2.11.12.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.4.4-3//zstd-jni-1.4.4-3.jar

--- a/dev/deps/dependencies-client-spark-3.0
+++ b/dev/deps/dependencies-client-spark-3.0
@@ -81,5 +81,5 @@ scala-reflect/2.12.10//scala-reflect-2.12.10.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.4.4-3//zstd-jni-1.4.4-3.jar

--- a/dev/deps/dependencies-client-spark-3.1
+++ b/dev/deps/dependencies-client-spark-3.1
@@ -81,5 +81,5 @@ scala-reflect/2.12.10//scala-reflect-2.12.10.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.4.8-1//zstd-jni-1.4.8-1.jar

--- a/dev/deps/dependencies-client-spark-3.2
+++ b/dev/deps/dependencies-client-spark-3.2
@@ -81,5 +81,5 @@ scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.5.0-4//zstd-jni-1.5.0-4.jar

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -81,5 +81,5 @@ scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5/snappy-java-1.1.10.5.jar
 zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar

--- a/dev/deps/dependencies-client-spark-3.4
+++ b/dev/deps/dependencies-client-spark-3.4
@@ -81,5 +81,5 @@ scala-reflect/2.12.17//scala-reflect-2.12.17.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.5.2-5//zstd-jni-1.5.2-5.jar

--- a/dev/deps/dependencies-client-spark-3.5
+++ b/dev/deps/dependencies-client-spark-3.5
@@ -81,5 +81,5 @@ scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.5.5-4//zstd-jni-1.5.5-4.jar

--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -96,5 +96,5 @@ scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.2//snappy-java-1.1.8.2.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
upgrade snappy-java from 1.1.8.2 to 1.1.10.5 reducing direct CVE vulnerabilities


### Why are the changes needed?
The snappy-java 1.1.8.2 version has the follow CVE vulnerabilities, see
https://scout.docker.com/vulnerabilities/id/CVE-2023-43642
https://scout.docker.com/vulnerabilities/id/CVE-2023-34455

### Does this PR introduce _any_ user-facing change?
No any user-facing change


### How was this patch tested?
`./build/make-distribution.sh` to package and run test on the local