### PR TITLE
[CELEBORN-1133][FOLLOWUP] Refactor FileInfo

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
@@ -107,6 +107,7 @@ public class DiskFileInfo extends FileInfo {
     }
   }
 
+  @Override
   public long getFileLength() {
     return bytesFlushed;
   }

--- a/common/src/main/java/org/apache/celeborn/common/meta/MapFileMeta.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/MapFileMeta.java
@@ -37,8 +37,8 @@ public class MapFileMeta implements FileMeta {
     return numSubPartitions;
   }
 
-  public void setNumSubpartitions(int numSubpartitions) {
-    this.numSubPartitions = numSubpartitions;
+  public void setNumSubPartitions(int numSubPartitions) {
+    this.numSubPartitions = numSubPartitions;
   }
 
   public void setBufferSize(int bufferSize) {

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriter.java
@@ -161,7 +161,7 @@ public final class MapPartitionDataWriter extends PartitionDataWriter {
               deleted = true;
             } else {
               StorageManager.hadoopFs()
-                  .create(new Path(Utils.getWriteSuccessFilePath((diskFileInfo.getIndexPath()))))
+                  .create(new Path(Utils.getWriteSuccessFilePath(diskFileInfo.getIndexPath())))
                   .close();
             }
           }
@@ -185,7 +185,7 @@ public final class MapPartitionDataWriter extends PartitionDataWriter {
     numSubpartitionBytes = new long[numSubpartitions];
     MapFileMeta mapFileMeta = (MapFileMeta) diskFileInfo.getFileMeta();
     mapFileMeta.setBufferSize(bufferSize);
-    mapFileMeta.setNumSubpartitions(numSubpartitions);
+    mapFileMeta.setNumSubPartitions(numSubpartitions);
   }
 
   public void regionStart(int currentDataRegionIndex, boolean isBroadcastRegion) {


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
```
common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java:[110,14] [MissingOverride] getFileLength implements method in FileInfo; expected @Override
common/src/main/java/org/apache/celeborn/common/meta/MapFileMeta.java:[40,38] [InconsistentCapitalization] Found the field 'numSubPartitions' with the same name as the parameter 'numSubpartitions' but with different capitalization.
worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataWriter.java:[164,65] [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
```



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA

