### PR TITLE
[CELEBORN-1216] Resolve error occurring during distribution creation with profile `-Pspark-2.4`

### DIFF
--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -257,7 +257,7 @@ function sbt_build_service {
   echo "Celeborn $VERSION$GITREVSTRING" > "$DIST_DIR/RELEASE"
   echo "Build flags: $@" >> "$DIST_DIR/RELEASE"
 
-  BUILD_COMMAND=("$SBT" clean package $@)
+  BUILD_COMMAND=("$SBT" clean package)
 
   # Actually build the jar
   echo -e "\nBuilding with..."


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

As title

### Why are the changes needed?

```
$ ./build/make-distribution.sh --sbt-enabled -Pspark-2.4
...
cp: /Users/fchen/Project/incubator-celeborn/master/target/scala-2.12/celeborn-master_2.12-0.5.0-SNAPSHOT.jar: No such file or directory
```

The SBT will derive the scala version from the spark project when the spark profile is specified.

This PR eliminates the user-specified profile, ensuring that the `copyJars` task aligns with the `package` task in terms of the scala version.


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Local test
