### PR TITLE
[CELEBORN-1312] Move handleRequestPartitions out of sync block

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -19,7 +19,7 @@ package org.apache.celeborn.client
 
 import java.util
 import java.util.{Set => JSet}
-import java.util.concurrent.{ConcurrentHashMap, ExecutorService, ScheduledExecutorService, ScheduledFuture, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, ScheduledFuture, TimeUnit}
 
 import scala.collection.JavaConverters._
 

--- a/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/ChangePartitionManager.scala
@@ -19,7 +19,7 @@ package org.apache.celeborn.client
 
 import java.util
 import java.util.{Set => JSet}
-import java.util.concurrent.{ConcurrentHashMap, ScheduledExecutorService, ScheduledFuture, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, ExecutorService, ScheduledExecutorService, ScheduledFuture, TimeUnit}
 
 import scala.collection.JavaConverters._
 
@@ -79,19 +79,19 @@ class ChangePartitionManager(
                 batchHandleChangePartitionExecutors.submit {
                   new Runnable {
                     override def run(): Unit = {
-                      requests.synchronized {
+                      val distinctPartitions = requests.synchronized {
                         // For each partition only need handle one request
-                        val distinctPartitions = requests.asScala.filter { case (partitionId, _) =>
+                        requests.asScala.filter { case (partitionId, _) =>
                           !inBatchPartitions.get(shuffleId).contains(partitionId)
                         }.map { case (partitionId, request) =>
                           inBatchPartitions.get(shuffleId).add(partitionId)
                           request.asScala.toArray.maxBy(_.epoch)
                         }.toArray
-                        if (distinctPartitions.nonEmpty) {
-                          handleRequestPartitions(
-                            shuffleId,
-                            distinctPartitions)
-                        }
+                      }
+                      if (distinctPartitions.nonEmpty) {
+                        handleRequestPartitions(
+                          shuffleId,
+                          distinctPartitions)
                       }
                     }
                   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
As title, `handleRequestPartitions` is quite heavy since it calls sync RPC.
It's unnecessary to put it in the sync block.
This fixes the same issue as https://github.com/apache/incubator-celeborn/pull/2207


### Why are the changes needed?
ditto


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA and manual test.
