### PR TITLE
[CELEBORN-1206] Add Pre-Queue for changePartitionRequests

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -89,13 +89,14 @@ class ChangePartitionManager(
                           pendingChangePartitionRequests.get(shuffleId).asScala.foreach {
                             case (partitionId, pendingRequestMap) =>
                               if (pendingRequestMap.size() > 0) {
-                                val requestSet = if (requests.containsKey(partitionId)) {
-                                  requests.get(partitionId)
-                                } else {
-                                  val set = new util.HashSet[ChangePartitionRequest]()
-                                  requests.put(partitionId, set)
-                                  set
-                                }
+                                val requestSet =
+                                  if (requests.containsKey(partitionId)) {
+                                    requests.get(partitionId)
+                                  } else {
+                                    val set = new util.HashSet[ChangePartitionRequest]()
+                                    requests.put(partitionId, set)
+                                    set
+                                  }
                                 pendingRequestMap.asScala.foreach(pendingRequest => {
                                   val oldEpoch = pendingRequest.epoch
                                   val latestPartition =

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -206,17 +206,15 @@ class ChangePartitionManager(
       } else {
         // If new slot for the partition has been allocated, reply and return.
         // Else register and allocate for it.
-        if (!batchHandleChangePartitionEnabled) {
-          getLatestPartition(shuffleId, partitionId, oldEpoch).foreach { latestLoc =>
-            context.reply(
-              partitionId,
-              StatusCode.SUCCESS,
-              Some(latestLoc),
-              lifecycleManager.workerStatusTracker.workerAvailable(oldPartition))
-            logDebug(s"New partition found, old partition $partitionId-$oldEpoch return it." +
-              s" shuffleId: $shuffleId $latestLoc")
-            return
-          }
+        getLatestPartition(shuffleId, partitionId, oldEpoch).foreach { latestLoc =>
+          context.reply(
+            partitionId,
+            StatusCode.SUCCESS,
+            Some(latestLoc),
+            lifecycleManager.workerStatusTracker.workerAvailable(oldPartition))
+          logDebug(s"New partition found, old partition $partitionId-$oldEpoch return it." +
+            s" shuffleId: $shuffleId $latestLoc")
+          return
         }
         val set = new util.HashSet[ChangePartitionRequest]()
         set.add(changePartition)

--- a/client/src/test/scala/org/apache/celeborn/client/ChangePartitionManagerSuite.scala
+++ b/client/src/test/scala/org/apache/celeborn/client/ChangePartitionManagerSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.mockito.Mockito._
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.client._
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.protocol.PartitionLocation
+import org.apache.celeborn.common.protocol.message.StatusCode
+
+class ChangePartitionManagerTest extends AnyFunSuite {
+
+  test("testPendingPartitionChangeRequests") {
+    val conf = new CelebornConf()
+      .set(CelebornConf.MASTER_ENDPOINTS.key, "localhost1:9097,localhost2:9097")
+    val App = "app-1"
+    val lifecycleManager = new LifecycleManager(App, conf)
+    val context = mock(classOf[RequestLocationCallContext])
+    val oldPartition = mock(classOf[PartitionLocation])
+
+    val manager = new ChangePartitionManager(conf, lifecycleManager)
+
+    val shuffleId = 1
+    val partitionId = 2
+    val epoch = 3
+    val cause = Some(StatusCode.SUCCESS)
+    val request =
+      ChangePartitionRequest(context, shuffleId, partitionId, epoch, oldPartition, cause)
+    manager.handleRequestPartitionLocation(
+      context,
+      shuffleId,
+      partitionId,
+      epoch,
+      oldPartition,
+      cause)
+
+    manager.start()
+    Thread.sleep(1000)
+
+    val changeRequests = manager.changePartitionRequests.get(shuffleId)
+    assert(changeRequests != null)
+    assert(changeRequests.containsKey(partitionId))
+    val requests = changeRequests.get(partitionId)
+    assert(requests.size() == 1)
+    assert(requests.contains(request))
+    manager.stop()
+    lifecycleManager.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add Pre-Queue for changePartitionRequests to buffler requests


### Why are the changes needed?
Encounter a specific challenge when processing changePartition in scenarios with large shuffling operations that generate an extensive number of splits. The issue manifests as the `LifecycleManager` locking requests during changePartition. This becomes problematic, particularly when individual requests are time-consuming, resulting in potential RPC request blocking. To address this, propose the introduction of a pre-queue(`pendingChangePartitionRequests`)  for `changePartitionRequests` as a preventive measure. The pre-queue aims to optimize the handling of requests and mitigate the risk of RPC requests being blocked during changePartition in the presence of large shuffle-induced splits.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add uts
