### PR TITLE
[CELEBORN-1301] Catch and throw FetchFailedException in CelebornInputStream#fillBuffer

### DIFF
--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -47,7 +47,8 @@ import org.apache.celeborn.reflect.DynMethods;
 public class SparkUtils {
   private static final Logger LOG = LoggerFactory.getLogger(SparkUtils.class);
 
-  public static final String FETCH_FAILURE_ERROR_MSG = "Celeborn FetchFailure with shuffle id ";
+  public static final String FETCH_FAILURE_ERROR_MSG =
+      "Celeborn FetchFailure appShuffleId/shuffleId: ";
 
   public static MapStatus createMapStatus(
       BlockManagerId loc, long[] uncompressedSizes, long mapTaskId) {

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -100,7 +100,7 @@ class CelebornShuffleReader[K, C](
           e: Exception): Exception = {
         new FetchFailedException(
           null,
-          handle.shuffleId,
+          appShuffleId,
           -1,
           -1,
           partitionId,

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -91,7 +91,7 @@ class CelebornShuffleReader[K, C](
     }
 
     val exceptionMaker = new ExceptionMaker() {
-      override def makeException(
+      override def makeFetchFailureException(
           appShuffleId: Int,
           shuffleId: Int,
           partitionId: Int,

--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -120,8 +120,8 @@ class CelebornShuffleReader[K, C](
                 context.attemptNumber(),
                 startMapIndex,
                 endMapIndex,
-                metricsCallback,
-                if (throwsFetchFailure) exceptionMaker else null)
+                if (throwsFetchFailure) exceptionMaker else null,
+                metricsCallback)
               streams.put(partitionId, inputStream)
             } catch {
               case e: IOException =>

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -226,8 +226,8 @@ public abstract class ShuffleClient {
         attemptNumber,
         startMapIndex,
         endMapIndex,
-        metricsCallback,
-        null);
+        null,
+        metricsCallback);
   }
 
   public abstract CelebornInputStream readPartition(
@@ -237,8 +237,8 @@ public abstract class ShuffleClient {
       int attemptNumber,
       int startMapIndex,
       int endMapIndex,
-      MetricsCallback metricsCallback,
-      ExceptionMaker exceptionMaker)
+      ExceptionMaker exceptionMaker,
+      MetricsCallback metricsCallback)
       throws IOException;
 
   public abstract boolean cleanupShuffle(int shuffleId);

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -32,6 +32,7 @@ import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.protocol.PartitionLocation;
 import org.apache.celeborn.common.rpc.RpcEndpointRef;
 import org.apache.celeborn.common.util.CelebornHadoopUtils;
+import org.apache.celeborn.common.util.ExceptionMaker;
 import org.apache.celeborn.common.write.PushState;
 
 /**
@@ -210,13 +211,34 @@ public abstract class ShuffleClient {
    * @return
    * @throws IOException
    */
-  public abstract CelebornInputStream readPartition(
+  public CelebornInputStream readPartition(
       int shuffleId,
       int partitionId,
       int attemptNumber,
       int startMapIndex,
       int endMapIndex,
       MetricsCallback metricsCallback)
+      throws IOException {
+    return readPartition(
+        shuffleId,
+        partitionId,
+        attemptNumber,
+        startMapIndex,
+        endMapIndex,
+        shuffleId,
+        metricsCallback,
+        null);
+  }
+
+  public abstract CelebornInputStream readPartition(
+      int shuffleId,
+      int appShuffleId,
+      int partitionId,
+      int attemptNumber,
+      int startMapIndex,
+      int endMapIndex,
+      MetricsCallback metricsCallback,
+      ExceptionMaker exceptionMaker)
       throws IOException;
 
   public abstract boolean cleanupShuffle(int shuffleId);

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -221,11 +221,11 @@ public abstract class ShuffleClient {
       throws IOException {
     return readPartition(
         shuffleId,
+        shuffleId,
         partitionId,
         attemptNumber,
         startMapIndex,
         endMapIndex,
-        shuffleId,
         metricsCallback,
         null);
   }

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1663,8 +1663,8 @@ public class ShuffleClientImpl extends ShuffleClient {
       int attemptNumber,
       int startMapIndex,
       int endMapIndex,
-      MetricsCallback metricsCallback,
-      ExceptionMaker exceptionMaker)
+      ExceptionMaker exceptionMaker,
+      MetricsCallback metricsCallback)
       throws IOException {
     if (partitionId == Utils$.MODULE$.UNKNOWN_APP_SHUFFLE_ID()) {
       logger.warn("Shuffle data is empty for shuffle {}: UNKNOWN_APP_SHUFFLE_ID.", shuffleId);
@@ -1688,12 +1688,12 @@ public class ShuffleClientImpl extends ShuffleClient {
           startMapIndex,
           endMapIndex,
           fetchExcludedWorkers,
-          metricsCallback,
           this,
           appShuffleId,
           shuffleId,
           partitionId,
-          exceptionMaker);
+          exceptionMaker,
+          metricsCallback);
     }
   }
 

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1658,11 +1658,13 @@ public class ShuffleClientImpl extends ShuffleClient {
   @Override
   public CelebornInputStream readPartition(
       int shuffleId,
+      int appShuffleId,
       int partitionId,
       int attemptNumber,
       int startMapIndex,
       int endMapIndex,
-      MetricsCallback metricsCallback)
+      MetricsCallback metricsCallback,
+      ExceptionMaker exceptionMaker)
       throws IOException {
     if (partitionId == Utils$.MODULE$.UNKNOWN_APP_SHUFFLE_ID()) {
       logger.warn("Shuffle data is empty for shuffle {}: UNKNOWN_APP_SHUFFLE_ID.", shuffleId);
@@ -1686,7 +1688,12 @@ public class ShuffleClientImpl extends ShuffleClient {
           startMapIndex,
           endMapIndex,
           fetchExcludedWorkers,
-          metricsCallback);
+          metricsCallback,
+          this,
+          appShuffleId,
+          shuffleId,
+          partitionId,
+          exceptionMaker);
     }
   }
 

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -58,12 +58,12 @@ public abstract class CelebornInputStream extends InputStream {
       int startMapIndex,
       int endMapIndex,
       ConcurrentHashMap<String, Long> fetchExcludedWorkers,
-      MetricsCallback metricsCallback,
       ShuffleClient shuffleClient,
       int appShuffleId,
       int shuffleId,
       int partitionId,
-      ExceptionMaker exceptionMaker)
+      ExceptionMaker exceptionMaker,
+      MetricsCallback metricsCallback)
       throws IOException {
     if (locations == null || locations.length == 0) {
       return emptyInputStream;
@@ -78,12 +78,12 @@ public abstract class CelebornInputStream extends InputStream {
           startMapIndex,
           endMapIndex,
           fetchExcludedWorkers,
-          metricsCallback,
           shuffleClient,
           appShuffleId,
           shuffleId,
           partitionId,
-          exceptionMaker);
+          exceptionMaker,
+          metricsCallback);
     }
   }
 
@@ -178,12 +178,12 @@ public abstract class CelebornInputStream extends InputStream {
         int startMapIndex,
         int endMapIndex,
         ConcurrentHashMap<String, Long> fetchExcludedWorkers,
-        MetricsCallback metricsCallback,
         ShuffleClient shuffleClient,
         int appShuffleId,
         int shuffleId,
         int partitionId,
-        ExceptionMaker exceptionMaker)
+        ExceptionMaker exceptionMaker,
+        MetricsCallback metricsCallback)
         throws IOException {
       this.conf = conf;
       this.clientFactory = clientFactory;

--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -624,9 +624,15 @@ public abstract class CelebornInputStream extends InputStream {
         IOException ioe = e;
         if (exceptionMaker != null) {
           if (shuffleClient.reportShuffleFetchFailure(appShuffleId, shuffleId)) {
+            /*
+             * [[ExceptionMaker.makeException]], for spark applications with celeborn.client.spark.fetch.throwsFetchFailure enabled will result in creating
+             * a FetchFailedException; and that will make the TaskContext as failed with shuffle fetch issues - see SPARK-19276 for more.
+             * Given this, Celeborn can wrap the FetchFailedException with our CelebornIOException
+             */
             ioe =
                 new CelebornIOException(
-                    exceptionMaker.makeException(appShuffleId, shuffleId, partitionId, e));
+                    exceptionMaker.makeFetchFailureException(
+                        appShuffleId, shuffleId, partitionId, e));
           }
         }
         throw ioe;

--- a/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
@@ -69,7 +69,6 @@ public class WorkerPartitionReader implements PartitionReader {
   private int fetchChunkRetryCnt;
   private int fetchChunkMaxRetry;
   private final boolean testFetch;
-  private ShuffleClient shuffleClient;
 
   WorkerPartitionReader(
       CelebornConf conf,
@@ -80,10 +79,8 @@ public class WorkerPartitionReader implements PartitionReader {
       int endMapIndex,
       int fetchChunkRetryCnt,
       int fetchChunkMaxRetry,
-      MetricsCallback metricsCallback,
-      ShuffleClient shuffleClient)
+      MetricsCallback metricsCallback)
       throws IOException, InterruptedException {
-    this.shuffleClient = shuffleClient;
     this.shuffleKey = shuffleKey;
     fetchMaxReqsInFlight = conf.clientFetchMaxReqsInFlight();
     results = new LinkedBlockingQueue<>();

--- a/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/WorkerPartitionReader.java
@@ -69,6 +69,7 @@ public class WorkerPartitionReader implements PartitionReader {
   private int fetchChunkRetryCnt;
   private int fetchChunkMaxRetry;
   private final boolean testFetch;
+  private ShuffleClient shuffleClient;
 
   WorkerPartitionReader(
       CelebornConf conf,
@@ -79,8 +80,10 @@ public class WorkerPartitionReader implements PartitionReader {
       int endMapIndex,
       int fetchChunkRetryCnt,
       int fetchChunkMaxRetry,
-      MetricsCallback metricsCallback)
+      MetricsCallback metricsCallback,
+      ShuffleClient shuffleClient)
       throws IOException, InterruptedException {
+    this.shuffleClient = shuffleClient;
     this.shuffleKey = shuffleKey;
     fetchMaxReqsInFlight = conf.clientFetchMaxReqsInFlight();
     results = new LinkedBlockingQueue<>();

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -123,8 +123,8 @@ public class DummyShuffleClient extends ShuffleClient {
       int attemptNumber,
       int startMapIndex,
       int endMapIndex,
-      MetricsCallback metricsCallback,
-      ExceptionMaker exceptionMaker)
+      ExceptionMaker exceptionMaker,
+      MetricsCallback metricsCallback)
       throws IOException {
     return null;
   }

--- a/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/test/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -38,6 +38,7 @@ import org.apache.celeborn.client.read.MetricsCallback;
 import org.apache.celeborn.common.CelebornConf;
 import org.apache.celeborn.common.protocol.PartitionLocation;
 import org.apache.celeborn.common.rpc.RpcEndpointRef;
+import org.apache.celeborn.common.util.ExceptionMaker;
 import org.apache.celeborn.common.util.JavaUtils;
 import org.apache.celeborn.common.write.PushState;
 
@@ -117,11 +118,14 @@ public class DummyShuffleClient extends ShuffleClient {
   @Override
   public CelebornInputStream readPartition(
       int shuffleId,
+      int appShuffleId,
       int partitionId,
       int attemptNumber,
       int startMapIndex,
       int endMapIndex,
-      MetricsCallback metricsCallback) {
+      MetricsCallback metricsCallback,
+      ExceptionMaker exceptionMaker)
+      throws IOException {
     return null;
   }
 

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionMaker.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionMaker.java
@@ -18,5 +18,6 @@
 package org.apache.celeborn.common.util;
 
 public interface ExceptionMaker {
-  Exception makeException(int appShuffleId, int shuffleId, int partitionId, Exception e);
+  Exception makeFetchFailureException(
+      int appShuffleId, int shuffleId, int partitionId, Exception e);
 }

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionMaker.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionMaker.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.celeborn.common.util;
 
 public interface ExceptionMaker {

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionMaker.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionMaker.java
@@ -1,11 +1,5 @@
 package org.apache.celeborn.common.util;
 
-public abstract class ExceptionMaker {
-  private int appShuffleId;
-  private int shuffleId;
-  private int partitionId;
-  private Exception e;
-
-  public abstract Exception makeException(
-      int appShuffleId, int shuffleId, int partitionId, Exception e);
+public interface ExceptionMaker {
+  Exception makeException(int appShuffleId, int shuffleId, int partitionId, Exception e);
 }

--- a/common/src/main/java/org/apache/celeborn/common/util/ExceptionMaker.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ExceptionMaker.java
@@ -1,0 +1,11 @@
+package org.apache.celeborn.common.util;
+
+public abstract class ExceptionMaker {
+  private int appShuffleId;
+  private int shuffleId;
+  private int partitionId;
+  private Exception e;
+
+  public abstract Exception makeException(
+      int appShuffleId, int shuffleId, int partitionId, Exception e);
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Catch and throw FetchFailedException in CelebornInputStream#fillBuffer to enable spark's stage rerun
when fillBuffer encounters fetch chunk exception


### Why are the changes needed?
ditto


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA
