### PR TITLE
[CELEBORN-1238] deviceCheckThreadPool is only initialized when diskCheck is enabled

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/DeviceMonitor.scala
@@ -21,7 +21,7 @@ import java.io.{BufferedReader, File, FileInputStream, InputStreamReader, IOExce
 import java.nio.charset.Charset
 import java.nio.file.{Files, Paths}
 import java.util
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ThreadPoolExecutor, TimeUnit}
 
 import scala.collection.JavaConverters._
 
@@ -198,7 +198,7 @@ class LocalDeviceMonitor(
 }
 
 object DeviceMonitor extends Logging {
-  val deviceCheckThreadPool = ThreadUtils.newDaemonCachedThreadPool("device-check-thread", 5)
+  var deviceCheckThreadPool: ThreadPoolExecutor = _
 
   def createDeviceMonitor(
       conf: CelebornConf,
@@ -208,6 +208,7 @@ object DeviceMonitor extends Logging {
       workerSource: AbstractSource): DeviceMonitor = {
     try {
       if (conf.workerDiskMonitorEnabled) {
+        deviceCheckThreadPool = ThreadUtils.newDaemonCachedThreadPool("device-check-thread", 5)
         val monitor =
           new LocalDeviceMonitor(conf, deviceObserver, deviceInfos, diskInfos, workerSource)
         monitor.init()


### PR DESCRIPTION
### What changes were proposed in this pull request?
deviceCheckThreadPool is only initialized when diskCheck is enabled


### Why are the changes needed?
deviceCheckThreadPool is only initialized when diskCheck is enabled


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing UTs.
