### PR TITLE
[CELEBORN-1182][0.4] Support application dimension ActiveConnectionCount metric to record the number of registered connections for each application

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/AbstractSource.scala
@@ -67,6 +67,8 @@ abstract class AbstractSource(conf: CelebornConf, role: String)
   val staticLabels: Map[String, String] = conf.metricsExtraLabels + roleLabel
   val staticLabelsString: String = MetricLabels.labelString(staticLabels)
 
+  val applicationLabel = "applicationId"
+
   protected val namedGauges: JQueue[NamedGauge[_]] = new ConcurrentLinkedQueue[NamedGauge[_]]()
 
   def addGauge[T](

--- a/common/src/main/scala/org/apache/celeborn/common/metrics/source/ResourceConsumptionSource.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/metrics/source/ResourceConsumptionSource.scala
@@ -33,6 +33,4 @@ object ResourceConsumptionSource {
   val HDFS_FILE_COUNT = "hdfsFileCount"
 
   val HDFS_BYTES_WRITTEN = "hdfsBytesWritten"
-
-  val APPLICATION_LABEL = "applicationId"
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -813,7 +813,7 @@ private[celeborn] class Master(
       appId: String): Unit = {
     resourceConsumptionSource.removeGauge(
       resourceConsumptionName,
-      ResourceConsumptionSource.APPLICATION_LABEL,
+      resourceConsumptionSource.applicationLabel,
       appId)
   }
 
@@ -893,7 +893,7 @@ private[celeborn] class Master(
       applicationId: String = null): Unit = {
     val resourceConsumptionLabel =
       if (applicationId == null) userIdentifier.toMap
-      else userIdentifier.toMap + (ResourceConsumptionSource.APPLICATION_LABEL -> applicationId)
+      else userIdentifier.toMap + (resourceConsumptionSource.applicationLabel -> applicationId)
     resourceConsumptionSource.addGauge(
       ResourceConsumptionSource.DISK_FILE_COUNT,
       resourceConsumptionLabel) { () =>

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/FetchHandler.scala
@@ -100,9 +100,9 @@ class FetchHandler(
   override def receive(client: TransportClient, msg: RequestMessage): Unit = {
     msg match {
       case r: BufferStreamEnd =>
-        handleEndStreamFromClient(r.getStreamId)
+        handleEndStreamFromClient(client, r.getStreamId)
       case r: ReadAddCredit =>
-        handleReadAddCredit(r.getCredit, r.getStreamId)
+        handleReadAddCredit(client, r.getCredit, r.getStreamId)
       case r: ChunkFetchRequest =>
         handleChunkFetchRequest(client, r.streamChunkSlice, r)
       case unknown: RequestMessage =>
@@ -137,9 +137,12 @@ class FetchHandler(
           openStream.getReadLocalShuffle,
           callback)
       case bufferStreamEnd: PbBufferStreamEnd =>
-        handleEndStreamFromClient(bufferStreamEnd.getStreamId, bufferStreamEnd.getStreamType)
+        handleEndStreamFromClient(
+          client,
+          bufferStreamEnd.getStreamId,
+          bufferStreamEnd.getStreamType)
       case readAddCredit: PbReadAddCredit =>
-        handleReadAddCredit(readAddCredit.getCredit, readAddCredit.getStreamId)
+        handleReadAddCredit(client, readAddCredit.getCredit, readAddCredit.getStreamId)
       case chunkFetchRequest: PbChunkFetchRequest =>
         handleChunkFetchRequest(
           client,
@@ -205,6 +208,7 @@ class FetchHandler(
       isLegacy: Boolean,
       readLocalShuffle: Boolean = false,
       callback: RpcResponseCallback): Unit = {
+    workerSource.recordAppActiveConnection(client, shuffleKey)
     workerSource.startTimer(WorkerSource.OPEN_STREAM_TIME, shuffleKey)
     try {
       var fileInfo = getRawFileInfo(shuffleKey, fileName)
@@ -275,6 +279,7 @@ class FetchHandler(
           creditStreamManager.registerStream(
             creditStreamHandler,
             client.getChannel,
+            shuffleKey,
             initialCredit,
             startIndex,
             endIndex,
@@ -345,23 +350,33 @@ class FetchHandler(
     rpcResponseCallback.onFailure(ExceptionUtils.wrapIOExceptionToUnRetryable(ioe))
   }
 
-  def handleEndStreamFromClient(streamId: Long): Unit = {
-    handleEndStreamFromClient(streamId, StreamType.CreditStream)
+  def handleEndStreamFromClient(client: TransportClient, streamId: Long): Unit = {
+    handleEndStreamFromClient(client, streamId, StreamType.CreditStream)
   }
 
-  def handleEndStreamFromClient(streamId: Long, streamType: StreamType): Unit = {
+  def handleEndStreamFromClient(
+      client: TransportClient,
+      streamId: Long,
+      streamType: StreamType): Unit = {
     streamType match {
       case StreamType.ChunkStream =>
         val (shuffleKey, fileName) = chunkStreamManager.getShuffleKeyAndFileName(streamId)
+        workerSource.recordAppActiveConnection(client, shuffleKey)
         getRawFileInfo(shuffleKey, fileName).closeStream(streamId)
       case StreamType.CreditStream =>
+        workerSource.recordAppActiveConnection(
+          client,
+          creditStreamManager.getStreamShuffleKey(streamId))
         creditStreamManager.notifyStreamEndByClient(streamId)
       case _ =>
         logError(s"Received a PbBufferStreamEnd message with unknown type $streamType")
     }
   }
 
-  def handleReadAddCredit(credit: Int, streamId: Long): Unit = {
+  def handleReadAddCredit(client: TransportClient, credit: Int, streamId: Long): Unit = {
+    workerSource.recordAppActiveConnection(
+      client,
+      creditStreamManager.getStreamShuffleKey(streamId))
     creditStreamManager.addCredit(credit, streamId)
   }
 
@@ -371,6 +386,10 @@ class FetchHandler(
       req: RequestMessage): Unit = {
     logDebug(s"Received req from ${NettyUtils.getRemoteAddress(client.getChannel)}" +
       s" to fetch block $streamChunkSlice")
+
+    workerSource.recordAppActiveConnection(
+      client,
+      chunkStreamManager.getShuffleKeyAndFileName(streamChunkSlice.streamId)._1)
 
     maxChunkBeingTransferred.foreach { threshold =>
       val chunksBeingTransferred = chunkStreamManager.chunksBeingTransferred // take high cpu usage
@@ -436,12 +455,12 @@ class FetchHandler(
   /** Invoked when the channel associated with the given client is active. */
   override def channelActive(client: TransportClient): Unit = {
     logDebug(s"channel active ${client.getSocketAddress}")
-    workerSource.incCounter(WorkerSource.ACTIVE_CONNECTION_COUNT)
+    workerSource.connectionActive(client)
     super.channelActive(client)
   }
 
   override def channelInactive(client: TransportClient): Unit = {
-    workerSource.incCounter(WorkerSource.ACTIVE_CONNECTION_COUNT, -1)
+    workerSource.connectionInactive(client)
     creditStreamManager.connectionTerminated(client.getChannel)
     logDebug(s"channel inactive ${client.getSocketAddress}")
   }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -464,6 +464,7 @@ private[celeborn] class Worker(
         commitThreadPool.shutdownNow()
         asyncReplyPool.shutdownNow()
       }
+      workerSource.appActiveConnections.clear()
       partitionsSorter.close(exitKind)
       storageManager.close(exitKind)
       memoryManager.close()
@@ -541,7 +542,7 @@ private[celeborn] class Worker(
       applicationId: String = null): Unit = {
     var resourceConsumptionLabel = userIdentifier.toMap
     if (applicationId != null)
-      resourceConsumptionLabel += (ResourceConsumptionSource.APPLICATION_LABEL -> applicationId)
+      resourceConsumptionLabel += (resourceConsumptionSource.applicationLabel -> applicationId)
     resourceConsumptionSource.addGauge(
       ResourceConsumptionSource.DISK_FILE_COUNT,
       resourceConsumptionLabel) { () =>
@@ -591,6 +592,7 @@ private[celeborn] class Worker(
           // When the running applications does not contain the application corresponding to expired shuffle key,
           // resource consumption source should remove lose application gauges.
           removeAppResourceConsumption(applicationId)
+          removeAppActiveConnection(applicationId)
         }
         logInfo(s"Cleaned up expired shuffle $shuffleKey")
       }
@@ -621,8 +623,12 @@ private[celeborn] class Worker(
       applicationId: String): Unit = {
     resourceConsumptionSource.removeGauge(
       resourceConsumptionName,
-      ResourceConsumptionSource.APPLICATION_LABEL,
+      resourceConsumptionSource.applicationLabel,
       applicationId)
+  }
+
+  private def removeAppActiveConnection(applicationId: String): Unit = {
+    workerSource.removeAppActiveConnection(applicationId)
   }
 
   override def getWorkerInfo: String = {

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManagerSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/CreditStreamManagerSuiteJ.java
@@ -80,18 +80,21 @@ public class CreditStreamManagerSuiteJ {
     fileInfo.setBufferSize(1024);
     Consumer<Long> streamIdConsumer = streamId -> Assert.assertTrue(streamId > 0);
 
+    String shuffleKey = "application_1694674023293_0003-0";
     long registerStream1 =
-        creditStreamManager.registerStream(streamIdConsumer, channel, 0, 1, 1, fileInfo);
+        creditStreamManager.registerStream(
+            streamIdConsumer, channel, shuffleKey, 0, 1, 1, fileInfo);
     Assert.assertTrue(registerStream1 > 0);
     Assert.assertEquals(1, creditStreamManager.getStreamsCount());
 
     long registerStream2 =
-        creditStreamManager.registerStream(streamIdConsumer, channel, 0, 1, 1, fileInfo);
+        creditStreamManager.registerStream(
+            streamIdConsumer, channel, shuffleKey, 0, 1, 1, fileInfo);
     Assert.assertNotEquals(registerStream1, registerStream2);
     Assert.assertEquals(2, creditStreamManager.getStreamsCount());
 
-    creditStreamManager.registerStream(streamIdConsumer, channel, 0, 1, 1, fileInfo);
-    creditStreamManager.registerStream(streamIdConsumer, channel, 0, 1, 1, fileInfo);
+    creditStreamManager.registerStream(streamIdConsumer, channel, shuffleKey, 0, 1, 1, fileInfo);
+    creditStreamManager.registerStream(streamIdConsumer, channel, shuffleKey, 0, 1, 1, fileInfo);
 
     MapDataPartition mapDataPartition1 =
         creditStreamManager.getStreams().get(registerStream1).getMapDataPartition();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Cherry pick #2167.

`WorkerSource` supports application dimension `ActiveConnectionCount` metric to record the number of registered connections for each application.

### Why are the changes needed?

`ActiveConnectionCount` metric records the number of registered connections at present. It's recommended to support dimension ActiveConnectionCount metric to record the number of registered connections for each application in Worker. Application dimension `ActiveConnectionCount` metric could provide users with the actual number of registered connections for each application.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal tests.