### PR TITLE
[CELEBORN-1197] Avoid using the sleep command with the s suffix in bash scripts

### DIFF
--- a/sbin/start-all.sh
+++ b/sbin/start-all.sh
@@ -48,7 +48,7 @@ do
   fi
 done
 # pause 5 seconds to make sure that master is ready.
-sleep 5s
+sleep 5
 
 # start workers
 for host in `echo "$HOST_LIST" | sed  "s/#.*$//;/^$/d" | grep '\[worker\]' | awk '{print $NF}'`


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the s suffix of sleep

### Why are the changes needed?
MacOS
```bash
./sbin/start-all.sh
```

```
usage: sleep seconds
```



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

