### PR TITLE
[CELEBORN-1168][MASTER] Master should pass wrapped WorkerInfo

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -253,6 +253,10 @@ class WorkerInfo(
     diskInfos.values().asScala.exists(p =>
       p.storageType == StorageInfo.Type.SSD || p.storageType == StorageInfo.Type.HDD)
   }
+
+  def healthyDiskNum(): Long = {
+    diskInfos.values.stream.filter((s) => s.status.equals(DiskStatus.HEALTHY)).count
+  }
 }
 
 object WorkerInfo {

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -254,8 +254,8 @@ class WorkerInfo(
       p.storageType == StorageInfo.Type.SSD || p.storageType == StorageInfo.Type.HDD)
   }
 
-  def healthyDiskNum(): Long = {
-    diskInfos.values.stream.filter((s) => s.status.equals(DiskStatus.HEALTHY)).count
+  def healthyDiskNum(): Int = {
+    diskInfos.values.asScala.count(s => s.status.equals(DiskStatus.HEALTHY))
   }
 }
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -126,13 +126,13 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     workerLostEvents.remove(lostWorker);
   }
 
-  public void updateWorkerRemoveMeta(WorkerInfo lostWorker) {
+  public void updateWorkerRemoveMeta(WorkerInfo workerToRemove) {
     // remove worker from workers
     synchronized (workers) {
-      workers.remove(lostWorker);
-      lostWorkers.put(lostWorker, System.currentTimeMillis());
+      workers.remove(workerToRemove);
+      lostWorkers.put(workerToRemove, System.currentTimeMillis());
     }
-    excludedWorkers.remove(lostWorker);
+    excludedWorkers.remove(workerToRemove);
   }
 
   public void removeWorkersUnavailableInfoMeta(List<WorkerInfo> unavailableWorkers) {

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/IMetadataHandler.java
@@ -20,10 +20,7 @@ package org.apache.celeborn.service.deploy.master.clustermeta;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.celeborn.common.identity.UserIdentifier;
-import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
-import org.apache.celeborn.common.quota.ResourceConsumption;
 
 public interface IMetadataHandler {
   void handleRequestSlots(
@@ -42,36 +39,20 @@ public interface IMetadataHandler {
   void handleWorkerExclude(
       List<WorkerInfo> workersToAdd, List<WorkerInfo> workersToRemove, String requestId);
 
-  void handleWorkerLost(
-      String host, int rpcPort, int pushPort, int fetchPort, int replicatePort, String requestId);
+  void handleWorkerLost(WorkerInfo lostWorker, String requestId);
 
-  void handleWorkerRemove(
-      String host, int rpcPort, int pushPort, int fetchPort, int replicatePort, String requestId);
+  void handleWorkerRemove(WorkerInfo targetWorker, String requestId);
 
   void handleRemoveWorkersUnavailableInfo(List<WorkerInfo> unavailableWorkers, String requestId);
 
   void handleWorkerHeartbeat(
-      String host,
-      int rpcPort,
-      int pushPort,
-      int fetchPort,
-      int replicatePort,
-      Map<String, DiskInfo> disks,
-      Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
+      WorkerInfo workerInfo,
       Map<String, Long> estimatedAppDiskUsage,
       long time,
       boolean highWorkload,
       String requestId);
 
-  void handleRegisterWorker(
-      String host,
-      int rpcPort,
-      int pushPort,
-      int fetchPort,
-      int replicatePort,
-      Map<String, DiskInfo> disks,
-      Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
-      String requestId);
+  void handleRegisterWorker(WorkerInfo workerInfo, String requestId);
 
   void handleReportWorkerUnavailable(List<WorkerInfo> failedNodes, String requestId);
 

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
@@ -24,11 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
-import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.meta.AppDiskUsageMetric;
-import org.apache.celeborn.common.meta.DiskInfo;
 import org.apache.celeborn.common.meta.WorkerInfo;
-import org.apache.celeborn.common.quota.ResourceConsumption;
 import org.apache.celeborn.common.rpc.RpcEnv;
 import org.apache.celeborn.service.deploy.master.network.CelebornRackResolver;
 
@@ -76,15 +73,13 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
   }
 
   @Override
-  public void handleWorkerLost(
-      String host, int rpcPort, int pushPort, int fetchPort, int replicatePort, String requestId) {
-    updateWorkerLostMeta(host, rpcPort, pushPort, fetchPort, replicatePort);
+  public void handleWorkerLost(WorkerInfo lostWorker, String requestId) {
+    updateWorkerLostMeta(lostWorker);
   }
 
   @Override
-  public void handleWorkerRemove(
-      String host, int rpcPort, int pushPort, int fetchPort, int replicatePort, String requestId) {
-    updateWorkerRemoveMeta(host, rpcPort, pushPort, fetchPort, replicatePort);
+  public void handleWorkerRemove(WorkerInfo lostWorker, String requestId) {
+    updateWorkerRemoveMeta(lostWorker);
   }
 
   @Override
@@ -95,42 +90,17 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
 
   @Override
   public void handleWorkerHeartbeat(
-      String host,
-      int rpcPort,
-      int pushPort,
-      int fetchPort,
-      int replicatePort,
-      Map<String, DiskInfo> disks,
-      Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
+      WorkerInfo workerInfo,
       Map<String, Long> estimatedAppDiskUsage,
       long time,
       boolean highWorkload,
       String requestId) {
-    updateWorkerHeartbeatMeta(
-        host,
-        rpcPort,
-        pushPort,
-        fetchPort,
-        replicatePort,
-        disks,
-        userResourceConsumption,
-        estimatedAppDiskUsage,
-        time,
-        highWorkload);
+    updateWorkerHeartbeatMeta(workerInfo, estimatedAppDiskUsage, time, highWorkload);
   }
 
   @Override
-  public void handleRegisterWorker(
-      String host,
-      int rpcPort,
-      int pushPort,
-      int fetchPort,
-      int replicatePort,
-      Map<String, DiskInfo> disks,
-      Map<UserIdentifier, ResourceConsumption> userResourceConsumption,
-      String requestId) {
-    updateRegisterWorkerMeta(
-        host, rpcPort, pushPort, fetchPort, replicatePort, disks, userResourceConsumption);
+  public void handleRegisterWorker(WorkerInfo workerInfo, String requestId) {
+    updateRegisterWorkerMeta(workerInfo);
   }
 
   @Override

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/DefaultMetaSystemSuiteJ.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
+import scala.Option;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,6 +80,10 @@ public class DefaultMetaSystemSuiteJ {
   private static final Map<UserIdentifier, ResourceConsumption> userResourceConsumption3 =
       new HashMap<>();
 
+  private WorkerInfo workerInfo1 = null;
+  private WorkerInfo workerInfo2 = null;
+  private WorkerInfo workerInfo3 = null;
+
   @Before
   public void setUp() {
     when(mockRpcEnv.setupEndpointRef(any(), any())).thenReturn(dummyRef);
@@ -100,6 +106,33 @@ public class DefaultMetaSystemSuiteJ {
     disks3.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
     disks3.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
     disks3.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
+    workerInfo1 =
+        new WorkerInfo(
+            HOSTNAME1,
+            RPCPORT1,
+            PUSHPORT1,
+            FETCHPORT1,
+            REPLICATEPORT1,
+            disks1,
+            userResourceConsumption1);
+    workerInfo2 =
+        new WorkerInfo(
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            disks2,
+            userResourceConsumption2);
+    workerInfo3 =
+        new WorkerInfo(
+            HOSTNAME3,
+            RPCPORT3,
+            PUSHPORT3,
+            FETCHPORT3,
+            REPLICATEPORT3,
+            disks3,
+            userResourceConsumption3);
   }
 
   @After
@@ -111,77 +144,17 @@ public class DefaultMetaSystemSuiteJ {
 
   @Test
   public void testHandleRegisterWorker() {
-
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
     assertEquals(3, statusSystem.workers.size());
   }
 
   @Test
   public void testHandleWorkerExclude() {
-    WorkerInfo workerInfo1 =
-        new WorkerInfo(
-            HOSTNAME1,
-            RPCPORT1,
-            PUSHPORT1,
-            FETCHPORT1,
-            REPLICATEPORT1,
-            disks1,
-            userResourceConsumption1);
-    WorkerInfo workerInfo2 =
-        new WorkerInfo(
-            HOSTNAME2,
-            RPCPORT2,
-            PUSHPORT2,
-            FETCHPORT2,
-            REPLICATEPORT2,
-            disks2,
-            userResourceConsumption2);
-
-    statusSystem.handleRegisterWorker(
-        workerInfo1.host(),
-        workerInfo1.rpcPort(),
-        workerInfo1.pushPort(),
-        workerInfo1.fetchPort(),
-        workerInfo1.replicatePort(),
-        workerInfo1.diskInfos(),
-        workerInfo1.userResourceConsumption(),
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        workerInfo2.host(),
-        workerInfo2.rpcPort(),
-        workerInfo2.pushPort(),
-        workerInfo2.fetchPort(),
-        workerInfo2.replicatePort(),
-        workerInfo2.diskInfos(),
-        workerInfo2.userResourceConsumption(),
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
 
     statusSystem.handleWorkerExclude(
         Arrays.asList(workerInfo1, workerInfo2), Collections.emptyList(), getNewReqeustId());
@@ -194,37 +167,12 @@ public class DefaultMetaSystemSuiteJ {
 
   @Test
   public void testHandleWorkerLost() {
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
-    statusSystem.handleWorkerLost(
-        HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
-    assertEquals(2, statusSystem.workers.size());
+    statusSystem.handleWorkerLost(workerInfo1, getNewReqeustId());
+    assert (statusSystem.workers.size() == 2);
   }
 
   private static final String APPID1 = "appId1";
@@ -233,61 +181,9 @@ public class DefaultMetaSystemSuiteJ {
 
   @Test
   public void testHandleRequestSlots() {
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
-
-    WorkerInfo workerInfo1 =
-        new WorkerInfo(
-            HOSTNAME1,
-            RPCPORT1,
-            PUSHPORT1,
-            FETCHPORT1,
-            REPLICATEPORT1,
-            disks1,
-            userResourceConsumption1);
-    WorkerInfo workerInfo2 =
-        new WorkerInfo(
-            HOSTNAME2,
-            RPCPORT2,
-            PUSHPORT2,
-            FETCHPORT2,
-            REPLICATEPORT2,
-            disks2,
-            userResourceConsumption2);
-    WorkerInfo workerInfo3 =
-        new WorkerInfo(
-            HOSTNAME3,
-            RPCPORT3,
-            PUSHPORT3,
-            FETCHPORT3,
-            REPLICATEPORT3,
-            disks3,
-            userResourceConsumption3);
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation = new HashMap<>();
@@ -304,33 +200,9 @@ public class DefaultMetaSystemSuiteJ {
 
   @Test
   public void testHandleReleaseSlots() {
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
     assertEquals(3, statusSystem.workers.size());
 
@@ -364,52 +236,9 @@ public class DefaultMetaSystemSuiteJ {
 
   @Test
   public void testHandleAppLost() {
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
-
-    WorkerInfo workerInfo1 =
-        new WorkerInfo(
-            HOSTNAME1,
-            RPCPORT1,
-            PUSHPORT1,
-            FETCHPORT1,
-            REPLICATEPORT1,
-            disks1,
-            userResourceConsumption1);
-    WorkerInfo workerInfo2 =
-        new WorkerInfo(
-            HOSTNAME2,
-            RPCPORT2,
-            PUSHPORT2,
-            FETCHPORT2,
-            REPLICATEPORT2,
-            disks2,
-            userResourceConsumption2);
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation = new HashMap<>();
@@ -428,52 +257,9 @@ public class DefaultMetaSystemSuiteJ {
 
   @Test
   public void testHandleUnRegisterShuffle() {
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
-
-    WorkerInfo workerInfo1 =
-        new WorkerInfo(
-            HOSTNAME1,
-            RPCPORT1,
-            PUSHPORT1,
-            FETCHPORT1,
-            REPLICATEPORT1,
-            disks1,
-            userResourceConsumption1);
-    WorkerInfo workerInfo2 =
-        new WorkerInfo(
-            HOSTNAME2,
-            RPCPORT2,
-            PUSHPORT2,
-            FETCHPORT2,
-            REPLICATEPORT2,
-            disks2,
-            userResourceConsumption2);
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation = new HashMap<>();
@@ -505,135 +291,37 @@ public class DefaultMetaSystemSuiteJ {
 
   @Test
   public void testHandleWorkerHeartbeat() {
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        new HashMap<>(),
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        new HashMap<>(),
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        new HashMap<>(),
-        userResourceConsumption3,
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
-    statusSystem.handleWorkerHeartbeat(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        new HashMap<>(),
-        userResourceConsumption1,
-        new HashMap<>(),
-        1,
-        false,
-        getNewReqeustId());
+    workerInfo1.updateThenGetDiskInfos(new HashMap<>(), Option.empty());
+    statusSystem.handleWorkerHeartbeat(workerInfo1, new HashMap<>(), 1, false, getNewReqeustId());
 
     assertEquals(statusSystem.excludedWorkers.size(), 1);
 
-    statusSystem.handleWorkerHeartbeat(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        new HashMap<>(),
-        userResourceConsumption2,
-        new HashMap<>(),
-        1,
-        false,
-        getNewReqeustId());
+    workerInfo2.updateThenGetDiskInfos(new HashMap<>(), Option.empty());
+    statusSystem.handleWorkerHeartbeat(workerInfo2, new HashMap<>(), 1, false, getNewReqeustId());
 
     assertEquals(statusSystem.excludedWorkers.size(), 2);
 
-    statusSystem.handleWorkerHeartbeat(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        new HashMap<>(),
-        1,
-        false,
-        getNewReqeustId());
+    statusSystem.handleWorkerHeartbeat(workerInfo3, new HashMap<>(), 1, false, getNewReqeustId());
 
     assertEquals(statusSystem.excludedWorkers.size(), 2);
 
-    statusSystem.handleWorkerHeartbeat(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        new HashMap<>(),
-        1,
-        true,
-        getNewReqeustId());
+    statusSystem.handleWorkerHeartbeat(workerInfo3, new HashMap<>(), 1, true, getNewReqeustId());
 
     assertEquals(statusSystem.excludedWorkers.size(), 3);
   }
 
   @Test
   public void testHandleReportWorkerFailure() {
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
     List<WorkerInfo> failedWorkers = new ArrayList<>();
-    failedWorkers.add(
-        new WorkerInfo(
-            HOSTNAME1,
-            RPCPORT1,
-            PUSHPORT1,
-            FETCHPORT1,
-            REPLICATEPORT1,
-            disks1,
-            userResourceConsumption1));
+    failedWorkers.add(workerInfo1);
 
     statusSystem.handleReportWorkerUnavailable(failedWorkers, getNewReqeustId());
     assertEquals(1, statusSystem.shutdownWorkers.size());

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
+import scala.Option;
+
 import org.junit.*;
 import org.mockito.Mockito;
 
@@ -217,21 +219,17 @@ public class RatisMasterStatusSystemSuiteJ {
     }
   }
 
+  private WorkerInfo workerInfo1 = null;
+  private WorkerInfo workerInfo2 = null;
+  private WorkerInfo workerInfo3 = null;
+
   @Test
   public void testRaftSystemException() throws Exception {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);
     try {
       stopNoneLeaderRaftServer(RATISSERVER1, RATISSERVER2, RATISSERVER3);
-      statusSystem.handleRegisterWorker(
-          HOSTNAME1,
-          RPCPORT1,
-          PUSHPORT1,
-          FETCHPORT1,
-          REPLICATEPORT1,
-          disks1,
-          userResourceConsumption1,
-          getNewReqeustId());
+      statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
       Assert.fail();
     } catch (CelebornRuntimeException e) {
       Assert.assertTrue(true);
@@ -245,36 +243,11 @@ public class RatisMasterStatusSystemSuiteJ {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);
 
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
     Thread.sleep(3000L);
 
-    Assert.assertEquals(STATUSSYSTEM1.workers.size(), 3);
     Assert.assertEquals(3, STATUSSYSTEM1.workers.size());
     Assert.assertEquals(3, STATUSSYSTEM2.workers.size());
     Assert.assertEquals(3, STATUSSYSTEM3.workers.size());
@@ -285,43 +258,8 @@ public class RatisMasterStatusSystemSuiteJ {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);
 
-    WorkerInfo workerInfo1 =
-        new WorkerInfo(
-            HOSTNAME1,
-            RPCPORT1,
-            PUSHPORT1,
-            FETCHPORT1,
-            REPLICATEPORT1,
-            disks1,
-            userResourceConsumption1);
-    WorkerInfo workerInfo2 =
-        new WorkerInfo(
-            HOSTNAME2,
-            RPCPORT2,
-            PUSHPORT2,
-            FETCHPORT2,
-            REPLICATEPORT2,
-            disks2,
-            userResourceConsumption2);
-
-    statusSystem.handleRegisterWorker(
-        workerInfo1.host(),
-        workerInfo1.rpcPort(),
-        workerInfo1.pushPort(),
-        workerInfo1.fetchPort(),
-        workerInfo1.replicatePort(),
-        workerInfo1.diskInfos(),
-        workerInfo1.userResourceConsumption(),
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        workerInfo2.host(),
-        workerInfo2.rpcPort(),
-        workerInfo2.pushPort(),
-        workerInfo2.fetchPort(),
-        workerInfo2.replicatePort(),
-        workerInfo2.diskInfos(),
-        workerInfo2.userResourceConsumption(),
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
 
     statusSystem.handleWorkerExclude(
         Arrays.asList(workerInfo1, workerInfo2), Collections.emptyList(), getNewReqeustId());
@@ -345,36 +283,11 @@ public class RatisMasterStatusSystemSuiteJ {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);
 
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
-    statusSystem.handleWorkerLost(
-        HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
+    statusSystem.handleWorkerLost(workerInfo1, getNewReqeustId());
     Thread.sleep(3000L);
 
     Assert.assertEquals(2, STATUSSYSTEM1.workers.size());
@@ -387,61 +300,9 @@ public class RatisMasterStatusSystemSuiteJ {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);
 
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
-
-    WorkerInfo workerInfo1 =
-        new WorkerInfo(
-            HOSTNAME1,
-            RPCPORT1,
-            PUSHPORT1,
-            FETCHPORT1,
-            REPLICATEPORT1,
-            disks1,
-            userResourceConsumption1);
-    WorkerInfo workerInfo2 =
-        new WorkerInfo(
-            HOSTNAME2,
-            RPCPORT2,
-            PUSHPORT2,
-            FETCHPORT2,
-            REPLICATEPORT2,
-            disks2,
-            userResourceConsumption2);
-    WorkerInfo workerInfo3 =
-        new WorkerInfo(
-            HOSTNAME3,
-            RPCPORT3,
-            PUSHPORT3,
-            FETCHPORT3,
-            REPLICATEPORT3,
-            disks3,
-            userResourceConsumption3);
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocation1 = new HashMap<>();
@@ -486,33 +347,9 @@ public class RatisMasterStatusSystemSuiteJ {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);
 
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
     Thread.sleep(3000L);
 
     Assert.assertEquals(3, STATUSSYSTEM1.workers.size());
@@ -570,53 +407,12 @@ public class RatisMasterStatusSystemSuiteJ {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);
 
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
     Thread.sleep(3000L);
-    WorkerInfo workerInfo1 =
-        new WorkerInfo(
-            HOSTNAME1,
-            RPCPORT1,
-            PUSHPORT1,
-            FETCHPORT1,
-            REPLICATEPORT1,
-            disks1,
-            userResourceConsumption1);
-    WorkerInfo workerInfo2 =
-        new WorkerInfo(
-            HOSTNAME2,
-            RPCPORT2,
-            PUSHPORT2,
-            FETCHPORT2,
-            REPLICATEPORT2,
-            disks2,
-            userResourceConsumption2);
+
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocations = new HashMap<>();
     allocations.put("disk1", 5);
@@ -643,52 +439,9 @@ public class RatisMasterStatusSystemSuiteJ {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);
 
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
-
-    WorkerInfo workerInfo1 =
-        new WorkerInfo(
-            HOSTNAME1,
-            RPCPORT1,
-            PUSHPORT1,
-            FETCHPORT1,
-            REPLICATEPORT1,
-            disks1,
-            userResourceConsumption1);
-    WorkerInfo workerInfo2 =
-        new WorkerInfo(
-            HOSTNAME2,
-            RPCPORT2,
-            PUSHPORT2,
-            FETCHPORT2,
-            REPLICATEPORT2,
-            disks2,
-            userResourceConsumption2);
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
     Map<String, Map<String, Integer>> workersToAllocate = new HashMap<>();
     Map<String, Integer> allocations = new HashMap<>();
@@ -741,64 +494,20 @@ public class RatisMasterStatusSystemSuiteJ {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);
 
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
-    statusSystem.handleWorkerHeartbeat(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        new HashMap<>(),
-        userResourceConsumption1,
-        new HashMap<>(),
-        1,
-        false,
-        getNewReqeustId());
+    workerInfo1.updateThenGetDiskInfos(new HashMap<>(), Option.empty());
+    statusSystem.handleWorkerHeartbeat(workerInfo1, new HashMap<>(), 1, false, getNewReqeustId());
     Thread.sleep(3000L);
 
     Assert.assertEquals(1, STATUSSYSTEM1.excludedWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM3.excludedWorkers.size());
 
-    statusSystem.handleWorkerHeartbeat(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        new HashMap<>(),
-        userResourceConsumption2,
-        new HashMap<>(),
-        1,
-        false,
-        getNewReqeustId());
+    workerInfo2.updateThenGetDiskInfos(new HashMap<>(), Option.empty());
+    statusSystem.handleWorkerHeartbeat(workerInfo2, new HashMap<>(), 1, false, getNewReqeustId());
     Thread.sleep(3000L);
 
     Assert.assertEquals(2, statusSystem.excludedWorkers.size());
@@ -806,18 +515,9 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(2, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM3.excludedWorkers.size());
 
-    statusSystem.handleWorkerHeartbeat(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        new HashMap<>(),
-        1,
-        false,
-        getNewReqeustId());
+    workerInfo1.updateThenGetDiskInfos(disks1, Option.empty());
+
+    statusSystem.handleWorkerHeartbeat(workerInfo1, new HashMap<>(), 1, false, getNewReqeustId());
     Thread.sleep(3000L);
 
     Assert.assertEquals(1, statusSystem.excludedWorkers.size());
@@ -825,18 +525,7 @@ public class RatisMasterStatusSystemSuiteJ {
     Assert.assertEquals(1, STATUSSYSTEM2.excludedWorkers.size());
     Assert.assertEquals(1, STATUSSYSTEM3.excludedWorkers.size());
 
-    statusSystem.handleWorkerHeartbeat(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        new HashMap<>(),
-        1,
-        true,
-        getNewReqeustId());
+    statusSystem.handleWorkerHeartbeat(workerInfo1, new HashMap<>(), 1, true, getNewReqeustId());
     Thread.sleep(3000L);
     Assert.assertEquals(2, statusSystem.excludedWorkers.size());
     Assert.assertEquals(2, STATUSSYSTEM1.excludedWorkers.size());
@@ -884,43 +573,8 @@ public class RatisMasterStatusSystemSuiteJ {
     disks3.put("disk2", new DiskInfo("disk2", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
     disks3.put("disk3", new DiskInfo("disk3", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
     disks3.put("disk4", new DiskInfo("disk4", 64 * 1024 * 1024 * 1024L, 100, 100, 0));
-  }
 
-  @Test
-  public void testHandleReportWorkerFailure() throws InterruptedException {
-    AbstractMetaManager statusSystem = pickLeaderStatusSystem();
-    Assert.assertNotNull(statusSystem);
-
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
-
-    List<WorkerInfo> failedWorkers = new ArrayList<>();
-    failedWorkers.add(
+    workerInfo1 =
         new WorkerInfo(
             HOSTNAME1,
             RPCPORT1,
@@ -928,7 +582,38 @@ public class RatisMasterStatusSystemSuiteJ {
             FETCHPORT1,
             REPLICATEPORT1,
             disks1,
-            userResourceConsumption1));
+            userResourceConsumption1);
+    workerInfo2 =
+        new WorkerInfo(
+            HOSTNAME2,
+            RPCPORT2,
+            PUSHPORT2,
+            FETCHPORT2,
+            REPLICATEPORT2,
+            disks2,
+            userResourceConsumption2);
+    workerInfo3 =
+        new WorkerInfo(
+            HOSTNAME3,
+            RPCPORT3,
+            PUSHPORT3,
+            FETCHPORT3,
+            REPLICATEPORT3,
+            disks3,
+            userResourceConsumption3);
+  }
+
+  @Test
+  public void testHandleReportWorkerFailure() throws InterruptedException {
+    AbstractMetaManager statusSystem = pickLeaderStatusSystem();
+    Assert.assertNotNull(statusSystem);
+
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
+
+    List<WorkerInfo> failedWorkers = new ArrayList<>();
+    failedWorkers.add(workerInfo1);
 
     statusSystem.handleReportWorkerUnavailable(failedWorkers, getNewReqeustId());
     Thread.sleep(3000L);
@@ -945,49 +630,14 @@ public class RatisMasterStatusSystemSuiteJ {
     AbstractMetaManager statusSystem = pickLeaderStatusSystem();
     Assert.assertNotNull(statusSystem);
 
-    statusSystem.handleRegisterWorker(
-        HOSTNAME1,
-        RPCPORT1,
-        PUSHPORT1,
-        FETCHPORT1,
-        REPLICATEPORT1,
-        disks1,
-        userResourceConsumption1,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME2,
-        RPCPORT2,
-        PUSHPORT2,
-        FETCHPORT2,
-        REPLICATEPORT2,
-        disks2,
-        userResourceConsumption2,
-        getNewReqeustId());
-    statusSystem.handleRegisterWorker(
-        HOSTNAME3,
-        RPCPORT3,
-        PUSHPORT3,
-        FETCHPORT3,
-        REPLICATEPORT3,
-        disks3,
-        userResourceConsumption3,
-        getNewReqeustId());
-
-    WorkerInfo workerInfo1 =
-        new WorkerInfo(
-            HOSTNAME1,
-            RPCPORT1,
-            PUSHPORT1,
-            FETCHPORT1,
-            REPLICATEPORT1,
-            disks1,
-            userResourceConsumption1);
+    statusSystem.handleRegisterWorker(workerInfo1, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo2, getNewReqeustId());
+    statusSystem.handleRegisterWorker(workerInfo3, getNewReqeustId());
 
     List<WorkerInfo> unavailableWorkers = new ArrayList<>();
     unavailableWorkers.add(workerInfo1);
 
-    statusSystem.handleWorkerLost(
-        HOSTNAME1, RPCPORT1, PUSHPORT1, FETCHPORT1, REPLICATEPORT1, getNewReqeustId());
+    statusSystem.handleWorkerLost(workerInfo1, getNewReqeustId());
     statusSystem.handleReportWorkerUnavailable(unavailableWorkers, getNewReqeustId());
 
     Thread.sleep(3000L);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
After get celeborn worker related RPC request, should wrapped those host and port, then pass this WorkerInfo to Handler.


### Why are the changes needed?
1. Clean Code
2. Reuse the toUniqueId methods in WorkerInfo instead of splicing them manually
3. Avoid modifying too much code for future changes to WorkerInfo

### Does this PR introduce _any_ user-facing change?
Only log changed


### How was this patch tested?
CI 
