### PR TITLE
[CELEBORN-1193] ResettableSlidingWindowReservoir should reset `full` to false

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/ResettableSlidingWindowReservoir.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/ResettableSlidingWindowReservoir.scala
@@ -55,5 +55,7 @@ class ResettableSlidingWindowReservoir(size: Int) extends Reservoir {
 
   def reset(): Unit = this.synchronized {
     util.Arrays.fill(measurements, 0)
+    full = false
+    index = 0
   }
 }

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/ResettableSlidingWindowReservoirSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/ResettableSlidingWindowReservoirSuite.scala
@@ -1,0 +1,18 @@
+package org.apache.celeborn.common.metrics
+
+import org.apache.celeborn.CelebornFunSuite
+
+class ResettableSlidingWindowReservoirSuite extends CelebornFunSuite {
+  test("test reset ResettableSlidingWindowReservoir") {
+    val reservoir = new ResettableSlidingWindowReservoir(10)
+    0 until 20 foreach (idx => reservoir.update(idx))
+    val snapshot = reservoir.getSnapshot
+    assert(snapshot.getValues.length == 10)
+    reservoir.reset()
+    val snapshot2 = reservoir.getSnapshot
+    assert(snapshot2.getValues.length == 0)
+    0 until 5 foreach (idx => reservoir.update(1))
+    val snapshot3 = reservoir.getSnapshot
+    assert(snapshot3.getValues.length == 5)
+  }
+}

--- a/common/src/test/scala/org/apache/celeborn/common/metrics/ResettableSlidingWindowReservoirSuite.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/metrics/ResettableSlidingWindowReservoirSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.celeborn.common.metrics
 
 import org.apache.celeborn.CelebornFunSuite


### PR DESCRIPTION


### What changes were proposed in this pull request?
When ResettableSlidingWindowReservoir reset,  it should reset` full` to `false`, `index` to `0`


### Why are the changes needed?
The ResettableSlidingWindowReservoir class, after invoking the reset operation, resets the data to zero, but fails to reset the 'index' and 'full' variables. Consequently, when retrieving a snapshot in the next operation, it is possible to obtain a considerable amount of zeros. This issue extends to the inaccurate calculation of metrics such as average and minimum values.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
add uts
