### PR TITLE
[CELEBORN-1287] Improve both combine and sort operation of shuffle read for CelebornShuffleReader

### DIFF
--- a/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-2/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -21,7 +21,7 @@ import java.io.IOException
 import java.util.concurrent.{ConcurrentHashMap, ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
 
-import org.apache.spark.{InterruptibleIterator, TaskContext}
+import org.apache.spark.{Aggregator, InterruptibleIterator, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleReader}
 import org.apache.spark.shuffle.celeborn.CelebornShuffleReader.streamCreatorPool
@@ -178,8 +178,44 @@ class CelebornShuffleReader[K, C](
     // An interruptible iterator must be used here in order to support task cancellation
     val interruptibleIter = new InterruptibleIterator[(Any, Any)](context, metricIter)
 
-    val aggregatedIter: Iterator[Product2[K, C]] =
-      if (dep.aggregator.isDefined) {
+    val resultIter: Iterator[Product2[K, C]] = {
+      // Sort the output if there is a sort ordering defined.
+      if (dep.keyOrdering.isDefined) {
+        // Create an ExternalSorter to sort the data.
+        val sorter: ExternalSorter[K, _, C] =
+          if (dep.aggregator.isDefined) {
+            if (dep.mapSideCombine) {
+              new ExternalSorter[K, C, C](
+                context,
+                Option(new Aggregator[K, C, C](
+                  identity,
+                  dep.aggregator.get.mergeCombiners,
+                  dep.aggregator.get.mergeCombiners)),
+                ordering = Some(dep.keyOrdering.get),
+                serializer = dep.serializer)
+            } else {
+              new ExternalSorter[K, Nothing, C](
+                context,
+                dep.aggregator.asInstanceOf[Option[Aggregator[K, Nothing, C]]],
+                ordering = Some(dep.keyOrdering.get),
+                serializer = dep.serializer)
+            }
+          } else {
+            new ExternalSorter[K, C, C](
+              context,
+              ordering = Some(dep.keyOrdering.get),
+              serializer = dep.serializer)
+          }
+        sorter.insertAll(interruptibleIter.asInstanceOf[Iterator[(K, Nothing)]])
+        context.taskMetrics().incMemoryBytesSpilled(sorter.memoryBytesSpilled)
+        context.taskMetrics().incDiskBytesSpilled(sorter.diskBytesSpilled)
+        context.taskMetrics().incPeakExecutionMemory(sorter.peakMemoryUsedBytes)
+        // Use completion callback to stop sorter if task was finished/cancelled.
+        context.addTaskCompletionListener(_ => {
+          sorter.stop()
+        })
+        CompletionIterator[Product2[K, C], Iterator[Product2[K, C]]](sorter.iterator, sorter.stop())
+      } else if (dep.aggregator.isDefined) {
         if (dep.mapSideCombine) {
           // We are reading values that are already combined
           val combinedKeyValuesIterator = interruptibleIter.asInstanceOf[Iterator[(K, C)]]
@@ -192,26 +228,8 @@ class CelebornShuffleReader[K, C](
           dep.aggregator.get.combineValuesByKey(keyValuesIterator, context)
         }
       } else {
-        interruptibleIter.asInstanceOf[Iterator[Product2[K, C]]]
+        interruptibleIter.asInstanceOf[Iterator[(K, C)]]
       }
-
-    // Sort the output if there is a sort ordering defined.
-    val resultIter = dep.keyOrdering match {
-      case Some(keyOrd: Ordering[K]) =>
-        // Create an ExternalSorter to sort the data.
-        val sorter =
-          new ExternalSorter[K, C, C](context, ordering = Some(keyOrd), serializer = dep.serializer)
-        sorter.insertAll(aggregatedIter)
-        context.taskMetrics().incMemoryBytesSpilled(sorter.memoryBytesSpilled)
-        context.taskMetrics().incDiskBytesSpilled(sorter.diskBytesSpilled)
-        context.taskMetrics().incPeakExecutionMemory(sorter.peakMemoryUsedBytes)
-        // Use completion callback to stop sorter if task was finished/cancelled.
-        context.addTaskCompletionListener(_ => {
-          sorter.stop()
-        })
-        CompletionIterator[Product2[K, C], Iterator[Product2[K, C]]](sorter.iterator, sorter.stop())
-      case None =>
-        aggregatedIter
     }
 
     resultIter match {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve both combine and sort operation of shuffle read for `CelebornShuffleReader` to reduce the number of spills to disk. 

### Why are the changes needed?

After the shuffle reader obtains the block, it will first perform a combine operation, and then perform a sort operation. It is known that both combine and sort may generate temporary files, so the performance may be poor when both sort and combine are used. In fact, combine operations can be performed during the sort process, and we can avoid the combine spill file.
Backport: [[SPARK-46512][CORE] Optimize shuffle reading when both sort and combine are used](https://github.com/apache/spark/pull/44512)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

GA and cluster.