### PR TITLE
[CELEBORN-1210] Fix potential memory leak in PartitionFilesCleaner

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -769,7 +769,7 @@ class PartitionFilesCleaner {
             () -> {
               try {
                 while (!partitionFilesSorter.isShutdown()) {
-                  while (fileSorters.isEmpty()) {
+                  if (fileSorters.isEmpty()) {
                     notEmpty.await();
                   }
                   lock.lockInterruptibly();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -772,7 +772,7 @@ class PartitionFilesCleaner {
                   lock.lockInterruptibly();
                   try {
                     while (queue.isEmpty()) {
-                      notEmpty.await(500, TimeUnit.MILLISECONDS);
+                      notEmpty.await();
                     }
                     Iterator<PartitionFilesSorter.FileSorter> it = queue.iterator();
                     while (it.hasNext()) {
@@ -816,13 +816,7 @@ class PartitionFilesCleaner {
   public void cleanupExpiredShuffleKey(Set<String> expiredShuffleKeys) {
     lock.lock();
     try {
-      Iterator<PartitionFilesSorter.FileSorter> it = queue.iterator();
-      while (it.hasNext()) {
-        PartitionFilesSorter.FileSorter sorter = it.next();
-        if (expiredShuffleKeys.contains(sorter.getShuffleKey())) {
-          it.remove();
-        }
-      }
+      queue.removeIf(sorter -> expiredShuffleKeys.contains(sorter.getShuffleKey()));
     } finally {
       lock.unlock();
     }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -769,11 +769,11 @@ class PartitionFilesCleaner {
             () -> {
               try {
                 while (!partitionFilesSorter.isShutdown()) {
+                  while (fileSorters.isEmpty()) {
+                    notEmpty.await();
+                  }
                   lock.lockInterruptibly();
                   try {
-                    while (fileSorters.isEmpty()) {
-                      notEmpty.await();
-                    }
                     Iterator<PartitionFilesSorter.FileSorter> it = fileSorters.iterator();
                     while (it.hasNext()) {
                       PartitionFilesSorter.FileSorter sorter = it.next();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -771,7 +771,8 @@ class PartitionFilesCleaner {
                 while (!partitionFilesSorter.isShutdown()) {
                   lock.lockInterruptibly();
                   try {
-                    if (fileSorters.isEmpty()) {
+                    // CELEBORN-1210: use while instead of if in case of spurious wakeup.
+                    while (fileSorters.isEmpty()) {
                       notEmpty.await();
                     }
                     Iterator<PartitionFilesSorter.FileSorter> it = fileSorters.iterator();

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -769,11 +769,11 @@ class PartitionFilesCleaner {
             () -> {
               try {
                 while (!partitionFilesSorter.isShutdown()) {
-                  if (fileSorters.isEmpty()) {
-                    notEmpty.await();
-                  }
                   lock.lockInterruptibly();
                   try {
+                    if (fileSorters.isEmpty()) {
+                      notEmpty.await();
+                    }
                     Iterator<PartitionFilesSorter.FileSorter> it = fileSorters.iterator();
                     while (it.hasNext()) {
                       PartitionFilesSorter.FileSorter sorter = it.next();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

1. let `cleanupExpiredShuffleKey` holds the same lock with add and cleaner thread
2. fix the removal during the iteration
3. simply call `condition.await()` instead of while loop with `condition.await(500ms)`

### Why are the changes needed?

The usage of `LinkedBlockingQueue queue` in `PartitionFilesCleaner` is not a typical producer-consumer model, but an order-agnostic buffer, which confuses me on the first round code reading.

Though `LinkedBlockingQueue` is a thread-safe collection, it means won't get a `ConcurrentModificationException` if the queue is modified while it is iterating, but the iteration is not guaranteed to see all queue entries. As `cleanupExpiredShuffleKey` is not guarded by the lock, elements removal from the cleaner thread may break the iteration and eventually cause a memory leak.

Ref: https://stackoverflow.com/questions/37945981/concurrently-iterating-over-a-blockingqueue

Another issue is the removal inside iteration. The typical usage is
```
Iterator itr = collection.listIterator(); 
while (itr.hasNext()) { 
    if (itr.next() xxx condition) { 
        itr.remove(); 
    }
}
```
The keypoint is that `itr.remove()` should be called instead of `collection.remove(x)`

### Does this PR introduce _any_ user-facing change?

I suppose there is a potential memory leak issue on the Worker without this patch.

### How was this patch tested?

Pass GA.