### PR TITLE
[CELEBORN-1195] Use batch rack resolve when restore meta from file

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
 import scala.Option;
-import scala.collection.JavaConverters;
 
 import org.apache.hadoop.net.Node;
 import org.slf4j.Logger;
@@ -287,11 +286,10 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
           snapshotMetaInfo.getWorkersList().stream()
               .map(PbSerDeUtils::fromPbWorkerInfo)
               .collect(Collectors.toSet());
-      scala.collection.Seq<String> workerHostSeq =
-          JavaConverters.asScalaIterator(workerInfoSet.stream().map(WorkerInfo::host).iterator())
-              .toSeq();
+      List<String> workerHostList =
+          workerInfoSet.stream().map(WorkerInfo::host).collect(Collectors.toList());
       scala.collection.immutable.Map<String, Node> resolveMap =
-          rackResolver.resolveToMap(workerHostSeq);
+          rackResolver.resolveToMap(workerHostList);
       workers.addAll(
           workerInfoSet.stream()
               .peek(

--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 
 import scala.Option;
 import scala.collection.JavaConverters;
-import scala.collection.Seq;
 
 import org.apache.hadoop.net.Node;
 import org.slf4j.Logger;
@@ -288,7 +287,7 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
           snapshotMetaInfo.getWorkersList().stream()
               .map(PbSerDeUtils::fromPbWorkerInfo)
               .collect(Collectors.toSet());
-      Seq<String> workerHostSeq =
+      scala.collection.Seq<String> workerHostSeq =
           JavaConverters.asScalaIterator(workerInfoSet.stream().map(WorkerInfo::host).iterator())
               .toSeq();
       scala.collection.immutable.Map<String, Node> resolveMap =

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolver.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolver.scala
@@ -18,6 +18,7 @@
 package org.apache.celeborn.service.deploy.master.network
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import com.google.common.base.Strings
@@ -54,6 +55,10 @@ class CelebornRackResolver(celebornConf: CelebornConf) extends Logging {
     coreResolve(hostNames)
   }
 
+  def resolveToMap(hostNames: Seq[String]): Map[String, Node] = {
+    hostNames.zip(resolve(hostNames)).toMap
+  }
+
   private def coreResolve(hostNames: Seq[String]): Seq[Node] = {
     if (hostNames.isEmpty) {
       return Seq.empty
@@ -80,8 +85,8 @@ class CelebornRackResolver(celebornConf: CelebornConf) extends Logging {
   }
 
   def isOnSameRack(primaryHost: String, replicaHost: String): Boolean = {
-    val primaryNode = resolve(primaryHost)
-    val replicaNode = resolve(replicaHost)
+    val nodes = resolve(Seq(primaryHost, replicaHost))
+    val (primaryNode, replicaNode) = (nodes.head, nodes.last)
     if (primaryNode == null || replicaNode == null) {
       false
     } else {

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolver.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolver.scala
@@ -54,6 +54,10 @@ class CelebornRackResolver(celebornConf: CelebornConf) extends Logging {
     coreResolve(hostNames)
   }
 
+  def resolveToMap(hostNames: java.util.List[String]): Map[String, Node] = {
+    resolveToMap(hostNames.asScala.toSeq)
+  }
+
   def resolveToMap(hostNames: Seq[String]): Map[String, Node] = {
     hostNames.zip(resolve(hostNames)).toMap
   }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolver.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolver.scala
@@ -18,7 +18,6 @@
 package org.apache.celeborn.service.deploy.master.network
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import com.google.common.base.Strings

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolverSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolverSuite.scala
@@ -53,6 +53,11 @@ class CelebornRackResolverSuite extends AnyFunSuite {
     assertEquals(names.size, result.size)
     assertEquals("/rack1", result(0).getNetworkLocation)
     assertEquals("/rack2", result(1).getNetworkLocation)
+
+    val resultMap: Map[String, Node] = resolver.resolveToMap(names)
+    assertEquals(names.size, resultMap.size)
+    assertEquals("/rack1", resultMap(hostName1).getNetworkLocation)
+    assertEquals("/rack2", resultMap(hostName2).getNetworkLocation)
   }
 
   test("CELEBORN-446: RackResolver support getDistance") {

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolverSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/network/CelebornRackResolverSuite.scala
@@ -19,6 +19,7 @@ package org.apache.celeborn.service.deploy.master.network
 
 import java.io.{File, FileWriter}
 import java.nio.charset.StandardCharsets
+import java.util
 
 import com.google.common.io.Files
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic.{NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY, NET_TOPOLOGY_TABLE_MAPPING_FILE_KEY}
@@ -58,6 +59,15 @@ class CelebornRackResolverSuite extends AnyFunSuite {
     assertEquals(names.size, resultMap.size)
     assertEquals("/rack1", resultMap(hostName1).getNetworkLocation)
     assertEquals("/rack2", resultMap(hostName2).getNetworkLocation)
+
+    val hostNamesList = new util.ArrayList[String]()
+    hostNamesList.add(hostName1)
+    hostNamesList.add(hostName2)
+    val resultMap2: Map[String, Node] = resolver.resolveToMap(hostNamesList)
+    assertEquals(hostNamesList.size, resultMap2.size)
+    assertEquals("/rack1", resultMap2(hostName1).getNetworkLocation)
+    assertEquals("/rack2", resultMap2(hostName2).getNetworkLocation)
+
   }
 
   test("CELEBORN-446: RackResolver support getDistance") {


### PR DESCRIPTION
### What changes were proposed in this pull request?、
```java
org.apache.celeborn.service.deploy.master.clustermeta.AbstractMetaManager#restoreMetaFromFile
```

### Why are the changes needed?
When the number of workers is large, the performance of parsing one by one will decrease.

YARN-9332. RackResolver tool should accept multiple hosts
https://issues.apache.org/jira/browse/YARN-9332



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

