### PR TITLE
[CELEBORN-1262] Bump Spark from 3.3.3 to 3.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <maven.version>3.8.8</maven.version>
 
     <flink.version>1.14.6</flink.version>
-    <spark.version>3.3.2</spark.version>
+    <spark.version>3.3.4</spark.version>
 
     <!-- use hadoop-3 as default  -->
     <hadoop.version>3.3.6</hadoop.version>
@@ -1144,7 +1144,7 @@
         <lz4-java.version>1.8.0</lz4-java.version>
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.3.3</spark.version>
+        <spark.version>3.3.4</spark.version>
         <zstd-jni.version>1.5.2-1</zstd-jni.version>
       </properties>
     </profile>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -581,7 +581,7 @@ object Spark33 extends SparkClientProjects {
   val sparkProjectScalaVersion = "2.12.15"
   // scalaBinaryVersion
   // val scalaBinaryVersion = "2.12"
-  val sparkVersion = "3.3.3"
+  val sparkVersion = "3.3.4"
   val zstdJniVersion = "1.5.2-1"
 
   override val includeColumnarShuffle: Boolean = true


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Spark from 3.3.3 to 3.3.4. Meanwhile, bump the default `spark.version` from 3.3.2 to 3.3.4.

### Why are the changes needed?

Spark 3.3.4 has been announced to release: [Spark 3.3.4 released](https://spark.apache.org/news/spark-3-3-4-released.html). The profile spark-3.3 could bump Spark from 3.3.3 to 3.3.4.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.