### PR TITLE
[CELEBORN-1179] Add support in Celeborn Workers to fetch application meta from the Master

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslServer.java
+++ b/common/src/main/java/org/apache/celeborn/common/network/sasl/CelebornSaslServer.java
@@ -134,7 +134,6 @@ public class CelebornSaslServer {
           PasswordCallback pc = (PasswordCallback) callback;
           String secret = secretRegistry.getSecretKey(userName);
           if (secret == null) {
-            // TODO: CELEBORN-1179 Add support for fetching the secret from the Celeborn master.
             throw new RuntimeException("Registration information not found for " + userName);
           }
           pc.setPassword(encodePassword(secret));

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -4636,7 +4636,7 @@ object CelebornConf extends Logging {
       .createWithDefault(8)
 
   val WORKER_APPLICATION_REGISTRY_CACHE_SIZE: ConfigEntry[Int] =
-    buildConf("celeborn.worker.applicationRegistryCache.size")
+    buildConf("celeborn.worker.applicationRegistry.cache.size")
       .categories("worker", "auth")
       .doc("Cache size of the application registry on Workers.")
       .version("0.5.0")

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1148,6 +1148,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(AUTH_ENABLED)
   }
 
+  def workerApplicationRegistryCacheSize: Int = get(WORKER_APPLICATION_REGISTRY_CACHE_SIZE)
+
   // //////////////////////////////////////////////////////
   //                     Internal Port                   //
   // //////////////////////////////////////////////////////
@@ -4632,4 +4634,12 @@ object CelebornConf extends Logging {
       .version("0.5.0")
       .intConf
       .createWithDefault(8)
+
+  val WORKER_APPLICATION_REGISTRY_CACHE_SIZE: ConfigEntry[Int] =
+    buildConf("celeborn.worker.applicationRegistryCache.size")
+      .categories("worker", "auth")
+      .doc("Cache size of the application registry on Workers.")
+      .version("0.5.0")
+      .intConf
+      .createWithDefault(10000)
 }

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -42,6 +42,7 @@ license: |
 | celeborn.storage.hdfs.kerberos.keytab | &lt;undefined&gt; | false | Kerberos keytab file path for HDFS storage connection. | 0.3.2 |  | 
 | celeborn.storage.hdfs.kerberos.principal | &lt;undefined&gt; | false | Kerberos principal for HDFS storage connection. | 0.3.2 |  | 
 | celeborn.worker.activeConnection.max | &lt;undefined&gt; | false | If the number of active connections on a worker exceeds this configuration value, the worker will be marked as high-load in the heartbeat report, and the master will not include that node in the response of RequestSlots. | 0.3.1 |  | 
+| celeborn.worker.applicationRegistryCache.size | 10000 | false | Cache size of the application registry on Workers. | 0.5.0 |  | 
 | celeborn.worker.bufferStream.threadsPerMountpoint | 8 | false | Threads count for read buffer per mount point. | 0.3.0 |  | 
 | celeborn.worker.clean.threads | 64 | false | Thread number of worker to clean up expired shuffle keys. | 0.3.2 |  | 
 | celeborn.worker.closeIdleConnections | false | false | Whether worker will close idle connections. | 0.2.0 |  | 

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -42,7 +42,7 @@ license: |
 | celeborn.storage.hdfs.kerberos.keytab | &lt;undefined&gt; | false | Kerberos keytab file path for HDFS storage connection. | 0.3.2 |  | 
 | celeborn.storage.hdfs.kerberos.principal | &lt;undefined&gt; | false | Kerberos principal for HDFS storage connection. | 0.3.2 |  | 
 | celeborn.worker.activeConnection.max | &lt;undefined&gt; | false | If the number of active connections on a worker exceeds this configuration value, the worker will be marked as high-load in the heartbeat report, and the master will not include that node in the response of RequestSlots. | 0.3.1 |  | 
-| celeborn.worker.applicationRegistryCache.size | 10000 | false | Cache size of the application registry on Workers. | 0.5.0 |  | 
+| celeborn.worker.applicationRegistry.cache.size | 10000 | false | Cache size of the application registry on Workers. | 0.5.0 |  | 
 | celeborn.worker.bufferStream.threadsPerMountpoint | 8 | false | Threads count for read buffer per mount point. | 0.3.0 |  | 
 | celeborn.worker.clean.threads | 64 | false | Thread number of worker to clean up expired shuffle keys. | 0.3.2 |  | 
 | celeborn.worker.closeIdleConnections | false | false | Whether worker will close idle connections. | 0.2.0 |  | 

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -892,7 +892,7 @@ private[celeborn] class Master(
       requestSlots.applicationId,
       new util.function.Function[String, util.Set[WorkerInfo]] {
         override def apply(key: String): util.Set[WorkerInfo] =
-          util.Collections.newSetFromMap(new JavaUtils.newConcurrentHashMap[
+          util.Collections.newSetFromMap(JavaUtils.newConcurrentHashMap[
             WorkerInfo,
             java.lang.Boolean]())
       })

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1107,15 +1107,15 @@ private[celeborn] class Master(
       context: RpcCallContext,
       pb: PbApplicationMetaRequest): Unit = {
     val appId = pb.getAppId
-    logDebug(
-      s"Handling request for application meta info $appId.")
-    if (!secretRegistry.isRegistered(appId)) {
+    logDebug(s"Handling request for application meta info $appId.")
+    val secret = secretRegistry.getSecretKey(appId)
+    if (secret == null) {
       logWarning(s"Could not find the application meta of $appId.")
       context.sendFailure(new CelebornException(s"$appId is not registered."))
     } else {
       val pbApplicationMeta = PbApplicationMeta.newBuilder()
         .setAppId(appId)
-        .setSecret(secretRegistry.getSecretKey(appId))
+        .setSecret(secret)
         .build()
       val transportMessage =
         new TransportMessage(MessageType.APPLICATION_META, pbApplicationMeta.toByteArray)

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -892,7 +892,7 @@ private[celeborn] class Master(
       requestSlots.applicationId,
       new util.function.Function[String, util.Set[WorkerInfo]] {
         override def apply(key: String): util.Set[WorkerInfo] =
-          util.Collections.newSetFromMap(new util.concurrent.ConcurrentHashMap[
+          util.Collections.newSetFromMap(new JavaUtils.newConcurrentHashMap[
             WorkerInfo,
             java.lang.Boolean]())
       })
@@ -1110,7 +1110,7 @@ private[celeborn] class Master(
     logDebug(
       s"Handling request for application meta info $appId.")
     if (!secretRegistry.isRegistered(appId)) {
-      logWarning(s"Couldn't find the app .")
+      logWarning(s"Could not find the application meta of $appId.")
       context.sendFailure(new CelebornException(s"$appId is not registered."))
     } else {
       val pbApplicationMeta = PbApplicationMeta.newBuilder()

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
@@ -99,7 +99,7 @@ public class WorkerSecretRegistryImpl implements SecretRegistry {
       throw new IllegalArgumentException(
           "AppId " + appId + " is already registered. Cannot re-register.");
     }
-    if (existingSecret != null) {
+    if (existingSecret == null) {
       secretCache.put(appId, secret);
     }
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker;
+
+import com.google.common.base.Preconditions;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.celeborn.common.client.MasterClient;
+import org.apache.celeborn.common.network.sasl.SecretRegistry;
+import org.apache.celeborn.common.protocol.PbApplicationMeta;
+import org.apache.celeborn.common.protocol.PbApplicationMetaRequest;
+
+/** A secret registry that fetches the secret from the master if it is not found locally. */
+public class WorkerSecretRegistryImpl implements SecretRegistry {
+  private static final Logger LOG = LoggerFactory.getLogger(WorkerSecretRegistryImpl.class);
+
+  // MasterClient is created in Worker after the secret registry is created and this order currently
+  // cannot be changed.
+  // So, we need to set the masterClient after the secret registry is created.
+  private MasterClient masterClient;
+  private final Cache<String, String> secretCache;
+
+  public WorkerSecretRegistryImpl(long maxCacheSize) {
+    secretCache = CacheBuilder.newBuilder().maximumSize(maxCacheSize).build();
+  }
+
+  /** Gets an appropriate SASL secret key for the given appId. */
+  @Override
+  public String getSecretKey(String appId) {
+    String secret = secretCache.getIfPresent(appId);
+    if (secret == null) {
+      LOG.debug("Missing the secret for {}; fetching it from the master", appId);
+      PbApplicationMetaRequest pbApplicationMetaRequest =
+          PbApplicationMetaRequest.newBuilder().setAppId(appId).build();
+      try {
+        PbApplicationMeta pbApplicationMeta =
+            masterClient.askSync(pbApplicationMetaRequest, PbApplicationMeta.class);
+        LOG.debug(
+            "Successfully fetched the application meta info for " + appId + " from the master");
+        register(pbApplicationMeta.getAppId(), pbApplicationMeta.getSecret());
+        secret = pbApplicationMeta.getSecret();
+      } catch (Throwable e) {
+        // We catch Throwable here because masterClient.askSync declares it in its definition.
+        // If the secret is null, the authentication will fail so just logging the exception here.
+        LOG.error("Failed to fetch the application meta info for {} from the master", appId, e);
+      }
+    }
+    return secret;
+  }
+
+  @Override
+  public boolean isRegistered(String appId) {
+    return secretCache.getIfPresent(appId) != null;
+  }
+
+  @Override
+  public void register(String appId, String secret) {
+    secretCache.put(appId, secret);
+  }
+
+  @Override
+  public void unregister(String appId) {
+    secretCache.invalidate(appId);
+  }
+
+  public void setMasterClient(MasterClient masterClient) {
+    this.masterClient = Preconditions.checkNotNull(masterClient);
+  }
+}

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
@@ -99,7 +99,9 @@ public class WorkerSecretRegistryImpl implements SecretRegistry {
       throw new IllegalArgumentException(
           "AppId " + appId + " is already registered. Cannot re-register.");
     }
-    secretCache.put(appId, secret);
+    if (existingSecret != null) {
+      secretCache.put(appId, secret);
+    }
   }
 
   @Override

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
@@ -17,9 +17,12 @@
 
 package org.apache.celeborn.service.deploy.worker;
 
+import java.util.concurrent.ExecutionException;
+
 import com.google.common.base.Preconditions;
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,38 +35,56 @@ import org.apache.celeborn.common.protocol.PbApplicationMetaRequest;
 public class WorkerSecretRegistryImpl implements SecretRegistry {
   private static final Logger LOG = LoggerFactory.getLogger(WorkerSecretRegistryImpl.class);
 
+  private final int maxCacheSize;
   // MasterClient is created in Worker after the secret registry is created and this order currently
   // cannot be changed.
   // So, we need to set the masterClient after the secret registry is created.
   private MasterClient masterClient;
-  private final Cache<String, String> secretCache;
+  private LoadingCache<String, String> secretCache;
 
-  public WorkerSecretRegistryImpl(long maxCacheSize) {
-    secretCache = CacheBuilder.newBuilder().maximumSize(maxCacheSize).build();
+  public WorkerSecretRegistryImpl(int maxCacheSize) {
+    this.maxCacheSize = maxCacheSize;
+  }
+
+  public void initialize(MasterClient masterClient) {
+    this.masterClient = Preconditions.checkNotNull(masterClient);
+    CacheLoader<String, String> cacheLoader =
+        new CacheLoader<String, String>() {
+          @Override
+          public String load(String appId) {
+            LOG.debug("Missing the secret for {}; fetching it from the master", appId);
+            PbApplicationMetaRequest pbApplicationMetaRequest =
+                PbApplicationMetaRequest.newBuilder().setAppId(appId).build();
+            try {
+              PbApplicationMeta pbApplicationMeta =
+                  masterClient.askSync(pbApplicationMetaRequest, PbApplicationMeta.class);
+              LOG.debug(
+                  "Successfully fetched the application meta info for "
+                      + appId
+                      + " from the master");
+              return pbApplicationMeta.getSecret();
+            } catch (Throwable e) {
+              // We catch Throwable here because masterClient.askSync declares it in its definition.
+              // If the secret is null, the authentication will fail so just logging the exception
+              // here.
+              LOG.error(
+                  "Failed to fetch the application meta info for {} from the master", appId, e);
+            }
+            return null;
+          }
+        };
+    secretCache = CacheBuilder.newBuilder().maximumSize(maxCacheSize).build(cacheLoader);
   }
 
   /** Gets an appropriate SASL secret key for the given appId. */
   @Override
   public String getSecretKey(String appId) {
-    String secret = secretCache.getIfPresent(appId);
-    if (secret == null) {
-      LOG.debug("Missing the secret for {}; fetching it from the master", appId);
-      PbApplicationMetaRequest pbApplicationMetaRequest =
-          PbApplicationMetaRequest.newBuilder().setAppId(appId).build();
-      try {
-        PbApplicationMeta pbApplicationMeta =
-            masterClient.askSync(pbApplicationMetaRequest, PbApplicationMeta.class);
-        LOG.debug(
-            "Successfully fetched the application meta info for " + appId + " from the master");
-        register(pbApplicationMeta.getAppId(), pbApplicationMeta.getSecret());
-        secret = pbApplicationMeta.getSecret();
-      } catch (Throwable e) {
-        // We catch Throwable here because masterClient.askSync declares it in its definition.
-        // If the secret is null, the authentication will fail so just logging the exception here.
-        LOG.error("Failed to fetch the application meta info for {} from the master", appId, e);
-      }
+    try {
+      return secretCache.get(appId);
+    } catch (ExecutionException ee) {
+      LOG.error("Failed to retrieve the the application meta info for {} ", appId, ee);
     }
-    return secret;
+    return null;
   }
 
   @Override
@@ -84,9 +105,5 @@ public class WorkerSecretRegistryImpl implements SecretRegistry {
   @Override
   public void unregister(String appId) {
     secretCache.invalidate(appId);
-  }
-
-  public void setMasterClient(MasterClient masterClient) {
-    this.masterClient = Preconditions.checkNotNull(masterClient);
   }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
@@ -75,7 +75,8 @@ public class WorkerSecretRegistryImpl implements SecretRegistry {
   public void register(String appId, String secret) {
     String existingSecret = secretCache.getIfPresent(appId);
     if (existingSecret != null && !existingSecret.equals(secret)) {
-      throw new IllegalArgumentException("AppId " + appId + " is already registered. Cannot re-register.");
+      throw new IllegalArgumentException(
+          "AppId " + appId + " is already registered. Cannot re-register.");
     }
     secretCache.put(appId, secret);
   }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImpl.java
@@ -73,6 +73,10 @@ public class WorkerSecretRegistryImpl implements SecretRegistry {
 
   @Override
   public void register(String appId, String secret) {
+    String existingSecret = secretCache.getIfPresent(appId);
+    if (existingSecret != null && !existingSecret.equals(secret)) {
+      throw new IllegalArgumentException("AppId " + appId + " is already registered. Cannot re-register.");
+    }
     secretCache.put(appId, secret);
   }
 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -662,6 +662,7 @@ private[celeborn] class Worker(
           // resource consumption source should remove lose application gauges.
           removeAppResourceConsumption(applicationId)
           removeAppActiveConnection(applicationId)
+          secretRegistry.unregister(applicationId)
         }
         logInfo(s"Cleaned up expired shuffle $shuffleKey")
       }

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -291,7 +291,7 @@ private[celeborn] class Worker(
     JavaUtils.newConcurrentHashMap[String, ConcurrentHashMap[Long, CommitInfo]]()
 
   private val masterClient = new MasterClient(internalRpcEnvInUse, conf, true)
-  secretRegistry.setMasterClient(masterClient)
+  secretRegistry.initialize(masterClient)
 
   // (workerInfo -> last connect timeout timestamp)
   val unavailablePeers: ConcurrentHashMap[WorkerInfo, Long] =

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImplSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImplSuiteJ.java
@@ -37,7 +37,7 @@ public class WorkerSecretRegistryImplSuiteJ {
   @Before
   public void setUp() {
     secretRegistry = new WorkerSecretRegistryImpl(10000);
-    secretRegistry.setMasterClient(masterClient);
+    secretRegistry.initialize(masterClient);
   }
 
   @Test

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImplSuiteJ.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/WorkerSecretRegistryImplSuiteJ.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.celeborn.service.deploy.worker;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.google.protobuf.GeneratedMessageV3;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.apache.celeborn.common.client.MasterClient;
+import org.apache.celeborn.common.protocol.PbApplicationMeta;
+
+public class WorkerSecretRegistryImplSuiteJ {
+
+  private WorkerSecretRegistryImpl secretRegistry;
+
+  private MasterClient masterClient = Mockito.mock(MasterClient.class);
+
+  @Before
+  public void setUp() {
+    secretRegistry = new WorkerSecretRegistryImpl(10000);
+    secretRegistry.setMasterClient(masterClient);
+  }
+
+  @Test
+  public void testGetSecretKeyCacheHit() throws Throwable {
+    String appId = "testAppId";
+    String secret = "testSecret";
+    secretRegistry.register(appId, secret);
+    assertEquals(secret, secretRegistry.getSecretKey(appId));
+    verify(masterClient, never()).askSync((GeneratedMessageV3) any(), eq(PbApplicationMeta.class));
+  }
+
+  @Test
+  public void testGetSecretKeyCacheMiss() throws Throwable {
+    String appId = "testAppId";
+    String secret = "testSecret";
+    when(masterClient.askSync((GeneratedMessageV3) any(), eq(PbApplicationMeta.class)))
+        .thenReturn(PbApplicationMeta.newBuilder().setAppId(appId).setSecret(secret).build());
+    assertEquals(secret, secretRegistry.getSecretKey(appId));
+    verify(masterClient, times(1)).askSync((GeneratedMessageV3) any(), eq(PbApplicationMeta.class));
+  }
+
+  @Test
+  public void testRegistration() {
+    String appId = "testAppId";
+    String secret = "testSecret";
+    secretRegistry.register(appId, secret);
+    assertTrue(secretRegistry.isRegistered(appId));
+    assertFalse(secretRegistry.isRegistered("nonExistentAppId"));
+  }
+
+  @Test
+  public void testUnregistration() {
+    String appId = "testAppId";
+    String secret = "testSecret";
+    secretRegistry.register(appId, secret);
+    assertTrue(secretRegistry.isRegistered(appId));
+    secretRegistry.unregister(appId);
+    assertFalse(secretRegistry.isRegistered(appId));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This enables a Celeborn Worker to retrieve the application meta from the Master if it hasn't received the secret from the Master before the application attempts to connect to it. Additionally, the Celeborn Worker's SecretRegistry has been converted into an LRU cache to prevent unbounded growth of the registry.

### Why are the changes needed?
This is last change needed for Auth support in Celeborn (https://issues.apache.org/jira/browse/CELEBORN-1011)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UTs and part of a bigger change which will be tested end-to-end.
