### PR TITLE
[CELEBORN-1190][FOLLOWUP] Apply error prone patch and suppress some problems

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/FlinkResultPartitionInfo.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/FlinkResultPartitionInfo.java
@@ -30,8 +30,8 @@ public class FlinkResultPartitionInfo {
   private final ProducerDescriptor producerDescriptor;
 
   public FlinkResultPartitionInfo(
-      JobID jobId, PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
-    this.jobID = jobId;
+      JobID jobID, PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+    this.jobID = jobID;
     this.partitionDescriptor = partitionDescriptor;
     this.producerDescriptor = producerDescriptor;
   }

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/BufferPacker.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/BufferPacker.java
@@ -219,6 +219,7 @@ public class BufferPacker {
 
     // Flink 1.18.0
     // [FLINK-32549][network] Tiered storage memory manager supports ownership transfer for buffers
+    @SuppressWarnings("MissingOverride")
     public void setRecycler(BufferRecycler bufferRecycler) {
       DynMethods.builder("setRecycler")
           .impl(buffer.getClass().getName(), BufferRecycler.class)

--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/buffer/PartitionSortedBuffer.java
@@ -325,7 +325,7 @@ public class PartitionSortedBuffer implements SortBuffer {
       // skip the data already read if there is remaining partial record after the previous
       // copy
       long position = (long) sourceSegmentOffset + (recordLength - recordRemainingBytes);
-      sourceSegmentIndex += (position / bufferSize);
+      sourceSegmentIndex = (int) (sourceSegmentIndex + (position / bufferSize));
       sourceSegmentOffset = (int) (position % bufferSize);
     } else {
       recordRemainingBytes = recordLength;

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleEnvironment.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleEnvironment.java
@@ -44,8 +44,8 @@ public class RemoteShuffleEnvironment extends AbstractRemoteShuffleEnvironment
   /**
    * @param networkBufferPool Network buffer pool for shuffle read and shuffle write.
    * @param resultPartitionManager A trivial {@link ResultPartitionManager}.
-   * @param resultPartitionFactory Factory class to create {@link RemoteShuffleResultPartition}. //
-   *     * @param inputGateFactory Factory class to create {@link RemoteShuffleInputGate}.
+   * @param resultPartitionFactory Factory class to create {@link RemoteShuffleResultPartition}.
+   * @param inputGateFactory Factory class to create {@link RemoteShuffleInputGate}.
    */
   public RemoteShuffleEnvironment(
       NetworkBufferPool networkBufferPool,

--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -202,7 +202,8 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   public void updateStatistics(
       SortBuffer.BufferWithChannel bufferWithChannel, boolean isBroadcast) {
     numBuffersOut.inc(isBroadcast ? numSubpartitions : 1);
-    long readableBytes = bufferWithChannel.getBuffer().readableBytes() - BufferUtils.HEADER_LENGTH;
+    long readableBytes =
+        (long) bufferWithChannel.getBuffer().readableBytes() - BufferUtils.HEADER_LENGTH;
     numBytesOut.inc(isBroadcast ? readableBytes * numSubpartitions : readableBytes);
   }
 }

--- a/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleEnvironment.java
+++ b/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleEnvironment.java
@@ -44,8 +44,8 @@ public class RemoteShuffleEnvironment extends AbstractRemoteShuffleEnvironment
   /**
    * @param networkBufferPool Network buffer pool for shuffle read and shuffle write.
    * @param resultPartitionManager A trivial {@link ResultPartitionManager}.
-   * @param resultPartitionFactory Factory class to create {@link RemoteShuffleResultPartition}. //
-   *     * @param inputGateFactory Factory class to create {@link RemoteShuffleInputGate}.
+   * @param resultPartitionFactory Factory class to create {@link RemoteShuffleResultPartition}.
+   * @param inputGateFactory Factory class to create {@link RemoteShuffleInputGate}.
    */
   public RemoteShuffleEnvironment(
       NetworkBufferPool networkBufferPool,

--- a/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -202,7 +202,8 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   public void updateStatistics(
       SortBuffer.BufferWithChannel bufferWithChannel, boolean isBroadcast) {
     numBuffersOut.inc(isBroadcast ? numSubpartitions : 1);
-    long readableBytes = bufferWithChannel.getBuffer().readableBytes() - BufferUtils.HEADER_LENGTH;
+    long readableBytes =
+        (long) bufferWithChannel.getBuffer().readableBytes() - BufferUtils.HEADER_LENGTH;
     numBytesProduced.inc(readableBytes);
     numBytesOut.inc(isBroadcast ? readableBytes * numSubpartitions : readableBytes);
   }

--- a/client-flink/flink-1.17/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleEnvironment.java
+++ b/client-flink/flink-1.17/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleEnvironment.java
@@ -44,8 +44,8 @@ public class RemoteShuffleEnvironment extends AbstractRemoteShuffleEnvironment
   /**
    * @param networkBufferPool Network buffer pool for shuffle read and shuffle write.
    * @param resultPartitionManager A trivial {@link ResultPartitionManager}.
-   * @param resultPartitionFactory Factory class to create {@link RemoteShuffleResultPartition}. //
-   *     * @param inputGateFactory Factory class to create {@link RemoteShuffleInputGate}.
+   * @param resultPartitionFactory Factory class to create {@link RemoteShuffleResultPartition}.
+   * @param inputGateFactory Factory class to create {@link RemoteShuffleInputGate}.
    */
   public RemoteShuffleEnvironment(
       NetworkBufferPool networkBufferPool,

--- a/client-flink/flink-1.17/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.17/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -214,7 +214,8 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   public void updateStatistics(
       SortBuffer.BufferWithChannel bufferWithChannel, boolean isBroadcast) {
     numBuffersOut.inc(isBroadcast ? numSubpartitions : 1);
-    long readableBytes = bufferWithChannel.getBuffer().readableBytes() - BufferUtils.HEADER_LENGTH;
+    long readableBytes =
+        (long) bufferWithChannel.getBuffer().readableBytes() - BufferUtils.HEADER_LENGTH;
     if (isBroadcast) {
       resultPartitionBytes.incAll(readableBytes);
     } else {

--- a/client-flink/flink-1.18/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleEnvironment.java
+++ b/client-flink/flink-1.18/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleEnvironment.java
@@ -44,8 +44,8 @@ public class RemoteShuffleEnvironment extends AbstractRemoteShuffleEnvironment
   /**
    * @param networkBufferPool Network buffer pool for shuffle read and shuffle write.
    * @param resultPartitionManager A trivial {@link ResultPartitionManager}.
-   * @param resultPartitionFactory Factory class to create {@link RemoteShuffleResultPartition}. //
-   *     * @param inputGateFactory Factory class to create {@link RemoteShuffleInputGate}.
+   * @param resultPartitionFactory Factory class to create {@link RemoteShuffleResultPartition}.
+   * @param inputGateFactory Factory class to create {@link RemoteShuffleInputGate}.
    */
   public RemoteShuffleEnvironment(
       NetworkBufferPool networkBufferPool,

--- a/client-flink/flink-1.18/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
+++ b/client-flink/flink-1.18/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleResultPartition.java
@@ -214,7 +214,8 @@ public class RemoteShuffleResultPartition extends ResultPartition {
   public void updateStatistics(
       SortBuffer.BufferWithChannel bufferWithChannel, boolean isBroadcast) {
     numBuffersOut.inc(isBroadcast ? numSubpartitions : 1);
-    long readableBytes = bufferWithChannel.getBuffer().readableBytes() - BufferUtils.HEADER_LENGTH;
+    long readableBytes =
+        (long) bufferWithChannel.getBuffer().readableBytes() - BufferUtils.HEADER_LENGTH;
     if (isBroadcast) {
       resultPartitionBytes.incAll(readableBytes);
     } else {

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -339,4 +339,11 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       shuffleClient.cleanup(shuffleId, mapId, taskContext.attemptNumber());
     }
   }
+
+  // Added in SPARK-32917, for Spark 3.2 and above
+  @SuppressWarnings("MissingOverride")
+  public long[] getPartitionLengths() {
+    throw new UnsupportedOperationException(
+        "Celeborn is not compatible with Spark push mode, please set spark.shuffle.push.enabled to false");
+  }
 }

--- a/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-2/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -106,16 +106,16 @@ public abstract class CelebornShuffleWriterSuiteBase {
       SparkUtils.createMapStatus(bmId, new long[numPartitions], new long[numPartitions]);
 
   @Mock(answer = Answers.RETURNS_SMART_NULLS)
-  private TaskContext taskContext = null;
+  private TaskContext taskContext;
 
   @Mock(answer = Answers.RETURNS_SMART_NULLS)
-  private ShuffleDependency<Integer, String, String> dependency = null;
+  private ShuffleDependency<Integer, String, String> dependency;
 
   @Mock(answer = Answers.RETURNS_SMART_NULLS)
-  private SparkEnv env = null;
+  private SparkEnv env;
 
   @Mock(answer = Answers.RETURNS_SMART_NULLS)
-  private BlockManager blockManager = null;
+  private BlockManager blockManager;
 
   private TaskMetrics metrics = null;
 

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/HashBasedShuffleWriter.java
@@ -408,6 +408,7 @@ public class HashBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   }
 
   // Added in SPARK-32917, for Spark 3.2 and above
+  @SuppressWarnings("MissingOverride")
   public long[] getPartitionLengths() {
     throw new UnsupportedOperationException(
         "Celeborn is not compatible with Spark push mode, please set spark.shuffle.push.enabled to false");

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SortBasedShuffleWriter.java
@@ -360,6 +360,7 @@ public class SortBasedShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   }
 
   // Added in SPARK-32917, for Spark 3.2 and above
+  @SuppressWarnings("MissingOverride")
   public long[] getPartitionLengths() {
     throw new UnsupportedOperationException(
         "Celeborn is not compatible with push-based shuffle, please set spark.shuffle.push.enabled to false");

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -328,6 +328,7 @@ public class SparkShuffleManager implements ShuffleManager {
   }
 
   // Added in SPARK-32055, for Spark 3.1 and above
+  @SuppressWarnings("MissingOverride")
   public <K, C> ShuffleReader<K, C> getReader(
       ShuffleHandle handle,
       int startMapIndex,
@@ -352,6 +353,7 @@ public class SparkShuffleManager implements ShuffleManager {
   }
 
   // Marked as final in SPARK-32055, reserved for Spark 3.0
+  @SuppressWarnings("MissingOverride")
   public <K, C> ShuffleReader<K, C> getReader(
       ShuffleHandle handle,
       int startPartition,

--- a/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
+++ b/client-spark/spark-3/src/test/java/org/apache/spark/shuffle/celeborn/CelebornShuffleWriterSuiteBase.java
@@ -107,16 +107,16 @@ public abstract class CelebornShuffleWriterSuiteBase {
       new TaskMemoryManager(UnifiedMemoryManager.apply(sparkConf, 1), 0);
 
   @Mock(answer = Answers.RETURNS_SMART_NULLS)
-  protected TaskContext taskContext = null;
+  protected TaskContext taskContext;
 
   @Mock(answer = Answers.RETURNS_SMART_NULLS)
-  protected ShuffleDependency<Integer, String, String> dependency = null;
+  protected ShuffleDependency<Integer, String, String> dependency;
 
   @Mock(answer = Answers.RETURNS_SMART_NULLS)
-  private SparkEnv env = null;
+  private SparkEnv env;
 
   @Mock(answer = Answers.RETURNS_SMART_NULLS)
-  private BlockManager blockManager = null;
+  private BlockManager blockManager;
 
   protected TaskMetrics metrics = null;
 

--- a/common/src/main/java/org/apache/celeborn/common/network/util/TransportFrameDecoder.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/util/TransportFrameDecoder.java
@@ -97,7 +97,7 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
       msgSize = first.readInt();
       curType = Message.Type.decode(first);
       bodySize = first.readInt();
-      nextFrameSize = msgSize + bodySize;
+      nextFrameSize = (long) msgSize + bodySize;
       totalSize -= HEADER_SIZE;
       if (!first.isReadable()) {
         buffers.removeFirst().release();
@@ -117,7 +117,7 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
     msgSize = headerBuf.readInt();
     curType = Message.Type.decode(headerBuf);
     bodySize = headerBuf.readInt();
-    nextFrameSize = msgSize + bodySize;
+    nextFrameSize = (long) msgSize + bodySize;
     totalSize -= HEADER_SIZE;
     return nextFrameSize;
   }

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/MetaHandler.java
@@ -97,7 +97,6 @@ public class MetaHandler {
       int replicatePort;
       Map<String, DiskInfo> diskInfos;
       Map<UserIdentifier, ResourceConsumption> userResourceConsumption;
-      List<Map<String, Integer>> slots = new ArrayList<>();
       Map<String, Long> estimatedAppDiskUsage = new HashMap<>();
       switch (cmdType) {
         case RequestSlots:

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -272,7 +272,7 @@ public class SlotsAllocatorSuiteJ {
       }
       int allocateToDiskSlots = 0;
       for (WorkerInfo worker : workers) {
-        allocateToDiskSlots += worker.usedSlots();
+        allocateToDiskSlots = (int) (allocateToDiskSlots + worker.usedSlots());
       }
       if (shouldReplicate) {
         assertTrue(partitionIds.size() * 2 >= unknownDiskSlots + allocateToDiskSlots);

--- a/pom.xml
+++ b/pom.xml
@@ -1247,7 +1247,16 @@
               <encoding>UTF-8</encoding>
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne</arg>
+                <arg>-Xplugin:ErrorProne \
+                  -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
+                  -Xep:FutureReturnValueIgnored:OFF \
+                  -Xep:TypeParameterUnusedInFormals:OFF \
+                  -Xep:UnusedVariable:OFF \
+                  -Xep:StringSplitter:OFF \
+                  -Xep:EmptyBlockTag:OFF \
+                  -Xep:EqualsGetClass:OFF \
+                  -Xep:MissingSummary:OFF \
+                  -Xep:BadImport:OFF</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -929,7 +929,16 @@
             <fork>true</fork>
             <compilerArgs>
               <arg>-XDcompilePolicy=simple</arg>
-              <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/protobuf/.* -Xep:FutureReturnValueIgnored:OFF -Xep:TypeParameterUnusedInFormals:OFF -Xep:UnusedVariable:OFF</arg>
+              <arg>-Xplugin:ErrorProne \
+                -XepExcludedPaths:.*/target/generated-sources/protobuf/.* \
+                -Xep:FutureReturnValueIgnored:OFF \
+                -Xep:TypeParameterUnusedInFormals:OFF \
+                -Xep:UnusedVariable:OFF \
+                -Xep:StringSplitter:OFF \
+                -Xep:EmptyBlockTag:OFF \
+                -Xep:EqualsGetClass:OFF \
+                -Xep:MissingSummary:OFF \
+                -Xep:BadImport:OFF</arg>
             </compilerArgs>
             <annotationProcessorPaths>
               <path>

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManager.java
@@ -57,21 +57,21 @@ public class CreditStreamManager {
   public CreditStreamManager(
       int minReadBuffers,
       int maxReadBuffers,
-      int threadsPerMountpoint,
+      int threadsPerMountPoint,
       int minBuffersToTriggerRead) {
     nextStreamId = new AtomicLong((long) new Random().nextInt(Integer.MAX_VALUE) * 1000);
     streams = JavaUtils.newConcurrentHashMap();
     activeMapPartitions = JavaUtils.newConcurrentHashMap();
     this.minReadBuffers = minReadBuffers;
     this.maxReadBuffers = maxReadBuffers;
-    threadsPerMountPoint = threadsPerMountpoint;
+    this.threadsPerMountPoint = threadsPerMountPoint;
     this.minBuffersToTriggerRead = minBuffersToTriggerRead;
     MemoryManager.instance().setCreditStreamManager(this);
     logger.debug(
         "Initialize buffer stream manager with {} {} {}",
         this.minReadBuffers,
         this.maxReadBuffers,
-        threadsPerMountpoint);
+        threadsPerMountPoint);
   }
 
   public long registerStream(

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -581,7 +581,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
               originShuffleBlockInfos.computeIfAbsent(mapId, v -> new ArrayList<>());
           ShuffleBlockInfo blockInfo = new ShuffleBlockInfo();
           blockInfo.offset = blockStartIndex;
-          blockInfo.length = compressedSize + 16;
+          blockInfo.length = compressedSize + 16L;
           singleMapIdShuffleBlockList.add(blockInfo);
 
           index += batchHeaderLen + compressedSize;


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Fix IntLongMath, InconsistentCapitalization, UnnecessaryAssignment
2. disable StringSplitter, EmptyBlockTag, EqualsGetClass, MissingSummary, BadImport


### Why are the changes needed?


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA


```bash
./build/make-distribution.sh --release
```

PR

total  202

```
  43 SynchronizeOnNonFinalField
  24 StaticAssignmentInConstructor
  21 JdkObsolete
  16 ThreadLocalUsage
  16 MutableConstantField
  16 MissingCasesInEnumSwitch
  11 UnusedMethod
  11 NonAtomicVolatileUpdate
   8 UnusedNestedClass
   8 NonOverridingEquals
   8 Finally
   4 MixedMutabilityReturnType
   4 DoubleBraceInitialization
   4 CatchAndPrintStackTrace
   4 CanonicalDuration
   2 ReferenceEquality
   1 ClassCanBeStatic
   1 ByteBufferBackingArray
```

