### PR TITLE
[CELEBORN-1271] Fix unregisterShuffle with celeborn.client.spark.fetch.throwsFetchFailure disabled

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -142,12 +142,8 @@ public class SparkShuffleManager implements ShuffleManager {
     }
     // For Spark driver side trigger unregister shuffle.
     if (lifecycleManager != null) {
-      if (celebornConf.clientFetchThrowsFetchFailure()) {
-        lifecycleManager.unregisterAppShuffle(appShuffleId);
-      } else {
-        lifecycleManager.unregisterShuffle(appShuffleId);
-      }
-      lifecycleManager.unregisterAppShuffleDeterminate(appShuffleId);
+      lifecycleManager.unregisterAppShuffle(
+          appShuffleId, celebornConf.clientFetchThrowsFetchFailure());
     }
     // For Spark executor side cleanup shuffle related info.
     if (shuffleClient != null) {

--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -136,25 +136,22 @@ public class SparkShuffleManager implements ShuffleManager {
   }
 
   @Override
-  public boolean unregisterShuffle(int shuffleId) {
-    if (sortShuffleIds.contains(shuffleId)) {
-      return sortShuffleManager().unregisterShuffle(shuffleId);
+  public boolean unregisterShuffle(int appShuffleId) {
+    if (sortShuffleIds.contains(appShuffleId)) {
+      return sortShuffleManager().unregisterShuffle(appShuffleId);
     }
     // For Spark driver side trigger unregister shuffle.
     if (lifecycleManager != null) {
       if (celebornConf.clientFetchThrowsFetchFailure()) {
-        lifecycleManager.unregisterAppShuffle(shuffleId);
+        lifecycleManager.unregisterAppShuffle(appShuffleId);
       } else {
-        lifecycleManager.unregisterShuffle(shuffleId);
+        lifecycleManager.unregisterShuffle(appShuffleId);
       }
+      lifecycleManager.unregisterAppShuffleDeterminate(appShuffleId);
     }
     // For Spark executor side cleanup shuffle related info.
     if (shuffleClient != null) {
-      if (celebornConf.clientFetchThrowsFetchFailure()) {
-        shuffleIdTracker.unregisterAppShuffleId(shuffleClient, shuffleId);
-      } else {
-        shuffleClient.cleanupShuffle(shuffleId);
-      }
+      shuffleIdTracker.unregisterAppShuffleId(shuffleClient, appShuffleId);
     }
     return true;
   }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -189,17 +189,25 @@ public class SparkShuffleManager implements ShuffleManager {
   }
 
   @Override
-  public boolean unregisterShuffle(int appShuffleId) {
-    if (sortShuffleIds.contains(appShuffleId)) {
-      return sortShuffleManager().unregisterShuffle(appShuffleId);
+  public boolean unregisterShuffle(int shuffleId) {
+    if (sortShuffleIds.contains(shuffleId)) {
+      return sortShuffleManager().unregisterShuffle(shuffleId);
     }
     // For Spark driver side trigger unregister shuffle.
     if (lifecycleManager != null) {
-      lifecycleManager.unregisterAppShuffle(appShuffleId);
+      if (celebornConf.clientFetchThrowsFetchFailure()) {
+        lifecycleManager.unregisterAppShuffle(shuffleId);
+      } else {
+        lifecycleManager.unregisterShuffle(shuffleId);
+      }
     }
     // For Spark executor side cleanup shuffle related info.
     if (shuffleClient != null) {
-      shuffleIdTracker.unregisterAppShuffleId(shuffleClient, appShuffleId);
+      if (celebornConf.clientFetchThrowsFetchFailure()) {
+        shuffleIdTracker.unregisterAppShuffleId(shuffleClient, shuffleId);
+      } else {
+        shuffleClient.cleanupShuffle(shuffleId);
+      }
     }
     return true;
   }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -189,25 +189,22 @@ public class SparkShuffleManager implements ShuffleManager {
   }
 
   @Override
-  public boolean unregisterShuffle(int shuffleId) {
-    if (sortShuffleIds.contains(shuffleId)) {
-      return sortShuffleManager().unregisterShuffle(shuffleId);
+  public boolean unregisterShuffle(int appShuffleId) {
+    if (sortShuffleIds.contains(appShuffleId)) {
+      return sortShuffleManager().unregisterShuffle(appShuffleId);
     }
     // For Spark driver side trigger unregister shuffle.
     if (lifecycleManager != null) {
       if (celebornConf.clientFetchThrowsFetchFailure()) {
-        lifecycleManager.unregisterAppShuffle(shuffleId);
+        lifecycleManager.unregisterAppShuffle(appShuffleId);
       } else {
-        lifecycleManager.unregisterShuffle(shuffleId);
+        lifecycleManager.unregisterShuffle(appShuffleId);
       }
+      lifecycleManager.unregisterAppShuffleDeterminate(appShuffleId);
     }
     // For Spark executor side cleanup shuffle related info.
     if (shuffleClient != null) {
-      if (celebornConf.clientFetchThrowsFetchFailure()) {
-        shuffleIdTracker.unregisterAppShuffleId(shuffleClient, shuffleId);
-      } else {
-        shuffleClient.cleanupShuffle(shuffleId);
-      }
+      shuffleIdTracker.unregisterAppShuffleId(shuffleClient, appShuffleId);
     }
     return true;
   }

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkShuffleManager.java
@@ -195,12 +195,8 @@ public class SparkShuffleManager implements ShuffleManager {
     }
     // For Spark driver side trigger unregister shuffle.
     if (lifecycleManager != null) {
-      if (celebornConf.clientFetchThrowsFetchFailure()) {
-        lifecycleManager.unregisterAppShuffle(appShuffleId);
-      } else {
-        lifecycleManager.unregisterShuffle(appShuffleId);
-      }
-      lifecycleManager.unregisterAppShuffleDeterminate(appShuffleId);
+      lifecycleManager.unregisterAppShuffle(
+          appShuffleId, celebornConf.clientFetchThrowsFetchFailure());
     }
     // For Spark executor side cleanup shuffle related info.
     if (shuffleClient != null) {

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -973,15 +973,20 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
     logInfo(s"Unregister for $shuffleId success.")
   }
 
-  def unregisterAppShuffle(appShuffleId: Int): Unit = {
+  def unregisterAppShuffle(appShuffleId: Int, hasMapping: Boolean): Unit = {
     logInfo(s"Unregister appShuffleId $appShuffleId starts...")
-    val shuffleIds = shuffleIdMapping.remove(appShuffleId)
-    if (shuffleIds != null) {
-      shuffleIds.synchronized(
-        shuffleIds.values.map {
-          case (shuffleId, _) =>
-            unregisterShuffle(shuffleId)
-        })
+    appShuffleDeterminateMap.remove(appShuffleId)
+    if (hasMapping) {
+      val shuffleIds = shuffleIdMapping.remove(appShuffleId)
+      if (shuffleIds != null) {
+        shuffleIds.synchronized(
+          shuffleIds.values.map {
+            case (shuffleId, _) =>
+              unregisterShuffle(shuffleId)
+          })
+      }
+    } else {
+      unregisterShuffle(appShuffleId)
     }
   }
 
@@ -1624,10 +1629,6 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
 
   def registerAppShuffleDeterminate(appShuffleId: Int, determinate: Boolean): Unit = {
     appShuffleDeterminateMap.put(appShuffleId, determinate)
-  }
-
-  def unregisterAppShuffleDeterminate(appShuffleId: Int): Unit = {
-    appShuffleDeterminateMap.remove(appShuffleId)
   }
 
   // Initialize at the end of LifecycleManager construction.

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -118,6 +118,10 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   def workerSnapshots(shuffleId: Int): util.Map[WorkerInfo, ShufflePartitionLocationInfo] =
     shuffleAllocatedWorkers.get(shuffleId)
 
+  @VisibleForTesting
+  def getUnregisterShuffleTime(): ConcurrentHashMap[Int, Long] =
+    unregisterShuffleTime
+
   val newMapFunc: function.Function[Int, ConcurrentHashMap[Int, PartitionLocation]] =
     new util.function.Function[Int, ConcurrentHashMap[Int, PartitionLocation]]() {
       override def apply(s: Int): ConcurrentHashMap[Int, PartitionLocation] = {
@@ -971,7 +975,6 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
 
   def unregisterAppShuffle(appShuffleId: Int): Unit = {
     logInfo(s"Unregister appShuffleId $appShuffleId starts...")
-    appShuffleDeterminateMap.remove(appShuffleId)
     val shuffleIds = shuffleIdMapping.remove(appShuffleId)
     if (shuffleIds != null) {
       shuffleIds.synchronized(
@@ -1621,6 +1624,10 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
 
   def registerAppShuffleDeterminate(appShuffleId: Int, determinate: Boolean): Unit = {
     appShuffleDeterminateMap.put(appShuffleId, determinate)
+  }
+
+  def unregisterAppShuffleDeterminate(appShuffleId: Int): Unit = {
+    appShuffleDeterminateMap.remove(appShuffleId)
   }
 
   // Initialize at the end of LifecycleManager construction.


### PR DESCRIPTION
### What changes were proposed in this pull request?
per https://issues.apache.org/jira/browse/CELEBORN-1271
fix the bug with SparkShuffleManager.unregisterShuffle when celeborn.client.spark.fetch.throwsFetchFailure=false


### Why are the changes needed?
the bug causes shuffle data can't be cleaned with unregisterShuffle


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
manual tested
