### PR TITLE
[CELEBORN-1291] Master crashed causing by huge app level worker consumption info

### DIFF
--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -806,8 +806,9 @@ private[celeborn] class Master(
 
     if (log.isDebugEnabled()) {
       val distributions = SlotsAllocator.slotsToDiskAllocations(slots)
-      logDebug(s"allocate slots for shuffle $shuffleKey $slots" +
-        s" distributions: ${distributions.asScala.map(m => m._1.toUniqueId() -> m._2)}")
+      logDebug(
+        s"allocate slots for shuffle $shuffleKey ${slots.asScala.map(m => m._1.toUniqueId() -> m._2)}" +
+          s" distributions: ${distributions.asScala.map(m => m._1.toUniqueId() -> m._2)}")
     }
 
     // reply false if offer slots failed


### PR DESCRIPTION
### What changes were proposed in this pull request?
When I upgrade to 0.4.0 and backport the app level consumption [pr](https://github.com/apache/incubator-celeborn/pull/1174).
WorkerInfo consumption contains very huge information. 
Since we enable debug level info for master, causing master print slots info very huge and stuck.
This pr fix this issue
<img width="1700" alt="截屏2024-02-26 17 36 17" src="https://github.com/apache/incubator-celeborn/assets/46485123/9631f9dd-ee69-4de9-aaf4-c0c7f706cb73">


### Why are the changes needed?
Fix bug


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

