### PR TITLE
[CELEBORN-1209][FOLLOW] Fix warning based on Spark Enabled ShuffleTracking after Spark 3.4

### DIFF
--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -99,11 +99,16 @@ public class SparkShuffleManager implements ShuffleManager {
               + "use Celeborn as Remote Shuffle Service to avoid performance degradation.",
           SQLConf.LOCAL_SHUFFLE_READER_ENABLED().key());
     }
-    if (conf.getBoolean("spark.dynamicAllocation.shuffleTracking.enabled", false)) {
+    if ((Boolean) conf.get(package$.MODULE$.DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED())) {
       logger.warn(
-          "Detected spark.dynamicAllocation.shuffleTracking.enabled (default is false) is enabled, "
-              + "it's highly recommended to disable it when use Celeborn as Remote Shuffle Service "
-              + "to avoid performance degradation.");
+          "Detected {} (default is {}) is enabled, it's highly recommended to disable it when "
+              + "use Celeborn as Remote Shuffle Service to avoid performance degradation.",
+          package$.MODULE$.DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED().key(),
+          package$
+              .MODULE$
+              .DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED()
+              .defaultValue()
+              .map(v -> (Boolean) v));
     }
     this.conf = conf;
     this.isDriver = isDriver;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

[SPARK-39846](https://issues.apache.org/jira/browse/SPARK-39846) set shuffle tracking enabled default value to true, fix warning.


### Why are the changes needed?
As title


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?

