### PR TITLE
[CELEBORN-1205] Disable Maven local caches to improve SBT building stability

### DIFF
--- a/build/sbt-config/repositories
+++ b/build/sbt-config/repositories
@@ -17,7 +17,7 @@
 
 [repositories]
   local
-  mavenLocal: file://${user.home}/.m2/repository/
+  # mavenLocal: file://${user.home}/.m2/repository/
   local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
   # The system property value of `celeborn.sbt.default.artifact.repository` is

--- a/build/sbt-config/repositories-asia.template
+++ b/build/sbt-config/repositories-asia.template
@@ -24,7 +24,7 @@
 
 [repositories]
   local
-  mavenLocal: file://${user.home}/.m2/repository/
+  # mavenLocal: file://${user.home}/.m2/repository/
   # The system property value of `celeborn.sbt.default.artifact.repository` is
   # fetched from the environment variable `DEFAULT_ARTIFACT_REPOSITORY` and
   # assigned within the build/sbt-launch-lib.bash script.

--- a/build/sbt-config/repositories-cn.template
+++ b/build/sbt-config/repositories-cn.template
@@ -25,7 +25,7 @@
 
 [repositories]
   local
-  mavenLocal: file://${user.home}/.m2/repository/
+  # mavenLocal: file://${user.home}/.m2/repository/
   # The system property value of `celeborn.sbt.default.artifact.repository` is
   # fetched from the environment variable `DEFAULT_ARTIFACT_REPOSITORY` and
   # assigned within the build/sbt-launch-lib.bash script.


### PR DESCRIPTION
### What changes were proposed in this pull request?
To eliminate build failure when using SBT.


### Why are the changes needed?
If the maven local cache is enabled, SBT can't find the correct dependencies.
If the maven local cache is disabled, SBT can find the correct dependencies.



### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
GA
