### PR TITLE
[CELEBORN-1264][FOLLOWUP] Improve tenant user level dynamic configuration interface of ConfigService

### DIFF
--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/BaseConfigServiceImpl.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/BaseConfigServiceImpl.java
@@ -81,7 +81,7 @@ public abstract class BaseConfigServiceImpl implements ConfigService {
   }
 
   @Override
-  public TenantConfig getRawTenantUserConfig(String tenantId, String userId) {
+  public TenantConfig getRawTenantUserConfigFromCache(String tenantId, String userId) {
     return tenantUserConfigAtomicReference.get().get(Pair.of(tenantId, userId));
   }
 

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/ConfigService.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/ConfigService.java
@@ -49,7 +49,8 @@ public interface ConfigService {
   TenantConfig getRawTenantConfigFromCache(String tenantId);
 
   /**
-   * Gets the tenant level dynamic configuration {@link DynamicConfig} from cache.
+   * Gets the tenant level dynamic configuration {@link DynamicConfig} from cache. When the tenant
+   * level config is null or empty, fallback to the system level config.
    *
    * @return The tenant level dynamic configuration.
    */
@@ -70,7 +71,9 @@ public interface ConfigService {
   TenantConfig getRawTenantUserConfigFromCache(String tenantId, String userId);
 
   /**
-   * Gets the raw tenant user level dynamic configuration {@link DynamicConfig} from cache.
+   * Gets the tenant user level dynamic configuration {@link DynamicConfig} from cache. When the
+   * tenant user level config is null or empty, fallback to the tenant level config. When the tenant
+   * level config is null or empty, fallback to the system level config again.
    *
    * @return The tenant user level dynamic configuration.
    */

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/ConfigService.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/ConfigService.java
@@ -21,14 +21,38 @@ import java.io.IOException;
 
 import org.apache.celeborn.common.CelebornConf;
 
+/**
+ * Config service provides the configuration management service with cache for the static and
+ * dynamic configuration(system level/tenant level/tenant user level).
+ */
 public interface ConfigService {
 
+  /**
+   * Gets the static configuration {@link CelebornConf}.
+   *
+   * @return The static configuration.
+   */
   CelebornConf getCelebornConf();
 
+  /**
+   * Gets the system level dynamic configuration {@link SystemConfig} from cache.
+   *
+   * @return The system level dynamic configuration.
+   */
   SystemConfig getSystemConfigFromCache();
 
+  /**
+   * Gets the raw tenant level dynamic configuration {@link TenantConfig} from cache.
+   *
+   * @return The raw tenant level dynamic configuration.
+   */
   TenantConfig getRawTenantConfigFromCache(String tenantId);
 
+  /**
+   * Gets the tenant level dynamic configuration {@link DynamicConfig} from cache.
+   *
+   * @return The tenant level dynamic configuration.
+   */
   default DynamicConfig getTenantConfigFromCache(String tenantId) {
     TenantConfig tenantConfig = getRawTenantConfigFromCache(tenantId);
     if (tenantConfig == null || tenantConfig.getConfigs().isEmpty()) {
@@ -38,10 +62,20 @@ public interface ConfigService {
     }
   }
 
-  TenantConfig getRawTenantUserConfig(String tenantId, String userId);
+  /**
+   * Gets the raw tenant user level dynamic configuration {@link TenantConfig} from cache.
+   *
+   * @return The raw tenant user level dynamic configuration.
+   */
+  TenantConfig getRawTenantUserConfigFromCache(String tenantId, String userId);
 
-  default DynamicConfig getTenantUserConfig(String tenantId, String userId) {
-    TenantConfig tenantConfig = getRawTenantUserConfig(tenantId, userId);
+  /**
+   * Gets the raw tenant user level dynamic configuration {@link DynamicConfig} from cache.
+   *
+   * @return The tenant user level dynamic configuration.
+   */
+  default DynamicConfig getTenantUserConfigFromCache(String tenantId, String userId) {
+    TenantConfig tenantConfig = getRawTenantUserConfigFromCache(tenantId, userId);
     if (tenantConfig == null) {
       return getTenantConfigFromCache(tenantId);
     } else {
@@ -49,7 +83,13 @@ public interface ConfigService {
     }
   }
 
+  /**
+   * Refreshes cache of the dynamic configuration(system level/tenant level/tenant user level).
+   *
+   * @throws IOException If refresh fails with exception.
+   */
   void refreshCache() throws IOException;
 
+  /** Shutdowns configuration management service. */
   void shutdown();
 }

--- a/service/src/main/java/org/apache/celeborn/server/common/service/config/DynamicConfig.java
+++ b/service/src/main/java/org/apache/celeborn/server/common/service/config/DynamicConfig.java
@@ -28,8 +28,8 @@ import org.apache.celeborn.common.util.Utils;
 
 /**
  * Dynamic configuration is a type of configuration that can be changed at runtime as needed. It can
- * be used at system level/tenant level. When applying dynamic configuration, the priority order is
- * as follows: tenant level overrides system level, which in turn overrides static
+ * be used at system level/tenant level/tenant user level. When applying dynamic configuration, the
+ * priority order is as follows: tenant level overrides system level, which in turn overrides static
  * configuration(CelebornConf). This means that if a configuration is defined at the tenant level,
  * it will be used instead of the system level or static configuration(CelebornConf). If the
  * tenant-level configuration is missing, the system-level configuration will be used. If the

--- a/service/src/test/java/org/apache/celeborn/server/common/service/config/ConfigServiceSuiteJ.java
+++ b/service/src/test/java/org/apache/celeborn/server/common/service/config/ConfigServiceSuiteJ.java
@@ -209,7 +209,7 @@ public class ConfigServiceSuiteJ {
 
   public void verifyTenantUserConfig(ConfigService configService) {
     // ------------- Verify UserConfig ----------------- //
-    DynamicConfig userConfig = configService.getTenantUserConfig("tenant_id1", "Jerry");
+    DynamicConfig userConfig = configService.getTenantUserConfigFromCache("tenant_id1", "Jerry");
     // verify userConfig's bytesConf -- use userConf
     Long value =
         userConfig.getValue(
@@ -255,7 +255,8 @@ public class ConfigServiceSuiteJ {
             ConfigType.BYTES);
     Assert.assertNull(value);
 
-    DynamicConfig userConfigNone = configService.getTenantUserConfig("tenant_id", "non_exist");
+    DynamicConfig userConfigNone =
+        configService.getTenantUserConfigFromCache("tenant_id", "non_exist");
     // verify userConfig's bytesConf -- defer to tenantConf
     value =
         userConfigNone.getValue(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve tenant user level dynamic configuration interface of `ConfigService` including:

- Renames `getRawTenantUserConfig` to `getRawTenantUserConfigFromCache`.
- Renames `getTenantUserConfig` to `getTenantUserConfigFromCache`.

### Why are the changes needed?

The naming of tenant user level dynamic configuration interface of `ConfigService` needs to be consistent with other interfaces which names with `FromCache`.

### Does this PR introduce _any_ user-facing change?

- Renames `getRawTenantUserConfig` to `getRawTenantUserConfigFromCache`.
- Renames `getTenantUserConfig` to `getTenantUserConfigFromCache`.

### How was this patch tested?

- `ConfigServiceSuiteJ`