### PR TITLE
[CELEBORN-1326] FakedRemoteInputChannel use task name of RemoteShuffleInputGateDelegation as owningTaskName

### DIFF
--- a/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGate.java
+++ b/client-flink/flink-1.14/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGate.java
@@ -199,7 +199,7 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
     FakedRemoteInputChannel(int channelIndex) {
       super(
           new SingleInputGate(
-              "",
+              inputGateDelegation.getTaskName(),
               inputGateDelegation.getGateIndex(),
               new IntermediateDataSetID(),
               ResultPartitionType.BLOCKING,

--- a/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGate.java
+++ b/client-flink/flink-1.15/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGate.java
@@ -211,7 +211,7 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
     FakedRemoteInputChannel(int channelIndex) {
       super(
           new SingleInputGate(
-              "",
+              inputGateDelegation.getTaskName(),
               inputGateDelegation.getGateIndex(),
               new IntermediateDataSetID(),
               ResultPartitionType.BLOCKING,

--- a/client-flink/flink-1.17/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGate.java
+++ b/client-flink/flink-1.17/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGate.java
@@ -211,7 +211,7 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
     FakedRemoteInputChannel(int channelIndex) {
       super(
           new SingleInputGate(
-              "",
+              inputGateDelegation.getTaskName(),
               inputGateDelegation.getGateIndex(),
               new IntermediateDataSetID(),
               ResultPartitionType.BLOCKING,

--- a/client-flink/flink-1.18/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGate.java
+++ b/client-flink/flink-1.18/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleInputGate.java
@@ -214,7 +214,7 @@ public class RemoteShuffleInputGate extends IndexedInputGate {
       // [FLINK-31642][network] Introduce the MemoryTierConsumerAgent to TieredStorageConsumerClient
       super(
           new SingleInputGate(
-              "",
+              inputGateDelegation.getTaskName(),
               inputGateDelegation.getGateIndex(),
               new IntermediateDataSetID(),
               ResultPartitionType.BLOCKING,


### PR DESCRIPTION
### What changes were proposed in this pull request?

`FakedRemoteInputChannel` use task name of `RemoteShuffleInputGateDelegation` as `owningTaskName` to get the task name from log of `SingleInputGate`.

### Why are the changes needed?

`FakedRemoteInputChannel` use empty string as `owningTaskName`, which could not get the task name from the log of `SingleInputGate`, which could support using task name of `RemoteShuffleInputGateDelegation` as `owningTaskName`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.