### PR TITLE
[CELEBORN-1170] Upgrade snappy-java from 1.1.8.2 to 1.1.10.5

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -27,6 +27,7 @@ on:
       - 'project/**'
       - '.github/workflows/deps.yml'
       - 'dev/dependencies.sh'
+      - 'dev/deps/**'
 
 concurrency:
   group: deps-${{ github.head_ref || github.run_id }}

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>snakeyaml</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dev/deps/dependencies-client-spark-3.3
+++ b/dev/deps/dependencies-client-spark-3.3
@@ -81,5 +81,5 @@ scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 shims/0.9.32//shims-0.9.32.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.10.5/snappy-java-1.1.10.5.jar
+snappy-java/1.1.10.5//snappy-java-1.1.10.5.jar
 zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
     <kubernetes-client.version>6.7.0</kubernetes-client.version>
     <rocksdbjni.version>8.5.3</rocksdbjni.version>
     <jackson.version>2.15.3</jackson.version>
+    <snappy.version>1.1.10.5</snappy.version>
 
     <shading.prefix>org.apache.celeborn.shaded</shading.prefix>
 
@@ -484,6 +485,11 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>${snappy.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -62,6 +62,7 @@ object Dependencies {
   val scalatestVersion = "3.2.16"
   val slf4jVersion = "1.7.36"
   val snakeyamlVersion = "1.33"
+  val snappyVersion = "1.1.10.5"
 
   // Versions for proto
   val protocVersion = "3.19.2"
@@ -120,6 +121,7 @@ object Dependencies {
   val slf4jJulToSlf4j = "org.slf4j" % "jul-to-slf4j" % slf4jVersion
   val slf4jJclOverSlf4j = "org.slf4j" % "jcl-over-slf4j" % slf4jVersion
   val snakeyaml = "org.yaml" % "snakeyaml" % snakeyamlVersion
+  val snappyJava = "org.xerial.snappy" % "snappy-java" % snappyVersion
   val zstdJni = "com.github.luben" % "zstd-jni" % zstdJniVersion
 
   // Test dependencies
@@ -340,6 +342,7 @@ object CelebornCommon {
         Dependencies.slf4jJulToSlf4j,
         Dependencies.slf4jApi,
         Dependencies.snakeyaml,
+        Dependencies.snappyJava,
         Dependencies.jacksonModule,
         Dependencies.jacksonCore,
         Dependencies.jacksonDatabind,


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
https://github.com/apache/incubator-celeborn/pull/2143

The snappy-java 1.1.8.2 version has the follow CVE vulnerabilities, see
https://scout.docker.com/vulnerabilities/id/CVE-2023-43642
https://scout.docker.com/vulnerabilities/id/CVE-2023-34455


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

