### PR TITLE
[CELEBORN-1169] Bump Spark from 3.4.1 to 3.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1152,7 +1152,7 @@
         <lz4-java.version>1.8.0</lz4-java.version>
         <scala.version>2.12.17</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.4.1</spark.version>
+        <spark.version>3.4.2</spark.version>
         <zstd-jni.version>1.5.2-5</zstd-jni.version>
       </properties>
     </profile>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -559,7 +559,7 @@ object Spark34 extends SparkClientProjects {
   val lz4JavaVersion = "1.8.0"
   val sparkProjectScalaVersion = "2.12.17"
 
-  val sparkVersion = "3.4.1"
+  val sparkVersion = "3.4.2"
   val zstdJniVersion = "1.5.2-5"
 
   override val includeColumnarShuffle: Boolean = true


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
[Spark 3.4.2 released](https://spark.apache.org/news/spark-3-4-2-released.html)
November 30, 2023


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

