### PR TITLE
[CELEBORN-1134][FOLLOWUP] Add execution.batch-shuffle-mode: ALL_EXCHANGES_BLOCKING to Flink Configuration of Deploy Flink client

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -208,6 +208,7 @@ Copy $CELEBORN_HOME/flink/*.jar to $FLINK_HOME/lib/
 To use Celeborn, following flink configurations should be added.
 ```properties
 shuffle-service-factory.class: org.apache.celeborn.plugin.flink.RemoteShuffleServiceFactory
+execution.batch-shuffle-mode: ALL_EXCHANGES_BLOCKING
 celeborn.master.endpoints: clb-1:9097,clb-2:9097,clb-3:9097
 
 celeborn.client.shuffle.batchHandleReleasePartition.enabled: true
@@ -225,3 +226,4 @@ taskmanager.network.memory.floating-buffers-per-gate: 4096
 taskmanager.network.memory.buffers-per-channel: 0
 taskmanager.memory.task.off-heap.size: 512m
 ```
+**Note**: The config option `execution.batch-shuffle-mode` should configure as `ALL_EXCHANGES_BLOCKING`.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `execution.batch-shuffle-mode: ALL_EXCHANGES_BLOCKING` to `Flink Configuration` of `Deploy Flink client` in `deploy.md`

### Why are the changes needed?

Validation whether `execution.batch-shuffle-mode` is `ALL_EXCHANGES_BLOCKING` is supported in #2106. `Flink Configuration` of `Deploy Flink client` should also add this configuration.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.