### PR TITLE
[CELEBORN-1330] Bump rocksdbjni version from 8.5.3 to 8.11.3

### DIFF
--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -93,7 +93,7 @@ ratis-server/2.5.1//ratis-server-2.5.1.jar
 ratis-shell/2.5.1//ratis-shell-2.5.1.jar
 ratis-thirdparty-misc/1.0.4//ratis-thirdparty-misc-1.0.4.jar
 reflections/0.10.2//reflections-0.10.2.jar
-rocksdbjni/8.5.3//rocksdbjni-8.5.3.jar
+rocksdbjni/8.11.3//rocksdbjni-8.11.3.jar
 scala-library/2.12.15//scala-library-2.12.15.jar
 scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 shims/0.9.32//shims-0.9.32.jar

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <snakeyaml.version>2.2</snakeyaml.version>
     <zstd-jni.version>1.5.2-1</zstd-jni.version>
     <kubernetes-client.version>6.7.0</kubernetes-client.version>
-    <rocksdbjni.version>8.5.3</rocksdbjni.version>
+    <rocksdbjni.version>8.11.3</rocksdbjni.version>
     <jackson.version>2.15.3</jackson.version>
     <snappy.version>1.1.10.5</snappy.version>
 

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -56,7 +56,7 @@ object Dependencies {
   val nettyVersion = "4.1.107.Final"
   val ratisVersion = "2.5.1"
   val roaringBitmapVersion = "0.9.32"
-  val rocksdbJniVersion = "8.5.3"
+  val rocksdbJniVersion = "8.11.3"
   val jacksonVersion = "2.15.3"
   val scalatestMockitoVersion = "1.17.14"
   val scalatestVersion = "3.2.16"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump `rocksdbjni` version from 8.5.3 to 8.11.3.

### Why are the changes needed?

The new version bring some bug fixes:

- Fix a corner case with auto_readahead_size where Prev Operation returns NOT SUPPORTED error when scans direction is changed from forward to backward.
- Avoid destroying the periodic task scheduler's default timer in order to prevent static destruction order issues.
- Fix double counting of BYTES_WRITTEN ticker when doing writes with transactions.
- Fix a WRITE_STALL counter that was reporting wrong value in few cases.
- A lookup by MultiGet in a TieredCache that goes to the local flash cache and finishes with very low latency, i.e before the subsequent call to WaitAll, is ignored, resulting in a false negative and a memory leak.
- Fix bug in auto_readahead_size that combined with IndexType::kBinarySearchWithFirstKey + fails or iterator lands at a wrong key
- Fixed some cases in which DB file corruption was detected but ignored on creating a backup with BackupEngine.
- Fix bugs where rocksdb.blobdb.blob.file.synced includes blob files failed to get synced and rocksdb.blobdb.blob.file.bytes.written includes blob bytes failed to get written.
- Fixed a possible memory leak or crash on a failure (such as I/O error) in automatic atomic flush of multiple column families.
- Fixed some cases of in-memory data corruption using mmap reads with BackupEngine, sst_dump, or ldb.
- Fixed issues with experimental preclude_last_level_data_seconds option that could interfere with expected data tiering.
- Fixed the handling of the edge case when all existing blob files become unreferenced. Such files are now correctly deleted.

The full release notes as follows: [rocksdbjni releases](https://github.com/facebook/rocksdb/releases).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.