### PR TITLE
[CELEBORN-1275] Fix bug that callback function may hang when unchecked exception missed

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/client/TransportClient.java
@@ -261,11 +261,16 @@ public class TransportClient implements Closeable {
         new RpcResponseCallback() {
           @Override
           public void onSuccess(ByteBuffer response) {
-            ByteBuffer copy = ByteBuffer.allocate(response.remaining());
-            copy.put(response);
-            // flip "copy" to make it readable
-            copy.flip();
-            result.set(copy);
+            try {
+              ByteBuffer copy = ByteBuffer.allocate(response.remaining());
+              copy.put(response);
+              // flip "copy" to make it readable
+              copy.flip();
+              result.set(copy);
+            } catch (Throwable t) {
+              logger.warn("Error in responding RPC callback", t);
+              result.setException(t);
+            }
           }
 
           @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Refer: [SPARK-28160](https://issues.apache.org/jira/browse/SPARK-28160) / https://github.com/apache/spark/pull/24964
ByteBuffer.allocate may throw OutOfMemoryError when the response is large but no enough memory is available. However, when this happens, TransportClient.sendRpcSync will just hang forever if the timeout set to unlimited.

### Why are the changes needed?
To catch the exception of `ByteBuffer.allocate` in corner case.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Quote the local test in https://github.com/apache/spark/pull/24964
```
I tested in my IDE by setting the value of size to -1 to verify the result. Without this patch, it won't be finished until timeout (May hang forever if timeout set to MAX_INT), or the expected IllegalArgumentException will be caught.

      @Override
      public void onSuccess(ByteBuffer response) {
        try {
          int size = response.remaining();
          ByteBuffer copy = ByteBuffer.allocate(size); // set size to -1 in runtime when debug
          copy.put(response);
          // flip "copy" to make it readable
          copy.flip();
          result.set(copy);
        } catch (Throwable t) {
          result.setException(t);
        }
      }
```

