### PR TITLE
[CELEBORN-448][FOLLOWUP] HeartbeatFromApplicationResponse should include manually excluded workers

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -978,7 +978,8 @@ private[celeborn] class Master(
     if (shouldResponse) {
       context.reply(HeartbeatFromApplicationResponse(
         StatusCode.SUCCESS,
-        new util.ArrayList(statusSystem.excludedWorkers),
+        new util.ArrayList(
+          (statusSystem.excludedWorkers.asScala ++ statusSystem.manuallyExcludedWorkers.asScala).asJava),
         needCheckedWorkerList,
         shutdownWorkerSnapshot))
     } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `HeartbeatFromApplicationResponse` does not include manually excluded workers.

### Why are the changes needed?

`HeartbeatFromApplicationResponse` should include manually excluded workers, otherwise `WorkerStatusTracker` misses the manually excluded workers.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Local test and GA.