### PR TITLE
[CELEBORN-1222] Fix Celeborn worker won't record HDFS writer

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -399,6 +399,8 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       workingDirWriters.computeIfAbsent(workingDir, workingDirWriterListFunc).put(
         diskFileInfo.getFilePath,
         writer)
+    } else {
+      hdfsWriters.put(diskFileInfo.getFilePath, writer)
     }
     writer
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
To record hdfs writer in worker.
To fix a bug introduced by https://github.com/apache/incubator-celeborn/pull/2130.

### Why are the changes needed?
If the hdfs writer won't be recorded, the worker won't clean the HDFS shuffle file if a partition is broken until the master cleans the HDFS.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA and cluster.
