### PR TITLE
[CELEBORN-1235] Start test nodes in random ports to allow multiple builds run in the same ci server

### DIFF
--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -58,7 +58,7 @@ public class RemoteShuffleMasterTest {
   public void setUp() {
     configuration = new Configuration();
     Random random = new Random();
-    int startPort = random.nextInt(65535 - 1200) + 1200;
+    int startPort = random.nextInt(65535 - 1024) + 1024;
     configuration.setInteger("celeborn.master.port", startPort);
     configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.util.Utils$;
 import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
 
 public class RemoteShuffleMasterTest {
@@ -57,8 +58,7 @@ public class RemoteShuffleMasterTest {
   @Before
   public void setUp() {
     configuration = new Configuration();
-    Random random = new Random();
-    int startPort = random.nextInt(65535 - 1024) + 1024;
+    int startPort = Utils$.MODULE$.selectRandomPort(1024, 65535);
     configuration.setInteger("celeborn.master.port", startPort);
     configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);

--- a/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.14/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -57,6 +57,10 @@ public class RemoteShuffleMasterTest {
   @Before
   public void setUp() {
     configuration = new Configuration();
+    Random random = new Random();
+    int startPort = random.nextInt(65535 - 1200) + 1200;
+    configuration.setInteger("celeborn.master.port", startPort);
+    configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);
   }
 

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -58,7 +58,7 @@ public class RemoteShuffleMasterTest {
   public void setUp() {
     configuration = new Configuration();
     Random random = new Random();
-    int startPort = random.nextInt(65535 - 1200) + 1200;
+    int startPort = random.nextInt(65535 - 1024) + 1024;
     configuration.setInteger("celeborn.master.port", startPort);
     configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.util.Utils$;
 import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
 
 public class RemoteShuffleMasterTest {
@@ -57,8 +58,7 @@ public class RemoteShuffleMasterTest {
   @Before
   public void setUp() {
     configuration = new Configuration();
-    Random random = new Random();
-    int startPort = random.nextInt(65535 - 1024) + 1024;
+    int startPort = Utils$.MODULE$.selectRandomPort(1024, 65535);
     configuration.setInteger("celeborn.master.port", startPort);
     configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);

--- a/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.15/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -57,6 +57,10 @@ public class RemoteShuffleMasterTest {
   @Before
   public void setUp() {
     configuration = new Configuration();
+    Random random = new Random();
+    int startPort = random.nextInt(65535 - 1200) + 1200;
+    configuration.setInteger("celeborn.master.port", startPort);
+    configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);
   }
 

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.util.Utils$;
 import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
 
 public class RemoteShuffleMasterTest {
@@ -64,8 +65,7 @@ public class RemoteShuffleMasterTest {
   @Before
   public void setUp() {
     configuration = new Configuration();
-    Random random = new Random();
-    int startPort = random.nextInt(65535 - 1024) + 1024;
+    int startPort = Utils$.MODULE$.selectRandomPort(1024, 65535);
     configuration.setInteger("celeborn.master.port", startPort);
     configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -64,6 +64,10 @@ public class RemoteShuffleMasterTest {
   @Before
   public void setUp() {
     configuration = new Configuration();
+    Random random = new Random();
+    int startPort = random.nextInt(65535 - 1200) + 1200;
+    configuration.setInteger("celeborn.master.port", startPort);
+    configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);
   }
 

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -65,7 +65,7 @@ public class RemoteShuffleMasterTest {
   public void setUp() {
     configuration = new Configuration();
     Random random = new Random();
-    int startPort = random.nextInt(65535 - 1200) + 1200;
+    int startPort = random.nextInt(65535 - 1024) + 1024;
     configuration.setInteger("celeborn.master.port", startPort);
     configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);

--- a/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.util.Utils$;
 import org.apache.celeborn.plugin.flink.utils.FlinkUtils;
 
 public class RemoteShuffleMasterTest {
@@ -64,8 +65,7 @@ public class RemoteShuffleMasterTest {
   @Before
   public void setUp() {
     configuration = new Configuration();
-    Random random = new Random();
-    int startPort = random.nextInt(65535 - 1024) + 1024;
+    int startPort = Utils$.MODULE$.selectRandomPort(1024, 65535);
     configuration.setInteger("celeborn.master.port", startPort);
     configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);

--- a/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -64,6 +64,10 @@ public class RemoteShuffleMasterTest {
   @Before
   public void setUp() {
     configuration = new Configuration();
+    Random random = new Random();
+    int startPort = random.nextInt(65535 - 1200) + 1200;
+    configuration.setInteger("celeborn.master.port", startPort);
+    configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);
   }
 

--- a/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
+++ b/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterTest.java
@@ -65,7 +65,7 @@ public class RemoteShuffleMasterTest {
   public void setUp() {
     configuration = new Configuration();
     Random random = new Random();
-    int startPort = random.nextInt(65535 - 1200) + 1200;
+    int startPort = random.nextInt(65535 - 1024) + 1024;
     configuration.setInteger("celeborn.master.port", startPort);
     configuration.setString("celeborn.master.endpoints", "localhost:" + startPort);
     remoteShuffleMaster = createShuffleMaster(configuration);

--- a/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/client/MasterClient.java
@@ -237,8 +237,9 @@ public class MasterClient {
 
       if (endpointRef == null) {
         throw new IllegalStateException(
-            "After trying all the available Master Addresses,"
-                + " an usable link still couldn't be created.");
+            "After trying all the available Master Addresses("
+                + String.join(",", masterEndpoints)
+                + "), an usable link still couldn't be created.");
       } else {
         LOG.info("connect to master {}.", endpointRef.address());
       }

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -347,7 +347,7 @@ object Utils extends Logging {
    * Shuffle the elements of an array into a random order, modifying the
    * original array. Returns the original array.
    */
-  def randomizeInPlace[T](arr: Array[T], rand: Random = new Random): Array[T] = {
+  def randomizeInPlace[T](arr: Array[T], rand: ScalaRandom = new ScalaRandom): Array[T] = {
     for (i <- (arr.length - 1) to 1 by -1) {
       val j = rand.nextInt(i + 1)
       val tmp = arr(j)

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -231,7 +231,6 @@ object Utils extends Logging {
     } catch {
       case NonFatal(t) =>
         logError(s"Uncaught exception in thread ${Thread.currentThread().getName}", t)
-
     }
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -25,14 +25,14 @@ import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.charset.StandardCharsets
 import java.util
-import java.util.{Locale, Properties, Random, UUID}
+import java.util.{Locale, Properties, UUID}
 import java.util.concurrent.{Callable, ThreadPoolExecutor, TimeoutException, TimeUnit}
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.io.Source
 import scala.reflect.ClassTag
-import scala.util.Try
+import scala.util.{Random => ScalaRandom, Try}
 import scala.util.control.{ControlThrowable, NonFatal}
 
 import com.google.protobuf.{ByteString, GeneratedMessageV3}
@@ -241,6 +241,10 @@ object Utils extends Logging {
       case e: ControlThrowable => throw e
       case t: Throwable => throw t
     }
+  }
+
+  def selectRandomPort(from: Int, to: Int): Int = {
+    ScalaRandom.nextInt(to - from) + from
   }
 
   def startServiceOnPort[T](

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -231,6 +231,7 @@ object Utils extends Logging {
     } catch {
       case NonFatal(t) =>
         logError(s"Uncaught exception in thread ${Thread.currentThread().getName}", t)
+
     }
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.charset.StandardCharsets
 import java.util
-import java.util.{Locale, Properties, UUID}
+import java.util.{Locale, Properties, Random, UUID}
 import java.util.concurrent.{Callable, ThreadPoolExecutor, TimeoutException, TimeUnit}
 
 import scala.annotation.tailrec
@@ -347,7 +347,7 @@ object Utils extends Logging {
    * Shuffle the elements of an array into a random order, modifying the
    * original array. Returns the original array.
    */
-  def randomizeInPlace[T](arr: Array[T], rand: ScalaRandom = new ScalaRandom): Array[T] = {
+  def randomizeInPlace[T](arr: Array[T], rand: Random = new Random): Array[T] = {
     for (i <- (arr.length - 1) to 1 by -1) {
       val j = rand.nextInt(i + 1)
       val tmp = arr(j)

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -40,6 +40,7 @@ import org.apache.celeborn.common.rpc.RpcEndpointRef;
 import org.apache.celeborn.common.rpc.RpcEnv;
 import org.apache.celeborn.common.rpc.netty.NettyRpcEndpointRef;
 import org.apache.celeborn.common.util.Utils;
+import org.apache.celeborn.common.util.Utils$;
 import org.apache.celeborn.service.deploy.master.clustermeta.AbstractMetaManager;
 
 public class RatisMasterStatusSystemSuiteJ {
@@ -116,8 +117,7 @@ public class RatisMasterStatusSystemSuiteJ {
         String id2 = UUID.randomUUID().toString();
         String id3 = UUID.randomUUID().toString();
 
-        Random rand = new Random();
-        int ratisPort1 = rand.nextInt(65535 - 1024) + 1024;
+        int ratisPort1 = Utils$.MODULE$.selectRandomPort(1024, 65535);
         int ratisPort2 = ratisPort1 + 1;
         int ratisPort3 = ratisPort2 + 1;
 

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -165,6 +165,9 @@ public class RatisMasterStatusSystemSuiteJ {
       } catch (Exception e) {
         stopAllRaftServers();
         retryCount += 1;
+        if (retryCount >= 3) {
+          throw e;
+        }
       }
       serversStarted = true;
     }

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -84,7 +84,7 @@ public class RatisMasterStatusSystemSuiteJ {
     int retryCount = 0;
     boolean serversStarted = false;
 
-    while (retryCount < 3 && !serversStarted) {
+    while (!serversStarted) {
       try {
         STATUSSYSTEM1 = new HAMasterMetaManager(mockRpcEnv, new CelebornConf());
         STATUSSYSTEM2 = new HAMasterMetaManager(mockRpcEnv, new CelebornConf());
@@ -161,7 +161,7 @@ public class RatisMasterStatusSystemSuiteJ {
         RATISSERVER1.start();
         RATISSERVER2.start();
         RATISSERVER3.start();
-        Thread.sleep(15 * 1000);
+        Thread.sleep(60 * 1000);
       } catch (Exception e) {
         stopAllRaftServers();
         retryCount += 1;

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -117,7 +117,7 @@ public class RatisMasterStatusSystemSuiteJ {
         String id3 = UUID.randomUUID().toString();
 
         Random rand = new Random();
-        int ratisPort1 = rand.nextInt(65535 - 1200) + 1200;
+        int ratisPort1 = rand.nextInt(65535 - 1024) + 1024;
         int ratisPort2 = ratisPort1 + 1;
         int ratisPort3 = ratisPort2 + 1;
 

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -161,15 +161,15 @@ public class RatisMasterStatusSystemSuiteJ {
         RATISSERVER1.start();
         RATISSERVER2.start();
         RATISSERVER3.start();
-        Thread.sleep(60 * 1000);
+        Thread.sleep(15 * 1000);
+        serversStarted = true;
       } catch (Exception e) {
         stopAllRaftServers();
         retryCount += 1;
-        if (retryCount >= 3) {
+        if (retryCount == 3) {
           throw e;
         }
       }
-      serversStarted = true;
     }
   }
 

--- a/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
+++ b/master/src/test/java/org/apache/celeborn/service/deploy/master/clustermeta/ha/RatisMasterStatusSystemSuiteJ.java
@@ -62,95 +62,112 @@ public class RatisMasterStatusSystemSuiteJ {
     resetRaftServer();
   }
 
+  private static void stopAllRaftServers() {
+    if (RATISSERVER1 != null) {
+      RATISSERVER1.stop();
+    }
+    if (RATISSERVER2 != null) {
+      RATISSERVER2.stop();
+    }
+    if (RATISSERVER3 != null) {
+      RATISSERVER3.stop();
+    }
+  }
+
   public static void resetRaftServer() throws IOException, InterruptedException {
     Mockito.when(mockRpcEnv.setupEndpointRef(Mockito.any(), Mockito.any()))
         .thenReturn(mockRpcEndpoint);
     when(mockRpcEnv.setupEndpointRef(any(), any())).thenReturn(dummyRef);
 
-    if (RATISSERVER1 != null) {
-      RATISSERVER1.stop();
+    stopAllRaftServers();
+
+    int retryCount = 0;
+    boolean serversStarted = false;
+
+    while (retryCount < 3 && !serversStarted) {
+      try {
+        STATUSSYSTEM1 = new HAMasterMetaManager(mockRpcEnv, new CelebornConf());
+        STATUSSYSTEM2 = new HAMasterMetaManager(mockRpcEnv, new CelebornConf());
+        STATUSSYSTEM3 = new HAMasterMetaManager(mockRpcEnv, new CelebornConf());
+
+        MetaHandler handler1 = new MetaHandler(STATUSSYSTEM1);
+        MetaHandler handler2 = new MetaHandler(STATUSSYSTEM2);
+        MetaHandler handler3 = new MetaHandler(STATUSSYSTEM3);
+
+        CelebornConf conf1 = new CelebornConf();
+        File tmpDir1 = File.createTempFile("celeborn-ratis1", "for-test-only");
+        tmpDir1.delete();
+        tmpDir1.mkdirs();
+        conf1.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR().key(), tmpDir1.getAbsolutePath());
+
+        CelebornConf conf2 = new CelebornConf();
+        File tmpDir2 = File.createTempFile("celeborn-ratis2", "for-test-only");
+        tmpDir2.delete();
+        tmpDir2.mkdirs();
+        conf2.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR().key(), tmpDir2.getAbsolutePath());
+
+        CelebornConf conf3 = new CelebornConf();
+        File tmpDir3 = File.createTempFile("celeborn-ratis3", "for-test-only");
+        tmpDir3.delete();
+        tmpDir3.mkdirs();
+        conf3.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR().key(), tmpDir3.getAbsolutePath());
+
+        String id1 = UUID.randomUUID().toString();
+        String id2 = UUID.randomUUID().toString();
+        String id3 = UUID.randomUUID().toString();
+
+        Random rand = new Random();
+        int ratisPort1 = rand.nextInt(65535 - 1200) + 1200;
+        int ratisPort2 = ratisPort1 + 1;
+        int ratisPort3 = ratisPort2 + 1;
+
+        MasterNode masterNode1 =
+            new MasterNode.Builder()
+                .setHost(Utils.localHostName(conf1))
+                .setRatisPort(ratisPort1)
+                .setRpcPort(ratisPort1)
+                .setNodeId(id1)
+                .build();
+        MasterNode masterNode2 =
+            new MasterNode.Builder()
+                .setHost(Utils.localHostName(conf2))
+                .setRatisPort(ratisPort2)
+                .setRpcPort(ratisPort2)
+                .setNodeId(id2)
+                .build();
+        MasterNode masterNode3 =
+            new MasterNode.Builder()
+                .setHost(Utils.localHostName(conf3))
+                .setRatisPort(ratisPort3)
+                .setRpcPort(ratisPort3)
+                .setNodeId(id3)
+                .build();
+
+        List<MasterNode> peersForNode1 = Arrays.asList(masterNode2, masterNode3);
+        List<MasterNode> peersForNode2 = Arrays.asList(masterNode1, masterNode3);
+        List<MasterNode> peersForNode3 = Arrays.asList(masterNode1, masterNode2);
+
+        RATISSERVER1 =
+            HARaftServer.newMasterRatisServer(handler1, conf1, masterNode1, peersForNode1);
+        RATISSERVER2 =
+            HARaftServer.newMasterRatisServer(handler2, conf2, masterNode2, peersForNode2);
+        RATISSERVER3 =
+            HARaftServer.newMasterRatisServer(handler3, conf3, masterNode3, peersForNode3);
+
+        STATUSSYSTEM1.setRatisServer(RATISSERVER1);
+        STATUSSYSTEM2.setRatisServer(RATISSERVER2);
+        STATUSSYSTEM3.setRatisServer(RATISSERVER3);
+
+        RATISSERVER1.start();
+        RATISSERVER2.start();
+        RATISSERVER3.start();
+        Thread.sleep(15 * 1000);
+      } catch (Exception e) {
+        stopAllRaftServers();
+        retryCount += 1;
+      }
+      serversStarted = true;
     }
-
-    if (RATISSERVER2 != null) {
-      RATISSERVER2.stop();
-    }
-
-    if (RATISSERVER3 != null) {
-      RATISSERVER3.stop();
-    }
-
-    STATUSSYSTEM1 = new HAMasterMetaManager(mockRpcEnv, new CelebornConf());
-    STATUSSYSTEM2 = new HAMasterMetaManager(mockRpcEnv, new CelebornConf());
-    STATUSSYSTEM3 = new HAMasterMetaManager(mockRpcEnv, new CelebornConf());
-
-    MetaHandler handler1 = new MetaHandler(STATUSSYSTEM1);
-    MetaHandler handler2 = new MetaHandler(STATUSSYSTEM2);
-    MetaHandler handler3 = new MetaHandler(STATUSSYSTEM3);
-
-    CelebornConf conf1 = new CelebornConf();
-    File tmpDir1 = File.createTempFile("celeborn-ratis1", "for-test-only");
-    tmpDir1.delete();
-    tmpDir1.mkdirs();
-    conf1.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR().key(), tmpDir1.getAbsolutePath());
-
-    CelebornConf conf2 = new CelebornConf();
-    File tmpDir2 = File.createTempFile("celeborn-ratis2", "for-test-only");
-    tmpDir2.delete();
-    tmpDir2.mkdirs();
-    conf2.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR().key(), tmpDir2.getAbsolutePath());
-
-    CelebornConf conf3 = new CelebornConf();
-    File tmpDir3 = File.createTempFile("celeborn-ratis3", "for-test-only");
-    tmpDir3.delete();
-    tmpDir3.mkdirs();
-    conf3.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR().key(), tmpDir3.getAbsolutePath());
-
-    String id1 = UUID.randomUUID().toString();
-    String id2 = UUID.randomUUID().toString();
-    String id3 = UUID.randomUUID().toString();
-    int ratisPort1 = 9872;
-    int ratisPort2 = 9873;
-    int ratisPort3 = 9874;
-
-    MasterNode masterNode1 =
-        new MasterNode.Builder()
-            .setHost(Utils.localHostName(conf1))
-            .setRatisPort(ratisPort1)
-            .setRpcPort(9872)
-            .setNodeId(id1)
-            .build();
-    MasterNode masterNode2 =
-        new MasterNode.Builder()
-            .setHost(Utils.localHostName(conf2))
-            .setRatisPort(ratisPort2)
-            .setRpcPort(9873)
-            .setNodeId(id2)
-            .build();
-    MasterNode masterNode3 =
-        new MasterNode.Builder()
-            .setHost(Utils.localHostName(conf3))
-            .setRatisPort(ratisPort3)
-            .setRpcPort(9874)
-            .setNodeId(id3)
-            .build();
-
-    List<MasterNode> peersForNode1 = Arrays.asList(masterNode2, masterNode3);
-    List<MasterNode> peersForNode2 = Arrays.asList(masterNode1, masterNode3);
-    List<MasterNode> peersForNode3 = Arrays.asList(masterNode1, masterNode2);
-
-    RATISSERVER1 = HARaftServer.newMasterRatisServer(handler1, conf1, masterNode1, peersForNode1);
-    RATISSERVER2 = HARaftServer.newMasterRatisServer(handler2, conf2, masterNode2, peersForNode2);
-    RATISSERVER3 = HARaftServer.newMasterRatisServer(handler3, conf3, masterNode3, peersForNode3);
-
-    STATUSSYSTEM1.setRatisServer(RATISSERVER1);
-    STATUSSYSTEM2.setRatisServer(RATISSERVER2);
-    STATUSSYSTEM3.setRatisServer(RATISSERVER3);
-
-    RATISSERVER1.start();
-    RATISSERVER2.start();
-    RATISSERVER3.start();
-
-    Thread.sleep(15 * 1000);
   }
 
   @Test

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -20,10 +20,11 @@ package org.apache.celeborn.service.deploy.master
 import com.google.common.io.Files
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
-
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.CelebornExitKind
+
+import scala.util.Random
 
 class MasterSuite extends AnyFunSuite
   with BeforeAndAfterAll
@@ -38,14 +39,16 @@ class MasterSuite extends AnyFunSuite
 
   test("test single node startup functionality") {
     val conf = new CelebornConf()
+    val randomMasterPort = Random.nextInt(65535 - 1200) + 1200
+    val randomHttpPort = randomMasterPort + 1
     conf.set(CelebornConf.HA_ENABLED.key, "false")
     conf.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR.key, getTmpDir())
     conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, getTmpDir())
     conf.set(CelebornConf.METRICS_ENABLED.key, "true")
     conf.set(CelebornConf.MASTER_HTTP_HOST.key, "127.0.0.1")
-    conf.set(CelebornConf.MASTER_HTTP_PORT.key, "11112")
+    conf.set(CelebornConf.MASTER_HTTP_PORT.key, randomHttpPort.toString)
 
-    val args = Array("-h", "localhost", "-p", "9097")
+    val args = Array("-h", "localhost", "-p", randomMasterPort.toString)
 
     val masterArgs = new MasterArguments(args, conf)
     val master = new Master(conf, masterArgs)

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -40,7 +40,7 @@ class MasterSuite extends AnyFunSuite
 
   test("test single node startup functionality") {
     val conf = new CelebornConf()
-    val randomMasterPort = Random.nextInt(65535 - 1200) + 1200
+    val randomMasterPort = Random.nextInt(65535 - 1024) + 1024
     val randomHttpPort = randomMasterPort + 1
     conf.set(CelebornConf.HA_ENABLED.key, "false")
     conf.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR.key, getTmpDir())

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -17,14 +17,15 @@
 
 package org.apache.celeborn.service.deploy.master
 
+import scala.util.Random
+
 import com.google.common.io.Files
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
+
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.CelebornExitKind
-
-import scala.util.Random
 
 class MasterSuite extends AnyFunSuite
   with BeforeAndAfterAll

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -25,7 +25,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
-import org.apache.celeborn.common.util.CelebornExitKind
+import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
 
 class MasterSuite extends AnyFunSuite
   with BeforeAndAfterAll
@@ -40,7 +40,7 @@ class MasterSuite extends AnyFunSuite
 
   test("test single node startup functionality") {
     val conf = new CelebornConf()
-    val randomMasterPort = Random.nextInt(65535 - 1024) + 1024
+    val randomMasterPort = Utils.selectRandomPort(1024, 65535)
     val randomHttpPort = randomMasterPort + 1
     conf.set(CelebornConf.HA_ENABLED.key, "false")
     conf.set(CelebornConf.HA_MASTER_RATIS_STORAGE_DIR.key, getTmpDir())

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/MasterSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.celeborn.service.deploy.master
 
-import scala.util.Random
-
 import com.google.common.io.Files
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/SplitTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/SplitTest.scala
@@ -35,7 +35,7 @@ class SplitTest extends AnyFunSuite with Logging with MiniClusterFeature
   override def beforeAll(): Unit = {
     logInfo("test initialized , setup celeborn mini cluster")
     val (m, w) = setupMiniClusterWithRandomPorts(workerConf =
-      Some(Map(CelebornConf.WORKER_FLUSHER_BUFFER_SIZE.key -> "10k")))
+      Map(CelebornConf.WORKER_FLUSHER_BUFFER_SIZE.key -> "10k"))
     workers = w
     port = m.conf.get(CelebornConf.MASTER_PORT)
   }

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/SplitTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/SplitTest.scala
@@ -31,15 +31,13 @@ import org.apache.celeborn.service.deploy.worker.Worker
 class SplitTest extends AnyFunSuite with Logging with MiniClusterFeature
   with BeforeAndAfterAll {
   var workers: collection.Set[Worker] = null
+  var port = 0
   override def beforeAll(): Unit = {
     logInfo("test initialized , setup celeborn mini cluster")
-    val masterConf = Map(
-      "celeborn.master.host" -> "localhost",
-      "celeborn.master.port" -> "9097")
-    val workerConf = Map(
-      "celeborn.master.endpoints" -> "localhost:9097",
-      CelebornConf.WORKER_FLUSHER_BUFFER_SIZE.key -> "10k")
-    workers = setUpMiniCluster(masterConf, workerConf)._2
+    val (m, w) = setupMiniClusterWithRandomPorts(workerConf =
+      Some(Map(CelebornConf.WORKER_FLUSHER_BUFFER_SIZE.key -> "10k")))
+    workers = w
+    port = m.conf.get(CelebornConf.MASTER_PORT)
   }
   override def afterAll(): Unit = {
     logInfo("all test complete , stop celeborn mini cluster")
@@ -52,7 +50,7 @@ class SplitTest extends AnyFunSuite with Logging with MiniClusterFeature
     configuration.setString(
       "shuffle-service-factory.class",
       "org.apache.celeborn.plugin.flink.RemoteShuffleServiceFactory")
-    configuration.setString(CelebornConf.MASTER_ENDPOINTS.key, "localhost:9097")
+    configuration.setString(CelebornConf.MASTER_ENDPOINTS.key, s"localhost:$port")
     configuration.setString("execution.batch-shuffle-mode", "ALL_EXCHANGES_BLOCKING")
     configuration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH)
     configuration.setString("taskmanager.memory.network.min", "1024m")

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/WordCountTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/WordCountTest.scala
@@ -17,10 +17,10 @@
 
 package org.apache.celeborn.tests.flink
 
+import org.apache.celeborn.common.CelebornConf
+
 import java.io.File
-
 import scala.collection.JavaConverters._
-
 import org.apache.flink.api.common.{ExecutionMode, RuntimeExecutionMode}
 import org.apache.flink.configuration.{Configuration, ExecutionOptions, RestOptions}
 import org.apache.flink.runtime.jobgraph.JobType
@@ -28,7 +28,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
-
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.service.deploy.MiniClusterFeature
 import org.apache.celeborn.service.deploy.worker.Worker
@@ -36,14 +35,13 @@ import org.apache.celeborn.service.deploy.worker.Worker
 class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
   with BeforeAndAfterAll {
   var workers: collection.Set[Worker] = null
+  var port = 0
 
   override def beforeAll(): Unit = {
     logInfo("test initialized , setup celeborn mini cluster")
-    val masterConf = Map(
-      "celeborn.master.host" -> "localhost",
-      "celeborn.master.port" -> "9097")
-    val workerConf = Map("celeborn.master.endpoints" -> "localhost:9097")
-    workers = setUpMiniCluster(masterConf, workerConf)._2
+    val (m, w) = setupMiniClusterWithRandomPorts()
+    workers = w
+    port = m.conf.get(CelebornConf.MASTER_PORT)
   }
 
   override def afterAll(): Unit = {
@@ -58,7 +56,7 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
     configuration.setString(
       "shuffle-service-factory.class",
       "org.apache.celeborn.plugin.flink.RemoteShuffleServiceFactory")
-    configuration.setString("celeborn.master.endpoints", "localhost:9097")
+    configuration.setString("celeborn.master.endpoints", s"localhost:$port")
     configuration.setString("execution.batch-shuffle-mode", "ALL_EXCHANGES_BLOCKING")
     configuration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH)
     configuration.setString("taskmanager.memory.network.min", "1024m")

--- a/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/WordCountTest.scala
+++ b/tests/flink-it/src/test/scala/org/apache/celeborn/tests/flink/WordCountTest.scala
@@ -17,10 +17,10 @@
 
 package org.apache.celeborn.tests.flink
 
-import org.apache.celeborn.common.CelebornConf
-
 import java.io.File
+
 import scala.collection.JavaConverters._
+
 import org.apache.flink.api.common.{ExecutionMode, RuntimeExecutionMode}
 import org.apache.flink.configuration.{Configuration, ExecutionOptions, RestOptions}
 import org.apache.flink.runtime.jobgraph.JobType
@@ -28,6 +28,8 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.service.deploy.MiniClusterFeature
 import org.apache.celeborn.service.deploy.worker.Worker

--- a/tests/mr-it/src/test/resources/log4j2-test.xml
+++ b/tests/mr-it/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="ERROR"/>
+                <ThresholdFilter level="INFO"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/tests/mr-it/src/test/resources/log4j2-test.xml
+++ b/tests/mr-it/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="INFO"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
+++ b/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
@@ -152,11 +152,17 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
         exitCode = job.waitForCompletion(true)
         if (exitCode) {
           finish = true
+        } else {
+          retryCount += 1
+          if (retryCount >= 2) {
+            throw new RuntimeException("failed to run wordcount")
+          }
         }
       } catch {
         case e: Exception =>
           retryCount += 1
-          if (retryCount == 2) {
+          if (retryCount >= 2) {
+            log.error("failed to run wordcount", e)
             throw e
           }
       }

--- a/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
+++ b/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
@@ -150,7 +150,9 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
         })
 
         exitCode = job.waitForCompletion(true)
-        finish = true
+        if (exitCode) {
+          finish = true
+        }
       } catch {
         case e: Exception =>
           retryCount += 1

--- a/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
+++ b/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
@@ -51,11 +51,7 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
 
   override def beforeAll(): Unit = {
     logInfo("test initialized , setup celeborn mini cluster")
-    val masterConf = Map(
-      "celeborn.master.host" -> "localhost",
-      "celeborn.master.port" -> "9097")
-    val workerConf = Map("celeborn.master.endpoints" -> "localhost:9097")
-    workers = setUpMiniCluster(masterConf, workerConf)._2
+    workers = setupMiniClusterWithRandomPorts()._2
 
     hadoopConf = new Configuration()
     hadoopConf.set("yarn.scheduler.capacity.root.queues", "default,other_queue")

--- a/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
+++ b/tests/mr-it/src/test/scala/org/apache/celeborn/tests/mr/WordCountTest.scala
@@ -17,12 +17,12 @@
 
 package org.apache.celeborn.tests.mr
 
-import org.apache.celeborn.common.CelebornConf
-
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
+
 import scala.collection.JavaConverters._
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.examples.WordCount
 import org.apache.hadoop.fs.Path
@@ -36,6 +36,8 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.server.MiniYARNCluster
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.Utils
 import org.apache.celeborn.service.deploy.MiniClusterFeature
@@ -110,7 +112,8 @@ class WordCountTest extends AnyFunSuite with Logging with MiniClusterFeature
     conf.set("mapreduce.job.user.classpath.first", "true")
 
     conf.set("mapreduce.job.reduce.slowstart.completedmaps", "1")
-    conf.set("mapreduce.celeborn.master.endpoints",
+    conf.set(
+      "mapreduce.celeborn.master.endpoints",
       s"localhost:${master.conf.get(CelebornConf.MASTER_PORT)}")
     conf.set(
       MRJobConfig.MAP_OUTPUT_COLLECTOR_CLASS_ATTR,

--- a/tests/spark-it/src/test/resources/log4j2-test.xml
+++ b/tests/spark-it/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="INFO"/>
+                <ThresholdFilter level="ERROR"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">

--- a/tests/spark-it/src/test/resources/log4j2-test.xml
+++ b/tests/spark-it/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="ERROR"/>
+                <ThresholdFilter level="DEBUG"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
@@ -29,7 +29,7 @@
         </File>
     </Appenders>
     <Loggers>
-        <Root level="INFO">
+        <Root level="DEBUG">
             <AppenderRef ref="stdout"/>
             <AppenderRef ref="file"/>
         </Root>

--- a/tests/spark-it/src/test/resources/log4j2-test.xml
+++ b/tests/spark-it/src/test/resources/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yy/MM/dd HH:mm:ss,SSS} %p [%t] %c{1}: %m%n%ex"/>
             <Filters>
-                <ThresholdFilter level="DEBUG"/>
+                <ThresholdFilter level="INFO"/>
             </Filters>
         </Console>
         <File name="file" fileName="target/unit-tests.log">
@@ -29,7 +29,7 @@
         </File>
     </Appenders>
     <Loggers>
-        <Root level="DEBUG">
+        <Root level="INFO">
             <AppenderRef ref="stdout"/>
             <AppenderRef ref="file"/>
         </Root>

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
@@ -33,20 +33,17 @@ import org.apache.celeborn.service.deploy.MiniClusterFeature
 import org.apache.celeborn.service.deploy.worker.CommitInfo
 
 class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniClusterFeature {
-  private val masterPort = 19097
 
-  celebornConf.set(CelebornConf.MASTER_ENDPOINTS.key, s"localhost:$masterPort")
+  celebornConf
     .set(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED.key, "true")
     .set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val masterConf = Map(
-      "celeborn.master.host" -> "localhost",
-      "celeborn.master.port" -> masterPort.toString)
-    val workerConf = Map(
-      "celeborn.master.endpoints" -> s"localhost:$masterPort")
-    setUpMiniCluster(masterConf, workerConf)
+    val (master, _) = setupMiniClusterWithRandomPorts()
+    celebornConf.set(
+      CelebornConf.MASTER_ENDPOINTS.key,
+      master.conf.get(CelebornConf.MASTER_ENDPOINTS.key))
   }
 
   test("test commit files without mocking failure") {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
@@ -86,7 +86,7 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
       params,
       new ShuffleFailedWorkers)
 
-    workerInfos.asScala.keySet.foreach { worker =>
+    workerInfos.keySet.foreach { worker =>
       worker.controller.shuffleCommitInfos.get(
         Utils.makeShuffleKey(APP, shuffleId)).values().asScala.foreach { commitInfo =>
         commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED
@@ -136,7 +136,7 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
       params,
       new ShuffleFailedWorkers)
 
-    workerInfos.asScala.keySet.foreach { worker =>
+    workerInfos.keySet.foreach { worker =>
       worker.controller.shuffleCommitInfos.get(
         Utils.makeShuffleKey(APP, shuffleId)).values().asScala.foreach { commitInfo =>
         commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerCommitFilesSuite.scala
@@ -86,7 +86,7 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
       params,
       new ShuffleFailedWorkers)
 
-    workerInfos.keySet.foreach { worker =>
+    workerInfos.asScala.keySet.foreach { worker =>
       worker.controller.shuffleCommitInfos.get(
         Utils.makeShuffleKey(APP, shuffleId)).values().asScala.foreach { commitInfo =>
         commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED
@@ -136,7 +136,7 @@ class LifecycleManagerCommitFilesSuite extends WithShuffleClientSuite with MiniC
       params,
       new ShuffleFailedWorkers)
 
-    workerInfos.keySet.foreach { worker =>
+    workerInfos.asScala.keySet.foreach { worker =>
       worker.controller.shuffleCommitInfos.get(
         Utils.makeShuffleKey(APP, shuffleId)).values().asScala.foreach { commitInfo =>
         commitInfo.status == CommitInfo.COMMIT_INPROCESS || commitInfo.status == CommitInfo.COMMIT_FINISHED

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerDestroySlotsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerDestroySlotsSuite.scala
@@ -30,20 +30,17 @@ import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
 import org.apache.celeborn.service.deploy.MiniClusterFeature
 
 class LifecycleManagerDestroySlotsSuite extends WithShuffleClientSuite with MiniClusterFeature {
-  private val masterPort = 19097
 
-  celebornConf.set(CelebornConf.MASTER_ENDPOINTS.key, s"localhost:$masterPort")
+  celebornConf
     .set(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED.key, "true")
     .set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val masterConf = Map(
-      "celeborn.master.host" -> "localhost",
-      "celeborn.master.port" -> masterPort.toString)
-    val workerConf = Map(
-      "celeborn.master.endpoints" -> s"localhost:$masterPort")
-    setUpMiniCluster(masterConf, workerConf)
+    val (master, _) = setupMiniClusterWithRandomPorts()
+    celebornConf.set(
+      CelebornConf.MASTER_ENDPOINTS.key,
+      master.conf.get(CelebornConf.MASTER_ENDPOINTS.key))
   }
 
   test("test destroy workers without mocking failure") {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerDestroySlotsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerDestroySlotsSuite.scala
@@ -65,7 +65,7 @@ class LifecycleManagerDestroySlotsSuite extends WithShuffleClientSuite with Mini
       updateEpoch = false)
 
     val slotsToDestroy = new WorkerResource
-    val destroyWorkers = workerInfos.keySet.take(2)
+    val destroyWorkers = workerInfos.asScala.keySet.take(2)
     destroyWorkers.foreach { worker =>
       val entry = res.workerResource.entrySet().asScala.filter(_.getKey == worker.workerInfo).head
       slotsToDestroy.put(entry.getKey, entry.getValue)
@@ -104,7 +104,7 @@ class LifecycleManagerDestroySlotsSuite extends WithShuffleClientSuite with Mini
       updateEpoch = false)
 
     val slotsToDestroy = new WorkerResource
-    val destroyWorkers = workerInfos.keySet.take(2)
+    val destroyWorkers = workerInfos.asScala.keySet.take(2)
     destroyWorkers.foreach { worker =>
       val entry = res.workerResource.entrySet().asScala.filter(_.getKey == worker.workerInfo).head
       slotsToDestroy.put(entry.getKey, entry.getValue)
@@ -143,7 +143,7 @@ class LifecycleManagerDestroySlotsSuite extends WithShuffleClientSuite with Mini
       updateEpoch = false)
 
     val slotsToDestroy = new WorkerResource
-    val destroyWorkers = workerInfos.keySet.take(2)
+    val destroyWorkers = workerInfos.asScala.keySet.take(2)
     destroyWorkers.foreach { worker =>
       val entry = res.workerResource.entrySet().asScala.filter(_.getKey == worker.workerInfo).head
       slotsToDestroy.put(entry.getKey, entry.getValue)

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerDestroySlotsSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerDestroySlotsSuite.scala
@@ -65,7 +65,7 @@ class LifecycleManagerDestroySlotsSuite extends WithShuffleClientSuite with Mini
       updateEpoch = false)
 
     val slotsToDestroy = new WorkerResource
-    val destroyWorkers = workerInfos.asScala.keySet.take(2)
+    val destroyWorkers = workerInfos.keySet.take(2)
     destroyWorkers.foreach { worker =>
       val entry = res.workerResource.entrySet().asScala.filter(_.getKey == worker.workerInfo).head
       slotsToDestroy.put(entry.getKey, entry.getValue)
@@ -104,7 +104,7 @@ class LifecycleManagerDestroySlotsSuite extends WithShuffleClientSuite with Mini
       updateEpoch = false)
 
     val slotsToDestroy = new WorkerResource
-    val destroyWorkers = workerInfos.asScala.keySet.take(2)
+    val destroyWorkers = workerInfos.keySet.take(2)
     destroyWorkers.foreach { worker =>
       val entry = res.workerResource.entrySet().asScala.filter(_.getKey == worker.workerInfo).head
       slotsToDestroy.put(entry.getKey, entry.getValue)
@@ -143,7 +143,7 @@ class LifecycleManagerDestroySlotsSuite extends WithShuffleClientSuite with Mini
       updateEpoch = false)
 
     val slotsToDestroy = new WorkerResource
-    val destroyWorkers = workerInfos.asScala.keySet.take(2)
+    val destroyWorkers = workerInfos.keySet.take(2)
     destroyWorkers.foreach { worker =>
       val entry = res.workerResource.entrySet().asScala.filter(_.getKey == worker.workerInfo).head
       slotsToDestroy.put(entry.getKey, entry.getValue)

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSetupEndpointSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSetupEndpointSuite.scala
@@ -31,18 +31,16 @@ import org.apache.celeborn.service.deploy.MiniClusterFeature
 class LifecycleManagerSetupEndpointSuite extends WithShuffleClientSuite with MiniClusterFeature {
   private val masterPort = 19097
 
-  celebornConf.set(CelebornConf.MASTER_ENDPOINTS.key, s"localhost:$masterPort")
+  celebornConf
     .set(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED.key, "true")
     .set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val masterConf = Map(
-      "celeborn.master.host" -> "localhost",
-      "celeborn.master.port" -> masterPort.toString)
-    val workerConf = Map(
-      "celeborn.master.endpoints" -> s"localhost:$masterPort")
-    setUpMiniCluster(masterConf, workerConf)
+    val (master, _) = setupMiniClusterWithRandomPorts()
+    celebornConf.set(
+      CelebornConf.MASTER_ENDPOINTS.key,
+      master.conf.get(CelebornConf.MASTER_ENDPOINTS.key))
   }
 
   test("test setup endpoints with all workers good") {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSetupEndpointSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSetupEndpointSuite.scala
@@ -68,7 +68,7 @@ class LifecycleManagerSetupEndpointSuite extends WithShuffleClientSuite with Min
     assert(res.status == StatusCode.SUCCESS)
     assert(res.workerResource.keySet().size() == 3)
 
-    val firstWorker = workerInfos.asScala.keySet.head
+    val firstWorker = workerInfos.keySet.head
     firstWorker.stop(CelebornExitKind.EXIT_IMMEDIATELY)
     firstWorker.rpcEnv.shutdown()
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSetupEndpointSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSetupEndpointSuite.scala
@@ -68,7 +68,7 @@ class LifecycleManagerSetupEndpointSuite extends WithShuffleClientSuite with Min
     assert(res.status == StatusCode.SUCCESS)
     assert(res.workerResource.keySet().size() == 3)
 
-    val firstWorker = workerInfos.keySet.head
+    val firstWorker = workerInfos.asScala.keySet.head
     firstWorker.stop(CelebornExitKind.EXIT_IMMEDIATELY)
     firstWorker.rpcEnv.shutdown()
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSuite.scala
@@ -25,20 +25,18 @@ import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.service.deploy.MiniClusterFeature
 
 class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeature {
-  private val masterPort = 19097
 
-  celebornConf.set(CelebornConf.MASTER_ENDPOINTS.key, s"localhost:$masterPort")
+  celebornConf
     .set(CelebornConf.CLIENT_PUSH_REPLICATE_ENABLED.key, "true")
     .set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val masterConf = Map(
-      "celeborn.master.host" -> "localhost",
-      "celeborn.master.port" -> masterPort.toString)
-    val workerConf = Map(
-      "celeborn.master.endpoints" -> s"localhost:$masterPort")
-    setUpMiniCluster(masterConf, workerConf)
+    val (master, _) = setupMiniClusterWithRandomPorts()
+    logInfo(s"master address is: ${master.conf.get(CelebornConf.MASTER_ENDPOINTS.key)}")
+    celebornConf.set(
+      CelebornConf.MASTER_ENDPOINTS.key,
+      master.conf.get(CelebornConf.MASTER_ENDPOINTS.key))
   }
 
   test("CELEBORN-1151: test request slots with client blacklist worker with filter enabled") {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSuite.scala
@@ -51,7 +51,7 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
     })
 
     // test request slots without worker excluded
-    val headWorkerInfo = workerInfos.asScala.keySet.head.workerInfo
+    val headWorkerInfo = workerInfos.keySet.head.workerInfo
     val res1 = lifecycleManager.requestMasterRequestSlotsWithRetry(0, arrayList)
       .workerResource.keySet()
     assert(res1.contains(headWorkerInfo))
@@ -59,7 +59,7 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
     // test request slots with 1 worker excluded, result should not contains the excluded worker
     val commitFilesFailedWorkers = new LifecycleManager.ShuffleFailedWorkers()
     commitFilesFailedWorkers.put(
-      workerInfos.asScala.keySet.head.workerInfo,
+      workerInfos.keySet.head.workerInfo,
       (StatusCode.PUSH_DATA_TIMEOUT_PRIMARY, System.currentTimeMillis()))
     lifecycleManager.workerStatusTracker.recordWorkerFailure(commitFilesFailedWorkers)
     val res2 = lifecycleManager.requestMasterRequestSlotsWithRetry(1, arrayList)
@@ -67,7 +67,7 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
     assert(!res2.contains(headWorkerInfo))
 
     // test request slots with all workers excluded, response should be WORKER_EXCLUDED
-    workerInfos.asScala.keySet.foreach(worker =>
+    workerInfos.keySet.foreach(worker =>
       commitFilesFailedWorkers.put(
         worker.workerInfo,
         (StatusCode.PUSH_DATA_TIMEOUT_PRIMARY, System.currentTimeMillis())))
@@ -89,7 +89,7 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
 
     // test request slots with all workers excluded, response should not excluded any worker
     val commitFilesFailedWorkers = new LifecycleManager.ShuffleFailedWorkers()
-    workerInfos.asScala.keySet.foreach(worker =>
+    workerInfos.keySet.foreach(worker =>
       commitFilesFailedWorkers.put(
         worker.workerInfo,
         (StatusCode.PUSH_DATA_TIMEOUT_PRIMARY, System.currentTimeMillis())))
@@ -97,7 +97,7 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
     val res = lifecycleManager.requestMasterRequestSlotsWithRetry(0, arrayList)
       .workerResource.keySet()
     assert(res.size() == workerInfos.size)
-    assert(res.contains(workerInfos.asScala.keySet.head.workerInfo))
+    assert(res.contains(workerInfos.keySet.head.workerInfo))
     lifecycleManager.stop()
   }
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/client/LifecycleManagerSuite.scala
@@ -19,6 +19,8 @@ package org.apache.celeborn.tests.client
 
 import java.util
 
+import scala.collection.JavaConverters._
+
 import org.apache.celeborn.client.{LifecycleManager, WithShuffleClientSuite}
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.protocol.message.StatusCode
@@ -49,7 +51,7 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
     })
 
     // test request slots without worker excluded
-    val headWorkerInfo = workerInfos.keySet.head.workerInfo
+    val headWorkerInfo = workerInfos.asScala.keySet.head.workerInfo
     val res1 = lifecycleManager.requestMasterRequestSlotsWithRetry(0, arrayList)
       .workerResource.keySet()
     assert(res1.contains(headWorkerInfo))
@@ -57,7 +59,7 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
     // test request slots with 1 worker excluded, result should not contains the excluded worker
     val commitFilesFailedWorkers = new LifecycleManager.ShuffleFailedWorkers()
     commitFilesFailedWorkers.put(
-      workerInfos.keySet.head.workerInfo,
+      workerInfos.asScala.keySet.head.workerInfo,
       (StatusCode.PUSH_DATA_TIMEOUT_PRIMARY, System.currentTimeMillis()))
     lifecycleManager.workerStatusTracker.recordWorkerFailure(commitFilesFailedWorkers)
     val res2 = lifecycleManager.requestMasterRequestSlotsWithRetry(1, arrayList)
@@ -65,7 +67,7 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
     assert(!res2.contains(headWorkerInfo))
 
     // test request slots with all workers excluded, response should be WORKER_EXCLUDED
-    workerInfos.keySet.foreach(worker =>
+    workerInfos.asScala.keySet.foreach(worker =>
       commitFilesFailedWorkers.put(
         worker.workerInfo,
         (StatusCode.PUSH_DATA_TIMEOUT_PRIMARY, System.currentTimeMillis())))
@@ -87,7 +89,7 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
 
     // test request slots with all workers excluded, response should not excluded any worker
     val commitFilesFailedWorkers = new LifecycleManager.ShuffleFailedWorkers()
-    workerInfos.keySet.foreach(worker =>
+    workerInfos.asScala.keySet.foreach(worker =>
       commitFilesFailedWorkers.put(
         worker.workerInfo,
         (StatusCode.PUSH_DATA_TIMEOUT_PRIMARY, System.currentTimeMillis())))
@@ -95,7 +97,7 @@ class LifecycleManagerSuite extends WithShuffleClientSuite with MiniClusterFeatu
     val res = lifecycleManager.requestMasterRequestSlotsWithRetry(0, arrayList)
       .workerResource.keySet()
     assert(res.size() == workerInfos.size)
-    assert(res.contains(workerInfos.keySet.head.workerInfo))
+    assert(res.contains(workerInfos.asScala.keySet.head.workerInfo))
     lifecycleManager.stop()
   }
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
@@ -48,7 +48,9 @@ class CelebornFetchFailureSuite extends AnyFunSuite
 
   override def createWorker(map: Map[String, String]): Worker = {
     val storageDir = createTmpDir()
-    workerDirs = workerDirs :+ storageDir
+    this.synchronized {
+      workerDirs = workerDirs :+ storageDir
+    }
     super.createWorker(map, storageDir)
   }
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
@@ -79,11 +79,11 @@ class CelebornFetchFailureSuite extends AnyFunSuite
               new File(s"$dir/celeborn-worker/shuffle_data/$appUniqueId/$celebornShuffleId")
             })
             val datafile = allFiles.filter(_.exists())
-                .flatMap(_.listFiles().iterator).headOption
+              .flatMap(_.listFiles().iterator).headOption
             datafile match {
               case Some(file) => file.delete()
               case None => throw new RuntimeException("unexpected, there must be some data file" +
-                s" under ${workerDirs.mkString(",")}")
+                  s" under ${workerDirs.mkString(",")}")
             }
           }
           case _ => throw new RuntimeException("unexpected, only support RssShuffleHandle here")

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornFetchFailureSuite.scala
@@ -75,14 +75,15 @@ class CelebornFetchFailureSuite extends AnyFunSuite
               h.userIdentifier,
               h.extension)
             val celebornShuffleId = SparkUtils.celebornShuffleId(shuffleClient, h, context, false)
-            val datafile =
-              workerDirs.map(dir => {
-                new File(s"$dir/celeborn-worker/shuffle_data/$appUniqueId/$celebornShuffleId")
-              }).filter(_.exists())
+            val allFiles = workerDirs.map(dir => {
+              new File(s"$dir/celeborn-worker/shuffle_data/$appUniqueId/$celebornShuffleId")
+            })
+            val datafile = allFiles.filter(_.exists())
                 .flatMap(_.listFiles().iterator).headOption
             datafile match {
               case Some(file) => file.delete()
-              case None => throw new RuntimeException("unexpected, there must be some data file")
+              case None => throw new RuntimeException("unexpected, there must be some data file" +
+                s" under ${workerDirs.mkString(",")}")
             }
           }
           case _ => throw new RuntimeException("unexpected, only support RssShuffleHandle here")

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornHashCheckDiskSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornHashCheckDiskSuite.scala
@@ -39,7 +39,7 @@ class CelebornHashCheckDiskSuite extends SparkTestBase {
     val workerConf = Map(
       CelebornConf.WORKER_STORAGE_DIRS.key -> "/tmp:capacity=1000",
       CelebornConf.WORKER_HEARTBEAT_TIMEOUT.key -> "10s")
-    workers = setupMiniClusterWithRandomPorts(Some(masterConf), Some(workerConf))._2
+    workers = setupMiniClusterWithRandomPorts(masterConf, workerConf)._2
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornHashCheckDiskSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornHashCheckDiskSuite.scala
@@ -39,7 +39,7 @@ class CelebornHashCheckDiskSuite extends SparkTestBase {
     val workerConf = Map(
       CelebornConf.WORKER_STORAGE_DIRS.key -> "/tmp:capacity=1000",
       CelebornConf.WORKER_HEARTBEAT_TIMEOUT.key -> "10s")
-    workers = setUpMiniCluster(masterConf, workerConf)._2
+    workers = setupMiniClusterWithRandomPorts(Some(masterConf), Some(workerConf))._2
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
@@ -44,7 +44,7 @@ class PushDataTimeoutTest extends AnyFunSuite
     // enabled, there is a possibility that two workers might be added to the excluded list due to
     // primary/replica timeout issues, then there are not enough workers to do replication if
     // available workers number = 1
-    setUpMiniCluster(masterConf = null, workerConf = workerConf, workerNum = 4)
+    setupMiniClusterWithRandomPorts(workerConf = Some(workerConf), workerNum = 4)
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/PushDataTimeoutTest.scala
@@ -44,7 +44,7 @@ class PushDataTimeoutTest extends AnyFunSuite
     // enabled, there is a possibility that two workers might be added to the excluded list due to
     // primary/replica timeout issues, then there are not enough workers to do replication if
     // available workers number = 1
-    setupMiniClusterWithRandomPorts(workerConf = Some(workerConf), workerNum = 4)
+    setupMiniClusterWithRandomPorts(workerConf = workerConf, workerNum = 4)
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/RetryReviveTest.scala
@@ -32,7 +32,7 @@ class RetryReviveTest extends AnyFunSuite
 
   override def beforeAll(): Unit = {
     logInfo("test initialized , setup celeborn mini cluster")
-    setUpMiniCluster(masterConf = null)
+    setupMiniClusterWithRandomPorts()
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/ShuffleFallbackSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/ShuffleFallbackSuite.scala
@@ -51,7 +51,7 @@ class ShuffleFallbackSuite extends AnyFunSuite
   }
 
   test(s"celeborn spark integration test - fallback") {
-    setUpMiniCluster(workerNum = 5)
+    setupMiniClusterWithRandomPorts(workerNum = 5)
     val sparkConf = new SparkConf().setAppName("celeborn-demo")
       .setMaster("local[2]")
       .set(s"spark.${CelebornConf.SPARK_SHUFFLE_FORCE_FALLBACK_ENABLED.key}", "true")
@@ -67,7 +67,7 @@ class ShuffleFallbackSuite extends AnyFunSuite
   }
 
   test(s"celeborn spark integration test - fallback with workers unavailable") {
-    setUpMiniCluster(workerNum = 0)
+    setupMiniClusterWithRandomPorts(workerNum = 0)
     val sparkConf = new SparkConf().setAppName("celeborn-demo")
       .setMaster("local[2]")
 

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SlotsAssignMaxWorkersLargeTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SlotsAssignMaxWorkersLargeTest.scala
@@ -32,8 +32,8 @@ class SlotsAssignMaxWorkersLargeTest extends AnyFunSuite
 
   override def beforeAll(): Unit = {
     logInfo("test initialized, setup Celeborn mini cluster")
-    setupMiniClusterWithRandomPorts(masterConf = Some(Map(
-      s"${CelebornConf.CLIENT_SLOT_ASSIGN_MAX_WORKERS.key}" -> "10")))
+    setupMiniClusterWithRandomPorts(masterConf = Map(
+      s"${CelebornConf.CLIENT_SLOT_ASSIGN_MAX_WORKERS.key}" -> "10"))
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SlotsAssignMaxWorkersLargeTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SlotsAssignMaxWorkersLargeTest.scala
@@ -32,9 +32,8 @@ class SlotsAssignMaxWorkersLargeTest extends AnyFunSuite
 
   override def beforeAll(): Unit = {
     logInfo("test initialized, setup Celeborn mini cluster")
-    val masterConf = Map(
-      s"${CelebornConf.CLIENT_SLOT_ASSIGN_MAX_WORKERS.key}" -> "10")
-    setUpMiniCluster(masterConf = masterConf, workerConf = null)
+    setupMiniClusterWithRandomPorts(masterConf = Some(Map(
+      s"${CelebornConf.CLIENT_SLOT_ASSIGN_MAX_WORKERS.key}" -> "10")))
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SlotsAssignMaxWorkersSmallTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SlotsAssignMaxWorkersSmallTest.scala
@@ -32,8 +32,8 @@ class SlotsAssignMaxWorkersSmallTest extends AnyFunSuite
 
   override def beforeAll(): Unit = {
     logInfo("test initialized, setup Celeborn mini cluster")
-    setupMiniClusterWithRandomPorts(masterConf = Some(Map(
-      s"${CelebornConf.CLIENT_SLOT_ASSIGN_MAX_WORKERS.key}" -> "5")))
+    setupMiniClusterWithRandomPorts(masterConf = Map(
+      s"${CelebornConf.CLIENT_SLOT_ASSIGN_MAX_WORKERS.key}" -> "5"))
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SlotsAssignMaxWorkersSmallTest.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SlotsAssignMaxWorkersSmallTest.scala
@@ -32,9 +32,8 @@ class SlotsAssignMaxWorkersSmallTest extends AnyFunSuite
 
   override def beforeAll(): Unit = {
     logInfo("test initialized, setup Celeborn mini cluster")
-    val masterConf = Map(
-      s"${CelebornConf.CLIENT_SLOT_ASSIGN_MAX_WORKERS.key}" -> "5")
-    setUpMiniCluster(masterConf = masterConf, workerConf = null)
+    setupMiniClusterWithRandomPorts(masterConf = Some(Map(
+      s"${CelebornConf.CLIENT_SLOT_ASSIGN_MAX_WORKERS.key}" -> "5")))
   }
 
   override def beforeEach(): Unit = {

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SparkTestBase.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SparkTestBase.scala
@@ -39,7 +39,7 @@ trait SparkTestBase extends AnyFunSuite
 
   override def beforeAll(): Unit = {
     logInfo("test initialized , setup Celeborn mini cluster")
-    setUpMiniCluster(workerNum = 5)
+    setupMiniClusterWithRandomPorts(workerNum = 5)
   }
 
   override def afterAll(): Unit = {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -851,6 +851,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
             fileMeta,
             filePath,
             StorageInfo.Type.HDD)
+          logInfo(s"created file at $filePath")
           diskFileInfos.computeIfAbsent(shuffleKey, diskFileInfoMapFunc).put(
             fileName,
             diskFileInfo)

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/HeartbeatFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/HeartbeatFeature.scala
@@ -36,7 +36,7 @@ trait HeartbeatFeature extends MiniClusterFeature {
     var workers: collection.Set[Worker] = null
     try {
       val (_master, _workers) =
-        setupMiniClusterWithRandomPorts(workerConf = Some(workerConf), workerNum = 1)
+        setupMiniClusterWithRandomPorts(workerConf = workerConf, workerNum = 1)
       master = _master
       workers = _workers
       workers.foreach { w =>

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/HeartbeatFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/HeartbeatFeature.scala
@@ -32,13 +32,11 @@ trait HeartbeatFeature extends MiniClusterFeature {
       dataClientFactory: TransportClientFactory,
       assertFunc: (TransportClient, TransportClient) => Unit): Unit = {
     logInfo("test initialized , setup celeborn mini cluster")
-    val masterConf = Map(
-      CelebornConf.MASTER_HOST.key -> "localhost",
-      CelebornConf.MASTER_PORT.key -> "9097")
     var master: Master = null
     var workers: collection.Set[Worker] = null
     try {
-      val (_master, _workers) = setUpMiniCluster(masterConf, workerConf, workerNum = 1)
+      val (_master, _workers) =
+        setupMiniClusterWithRandomPorts(workerConf = Some(workerConf), workerNum = 1)
       master = _master
       workers = _workers
       workers.foreach { w =>
@@ -62,7 +60,6 @@ trait HeartbeatFeature extends MiniClusterFeature {
 
   def getTestHeartbeatFromWorker2ClientConf: (Map[String, String], CelebornConf) = {
     val workerConf = Map(
-      CelebornConf.MASTER_ENDPOINTS.key -> "localhost:9097",
       "celeborn.push.heartbeat.interval" -> "4s",
       "celeborn.worker.push.heartbeat.enabled" -> "true",
       "celeborn.worker.fetch.heartbeat.enabled" -> "true",
@@ -90,7 +87,6 @@ trait HeartbeatFeature extends MiniClusterFeature {
 
   def getTestHeartbeatFromWorker2ClientWithNoHeartbeatConf: (Map[String, String], CelebornConf) = {
     val workerConf = Map(
-      "celeborn.master.endpoints" -> "localhost:9097",
       "celeborn.push.heartbeat.interval" -> "4s",
       "celeborn.fetch.heartbeat.interval" -> "4s",
       "celeborn.worker.push.heartbeat.enabled" -> "false",
@@ -119,7 +115,6 @@ trait HeartbeatFeature extends MiniClusterFeature {
 
   def getTestHeartbeatFromWorker2ClientWithCloseChannelConf: (Map[String, String], CelebornConf) = {
     val workerConf = Map(
-      CelebornConf.MASTER_ENDPOINTS.key -> "localhost:9097",
       "celeborn.fetch.io.connectionTimeout" -> "9s",
       "celeborn.push.io.connectionTimeout" -> "9s",
       "celeborn.push.heartbeat.interval" -> "4s",

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -61,7 +61,7 @@ trait MiniClusterFeature extends Logging {
     var created = false
     var master: Master = null
     var workers: collection.Set[Worker] = null
-    while (retryCount < 3 && !created) {
+    while (retryCount < 5 && !created) {
       try {
         val randomPort = Random.nextInt(65535 - 1200) + 1200
         val finalMasterConf = Map(

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
 import scala.util.Random
+
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -68,8 +68,7 @@ trait MiniClusterFeature extends Logging {
         val finalMasterConf = Map(
           s"${CelebornConf.MASTER_HOST.key}" -> "localhost",
           s"${CelebornConf.MASTER_PORT.key}" -> s"$randomPort",
-          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort",
-          s"${CelebornConf.CLIENT_SLOT_ASSIGN_MAX_WORKERS.key}" -> "10") ++
+          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort") ++
           masterConf.getOrElse(Map())
         val finalWorkerConf = Map(
           s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort") ++

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -176,7 +176,7 @@ trait MiniClusterFeature extends Logging {
         case ex: AssertionError =>
           logWarning("worker registration cannot be done, retrying", ex)
           workerRegistrationRetryCount += 1
-          if (workerRegistrationRetryCount  == 3) {
+          if (workerRegistrationRetryCount == 3) {
             logWarning("worker registration failed, reached to the max retry", ex)
             throw ex;
           }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -20,10 +20,10 @@ package org.apache.celeborn.service.deploy
 import java.net.BindException
 import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
 import scala.util.Random
-
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -196,7 +196,7 @@ trait MiniClusterFeature extends Logging {
       })
       workerThread.setName(s"worker ${i} starter thread")
       workerThread.start()
-      workerInfos.put(workers(i), workerThread)
+      workerInfos.put(workers(i - 1), workerThread)
     }
 
     var workerRegistrationRetryCount = 0

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -47,8 +47,8 @@ trait MiniClusterFeature extends Logging {
   }
 
   def setupMiniClusterWithRandomPorts(
-      masterConf: Option[Map[String, String]] = None,
-      workerConf: Option[Map[String, String]] = None,
+      masterConf: Map[String, String] = Map(),
+      workerConf: Map[String, String] = Map(),
       workerNum: Int = 3): (Master, collection.Set[Worker]) = {
     var retryCount = 0
     var created = false
@@ -61,10 +61,10 @@ trait MiniClusterFeature extends Logging {
           s"${CelebornConf.MASTER_HOST.key}" -> "localhost",
           s"${CelebornConf.MASTER_PORT.key}" -> s"$randomPort",
           s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort") ++
-          masterConf.getOrElse(Map())
+          masterConf
         val finalWorkerConf = Map(
           s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort") ++
-          workerConf.getOrElse(Map())
+          workerConf
         logInfo(s"generated configuration $finalMasterConf")
         val (m, w) =
           setUpMiniCluster(masterConf = finalMasterConf, workerConf = finalWorkerConf, workerNum)

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -17,6 +17,7 @@
 
 package org.apache.celeborn.service.deploy
 
+import java.net.BindException
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -80,7 +81,7 @@ trait MiniClusterFeature extends Logging {
         workers = w
         created = true
       } catch {
-        case e: Exception =>
+        case e: BindException =>
           if (retryCount < 3) {
             logError("failed to setup mini cluster, reached the max retry count")
             throw e

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -203,11 +203,17 @@ trait MiniClusterFeature extends Logging {
     }
     threads.foreach(_.start())
     Thread.sleep(5000)
-    (0 until workerNum).foreach { i => workerInfos.put(workers(i), threads(i)) }
     var allWorkersStarted = false
     var workersWaitingTime = 0
     while (!allWorkersStarted) {
       try {
+        (0 until workerNum).foreach { i => {
+          if (workers(i) == null) {
+            throw new IllegalStateException(s"worker $i hasn't been initialized")
+          } else {
+            workerInfos.put(workers(i), threads(i))
+          }
+        } }
         workerInfos.foreach { case (worker, _) => assert(worker.registered.get()) }
         allWorkersStarted = true
       } catch {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -32,7 +32,18 @@ import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
 
 trait MiniClusterFeature extends Logging {
+  private val masterPort = Random.nextInt(65535 - 1024) + 1024
 
+  private val workerPort = {
+    var port = masterPort
+    while (port == masterPort) {
+      port = Random.nextInt(65535 - 1024) + 1024
+    }
+    port
+  }
+
+  val masterHttpPort = new AtomicInteger(masterPort)
+  val workerHttpPort = new AtomicInteger(workerPort)
   var masterInfo: (Master, Thread) = _
   val workerInfos = new ConcurrentHashMap[Worker, Thread]()
 
@@ -91,7 +102,7 @@ trait MiniClusterFeature extends Logging {
   private def createMaster(map: Map[String, String] = null): Master = {
     val conf = new CelebornConf()
     conf.set(CelebornConf.METRICS_ENABLED.key, "false")
-    val httpPort = Random.nextInt(65535 - 1024) + 1024
+    val httpPort = masterHttpPort.getAndIncrement()
     conf.set(CelebornConf.MASTER_HTTP_PORT.key, s"$httpPort")
     logInfo(s"set ${CelebornConf.MASTER_HTTP_PORT.key} to $httpPort")
     if (map != null) {
@@ -116,7 +127,7 @@ trait MiniClusterFeature extends Logging {
     conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, storageDir)
     conf.set(CelebornConf.WORKER_DISK_MONITOR_ENABLED.key, "false")
     conf.set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
-    conf.set(CelebornConf.WORKER_HTTP_PORT.key, s"${Random.nextInt(65535 - 1024) + 1024}")
+    conf.set(CelebornConf.WORKER_HTTP_PORT.key, s"${workerHttpPort.incrementAndGet()}")
     conf.set("celeborn.fetch.io.threads", "4")
     conf.set("celeborn.push.io.threads", "4")
     if (map != null) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -59,11 +59,13 @@ trait MiniClusterFeature extends Logging {
         val randomPort = chooseRandomPort(1024, 65535)
         val finalMasterConf = Map(
           s"${CelebornConf.MASTER_HOST.key}" -> "localhost",
+          s"${CelebornConf.PORT_MAX_RETRY.key}" -> "0",
           s"${CelebornConf.MASTER_PORT.key}" -> s"$randomPort",
           s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort") ++
           masterConf
         val finalWorkerConf = Map(
-          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort") ++
+          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort",
+          s"${CelebornConf.PORT_MAX_RETRY.key}" -> "0") ++
           workerConf
         logInfo(s"generated configuration $finalMasterConf")
         val (m, w) =

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -169,15 +169,15 @@ trait MiniClusterFeature extends Logging {
     var workerRegistrationDone = false
     while (!workerRegistrationDone) {
       try {
-        Thread.sleep(20000L)
+        Thread.sleep(60000L)
         workerInfos.foreach { case (worker, _) => assert(worker.registered.get()) }
         workerRegistrationDone = true
       } catch {
         case ex: AssertionError =>
-          logWarning("worker registration cannot be done, retrying", ex)
+          logError("worker registration cannot be done, retrying", ex)
           workerRegistrationRetryCount += 1
           if (workerRegistrationRetryCount == 3) {
-            logWarning("worker registration failed, reached to the max retry", ex)
+            logError("worker registration failed, reached to the max retry", ex)
             throw ex;
           }
       }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -19,15 +19,16 @@ package org.apache.celeborn.service.deploy
 
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.mutable
+import scala.util.Random
+
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
 import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
 import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
-
-import scala.util.Random
 
 trait MiniClusterFeature extends Logging {
   private def masterPort = Random.nextInt(65535 - 1200) + 1200
@@ -53,9 +54,9 @@ trait MiniClusterFeature extends Logging {
   })
 
   def setupMiniClusterWithRandomPorts(
-                                       masterConf: Option[Map[String, String]] = None,
-                                       workerConf: Option[Map[String, String]] = None,
-                                       workerNum: Int = 3): (Master, collection.Set[Worker]) = {
+      masterConf: Option[Map[String, String]] = None,
+      workerConf: Option[Map[String, String]] = None,
+      workerNum: Int = 3): (Master, collection.Set[Worker]) = {
     var retryCount = 0
     var created = false
     var master: Master = null

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -48,6 +48,7 @@ trait MiniClusterFeature extends Logging {
   val workerInfos = new mutable.HashMap[Worker, Thread]()
 
   class RunnerWrap[T](code: => T) extends Thread {
+
     override def run(): Unit = {
       Utils.tryLogNonFatalError(code)
     }
@@ -172,9 +173,10 @@ trait MiniClusterFeature extends Logging {
       throw new BindException("cannot start master rpc endpoint")
     }
 
-    (1 to workerNum).foreach { _ =>
+    (1 to workerNum).foreach { i =>
       val worker = createWorker(workerConf)
       val workerThread = new RunnerWrap(worker.initialize())
+      workerThread.setName(s"worker ${i} starter thread")
       workerThread.start()
       workerInfos.put(worker, workerThread)
     }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -20,15 +20,16 @@ package org.apache.celeborn.service.deploy
 import java.net.BindException
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.mutable
 import scala.util.Random
+
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
 import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
 import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
-
-import scala.collection.mutable
 
 trait MiniClusterFeature extends Logging {
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -172,14 +172,14 @@ trait MiniClusterFeature extends Logging {
     val threads = (1 to workerNum).map { i =>
       val workerThread = new RunnerWrap({
         var workerStartRetry = 0
-        while (!workersStartFlag(i)) {
+        while (!workersStartFlag(i - 1)) {
           try {
             val worker = createWorker(workerConf)
             this.synchronized {
               workers(i - 1) = worker
             }
             worker.initialize()
-            workersStartFlag(i) = true
+            workersStartFlag(i - 1) = true
           } catch {
             case ex: Exception =>
               if (workers(i - 1) != null) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -26,6 +26,7 @@ import scala.util.Random
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
+import org.apache.celeborn.common.util.Utils.selectRandomPort
 import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
 import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
@@ -42,10 +43,6 @@ trait MiniClusterFeature extends Logging {
     }
   }
 
-  private def chooseRandomPort(from: Int, to: Int): Int = {
-    Random.nextInt(to - from) + from
-  }
-
   def setupMiniClusterWithRandomPorts(
       masterConf: Map[String, String] = Map(),
       workerConf: Map[String, String] = Map(),
@@ -56,7 +53,7 @@ trait MiniClusterFeature extends Logging {
     var workers: collection.Set[Worker] = null
     while (!created) {
       try {
-        val randomPort = chooseRandomPort(1024, 65535)
+        val randomPort = selectRandomPort(1024, 65535)
         val finalMasterConf = Map(
           s"${CelebornConf.MASTER_HOST.key}" -> "localhost",
           s"${CelebornConf.PORT_MAX_RETRY.key}" -> "0",
@@ -95,7 +92,7 @@ trait MiniClusterFeature extends Logging {
   private def createMaster(map: Map[String, String] = null): Master = {
     val conf = new CelebornConf()
     conf.set(CelebornConf.METRICS_ENABLED.key, "false")
-    val httpPort = chooseRandomPort(1024, 65535)
+    val httpPort = selectRandomPort(1024, 65535)
     conf.set(CelebornConf.MASTER_HTTP_PORT.key, s"$httpPort")
     logInfo(s"set ${CelebornConf.MASTER_HTTP_PORT.key} to $httpPort")
     if (map != null) {
@@ -120,7 +117,7 @@ trait MiniClusterFeature extends Logging {
     conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, storageDir)
     conf.set(CelebornConf.WORKER_DISK_MONITOR_ENABLED.key, "false")
     conf.set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
-    conf.set(CelebornConf.WORKER_HTTP_PORT.key, s"${chooseRandomPort(1024, 65535)}")
+    conf.set(CelebornConf.WORKER_HTTP_PORT.key, s"${selectRandomPort(1024, 65535)}")
     conf.set("celeborn.fetch.io.threads", "4")
     conf.set("celeborn.push.io.threads", "4")
     if (map != null) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -62,7 +62,7 @@ trait MiniClusterFeature extends Logging {
     var created = false
     var master: Master = null
     var workers: collection.Set[Worker] = null
-    while (retryCount < 5 && !created) {
+    while (retryCount < 3 && !created) {
       try {
         val randomPort = Random.nextInt(65535 - 1200) + 1200
         val finalMasterConf = Map(
@@ -82,12 +82,11 @@ trait MiniClusterFeature extends Logging {
         created = true
       } catch {
         case e: BindException =>
-          if (retryCount < 3) {
+          logError(s"failed to setup mini cluster, retrying (retry count: $retryCount")
+          retryCount += 1
+          if (retryCount == 3) {
             logError("failed to setup mini cluster, reached the max retry count")
             throw e
-          } else {
-            logError(s"failed to setup mini cluster, retrying (retry count: $retryCount")
-            retryCount += 1
           }
       }
     }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -180,6 +180,9 @@ trait MiniClusterFeature extends Logging {
             workerStarted = true
           } catch {
             case ex: Exception =>
+              if (workers(i - 1) != null) {
+                workers(i - 1).shutdownGracefully()
+              }
               workerStartRetry += 1
               logError(s"cannot start worker $i, retrying: ", ex)
               if (workerStartRetry == 3) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -32,18 +32,7 @@ import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
 
 trait MiniClusterFeature extends Logging {
-  private val masterPort = Random.nextInt(65535 - 1024) + 1024
 
-  private val workerPort = {
-    var port = masterPort
-    while (port == masterPort) {
-      port = Random.nextInt(65535 - 1024) + 1024
-    }
-    port
-  }
-
-  val masterHttpPort = new AtomicInteger(masterPort)
-  val workerHttpPort = new AtomicInteger(workerPort)
   var masterInfo: (Master, Thread) = _
   val workerInfos = new mutable.HashMap[Worker, Thread]()
 
@@ -102,7 +91,7 @@ trait MiniClusterFeature extends Logging {
   private def createMaster(map: Map[String, String] = null): Master = {
     val conf = new CelebornConf()
     conf.set(CelebornConf.METRICS_ENABLED.key, "false")
-    val httpPort = masterHttpPort.getAndIncrement()
+    val httpPort = Random.nextInt(65535 - 1024) + 1024
     conf.set(CelebornConf.MASTER_HTTP_PORT.key, s"$httpPort")
     logInfo(s"set ${CelebornConf.MASTER_HTTP_PORT.key} to $httpPort")
     if (map != null) {
@@ -127,7 +116,7 @@ trait MiniClusterFeature extends Logging {
     conf.set(CelebornConf.WORKER_STORAGE_DIRS.key, storageDir)
     conf.set(CelebornConf.WORKER_DISK_MONITOR_ENABLED.key, "false")
     conf.set(CelebornConf.CLIENT_PUSH_BUFFER_MAX_SIZE.key, "256K")
-    conf.set(CelebornConf.WORKER_HTTP_PORT.key, s"${workerHttpPort.incrementAndGet()}")
+    conf.set(CelebornConf.WORKER_HTTP_PORT.key, s"${Random.nextInt(65535 - 1024) + 1024}")
     conf.set("celeborn.fetch.io.threads", "4")
     conf.set("celeborn.push.io.threads", "4")
     if (map != null) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -82,10 +82,10 @@ trait MiniClusterFeature extends Logging {
         created = true
       } catch {
         case e: BindException =>
-          logError(s"failed to setup mini cluster, retrying (retry count: $retryCount")
+          logError(s"failed to setup mini cluster, retrying (retry count: $retryCount", e)
           retryCount += 1
           if (retryCount == 3) {
-            logError("failed to setup mini cluster, reached the max retry count")
+            logError("failed to setup mini cluster, reached the max retry count", e)
             throw e
           }
       }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -171,7 +171,7 @@ trait MiniClusterFeature extends Logging {
             val worker = createWorker(workerConf)
             worker.initialize()
             workerStarted = true
-            workerInfos.put(worker, workerThread)
+            workerInfos.put(worker, Thread.currentThread())
           } catch {
             case ex: Exception =>
               workerStartRetry += 1

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -201,7 +201,7 @@ trait MiniClusterFeature extends Logging {
       workerThread
     }
     Thread.sleep(20000L)
-    (0 until workerNum).foreach {i => workerInfos.put(workers(i), threads(i))}
+    (0 until workerNum).foreach { i => workerInfos.put(workers(i), threads(i)) }
 
     var workerRegistrationRetryCount = 0
     var workerRegistrationDone = false

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -195,7 +195,7 @@ trait MiniClusterFeature extends Logging {
       workerThread.start()
       workerThread
     }
-
+    Thread.sleep(20000)
     (0 until workerNum).foreach { i => workerInfos.put(workers(i), threads(i)) }
 
     workerInfos.foreach { case (worker, _) => assert(worker.registered.get()) }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -208,13 +208,15 @@ trait MiniClusterFeature extends Logging {
     var workersWaitingTime = 0
     while (!allWorkersStarted) {
       try {
-        (0 until workerNum).foreach { i => {
-          if (workers(i) == null) {
-            throw new IllegalStateException(s"worker $i hasn't been initialized")
-          } else {
-            workerInfos.put(workers(i), threads(i))
+        (0 until workerNum).foreach { i =>
+          {
+            if (workers(i) == null) {
+              throw new IllegalStateException(s"worker $i hasn't been initialized")
+            } else {
+              workerInfos.put(workers(i), threads(i))
+            }
           }
-        } }
+        }
         workerInfos.foreach { case (worker, _) => assert(worker.registered.get()) }
         allWorkersStarted = true
       } catch {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -19,7 +19,10 @@ package org.apache.celeborn.service.deploy
 
 import java.net.BindException
 import java.nio.file.Files
+import java.util.concurrent.locks.{Lock, ReentrantLock}
+
 import scala.collection.mutable
+
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.internal.Logging
 import org.apache.celeborn.common.util.{CelebornExitKind, Utils}
@@ -27,8 +30,6 @@ import org.apache.celeborn.common.util.Utils.selectRandomPort
 import org.apache.celeborn.service.deploy.master.{Master, MasterArguments}
 import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
-
-import java.util.concurrent.locks.{Lock, ReentrantLock}
 
 trait MiniClusterFeature extends Logging {
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -175,7 +175,7 @@ trait MiniClusterFeature extends Logging {
     }
 
     val workers = new Array[Worker](workerNum)
-    (1 to workerNum).foreach { i =>
+    val threads = (1 to workerNum).map { i =>
       val workerThread = new RunnerWrap({
         val worker = createWorker(workerConf)
         this.synchronized {
@@ -198,8 +198,10 @@ trait MiniClusterFeature extends Logging {
       })
       workerThread.setName(s"worker ${i} starter thread")
       workerThread.start()
-      workerInfos.put(workers(i - 1), workerThread)
+      workerThread
     }
+    Thread.sleep(20000L)
+    (0 until workerNum).foreach {i => workerInfos.put(workers(i), threads(i))}
 
     var workerRegistrationRetryCount = 0
     var workerRegistrationDone = false

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -62,7 +62,7 @@ trait MiniClusterFeature extends Logging {
     var created = false
     var master: Master = null
     var workers: collection.Set[Worker] = null
-    while (retryCount < 3 && !created) {
+    while (!created) {
       try {
         val randomPort = Random.nextInt(65535 - 1024) + 1024
         val finalMasterConf = Map(
@@ -167,18 +167,18 @@ trait MiniClusterFeature extends Logging {
 
     var workerRegistrationRetryCount = 0
     var workerRegistrationDone = false
-    while (workerRegistrationRetryCount < 3 && !workerRegistrationDone) {
+    while (!workerRegistrationDone) {
       try {
         Thread.sleep(20000L)
         workerInfos.foreach { case (worker, _) => assert(worker.registered.get()) }
         workerRegistrationDone = true
       } catch {
         case ex: AssertionError =>
-          if (workerRegistrationRetryCount < 3) {
-            logWarning("worker registration cannot be done, retrying", ex)
-            workerRegistrationRetryCount += 1
-          } else {
-            throw ex
+          logWarning("worker registration cannot be done, retrying", ex)
+          workerRegistrationRetryCount += 1
+          if (workerRegistrationRetryCount  == 3) {
+            logWarning("worker registration failed, reached to the max retry", ex)
+            throw ex;
           }
       }
     }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -64,8 +64,7 @@ trait MiniClusterFeature extends Logging {
           s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort") ++
           masterConf
         val finalWorkerConf = Map(
-          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort",
-          s"${CelebornConf.PORT_MAX_RETRY.key}" -> "0") ++
+          s"${CelebornConf.MASTER_ENDPOINTS.key}" -> s"localhost:$randomPort") ++
           workerConf
         logInfo(s"generated configuration $finalMasterConf")
         val (m, w) =

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -32,12 +32,12 @@ import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
 
 trait MiniClusterFeature extends Logging {
-  private def masterPort = Random.nextInt(65535 - 1200) + 1200
+  private def masterPort = Random.nextInt(65535 - 1024) + 1024
 
   private def workerPort = {
     var port = masterPort
     while (port == masterPort) {
-      port = Random.nextInt(65535 - 1200) + 1200
+      port = Random.nextInt(65535 - 1024) + 1024
     }
     port
   }
@@ -64,7 +64,7 @@ trait MiniClusterFeature extends Logging {
     var workers: collection.Set[Worker] = null
     while (retryCount < 3 && !created) {
       try {
-        val randomPort = Random.nextInt(65535 - 1200) + 1200
+        val randomPort = Random.nextInt(65535 - 1024) + 1024
         val finalMasterConf = Map(
           s"${CelebornConf.MASTER_HOST.key}" -> "localhost",
           s"${CelebornConf.MASTER_PORT.key}" -> s"$randomPort",

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -195,9 +195,9 @@ trait MiniClusterFeature extends Logging {
         }
       })
       workerThread.setName(s"worker ${i} starter thread")
-      workerThread.start()
       workerThread
     }
+    threads.foreach(_.start())
     Thread.sleep(20000)
     (0 until workerNum).foreach { i => workerInfos.put(workers(i), threads(i)) }
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -32,9 +32,9 @@ import org.apache.celeborn.service.deploy.worker.{Worker, WorkerArguments}
 import org.apache.celeborn.service.deploy.worker.memory.MemoryManager
 
 trait MiniClusterFeature extends Logging {
-  private def masterPort = Random.nextInt(65535 - 1024) + 1024
+  private val masterPort = Random.nextInt(65535 - 1024) + 1024
 
-  private def workerPort = {
+  private val workerPort = {
     var port = masterPort
     while (port == masterPort) {
       port = Random.nextInt(65535 - 1024) + 1024
@@ -190,7 +190,7 @@ trait MiniClusterFeature extends Logging {
         case ex: AssertionError =>
           logError("worker registration cannot be done, retrying", ex)
           workerRegistrationRetryCount += 1
-          if (workerRegistrationRetryCount == 3) {
+          if (workerRegistrationRetryCount == 10) {
             logError("worker registration failed, reached to the max retry", ex)
             throw ex;
           }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -187,6 +187,7 @@ trait MiniClusterFeature extends Logging {
               if (workers(i - 1) != null) {
                 workers(i - 1).shutdownGracefully()
               }
+              workerStarted = false
               workerStartRetry += 1
               logError(s"cannot start worker $i, retrying: ", ex)
               if (workerStartRetry == 3) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -179,7 +179,7 @@ trait MiniClusterFeature extends Logging {
       val workerThread = new RunnerWrap({
         val worker = createWorker(workerConf)
         this.synchronized {
-          workers(i) = worker
+          workers(i - 1) = worker
         }
         var workerStarted = false
         var workerStartRetry = 0

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -220,7 +220,7 @@ trait MiniClusterFeature extends Logging {
       }
     }
     (0 until workerNum).foreach { i => workerInfos.put(workers(i), threads(i)) }
-    workerInfos.foreach { case (worker, _) => assert(worker.registered.get())}
+    workerInfos.foreach { case (worker, _) => assert(worker.registered.get()) }
     (master, workerInfos.keySet)
   }
 

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/MiniClusterFeature.scala
@@ -178,7 +178,9 @@ trait MiniClusterFeature extends Logging {
     (1 to workerNum).foreach { i =>
       val workerThread = new RunnerWrap({
         val worker = createWorker(workerConf)
-        workers(i) = worker
+        this.synchronized {
+          workers(i) = worker
+        }
         var workerStarted = false
         var workerStartRetry = 0
         while (!workerStarted) {

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/cluster/ReadWriteTestBase.scala
@@ -38,16 +38,13 @@ import org.apache.celeborn.service.deploy.MiniClusterFeature
 
 trait ReadWriteTestBase extends AnyFunSuite
   with Logging with MiniClusterFeature with BeforeAndAfterAll {
-  val masterPort = 19097
+
+  var masterPort = 0
 
   override def beforeAll(): Unit = {
-    val masterConf = Map(
-      "celeborn.master.host" -> "localhost",
-      "celeborn.master.port" -> masterPort.toString)
-    val workerConf = Map(
-      "celeborn.master.endpoints" -> s"localhost:$masterPort")
     logInfo("test initialized , setup Celeborn mini cluster")
-    setUpMiniCluster(masterConf, workerConf)
+    val (m, _) = setupMiniClusterWithRandomPorts()
+    masterPort = m.conf.masterPort
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

this PR is to improve the test implementations so that it starts test nodes in random ports instead of using the hardcoded ones

### Why are the changes needed?

currently the test nodes are started in the hard coded ports, this prevents to run multiple builds in the same CI/CD server (which is not uncommonly seen in many companies infra)

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

it runs in our private CI/CD infra with many parallel builds very well