### PR TITLE
[CELEBORN-1198] Keep debug info when use SBT build

### DIFF
--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -162,7 +162,7 @@ object CelebornCommonSettings {
     crossScalaVersions := ALL_SCALA_VERSIONS,
     fork := true,
     scalacOptions ++= Seq("-target:jvm-1.8"),
-    javacOptions ++= Seq("-encoding", UTF_8.name(), "-source", "1.8"),
+    javacOptions ++= Seq("-encoding", UTF_8.name(), "-source", "1.8", "-g"),
   
     // -target cannot be passed as a parameter to javadoc. See https://github.com/sbt/sbt/issues/355
     Compile / compile / javacOptions ++= Seq("-target", "1.8"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add "-g" to javac compile parameters when using SBT build

> -g
Generates all debugging information, including local variables. By default, only line number and source file information is generated.

https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html


### Why are the changes needed?
`maven-compiler-plugin` defaults to debug=true, `plexus-compiler-javac` will add the parameter `-g`.

SBT does not have this behavior by default, which leads to some differences between the jars of maven and sbt builds, although the code logic is the same.

https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#debug

https://github.com/apache/maven-compiler-plugin/blob/736da68adf543cf56cd82a68e5ad28d397ace2f4/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java#L734

https://github.com/codehaus-plexus/plexus-compiler/blob/6ae79d7f2feca3a02e75f7661468abac6a9a0a11/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java#L279-L285


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
```bash
./build/sbt celeborn-worker/package
```


#### Current
`String paramString`

<img width="1450" alt="image" src="https://github.com/apache/incubator-celeborn/assets/3898450/9582402c-93e1-4dc2-b094-0f23c30390a9">

#### PR
<img width="1278" alt="image" src="https://github.com/apache/incubator-celeborn/assets/3898450/82ac3c3d-b3ad-4c94-a73f-09e88371911d">



