### PR TITLE
[CELEBORN-1178] Destroy fail reserved slots in LifecycleManager#reserveSlotsWithRetry

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1167,7 +1167,8 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         candidates.removeAll(reserveFailedWorkers)
         // Find out all failed partition locations and remove failed worker's partition location
         // from slots.
-        val failedPartitionLocations = getFailedPartitionLocations(reserveFailedWorkers, requestSlots)
+        val failedPartitionLocations =
+          getFailedPartitionLocations(reserveFailedWorkers, requestSlots)
         // When enable replicate, if one of the partition location reserve slots failed, we also
         // need to release another corresponding partition location and remove it from slots.
         if (pushReplicateEnabled && failedPartitionLocations.nonEmpty && !slots.isEmpty) {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1167,7 +1167,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         candidates.removeAll(reserveFailedWorkers)
         // Find out all failed partition locations and remove failed worker's partition location
         // from slots.
-        val failedPartitionLocations = getFailedPartitionLocations(reserveFailedWorkers, slots)
+        val failedPartitionLocations = getFailedPartitionLocations(reserveFailedWorkers, requestSlots)
         // When enable replicate, if one of the partition location reserve slots failed, we also
         // need to release another corresponding partition location and remove it from slots.
         if (pushReplicateEnabled && failedPartitionLocations.nonEmpty && !slots.isEmpty) {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1043,13 +1043,14 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
    * @param slots                    allocated WorkerResource
    * @param failedPartitionLocations reserve slot failed partition location
    */
-  private def releasePeerPartitionLocation(
+  private def releasePartitionLocation(
       shuffleId: Int,
       slots: WorkerResource,
-      failedPartitionLocations: mutable.HashMap[Int, PartitionLocation]): Unit = {
+      failedPartitionLocations: mutable.HashMap[Int, PartitionLocation],
+      releasePeer: Boolean = false): Unit = {
     val destroyResource = new WorkerResource
     failedPartitionLocations.values
-      .flatMap { partition => Option(partition.getPeer) }
+      .flatMap { partition => if (releasePeer) Option(partition.getPeer) else Option(partition) }
       .foreach { partition =>
         var destroyWorkerInfo = partition.getWorker
         val workerInfoWithRpcRef = slots.keySet().asScala.find(_.equals(destroyWorkerInfo))
@@ -1057,7 +1058,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
             logWarning(s"Cannot find workInfo for $shuffleId from previous success workResource:" +
               s" ${destroyWorkerInfo.readableAddress()}, init according to partition info")
             try {
-              if (workerStatusTracker.workerAvailable(destroyWorkerInfo)) {
+              if (!workerStatusTracker.workerExcluded(destroyWorkerInfo)) {
                 destroyWorkerInfo.endpoint = rpcEnv.setupEndpointRef(
                   RpcAddress.apply(destroyWorkerInfo.host, destroyWorkerInfo.rpcPort),
                   WORKER_EP)
@@ -1095,8 +1096,11 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       }
     if (!destroyResource.isEmpty) {
       destroySlotsWithRetry(shuffleId, destroyResource)
-      logInfo(s"Destroyed peer partitions for reserve buffer failed workers " +
-        s"shuffleId $shuffleId, $destroyResource")
+      val msg = destroyResource.asScala.map(entry =>
+        s"${entry._1.endpoint}, ${entry._2._1.asScala.map(
+          _.getUniqueId)}, ${entry._2._2.asScala.map(_.getUniqueId)}")
+      logWarning(s"Destroyed partitions for reserve buffer failed workers " +
+        s"shuffleId $shuffleId, $msg")
     }
   }
 
@@ -1105,7 +1109,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
    * and remove failed worker's partition locations from total slots.
    * For each reduce id, we only need to maintain one of the pair locations
    * even if enabling replicate. If Celeborn wants to release the failed partition location,
-   * the corresponding peers will be handled in [[releasePeerPartitionLocation]]
+   * the corresponding peers will be handled in [[releasePartitionLocation]]
    *
    * @param reserveFailedWorkers reserve slot failed WorkerInfo list of slots
    * @param slots                the slots tried to reserve a slot
@@ -1116,7 +1120,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       slots: WorkerResource): mutable.HashMap[Int, PartitionLocation] = {
     val failedPartitionLocations = new mutable.HashMap[Int, PartitionLocation]()
     reserveFailedWorkers.asScala.foreach { workerInfo =>
-      val (failedPrimaryLocations, failedReplicaLocations) = slots.remove(workerInfo)
+      val (failedPrimaryLocations, failedReplicaLocations) = slots.get(workerInfo)
       if (null != failedPrimaryLocations) {
         failedPrimaryLocations.asScala.foreach { failedPrimaryLocation =>
           failedPartitionLocations += (failedPrimaryLocation.getId -> failedPrimaryLocation)
@@ -1168,11 +1172,14 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         // Find out all failed partition locations and remove failed worker's partition location
         // from slots.
         val failedPartitionLocations =
-          getFailedPartitionLocations(reserveFailedWorkers, requestSlots)
+          getFailedPartitionLocations(reserveFailedWorkers, slots)
         // When enable replicate, if one of the partition location reserve slots failed, we also
         // need to release another corresponding partition location and remove it from slots.
+        if (failedPartitionLocations.nonEmpty && !slots.isEmpty) {
+          releasePartitionLocation(shuffleId, slots, failedPartitionLocations)
+        }
         if (pushReplicateEnabled && failedPartitionLocations.nonEmpty && !slots.isEmpty) {
-          releasePeerPartitionLocation(shuffleId, slots, failedPartitionLocations)
+          releasePartitionLocation(shuffleId, slots, failedPartitionLocations, true)
         }
         if (retryTimes < reserveSlotsMaxRetries) {
           // get retryCandidates resource and retry reserve buffer
@@ -1212,7 +1219,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     if (!success) {
       // Reserve slot failed workers' partition location and corresponding peer partition location
       // has been removed from slots by call [[getFailedPartitionLocations]] and
-      // [[releasePeerPartitionLocation]]. Now in the slots are all the successful partition
+      // [[releasePartitionLocation]]. Now in the slots are all the successful partition
       // locations.
       logWarning(s"Reserve buffers for $shuffleId still fail after retrying, clear buffers.")
       destroySlotsWithRetry(shuffleId, slots)

--- a/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/WorkerStatusTracker.scala
@@ -52,6 +52,10 @@ class WorkerStatusTracker(
     }
   }
 
+  def workerExcluded(worker: WorkerInfo): Boolean = {
+    excludedWorkers.containsKey(worker)
+  }
+
   def workerAvailable(worker: WorkerInfo): Boolean = {
     !excludedWorkers.containsKey(worker) && !shuttingWorkers.contains(worker)
   }

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerPartitionLocationInfo.scala
@@ -180,6 +180,14 @@ class WorkerPartitionLocationInfo extends Logging {
       replicaPartitionLocations.asScala.values.forall(_.isEmpty))
   }
 
+  def toStringSimplified: String = {
+    s"""
+       | Partition Location Info:
+       | primary: ${primaryPartitionLocations.values().asScala.map(_.keySet().asScala)}
+       | replica: ${replicaPartitionLocations.values().asScala.map(_.keySet().asScala)}
+       |""".stripMargin
+  }
+
   override def toString: String = {
     s"""
        | Partition Location Info:

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -656,6 +656,10 @@ private[deploy] class Controller(
           replicaLocations))
       return
     }
+    if (log.isDebugEnabled()) {
+      logDebug(
+        s"[handleDestroy] primaryIds: ${primaryLocations.asScala}, replicaIds: ${replicaLocations.asScala}")
+    }
 
     val failedPrimaries = new jArrayList[String]()
     val failedReplicas = new jArrayList[String]()

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -705,6 +705,8 @@ private[celeborn] class Worker(
     while (!partitionLocationInfo.isEmpty && waitTime < timeout) {
       Thread.sleep(interval)
       waitTimes += 1
+      logWarning(
+        s"Wait partitionLocation empty, current ${partitionLocationInfo.toStringSimplified}")
     }
     if (partitionLocationInfo.isEmpty) {
       logInfo(s"Waiting for all PartitionLocation released cost ${waitTime}ms.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
I'm testing main branch and encountered the following scenario.
I run `sbin/stop-worker.sh` near simultaneously on 3 out of 6 workers, and I'm expecting the 3 workers
will soon shutdown because I enabled graceful shutdown. However, only the first worker I stopped
shutdown in 15s as expected, the other two won't shutdown until shutdown timeout.

After digging into it, I found `LifecycleManager#reserveSlotsWithRetry` will reserve for the same location
twice:
1. At T1, only worker1 shutdown, pushes receive HARD_SPLIT and goes to revive
2. At T2, LifecycleManager handles revive requests in batch, and try to reallocate the locs to other workers
3. At T3, reserve to worker3 succeeds because it's not shutdown yet, but reserve to worker2 fails because it's shutdown
4. At T4, LifecycleManager will re-allocate the failed slots to other workers except worker1 and worker2. However, at this time Worker3 is also shutdown, so it fails to reserve on worker3
5. At T5, it re-allocates slots that failed to worker3. However, `getFailedPartitionLocations` will return slots allocated to worker3 in step 3, and increment the epoch to 2. At this time, worker3 has slots of epoch 1, but they will never to pushed to because newer epoch 3 is generated at the same time
6. Since the epoch 2 locs in worker3 will never be pushed to, it will never get a chance to return HARD_SPLIT, as a result it can't fast shutdown untile timeout.

This PR fixes this by destroying failed to be reserved slots in the process of `reserveSlotsWithRetry`

### Why are the changes needed?
ditto


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test.

Before:
![image](https://github.com/apache/incubator-celeborn/assets/948245/50c55524-d37f-494e-a5aa-fba682438cda)
After:
![image](https://github.com/apache/incubator-celeborn/assets/948245/8c90a869-b388-46f3-a86b-a37fd0f4ce0f)

