### PR TITLE
[MINOR] Fix style and Gluten link in Developers Doc

### DIFF
--- a/docs/developers/glutensupport.md
+++ b/docs/developers/glutensupport.md
@@ -19,9 +19,9 @@ license: |
 # Gluten Support
 ## Velox Backend
 
-[Gluten](https://github.com/oap-project/gluten) with velox backend supports Celeborn as remote shuffle service. Below introduction is used to enable this feature
+[Gluten](https://github.com/apache/incubator-gluten) with velox backend supports Celeborn as remote shuffle service. Below introduction is used to enable this feature
 
-First refer to this URL(https://github.com/oap-project/gluten/blob/main/docs/get-started/Velox.md) to build Gluten with velox backend.
+First refer to [Get Started With Velox](https://github.com/apache/incubator-gluten/blob/main/docs/get-started/Velox.md) to build Gluten with velox backend.
 
 When compiling the Gluten Java module, it's required to enable `rss` profile, as follows:
 

--- a/docs/developers/overview.md
+++ b/docs/developers/overview.md
@@ -90,7 +90,7 @@ and easy to implement plugins for various engines.
 
 Currently, Celeborn officially supports [Spark](https://spark.apache.org/)(both Spark 2.x and Spark 3.x),
 [Flink](https://flink.apache.org/)(1.14/1.15/1.17), and
-[Gluten](https://github.com/oap-project/gluten). Also developers are integrating Celeborn with other engines,
+[Gluten](https://github.com/apache/incubator-gluten). Also developers are integrating Celeborn with other engines,
 for example [MR3](https://mr3docs.datamonad.com/docs/mr3/).
 
 Celeborn community is also working on integrating Celeborn with other engines.

--- a/docs/developers/slotsallocation.md
+++ b/docs/developers/slotsallocation.md
@@ -37,6 +37,7 @@ celeborn.master.slot.assign.loadAware.fetchTimeWeight 0
 ```
 ### Detail
 Load-aware slots allocation will take following elements into consideration.
+
 - disk's fetch time 
 - disk's flush time 
 - disk's usable space


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix style and Gluten link in Developers Doc.

### Why are the changes needed?

- `slotsallocation.md` has the following wrong style:

<img width="1434" alt="image" src="https://github.com/apache/incubator-celeborn/assets/10048174/97fb53ed-473d-4f3d-8231-1fb613df9132">

- Gluten is apache incubating projetc, of which the link of Gluten project should be [Gluten](https://github.com/apache/incubator-gluten).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.