### PR TITLE
[CELEBORN-1293] Output received signals at master and worker

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -214,6 +214,7 @@ Apache Spark
 ./client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
 ./common/src/main/java/org/apache/celeborn/common/unsafe/Platform.java
 ./common/src/main/java/org/apache/celeborn/common/util/JavaUtils.java
+./common/src/main/scala/org/apache/celeborn/common/util/SignalUtils.scala
 ./worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/DB.java
 ./worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/DBIterator.java
 ./worker/src/main/java/org/apache/celeborn/service/deploy/worker/shuffledb/LevelDB.java

--- a/common/src/main/scala/org/apache/celeborn/common/util/SignalUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/SignalUtils.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.common.util;
+
+import java.util.Collections
+
+import scala.collection.JavaConverters._
+
+import org.apache.commons.lang3.SystemUtils
+import org.slf4j.Logger
+import sun.misc.{Signal, SignalHandler}
+
+import org.apache.celeborn.common.internal.Logging
+
+/**
+ * Contains utilities for working with posix signals.
+ * <p>Note: code copied from Apache Spark.
+ */
+private[celeborn] object SignalUtils extends Logging {
+
+  /** A flag to make sure we only register the logger once. */
+  private var loggerRegistered = false
+
+  /** Register a signal handler to log signals on UNIX-like systems. */
+  def registerLogger(log: Logger): Unit = synchronized {
+    if (!loggerRegistered) {
+      Seq("TERM", "HUP", "INT").foreach { sig =>
+        SignalUtils.register(sig) {
+          log.error("RECEIVED SIGNAL " + sig)
+          false
+        }
+      }
+      loggerRegistered = true
+    }
+  }
+
+  /**
+   * Adds an action to be run when a given signal is received by this process.
+   *
+   * Note that signals are only supported on unix-like operating systems and work on a best-effort
+   * basis: if a signal is not available or cannot be intercepted, only a warning is emitted.
+   *
+   * All actions for a given signal are run in a separate thread.
+   */
+  def register(signal: String)(action: => Boolean): Unit = {
+    if (SystemUtils.IS_OS_UNIX) {
+      register(signal, s"Failed to register signal handler for $signal", logStackTrace = true)(
+        action)
+    }
+  }
+
+  /**
+   * Adds an action to be run when a given signal is received by this process.
+   *
+   * This method receives failMessage as additional parameter, which would be logged when it fails
+   * to register the signal. Here the failures include the cases 1) OS doesn't support signal at
+   * all 2) OS doesn't support given signal (Could be possible with non-POSIX signals)
+   *
+   * All actions for a given signal are run in a separate thread.
+   */
+  def register(
+      signal: String,
+      failMessage: String,
+      logStackTrace: Boolean = true)(
+      action: => Boolean): Unit = synchronized {
+    try {
+      val handler = handlers.getOrElseUpdate(
+        signal, {
+          logInfo(s"Registering signal handler for $signal")
+          new ActionHandler(new Signal(signal))
+        })
+      handler.register(action)
+    } catch {
+      case ex: Exception =>
+        if (logStackTrace) {
+          logWarning(failMessage, ex)
+        } else {
+          logWarning(failMessage)
+        }
+    }
+  }
+
+  /**
+   * A handler for the given signal that runs a collection of actions.
+   */
+  private class ActionHandler(signal: Signal) extends SignalHandler {
+
+    /**
+     * List of actions upon the signal; the callbacks should return true if the signal is "handled",
+     * i.e. should not escalate to the next callback.
+     */
+    private val actions = Collections.synchronizedList(new java.util.LinkedList[() => Boolean])
+
+    // original signal handler, before this handler was attached
+    private val prevHandler: SignalHandler = Signal.handle(signal, this)
+
+    /**
+     * Called when this handler's signal is received. Note that if the same signal is received
+     * before this method returns, it is escalated to the previous handler.
+     */
+    override def handle(sig: Signal): Unit = {
+      // register old handler, will receive incoming signals while this handler is running
+      Signal.handle(signal, prevHandler)
+
+      // Run all actions, escalate to parent handler if no action catches the signal
+      // (i.e. all actions return false). Note that calling `map` is to ensure that
+      // all actions are run, `forall` is short-circuited and will stop evaluating
+      // after reaching a first false predicate.
+      val escalate = actions.asScala.map(action => action()).forall(_ == false)
+      if (escalate) {
+        prevHandler.handle(sig)
+      }
+
+      // re-register this handler
+      Signal.handle(signal, this)
+    }
+
+    /**
+     * Adds an action to be run by this handler.
+     * @param action An action to be run when a signal is received. Return true if the signal
+     *               should be stopped with this handler, false if it should be escalated.
+     */
+    def register(action: => Boolean): Unit = actions.add(() => action)
+  }
+
+  /** Mapping from signal to their respective handlers. */
+  private val handlers = new scala.collection.mutable.HashMap[String, ActionHandler]
+}

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -45,7 +45,7 @@ import org.apache.celeborn.common.protocol.message.ControlMessages._
 import org.apache.celeborn.common.quota.ResourceConsumption
 import org.apache.celeborn.common.rpc._
 import org.apache.celeborn.common.rpc.{RpcSecurityContextBuilder, ServerSaslContextBuilder}
