### PR TITLE
[CELEBORN-1221] Bump Flink from 1.17.0 to 1.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1329,7 +1329,7 @@
         <module>tests/flink-it</module>
       </modules>
       <properties>
-        <flink.version>1.17.0</flink.version>
+        <flink.version>1.17.2</flink.version>
         <flink.binary.version>1.17</flink.binary.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-1.17_${scala.binary.version}</celeborn.flink.plugin.artifact>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -811,7 +811,7 @@ object Flink115 extends FlinkClientProjects {
 }
 
 object Flink117 extends FlinkClientProjects {
-  val flinkVersion = "1.17.0"
+  val flinkVersion = "1.17.2"
 
   // note that SBT does not allow using the period symbol (.) in project names.
   val flinkClientProjectPath = "client-flink/flink-1.17"
@@ -851,7 +851,7 @@ trait FlinkClientProjects {
     .aggregate(flinkCommon, flinkClient, flinkIt)
 
   // get flink major version. e.g:
-  //   1.17.0 -> 1.17
+  //   1.17.2 -> 1.17
   //   1.15.4 -> 1.15
   //   1.14.6 -> 1.14
   lazy val flinkMajorVersion: String = flinkVersion.split("\\.").take(2).reduce(_ + "." + _)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Flink from 1.17.0 to 1.17.2.

### Why are the changes needed?

Flink 1.17.2 has been announced to release: [Apache Flink 1.17.2 Release Announcement](https://flink.apache.org/2023/11/29/apache-flink-1.17.2-release-announcement). The profile flink-1.17 could bump Flink from 1.17.0 to 1.17.2.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.