### PR TITLE
[CELEBORN-1036][FOLLOWUP] When inflightBatchesPerAddress clear, totalInflightReqs should reset

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/write/InFlightRequestTracker.java
+++ b/common/src/main/java/org/apache/celeborn/common/write/InFlightRequestTracker.java
@@ -188,6 +188,7 @@ public class InFlightRequestTracker {
     if (!inflightBatchesPerAddress.isEmpty()) {
       logger.warn("Clear {}", this.getClass().getSimpleName());
       inflightBatchesPerAddress.clear();
+      totalInflightReqs.reset();
     }
     pushStrategy.clear();
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When   `inflightBatchesPerAddress`  clear in  `InFlightRequestTracker.cleanup `, `totalInflightReqs` should also reset to avoid getting stuck when exiting.


### Why are the changes needed?
`inflightBatchesPerAddress` has cleared and be empty,but totalInflightReqs is always bigger than 0.
![image](https://github.com/apache/incubator-celeborn/assets/46274164/28223f1e-ac9b-4e0b-a26d-9b529af6bca1)

This occurred during the first attempt of the task, where the request for map end failed, but the driver marked that the map has already ended.
![image](https://github.com/apache/incubator-celeborn/assets/46274164/7f43d808-2f9b-4775-b04f-30afe4d31e5a)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
through exists uts

