### PR TITLE
[CELEBORN-1284][FOLLOWUP] Fix license style of quota_management.md

### DIFF
--- a/docs/quota_management.md
+++ b/docs/quota_management.md
@@ -1,19 +1,19 @@
 ---
 license: |
-Licensed to the Apache Software Foundation (ASF) under one or more
-contributor license agreements.  See the NOTICE file distributed with
-this work for additional information regarding copyright ownership.
-The ASF licenses this file to You under the Apache License, Version 2.0
-(the "License"); you may not use this file except in compliance with
-the License.  You may obtain a copy of the License at
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
       https://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 ---
 
 Quota Management
@@ -42,6 +42,7 @@ Celeborn supports fine-grained quota management, including four indicators:
 The `LifecycleManager` will request the `Master` to check the quota for the current user defined by user setting.
 Users can set `celeborn.quota.identity.provider` to choose an identity provider.
 Celeborn support the following types at present:
+
 - `org.apache.celeborn.common.identity.HadoopBasedIdentityProvider`: The username will be obtained by `UserGroupInformation.getUserName()`, tenant id will be default.
 - `org.apache.celeborn.common.identity.DefaultIdentityProvider`: The username and tenant id are default values or user-specific values set by `celeborn.quota.identity.user-specific.tenant` and `celeborn.quota.identity.user-specific.userName`.
 
@@ -55,23 +56,25 @@ Users can also implement their own identity provider by inheriting the `org.apac
 For example, there are some quota configurations as follows:
 
 The quota for user `tenant_01.Jerry` is
+
 - diskBytesWritten: 100G
 - diskFileCount: 10000
 - hdfsBytesWritten: 10G
 - diskFileCount: Long.MAX_VALUE
 
 The quota for tenant id `tenant_01` is
+
 - diskBytesWritten: 10G
 - diskFileCount: 1000
 - hdfsBytesWritten: 10G
 - diskFileCount: Long.MAX_VALUE
 
 The quota for `system default` is
+
 - diskBytesWritten: 1G
 - diskFileCount: 100
 - hdfsBytesWritten: 1G
 - diskFileCount: Long.MAX_VALUE
-
 
 ### FileSystem Store Backend
 
@@ -98,7 +101,6 @@ Here's an example quota setting YAML file of above quota examples:
          celeborn.quota.tenant.diskBytesWritten: 100G
          celeborn.quota.tenant.diskFileCount: 10000
 ```
-
 
 ### Database Store Backend
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix license style of `quota_management.md`.

### Why are the changes needed?

The license style of `quota_management.md` is wrong.

<img width="1438" alt="image" src="https://github.com/apache/incubator-celeborn/assets/10048174/4a00724d-5fec-4b25-b134-d814c3152efd">

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.