### PR TITLE
[CELEBORN-1241][FOLLOWUP] Fix duplicate CelebornRackResolver issue for SingleMasterMetaManager

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/SingleMasterMetaManager.java
@@ -47,7 +47,7 @@ public class SingleMasterMetaManager extends AbstractMetaManager {
     this.initialEstimatedPartitionSize = conf.initialEstimatedPartitionSize();
     this.estimatedPartitionSize = initialEstimatedPartitionSize;
     this.appDiskUsageMetric = new AppDiskUsageMetric(conf);
-    this.rackResolver = new CelebornRackResolver(conf);
+    this.rackResolver = rackResolver;
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This pr followup CELEBORN-1241/https://github.com/apache/incubator-celeborn/pull/2246

For `SingleMasterMetaManager`, the given CelebornRackResolver is not used and a new one created in the constructor.

And in each CelebornRackResolver, there is `master-rack-resolver-refresher` thread pool. So, there is also duplicated thread pool issue.

### Why are the changes needed?
Fix duplicated `CelebornRackResolver` issue.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Not needed.
