### PR TITLE
[CELEBORN-1252] Fix resource consumption of worker does not update when update interval is greater than heartbeat interval

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -543,7 +543,6 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def estimatedPartitionSizeForEstimationUpdateInterval: Long =
     get(ESTIMATED_PARTITION_SIZE_UPDATE_INTERVAL)
   def masterResourceConsumptionInterval: Long = get(MASTER_RESOURCE_CONSUMPTION_INTERVAL)
-  def workerResourceConsumptionInterval: Long = get(WORKER_RESOURCE_CONSUMPTION_INTERVAL)
 
   // //////////////////////////////////////////////////////
   //               Address && HA && RATIS                //
@@ -2183,14 +2182,6 @@ object CelebornConf extends Logging {
       .categories("master")
       .doc("Time length for a window about compute user resource consumption.")
       .version("0.3.0")
-      .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("30s")
-
-  val WORKER_RESOURCE_CONSUMPTION_INTERVAL: ConfigEntry[Long] =
-    buildConf("celeborn.worker.userResourceConsumption.update.interval")
-      .categories("worker")
-      .doc("Time length for a window about compute user resource consumption.")
-      .version("0.3.2")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("30s")
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -191,11 +191,11 @@ class WorkerInfo(
   def updateThenGetUserResourceConsumption(userConsumption: util.Map[
     UserIdentifier,
     ResourceConsumption]): util.Map[UserIdentifier, ResourceConsumption] = {
-    userResourceConsumption.asScala.foreach { case (identifier, _) =>
-      userResourceConsumption.put(
-        identifier,
-        userConsumption.getOrDefault(identifier, ResourceConsumption(0, 0, 0, 0)))
+    userResourceConsumption.keys().asScala.filterNot(userConsumption.containsKey).foreach {
+      identifier =>
+        userResourceConsumption.put(identifier, ResourceConsumption(0, 0, 0, 0))
     }
+    userResourceConsumption.putAll(userConsumption)
     userResourceConsumption
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -188,11 +188,14 @@ class WorkerInfo(
     JavaUtils.newConcurrentHashMap[String, DiskInfo](diskInfos)
   }
 
-  def updateThenGetUserResourceConsumption(consumption: util.Map[
+  def updateThenGetUserResourceConsumption(userConsumption: util.Map[
     UserIdentifier,
     ResourceConsumption]): util.Map[UserIdentifier, ResourceConsumption] = {
-    userResourceConsumption.clear()
-    userResourceConsumption.putAll(consumption)
+    userResourceConsumption.asScala.foreach { case (identifier, _) =>
+      userResourceConsumption.put(
+        identifier,
+        userConsumption.getOrDefault(identifier, ResourceConsumption(0, 0, 0, 0)))
+    }
     userResourceConsumption
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/meta/WorkerInfo.scala
@@ -191,11 +191,11 @@ class WorkerInfo(
   def updateThenGetUserResourceConsumption(resourceConsumptions: util.Map[
     UserIdentifier,
     ResourceConsumption]): util.Map[UserIdentifier, ResourceConsumption] = {
-    userResourceConsumption.keys().asScala.filterNot(userConsumption.containsKey).foreach {
+    userResourceConsumption.keys().asScala.filterNot(resourceConsumptions.containsKey).foreach {
       identifier =>
         userResourceConsumption.put(identifier, ResourceConsumption(0, 0, 0, 0))
     }
-    userResourceConsumption.putAll(userConsumption)
+    userResourceConsumption.putAll(resourceConsumptions)
     userResourceConsumption
   }
 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -122,7 +122,6 @@ license: |
 | celeborn.worker.storage.disk.reserve.size | 5G | Celeborn worker reserved space for each disk. | 0.3.0 | celeborn.worker.disk.reserve.size | 
 | celeborn.worker.storage.expireDirs.timeout | 1h | The timeout for a expire dirs to be deleted on disk. | 0.3.2 |  | 
 | celeborn.worker.storage.workingDir | celeborn-worker/shuffle_data | Worker's working dir path name. | 0.3.0 | celeborn.worker.workingDir | 
-| celeborn.worker.userResourceConsumption.update.interval | 30s | Time length for a window about compute user resource consumption. | 0.3.2 |  | 
 | celeborn.worker.writer.close.timeout | 120s | Timeout for a file writer to close | 0.2.0 |  | 
 | celeborn.worker.writer.create.maxAttempts | 3 | Retry count for a file writer to create if its creation was failed. | 0.2.0 |  | 
 <!--end-include-->

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -23,9 +23,9 @@ license: |
 
 ## Upgrading from 0.4 to 0.5
 
-- Since 0.5.0 Celeborn worker metrics `ChunkStreamCount` is renamed as `ActiveChunkStreamCount`.
+- Since 0.5.0, Celeborn worker metrics `ChunkStreamCount` is renamed as `ActiveChunkStreamCount`.
 
-- Since 0.5.0 Celeborn worker metrics `CreditStreamCount` is renamed as `ActiveCreditStreamCount`.
+- Since 0.5.0, Celeborn worker metrics `CreditStreamCount` is renamed as `ActiveCreditStreamCount`.
 
 ## Upgrading from 0.3 to 0.4
 
@@ -50,7 +50,7 @@ license: |
 
 - Since 0.4.0, Celeborn deprecate `celeborn.storage.activeTypes`. Please use `celeborn.storage.availableTypes` instead.
 
-- Since 0.4.0 Celeborn worker remove configuration `celeborn.worker.userResourceConsumption.update.interval`.
+- Since 0.4.0, Celeborn worker remove configuration `celeborn.worker.userResourceConsumption.update.interval`.
 
 - Since 0.4.0, Celeborn master metrics `PartitionWritten` is renamed as `ActiveShuffleSize`.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -27,6 +27,8 @@ license: |
 
 - Since 0.5.0 Celeborn worker metrics `CreditStreamCount` is renamed as `ActiveCreditStreamCount`.
 
+- Since 0.5.0 Celeborn worker remove configuration `celeborn.worker.userResourceConsumption.update.interval`.
+
 ## Upgrading from 0.3 to 0.4
 
 - Since 0.4.0, Celeborn won't be compatible with Celeborn client that versions below 0.3.0.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -27,8 +27,6 @@ license: |
 
 - Since 0.5.0 Celeborn worker metrics `CreditStreamCount` is renamed as `ActiveCreditStreamCount`.
 
-- Since 0.5.0 Celeborn worker remove configuration `celeborn.worker.userResourceConsumption.update.interval`.
-
 ## Upgrading from 0.3 to 0.4
 
 - Since 0.4.0, Celeborn won't be compatible with Celeborn client that versions below 0.3.0.
@@ -51,6 +49,8 @@ license: |
   Please use `celeborn.worker.storage.dirs` instead.
 
 - Since 0.4.0, Celeborn deprecate `celeborn.storage.activeTypes`. Please use `celeborn.storage.availableTypes` instead.
+
+- Since 0.4.0 Celeborn worker remove configuration `celeborn.worker.userResourceConsumption.update.interval`.
 
 - Since 0.4.0, Celeborn master metrics `PartitionWritten` is renamed as `ActiveShuffleSize`.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -50,7 +50,7 @@ license: |
 
 - Since 0.4.0, Celeborn deprecate `celeborn.storage.activeTypes`. Please use `celeborn.storage.availableTypes` instead.
 
-- Since 0.4.0, Celeborn worker remove configuration `celeborn.worker.userResourceConsumption.update.interval`.
+- Since 0.4.0, Celeborn worker removes configuration `celeborn.worker.userResourceConsumption.update.interval`.
 
 - Since 0.4.0, Celeborn master metrics `PartitionWritten` is renamed as `ActiveShuffleSize`.
 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -877,28 +877,28 @@ private[celeborn] class Master(
   private def handleCheckQuota(
       userIdentifier: UserIdentifier,
       context: RpcCallContext): Unit = {
-
-    resourceConsumptionSource.addGauge(
-      ResourceConsumptionSource.DISK_FILE_COUNT,
-      userIdentifier.toMap) { () =>
-      computeUserResourceConsumption(userIdentifier).diskFileCount
+    if (!userResourceConsumptions.containsKey(userIdentifier)) {
+      resourceConsumptionSource.addGauge(
+        ResourceConsumptionSource.DISK_FILE_COUNT,
+        userIdentifier.toMap) { () =>
+        computeUserResourceConsumption(userIdentifier).diskFileCount
+      }
+      resourceConsumptionSource.addGauge(
+        ResourceConsumptionSource.DISK_BYTES_WRITTEN,
+        userIdentifier.toMap) { () =>
+        computeUserResourceConsumption(userIdentifier).diskBytesWritten
+      }
+      resourceConsumptionSource.addGauge(
+        ResourceConsumptionSource.HDFS_FILE_COUNT,
+        userIdentifier.toMap) { () =>
+        computeUserResourceConsumption(userIdentifier).hdfsFileCount
+      }
+      resourceConsumptionSource.addGauge(
+        ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
+        userIdentifier.toMap) { () =>
+        computeUserResourceConsumption(userIdentifier).hdfsBytesWritten
+      }
     }
-    resourceConsumptionSource.addGauge(
-      ResourceConsumptionSource.DISK_BYTES_WRITTEN,
-      userIdentifier.toMap) { () =>
-      computeUserResourceConsumption(userIdentifier).diskBytesWritten
-    }
-    resourceConsumptionSource.addGauge(
-      ResourceConsumptionSource.HDFS_FILE_COUNT,
-      userIdentifier.toMap) { () =>
-      computeUserResourceConsumption(userIdentifier).hdfsFileCount
-    }
-    resourceConsumptionSource.addGauge(
-      ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
-      userIdentifier.toMap) { () =>
-      computeUserResourceConsumption(userIdentifier).hdfsBytesWritten
-    }
-
     val userResourceConsumption = computeUserResourceConsumption(userIdentifier)
     val quota = quotaManager.getQuota(userIdentifier)
     val (isAvailable, reason) =

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -877,6 +877,7 @@ private[celeborn] class Master(
   private def handleCheckQuota(
       userIdentifier: UserIdentifier,
       context: RpcCallContext): Unit = {
+
     resourceConsumptionSource.addGauge(
       ResourceConsumptionSource.DISK_FILE_COUNT,
       userIdentifier.toMap) { () =>
@@ -897,6 +898,7 @@ private[celeborn] class Master(
       userIdentifier.toMap) { () =>
       computeUserResourceConsumption(userIdentifier).hdfsBytesWritten
     }
+
     val userResourceConsumption = computeUserResourceConsumption(userIdentifier)
     val quota = quotaManager.getQuota(userIdentifier)
     val (isAvailable, reason) =

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -877,27 +877,25 @@ private[celeborn] class Master(
   private def handleCheckQuota(
       userIdentifier: UserIdentifier,
       context: RpcCallContext): Unit = {
-    if (!userResourceConsumptions.containsKey(userIdentifier)) {
-      resourceConsumptionSource.addGauge(
-        ResourceConsumptionSource.DISK_FILE_COUNT,
-        userIdentifier.toMap) { () =>
-        computeUserResourceConsumption(userIdentifier).diskFileCount
-      }
-      resourceConsumptionSource.addGauge(
-        ResourceConsumptionSource.DISK_BYTES_WRITTEN,
-        userIdentifier.toMap) { () =>
-        computeUserResourceConsumption(userIdentifier).diskBytesWritten
-      }
-      resourceConsumptionSource.addGauge(
-        ResourceConsumptionSource.HDFS_FILE_COUNT,
-        userIdentifier.toMap) { () =>
-        computeUserResourceConsumption(userIdentifier).hdfsFileCount
-      }
-      resourceConsumptionSource.addGauge(
-        ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
-        userIdentifier.toMap) { () =>
-        computeUserResourceConsumption(userIdentifier).hdfsBytesWritten
-      }
+    resourceConsumptionSource.addGauge(
+      ResourceConsumptionSource.DISK_FILE_COUNT,
+      userIdentifier.toMap) { () =>
+      computeUserResourceConsumption(userIdentifier).diskFileCount
+    }
+    resourceConsumptionSource.addGauge(
+      ResourceConsumptionSource.DISK_BYTES_WRITTEN,
+      userIdentifier.toMap) { () =>
+      computeUserResourceConsumption(userIdentifier).diskBytesWritten
+    }
+    resourceConsumptionSource.addGauge(
+      ResourceConsumptionSource.HDFS_FILE_COUNT,
+      userIdentifier.toMap) { () =>
+      computeUserResourceConsumption(userIdentifier).hdfsFileCount
+    }
+    resourceConsumptionSource.addGauge(
+      ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
+      userIdentifier.toMap) { () =>
+      computeUserResourceConsumption(userIdentifier).hdfsBytesWritten
     }
     val userResourceConsumption = computeUserResourceConsumption(userIdentifier)
     val quota = quotaManager.getQuota(userIdentifier)

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -530,38 +530,22 @@ private[celeborn] class Worker(
         resourceConsumptionSource.addGauge(
           ResourceConsumptionSource.DISK_FILE_COUNT,
           userIdentifier.toMap) { () =>
-          if (workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
-            workerInfo.userResourceConsumption.get(userIdentifier).diskFileCount
-          } else {
-            0L
-          }
+          workerInfo.userResourceConsumption.get(userIdentifier).diskFileCount
         }
         resourceConsumptionSource.addGauge(
           ResourceConsumptionSource.DISK_BYTES_WRITTEN,
           userIdentifier.toMap) { () =>
-          if (workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
-            workerInfo.userResourceConsumption.get(userIdentifier).diskBytesWritten
-          } else {
-            0L
-          }
+          workerInfo.userResourceConsumption.get(userIdentifier).diskBytesWritten
         }
         resourceConsumptionSource.addGauge(
           ResourceConsumptionSource.HDFS_FILE_COUNT,
           userIdentifier.toMap) { () =>
-          if (workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
-            workerInfo.userResourceConsumption.get(userIdentifier).hdfsFileCount
-          } else {
-            0L
-          }
+          workerInfo.userResourceConsumption.get(userIdentifier).hdfsFileCount
         }
         resourceConsumptionSource.addGauge(
           ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
           userIdentifier.toMap) { () =>
-          if (workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
-            workerInfo.userResourceConsumption.get(userIdentifier).hdfsBytesWritten
-          } else {
-            0L
-          }
+          workerInfo.userResourceConsumption.get(userIdentifier).hdfsBytesWritten
         }
       }
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -526,26 +526,42 @@ private[celeborn] class Worker(
   private def handleResourceConsumption(): util.Map[UserIdentifier, ResourceConsumption] = {
     val resourceConsumptionSnapshot = storageManager.userResourceConsumptionSnapshot()
     resourceConsumptionSnapshot.foreach { case (userIdentifier, _) =>
-      if (workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
+      if (!workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
         resourceConsumptionSource.addGauge(
           ResourceConsumptionSource.DISK_FILE_COUNT,
           userIdentifier.toMap) { () =>
-          workerInfo.userResourceConsumption.get(userIdentifier).diskFileCount
+          if (workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
+            workerInfo.userResourceConsumption.get(userIdentifier).diskFileCount
+          } else {
+            0L
+          }
         }
         resourceConsumptionSource.addGauge(
           ResourceConsumptionSource.DISK_BYTES_WRITTEN,
           userIdentifier.toMap) { () =>
-          workerInfo.userResourceConsumption.get(userIdentifier).diskBytesWritten
+          if (workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
+            workerInfo.userResourceConsumption.get(userIdentifier).diskBytesWritten
+          } else {
+            0L
+          }
         }
         resourceConsumptionSource.addGauge(
           ResourceConsumptionSource.HDFS_FILE_COUNT,
           userIdentifier.toMap) { () =>
-          workerInfo.userResourceConsumption.get(userIdentifier).hdfsFileCount
+          if (workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
+            workerInfo.userResourceConsumption.get(userIdentifier).hdfsFileCount
+          } else {
+            0L
+          }
         }
         resourceConsumptionSource.addGauge(
           ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
           userIdentifier.toMap) { () =>
-          workerInfo.userResourceConsumption.get(userIdentifier).hdfsBytesWritten
+          if (workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
+            workerInfo.userResourceConsumption.get(userIdentifier).hdfsBytesWritten
+          } else {
+            0L
+          }
         }
       }
     }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -526,27 +526,25 @@ private[celeborn] class Worker(
   private def handleResourceConsumption(): util.Map[UserIdentifier, ResourceConsumption] = {
     val resourceConsumptionSnapshot = storageManager.userResourceConsumptionSnapshot()
     resourceConsumptionSnapshot.foreach { case (userIdentifier, _) =>
-      if (!workerInfo.userResourceConsumption.containsKey(userIdentifier)) {
-        resourceConsumptionSource.addGauge(
-          ResourceConsumptionSource.DISK_FILE_COUNT,
-          userIdentifier.toMap) { () =>
-          workerInfo.userResourceConsumption.get(userIdentifier).diskFileCount
-        }
-        resourceConsumptionSource.addGauge(
-          ResourceConsumptionSource.DISK_BYTES_WRITTEN,
-          userIdentifier.toMap) { () =>
-          workerInfo.userResourceConsumption.get(userIdentifier).diskBytesWritten
-        }
-        resourceConsumptionSource.addGauge(
-          ResourceConsumptionSource.HDFS_FILE_COUNT,
-          userIdentifier.toMap) { () =>
-          workerInfo.userResourceConsumption.get(userIdentifier).hdfsFileCount
-        }
-        resourceConsumptionSource.addGauge(
-          ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
-          userIdentifier.toMap) { () =>
-          workerInfo.userResourceConsumption.get(userIdentifier).hdfsBytesWritten
-        }
+      resourceConsumptionSource.addGauge(
+        ResourceConsumptionSource.DISK_FILE_COUNT,
+        userIdentifier.toMap) { () =>
+        workerInfo.userResourceConsumption.get(userIdentifier).diskFileCount
+      }
+      resourceConsumptionSource.addGauge(
+        ResourceConsumptionSource.DISK_BYTES_WRITTEN,
+        userIdentifier.toMap) { () =>
+        workerInfo.userResourceConsumption.get(userIdentifier).diskBytesWritten
+      }
+      resourceConsumptionSource.addGauge(
+        ResourceConsumptionSource.HDFS_FILE_COUNT,
+        userIdentifier.toMap) { () =>
+        workerInfo.userResourceConsumption.get(userIdentifier).hdfsFileCount
+      }
+      resourceConsumptionSource.addGauge(
+        ResourceConsumptionSource.HDFS_BYTES_WRITTEN,
+        userIdentifier.toMap) { () =>
+        workerInfo.userResourceConsumption.get(userIdentifier).hdfsBytesWritten
       }
     }
     workerInfo.updateThenGetUserResourceConsumption(resourceConsumptionSnapshot.asJava)


### PR DESCRIPTION
### What changes were proposed in this pull request?

 Resource consumption of worker does not update when update interval of resource consumpution is greater than heartbeat interval.

<img width="1741" alt="截屏2024-01-24 14 49 50" src="https://github.com/apache/incubator-celeborn/assets/46485123/21cfd412-c69e-4955-8bc8-155ee470697d">

This pull request introduces below changes:

1. Avoid master repeat add gauge for same user
2. For worker, user resource consumption can directly get from worker's snapshot, didn't need update interval 


### Why are the changes needed?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.