### PR TITLE
[CELEBORN-1288] Prompt configuration items when receiving IdleStateEvent

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/TransportContext.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/TransportContext.java
@@ -177,7 +177,8 @@ public class TransportContext {
         conf.connectionTimeoutMs(),
         closeIdleConnections,
         enableHeartbeat,
-        conf.clientHeartbeatInterval());
+        conf.clientHeartbeatInterval(),
+        this);
   }
 
   public TransportConf getConf() {

--- a/common/src/main/java/org/apache/celeborn/common/network/server/TransportChannelHandler.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/server/TransportChannelHandler.java
@@ -34,6 +34,7 @@ import org.apache.celeborn.common.network.protocol.Heartbeat;
 import org.apache.celeborn.common.network.protocol.RequestMessage;
 import org.apache.celeborn.common.network.protocol.ResponseMessage;
 import org.apache.celeborn.common.network.util.NettyUtils;
+import org.apache.celeborn.common.util.Utils;
 
 /**
  * The single Transport-level Channel handler which is used for delegating requests to the {@link
@@ -173,11 +174,11 @@ public class TransportChannelHandler extends ChannelInboundHandlerAdapter {
           if (responseHandler.hasOutstandingRequests()) {
             String address = NettyUtils.getRemoteAddress(ctx.channel());
             logger.error(
-                "Connection to {} has been quiet for {} ms while there are outstanding "
-                    + "requests. Assuming connection is dead; please adjust"
-                    + " celeborn.{}.io.connectionTimeout if this is wrong.",
+                "Connection to {} has been quiet for {} while there are outstanding "
+                    + "requests. Assuming the connection is dead, consider adjusting "
+                    + "celeborn.{}.io.connectionTimeout if this is wrong.",
                 address,
-                requestTimeoutNs / 1000 / 1000,
+                Utils.msDurationToString(requestTimeoutNs / 1000 / 1000),
                 transportContext.getConf().getModuleName());
           }
           if (closeIdleConnections) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When an `IdleStateEvent ` is received, the configuration items of the corresponding module are output.

### Why are the changes needed?
Now that the `IdleStateEvent` event is received, only the timeout time is output, but the corresponding configuration items are not output.

```
24/02/26 04:12:08,062 [data-client-5-8] ERROR TransportChannelHandler: Connection to /XXX:YYY has been quiet for 240000 ms while there are outstanding requests.
```



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
