### PR TITLE
[MINOR] Update log level of CommitFiles success for `CommitHandler` from error to info

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/CommitHandler.scala
@@ -305,7 +305,7 @@ abstract class CommitHandler(
             case scala.util.Success(res) =>
               res.status match {
                 case StatusCode.SUCCESS | StatusCode.PARTIAL_SUCCESS | StatusCode.SHUFFLE_NOT_REGISTERED | StatusCode.REQUEST_FAILED | StatusCode.WORKER_EXCLUDED =>
-                  logError(s"Request commitFiles return ${res.status} for " +
+                  logInfo(s"Request commitFiles return ${res.status} for " +
                     s"${Utils.makeShuffleKey(appUniqueId, shuffleId)}")
                   if (res.status != StatusCode.SUCCESS && res.status != StatusCode.WORKER_EXCLUDED) {
                     commitFilesFailedWorkers.put(worker, (res.status, System.currentTimeMillis()))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update log level of CommitFiles success for `CommitHandler` from error to info.

Cherry pick #2174 to branch-0.3.

### Why are the changes needed?

The log level of sending CommitFiles success for `CommitHandler` should not be error.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.