### PR TITLE
[CELEBORN-1270] Introduce PbPartitionLocationList to (de-)serialize PartitionLocations more efficiently

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -577,9 +577,14 @@ public class ShuffleClientImpl extends ShuffleClient {
         StatusCode respStatus = Utils.toStatusCode(response.getStatus());
         if (StatusCode.SUCCESS.equals(respStatus)) {
           ConcurrentHashMap<Integer, PartitionLocation> result = JavaUtils.newConcurrentHashMap();
-          for (int i = 0; i < response.getPartitionLocationsList().size(); i++) {
+          List<PbPartitionLocation> partitionLocationsList = response.getPartitionLocationsList();
+          if (CollectionUtils.isEmpty(partitionLocationsList)) {
+            partitionLocationsList =
+                response.getPartitionLocationList().getPartitionLocationsList();
+          }
+          for (int i = 0; i < partitionLocationsList.size(); i++) {
             PartitionLocation partitionLoc =
-                PbSerDeUtils.fromPbPartitionLocation(response.getPartitionLocationsList().get(i));
+                PbSerDeUtils.fromPbPartitionLocation(partitionLocationsList.get(i));
             pushExcludedWorkers.remove(partitionLoc.hostAndPushPort());
             if (partitionLoc.hasPeer()) {
               pushExcludedWorkers.remove(partitionLoc.getPeer().hostAndPushPort());

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -51,7 +51,7 @@ import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.rpc._
 import org.apache.celeborn.common.rpc.netty.{LocalNettyRpcCallContext, RemoteNettyRpcCallContext}
 import org.apache.celeborn.common.security.{ClientSaslContextBuilder, RpcSecurityContext, RpcSecurityContextBuilder}
-import org.apache.celeborn.common.util.{JavaUtils, PbSerDeUtils, ThreadUtils, Utils}
+import org.apache.celeborn.common.util.{CollectionUtils, JavaUtils, PbSerDeUtils, ThreadUtils, Utils}
 // Can Remove this if celeborn don't support scala211 in future
 import org.apache.celeborn.common.util.FunctionConverter._
 import org.apache.celeborn.common.util.ThreadUtils.awaitResult
@@ -574,8 +574,13 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
             partitionType match {
               case PartitionType.MAP =>
                 if (response.getStatus == StatusCode.SUCCESS.getValue) {
+                  var partitionLocationsList = response.getPartitionLocationsList
+                  if (CollectionUtils.isEmpty(partitionLocationsList)) {
+                    partitionLocationsList =
+                      response.getPartitionLocationList.getPartitionLocationsList
+                  }
                   val partitionLocations =
-                    response.getPartitionLocationsList.asScala.filter(
+                    partitionLocationsList.asScala.filter(
                       _.getId == context.partitionId).map(r =>
                       PbSerDeUtils.fromPbPartitionLocation(r)).toArray
                   processMapTaskReply(

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -140,10 +140,16 @@ message PbPartitionLocation {
   bytes mapIdBitmap = 11;
 }
 
+message PbPartitionLocationList {
+  repeated PbPartitionLocation partitionLocations = 1;
+}
+
 message PbWorkerResource {
   repeated PbPartitionLocation primaryPartitions = 1;
   repeated PbPartitionLocation replicaPartitions = 2;
   string networkLocation = 3;
+  PbPartitionLocationList primaryPartitionList = 4;
+  PbPartitionLocationList replicaPartitionList = 5;
 }
 
 message PbDiskInfo {
@@ -168,6 +174,7 @@ message PbWorkerInfo {
 
 message PbFileGroup {
   repeated PbPartitionLocation locations = 1;
+  PbPartitionLocationList locationList = 2;
 }
 
 message PbRegisterWorker {
@@ -250,6 +257,7 @@ message PbRegisterMapPartitionTask {
 message PbRegisterShuffleResponse {
   int32 status = 1;
   repeated PbPartitionLocation partitionLocations = 2;
+  PbPartitionLocationList partitionLocationList = 3;
 }
 
 message PbRequestSlots {
@@ -444,6 +452,8 @@ message PbReserveSlots {
   int64 pushDataTimeout = 10;
   bool partitionSplitEnabled = 11;
   int32 availableStorageTypes = 12;
+  PbPartitionLocationList primaryLocationList = 13;
+  PbPartitionLocationList replicaLocationList = 14;
 }
 
 message PbReserveSlotsResponse {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce `PbPartitionLocationList` to (de-)serialize `PartitionLocations` more efficiently.

### Why are the changes needed?

To reduce memory footprint of the following messages:

- `PbWorkerResource`
- `PbRegisterShuffleResponse`
- `PbFileGroup`
- `PbReserveSlots`

### Does this PR introduce _any_ user-facing change?

Yes. Support backward compatibility.

### How was this patch tested?

- `PbSerDeUtilsTest#fromAndToPbWorkerResource`