### PR TITLE
[CELEBORN-1219] tabkeBuffer() avoid checking source.metricsCollectCriticalEnabled twice

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
@@ -368,23 +368,22 @@ public abstract class PartitionDataWriter implements DeviceObserver {
   }
 
   protected void takeBuffer() {
-    // metrics start
-    String metricsName = null;
-    String fileAbsPath = null;
     if (source.metricsCollectCriticalEnabled()) {
+      // metrics start
+      String metricsName = null;
+      String fileAbsPath = null;
       metricsName = WorkerSource.TAKE_BUFFER_TIME();
       fileAbsPath = diskFileInfo.getFilePath();
       source.startTimer(metricsName, fileAbsPath);
-    }
-
-    // real action
-    synchronized (flushLock) {
-      flushBuffer = flusher.takeBuffer();
-    }
-
-    // metrics end
-    if (source.metricsCollectCriticalEnabled()) {
+      // real action
+      synchronized (flushLock) {
+        flushBuffer = flusher.takeBuffer();
+      }
       source.stopTimer(metricsName, fileAbsPath);
+    } else {
+      synchronized (flushLock) {
+        flushBuffer = flusher.takeBuffer();
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
 tabkeBuffer() avoid checking source.metricsCollectCriticalEnabled twice


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

