### PR TITLE
[CELEBORN-1220][IMPROVEMENT] Make trim logic more robust

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -317,10 +317,13 @@ public class MemoryManager {
     if (trimInProcess.compareAndSet(false, true)) {
       actionService.submit(
           () -> {
-            // In current code, StorageManager will add into this before ChannelsLimiter,
-            // so all behaviors of StorageManger will execute before ChannelsLimiter.
-            memoryPressureListeners.forEach(MemoryPressureListener::onTrim);
-            trimInProcess.set(false);
+            try {
+              // In current code, StorageManager will add into this before ChannelsLimiter,
+              // so all behaviors of StorageManger will execute before ChannelsLimiter.
+              memoryPressureListeners.forEach(MemoryPressureListener::onTrim);
+            } finally {
+              trimInProcess.set(false);
+            }
           });
     }
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -323,7 +323,8 @@ public class MemoryManager {
               memoryPressureListeners.forEach(MemoryPressureListener::onTrim);
             } finally {
               // MemoryManager uses this flag to avoid parallel trigger trim action,
-              // We should make sure set this value back, otherwise it won't trigger trim action again.
+              // We should make sure set this value back, otherwise it won't trigger trim action
+              // again.
               trimInProcess.set(false);
             }
           });

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -322,6 +322,8 @@ public class MemoryManager {
               // so all behaviors of StorageManger will execute before ChannelsLimiter.
               memoryPressureListeners.forEach(MemoryPressureListener::onTrim);
             } finally {
+              // MemoryManager use this flag to avoid trigger trim action parallel,
+              // We should make sure set this value back, or it won't trigger trim action again.
               trimInProcess.set(false);
             }
           });

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -322,7 +322,7 @@ public class MemoryManager {
               // so all behaviors of StorageManger will execute before ChannelsLimiter.
               memoryPressureListeners.forEach(MemoryPressureListener::onTrim);
             } finally {
-              // MemoryManager use this flag to avoid trigger trim action parallel,
+              // MemoryManager uses this flag to avoid parallel trigger trim action,
               // We should make sure set this value back, or it won't trigger trim action again.
               trimInProcess.set(false);
             }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -323,7 +323,7 @@ public class MemoryManager {
               memoryPressureListeners.forEach(MemoryPressureListener::onTrim);
             } finally {
               // MemoryManager uses this flag to avoid parallel trigger trim action,
-              // We should make sure set this value back, or it won't trigger trim action again.
+              // We should make sure set this value back, otherwise it won't trigger trim action again.
               trimInProcess.set(false);
             }
           });

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -696,11 +696,12 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
 
   override def onTrim(): Unit = {
     logInfo(s"Trigger ${this.getClass.getCanonicalName} trim action")
-    flushFileWriters()
     try {
+      flushFileWriters()
       Thread.sleep(conf.workerDirectMemoryTrimFlushWaitInterval)
     } catch {
-      case _: Exception => // Do nothing
+      case e: Exception =>
+        logError(s"Trigger ${this.getClass.getCanonicalName} trim failed.", e)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
We meet a case that trim action stoped but didn't set trimInProcess back, then the worker won't trigger a new trim and pause push data, already pushed data(replicate data can work well) won't release, then won't recover receive push data request.

This pr make the logic more robust


### Why are the changes needed?
Make logic more robust


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No
