### PR TITLE
[CELEBORN-1052][FOLLOWUP] Improve the implementation of ConfigService

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -367,8 +367,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     }
   }
 
-  def dynamicConfigStoreBackend: String = get(DYNAMIC_CONFIG_STORE_BACKEND)
-  def dynamicConfigEnabled: Boolean = get(DYNAMIC_CONFIG_ENABLED)
+  def dynamicConfigStoreBackend: Option[String] = get(DYNAMIC_CONFIG_STORE_BACKEND)
   def dynamicConfigRefreshInterval: Long = get(DYNAMIC_CONFIG_REFRESH_INTERVAL)
   def dynamicConfigStoreDbFetchPageSize: Int = get(DYNAMIC_CONFIG_STORE_DB_FETCH_PAGE_SIZE)
   def dynamicConfigStoreDbHikariDriverClassName: String =
@@ -4425,23 +4424,16 @@ object CelebornConf extends Logging {
       .stringConf
       .createOptional
 
-  val DYNAMIC_CONFIG_STORE_BACKEND: ConfigEntry[String] =
+  val DYNAMIC_CONFIG_STORE_BACKEND: OptionalConfigEntry[String] =
     buildConf("celeborn.dynamicConfig.store.backend")
       .categories("master", "worker")
-      .doc("Store backend for dynamic config service. Available options: FS, DB.")
+      .doc("Store backend for dynamic config service. Available options: FS, DB. " +
+        "If not provided, it means that dynamic configuration is disabled.")
       .version("0.4.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(Set("FS", "DB"))
-      .createWithDefault("FS")
-
-  val DYNAMIC_CONFIG_ENABLED: ConfigEntry[Boolean] =
-    buildConf("celeborn.dynamicConfig.enabled")
-      .categories("master", "worker")
-      .version("0.5.0")
-      .doc("Whether to enable dynamic configuration.")
-      .booleanConf
-      .createWithDefault(false)
+      .createOptional
 
   val DYNAMIC_CONFIG_REFRESH_INTERVAL: ConfigEntry[Long] =
     buildConf("celeborn.dynamicConfig.refresh.interval")

--- a/docs/configuration/master.md
+++ b/docs/configuration/master.md
@@ -20,9 +20,8 @@ license: |
 | Key | Default | Description | Since | Deprecated |
 | --- | ------- | ----------- | ----- | ---------- |
 | celeborn.cluster.name | default | Celeborn cluster name. | 0.5.0 |  | 
-| celeborn.dynamicConfig.enabled | false | Whether to enable dynamic configuration. | 0.5.0 |  | 
 | celeborn.dynamicConfig.refresh.interval | 120s | Interval for refreshing the corresponding dynamic config periodically. | 0.4.0 |  | 
-| celeborn.dynamicConfig.store.backend | FS | Store backend for dynamic config service. Available options: FS, DB. | 0.4.0 |  | 
+| celeborn.dynamicConfig.store.backend | &lt;undefined&gt; | Store backend for dynamic config service. Available options: FS, DB. If not provided, it means that dynamic configuration is disabled. | 0.4.0 |  | 
 | celeborn.dynamicConfig.store.db.fetch.pageSize | 1000 | The page size for db store to query configurations. | 0.5.0 |  | 
 | celeborn.dynamicConfig.store.db.hikari.connectionTimeout | 30s | The connection timeout that a client will wait for a connection from the pool for db store backend. | 0.5.0 |  | 
 | celeborn.dynamicConfig.store.db.hikari.driverClassName |  | The jdbc driver class name of db store backend. | 0.5.0 |  | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -20,9 +20,8 @@ license: |
 | Key | Default | Description | Since | Deprecated |
 | --- | ------- | ----------- | ----- | ---------- |
 | celeborn.cluster.name | default | Celeborn cluster name. | 0.5.0 |  | 
-| celeborn.dynamicConfig.enabled | false | Whether to enable dynamic configuration. | 0.5.0 |  | 
 | celeborn.dynamicConfig.refresh.interval | 120s | Interval for refreshing the corresponding dynamic config periodically. | 0.4.0 |  | 
-| celeborn.dynamicConfig.store.backend | FS | Store backend for dynamic config service. Available options: FS, DB. | 0.4.0 |  | 
+| celeborn.dynamicConfig.store.backend | &lt;undefined&gt; | Store backend for dynamic config service. Available options: FS, DB. If not provided, it means that dynamic configuration is disabled. | 0.4.0 |  | 
 | celeborn.dynamicConfig.store.db.fetch.pageSize | 1000 | The page size for db store to query configurations. | 0.5.0 |  | 
 | celeborn.dynamicConfig.store.db.hikari.connectionTimeout | 30s | The connection timeout that a client will wait for a connection from the pool for db store backend. | 0.5.0 |  | 
 | celeborn.dynamicConfig.store.db.hikari.driverClassName |  | The jdbc driver class name of db store backend. | 0.5.0 |  | 

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/BaseConfigServiceImpl.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/BaseConfigServiceImpl.java
@@ -49,25 +49,20 @@ public abstract class BaseConfigServiceImpl implements ConfigService {
   public BaseConfigServiceImpl(CelebornConf celebornConf) throws IOException {
     this.celebornConf = celebornConf;
     this.systemConfigAtomicReference.set(new SystemConfig(celebornConf));
-    this.refreshAllCache();
-    boolean dynamicConfigEnabled = celebornConf.dynamicConfigEnabled();
-    if (dynamicConfigEnabled) {
-      LOG.info("Celeborn dynamic config is enabled.");
-      long dynamicConfigRefreshInterval = celebornConf.dynamicConfigRefreshInterval();
-      this.configRefreshService.scheduleWithFixedDelay(
-          () -> {
-            try {
-              refreshAllCache();
-            } catch (Throwable e) {
-              LOG.error("Refresh config encounter exception: {}", e.getMessage(), e);
-            }
-          },
-          dynamicConfigRefreshInterval,
-          dynamicConfigRefreshInterval,
-          TimeUnit.MILLISECONDS);
-    } else {
-      LOG.info("Celeborn dynamic config is disabled, config can not be refreshed after updated.");
-    }
+    this.refreshCache();
+    long dynamicConfigRefreshInterval = celebornConf.dynamicConfigRefreshInterval();
+    this.configRefreshService.scheduleWithFixedDelay(
+        () -> {
+          try {
+            refreshCache();
+          } catch (Throwable e) {
+            LOG.error(
+                "Failed to refresh dynamic configs. Encounter exception: {}.", e.getMessage(), e);
+          }
+        },
+        dynamicConfigRefreshInterval,
+        dynamicConfigRefreshInterval,
+        TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/ConfigService.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/ConfigService.java
@@ -49,7 +49,7 @@ public interface ConfigService {
     }
   }
 
-  void refreshAllCache() throws IOException;
+  void refreshCache() throws IOException;
 
   void shutdown();
 }

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/DbConfigServiceImpl.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/DbConfigServiceImpl.java
@@ -18,8 +18,6 @@
 package org.apache.celeborn.server.common.service.config;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -37,7 +35,7 @@ public class DbConfigServiceImpl extends BaseConfigServiceImpl implements Config
   }
 
   @Override
-  public void refreshAllCache() throws IOException {
+  public void refreshCache() throws IOException {
     if (iServiceManager == null) {
       synchronized (this) {
         if (iServiceManager == null) {
@@ -47,18 +45,14 @@ public class DbConfigServiceImpl extends BaseConfigServiceImpl implements Config
     }
 
     systemConfigAtomicReference.set(iServiceManager.getSystemConfig());
-    List<TenantConfig> allTenantConfigs = iServiceManager.getAllTenantConfigs();
-    Map<String, TenantConfig> tenantConfigMap =
-        allTenantConfigs.stream()
-            .collect(Collectors.toMap(TenantConfig::getTenantId, Function.identity()));
-    tenantConfigAtomicReference.set(tenantConfigMap);
-    List<TenantConfig> allTenantUserConfigs = iServiceManager.getAllTenantUserConfigs();
-    Map<Pair<String, String>, TenantConfig> tenantUserConfigMap =
-        allTenantUserConfigs.stream()
+    tenantConfigAtomicReference.set(
+        iServiceManager.getAllTenantConfigs().stream()
+            .collect(Collectors.toMap(TenantConfig::getTenantId, Function.identity())));
+    tenantUserConfigAtomicReference.set(
+        iServiceManager.getAllTenantUserConfigs().stream()
             .collect(
                 Collectors.toMap(
                     tenantConfig -> Pair.of(tenantConfig.getTenantId(), tenantConfig.getName()),
-                    Function.identity()));
-    tenantUserConfigAtomicReference.set(tenantUserConfigMap);
+                    Function.identity())));
   }
 }

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/DynamicConfigServiceFactory.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/DynamicConfigServiceFactory.java
@@ -24,14 +24,16 @@ import org.apache.celeborn.common.CelebornConf;
 public class DynamicConfigServiceFactory {
 
   public static ConfigService getConfigService(CelebornConf celebornConf) throws IOException {
-    String configStoreBackend = celebornConf.dynamicConfigStoreBackend();
-    if ("FS".equals(configStoreBackend)) {
-      return new FsConfigServiceImpl(celebornConf);
-    } else if ("DB".equals(configStoreBackend)) {
-      return new DbConfigServiceImpl(celebornConf);
+    if (celebornConf.dynamicConfigStoreBackend().isEmpty()) {
+      return null;
+    } else {
+      String configStoreBackend = celebornConf.dynamicConfigStoreBackend().get();
+      // celeborn.dynamicConfig.store.backend checks value with FS, DB.
+      if ("FS".equals(configStoreBackend)) {
+        return new FsConfigServiceImpl(celebornConf);
+      } else {
+        return new DbConfigServiceImpl(celebornConf);
+      }
     }
-
-    throw new UnsupportedOperationException(
-        "Unsupported dynamic config store backend:" + configStoreBackend);
   }
 }

--- a/service/src/test/java/org/apache/celeborn/server/common/service/config/ConfigServiceSuiteJ.java
+++ b/service/src/test/java/org/apache/celeborn/server/common/service/config/ConfigServiceSuiteJ.java
@@ -59,7 +59,7 @@ public class ConfigServiceSuiteJ {
       throw new RuntimeException(e);
     }
 
-    configService.refreshAllCache();
+    configService.refreshCache();
     verifyConfigChanged(configService);
   }
 
@@ -76,7 +76,7 @@ public class ConfigServiceSuiteJ {
     // change -> refresh config
     file = getClass().getResource("/dynamicConfig_2.yaml").getFile();
     celebornConf.set(CelebornConf.QUOTA_CONFIGURATION_PATH(), file);
-    configService.refreshAllCache();
+    configService.refreshCache();
 
     verifyConfigChanged(configService);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve the implementation of `ConfigService` including:

- Removes `celeborn.dynamicConfig.enabled`.
- Changes `celeborn.dynamicConfig.store.backend` to optional.
- Renames `refreshAllCache` to `refreshCache` in `ConfigService`.
- Checks whether the dynamic config file exists and is file in `FsConfigServiceImpl`.

### Why are the changes needed?

Whether to enable dynamic config could check via whether `celeborn.dynamicConfig.store.backend` is provided, instead of `celeborn.dynamicConfig.enabled`. The `refreshAllCache` interface could rename to `refreshCache` and throw Exception simply. Meanwhile, `FsConfigServiceImpl` should check whether the dynamic config file exists and is file.

### Does this PR introduce _any_ user-facing change?

- Renames `refreshAllCache` to `refreshCache` in `ConfigService`.

### How was this patch tested?

- `ConfigServiceSuiteJ`