### PR TITLE
[CELEBORN-1206] Add Pre-Queue for changePartitionRequests

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -372,6 +372,7 @@ class ChangePartitionManager(
 
   def removeExpiredShuffle(shuffleId: Int): Unit = {
     changePartitionRequests.remove(shuffleId)
+    pendingPartitionChangeRequests.remove(shuffleId)
     inBatchPartitions.remove(shuffleId)
   }
 }

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -46,7 +46,7 @@ class ChangePartitionManager(
 
   private val pushReplicateEnabled = conf.clientPushReplicateEnabled
   // shuffleId -> (partitionId -> set of ChangePartition)
-  val changePartitionRequests =
+  private val changePartitionRequests =
     JavaUtils.newConcurrentHashMap[Int, ConcurrentHashMap[Integer, JSet[ChangePartitionRequest]]]()
 
   private val pendingPartitionChangeRequests =
@@ -157,6 +157,16 @@ class ChangePartitionManager(
           }
         }
       }
+    }
+  }
+
+  // for testing
+  def getAllPartitionRequests(shuffleId: Int): util.Set[ChangePartitionRequest] = {
+    val requests = changePartitionRequests.get(shuffleId)
+    if (requests == null) {
+      new util.HashSet[ChangePartitionRequest]()
+    } else {
+      requests.values().asScala.flatMap(_.asScala).toSet.asJava
     }
   }
 

--- a/client/src/test/scala/org/apache/celeborn/client/ChangePartitionManagerSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/ChangePartitionManagerSuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.mockito.Mockito._
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.client._
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.protocol.PartitionLocation
+import org.apache.celeborn.common.protocol.message.StatusCode
+
+class ChangePartitionManagerTest extends AnyFunSuite {
+
+  test("testPendingPartitionChangeRequests") {
+
+    val conf = new CelebornConf()
+      .set(CelebornConf.MASTER_ENDPOINTS.key, "localhost1:9097,localhost2:9097")
+    val App = "app-1"
+    val lifecycleManager = new LifecycleManager(App, conf)
+    val context = mock(classOf[RequestLocationCallContext])
+    val oldPartition = mock(classOf[PartitionLocation])
+
+    val manager = new ChangePartitionManager(conf, lifecycleManager)
+
+    val shuffleId = 1
+    val partitionId = 2
+    val epoch = 3
+    val cause = Some(StatusCode.SUCCESS)
+    val request =
+      ChangePartitionRequest(context, shuffleId, partitionId, epoch, oldPartition, cause)
+    manager.handleRequestPartitionLocation(
+      context,
+      shuffleId,
+      partitionId,
+      epoch,
+      oldPartition,
+      cause)
+
+    manager.start()
+    Thread.sleep(1000)
+
+    val changeRequests = manager.changePartitionRequests.get(shuffleId)
+    assert(changeRequests != null)
+    assert(changeRequests.containsKey(partitionId))
+    val requests = changeRequests.get(partitionId)
+    assert(requests.size() == 1)
+    assert(requests.contains(request))
+
+    manager.stop()
+  }
+}

--- a/client/src/test/scala/org/apache/celeborn/client/ChangePartitionManagerSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/ChangePartitionManagerSuite.scala
@@ -53,12 +53,9 @@ class ChangePartitionManagerTest extends AnyFunSuite {
     manager.start()
     Thread.sleep(1000)
 
-    val changeRequests = manager.changePartitionRequests.get(shuffleId)
-    assert(changeRequests != null)
-    assert(changeRequests.containsKey(partitionId))
-    val requests = changeRequests.get(partitionId)
-    assert(requests.size() == 1)
-    assert(requests.contains(request))
+    val changeRequests = manager.getAllPartitionRequests(shuffleId)
+    assert(!changeRequests.isEmpty)
+    assert(changeRequests.contains(request))
 
     manager.stop()
   }

--- a/client/src/test/scala/org/apache/celeborn/client/ChangePartitionManagerSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/ChangePartitionManagerSuite.scala
@@ -23,7 +23,7 @@ import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.protocol.PartitionLocation
 import org.apache.celeborn.common.protocol.message.StatusCode
 
-class ChangePartitionManagerTest extends AnyFunSuite {
+class ChangePartitionManagerSuite extends AnyFunSuite {
 
   test("testPendingPartitionChangeRequests") {
 
@@ -58,5 +58,6 @@ class ChangePartitionManagerTest extends AnyFunSuite {
     assert(changeRequests.contains(request))
 
     manager.stop()
+    lifecycleManager.stop()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add Pre-Queue for changePartitionRequests to buffler requests


### Why are the changes needed?
Encounter a specific challenge when processing changePartition in scenarios with large shuffling operations that generate an extensive number of splits. The issue manifests as the `LifecycleManager` locking requests during changePartition. This becomes problematic, particularly when individual requests are time-consuming, resulting in potential RPC request blocking. To address this, propose the introduction of a pre-queue(`pendingChangePartitionRequests`)  for `changePartitionRequests` as a preventive measure. The pre-queue aims to optimize the handling of requests and mitigate the risk of RPC requests being blocked during changePartition in the presence of large shuffle-induced splits.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add uts
