### PR TITLE
[CELEBORN-1240][FOLLOWUP] Web lint check uses different groups

### DIFF
--- a/.github/workflows/web_lint.yml
+++ b/.github/workflows/web_lint.yml
@@ -28,7 +28,7 @@ on:
       - branch-*
 
 concurrency:
-  group: style-${{ github.ref }}
+  group: style-web-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?
`web_lint.yml` and `style.yml` use the same group, which causes one of their CIs to fail to run.

```
Canceling since a higher priority waiting request for 'style-refs/pull/PR_ID/merge' exists
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