-import org.apache.celeborn.common.util.{CelebornHadoopUtils, CollectionUtils, JavaUtils, PbSerDeUtils, ThreadUtils, Utils}
+import org.apache.celeborn.common.util.{CelebornHadoopUtils, CollectionUtils, JavaUtils, PbSerDeUtils, SignalUtils, ThreadUtils, Utils}
 import org.apache.celeborn.server.common.{HttpService, Service}
 import org.apache.celeborn.service.deploy.master.clustermeta.SingleMasterMetaManager
 import org.apache.celeborn.service.deploy.master.clustermeta.ha.{HAHelper, HAMasterMetaManager, MetaHandler}
@@ -1267,6 +1267,7 @@ private[celeborn] class Master(
 
 private[deploy] object Master extends Logging {
   def main(args: Array[String]): Unit = {
+    SignalUtils.registerLogger(log)
     val conf = new CelebornConf()
     val masterArgs = new MasterArguments(args, conf)
     try {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -49,7 +49,7 @@ import org.apache.celeborn.common.protocol.message.ControlMessages._
 import org.apache.celeborn.common.quota.ResourceConsumption
 import org.apache.celeborn.common.rpc._
 import org.apache.celeborn.common.rpc.{RpcSecurityContextBuilder, ServerSaslContextBuilder}
-import org.apache.celeborn.common.util.{CelebornExitKind, CollectionUtils, JavaUtils, ShutdownHookManager, ThreadUtils, Utils}
+import org.apache.celeborn.common.util.{CelebornExitKind, CollectionUtils, JavaUtils, ShutdownHookManager, SignalUtils, ThreadUtils, Utils}
 // Can Remove this if celeborn don't support scala211 in future
 import org.apache.celeborn.common.util.FunctionConverter._
 import org.apache.celeborn.server.common.{HttpService, Service}
@@ -934,6 +934,7 @@ private[celeborn] class Worker(
 
 private[deploy] object Worker extends Logging {
   def main(args: Array[String]): Unit = {
+    SignalUtils.registerLogger(log)
     val conf = new CelebornConf
     val workerArgs = new WorkerArguments(args, conf)
     // There are many entries for setting the master address, and we should unify the entries as


### PR DESCRIPTION
### What changes were proposed in this pull request?
When we shut down the master or worker, we can output the signal as a record.

### Why are the changes needed?
Conveniently track the status of master and workers.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
local test

```bash
./sbin/stop-all.sh
```

```
12:20:59.932 [SIGTERM handler] ERROR org.apache.celeborn.service.deploy.master.Master - RECEIVED SIGNAL TERM
```

```
12:20:59.563 [SIGTERM handler] ERROR org.apache.celeborn.service.deploy.worker.Worker - RECEIVED SIGNAL TERM
```

