### PR TITLE
[CELEBORN-1209][CLIENT] Print Warning Log if User use Celeborn with enabled Spark ShuffleTracking

### DIFF
--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -99,6 +99,12 @@ public class SparkShuffleManager implements ShuffleManager {
               + "use Celeborn as Remote Shuffle Service to avoid performance degradation.",
           SQLConf.LOCAL_SHUFFLE_READER_ENABLED().key());
     }
+    if (conf.getBoolean("spark.dynamicAllocation.shuffleTracking.enabled", false)) {
+      logger.warn(
+          "Detected spark.dynamicAllocation.shuffleTracking.enabled (default is false) is enabled, "
+              + "it's highly recommended to disable it when use Celeborn as Remote Shuffle Service "
+              + "to avoid performance degradation.");
+    }
     this.conf = conf;
     this.isDriver = isDriver;
     this.celebornConf = SparkUtils.fromSparkConf(conf);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add `spark.dynamicAllocation.shuffleTracking.enabled` check in `SparkShuffleManager`


### Why are the changes needed?

Warn users that enabling both features will incur a performance penalty and that shuffleTracking should be turned off when Celeborn is turned on.


### Does this PR introduce _any_ user-facing change?

Yes, user will find this warn log when enabled both.

### How was this patch tested?
