### PR TITLE
[MINOR] Fix typo of celeborn.network.bind.preferIpAddress doc

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1378,7 +1378,7 @@ object CelebornConf extends Logging {
     buildConf("celeborn.network.bind.preferIpAddress")
       .categories("network")
       .version("0.3.0")
-      .doc("When `ture`, prefer to use IP address, otherwise FQDN. This configuration only " +
+      .doc("When `true`, prefer to use IP address, otherwise FQDN. This configuration only " +
         "takes effects when the bind hostname is not set explicitly, in such case, Celeborn " +
         "will find the first non-loopback address to bind.")
       .booleanConf

--- a/docs/configuration/network.md
+++ b/docs/configuration/network.md
@@ -41,7 +41,7 @@ license: |
 | celeborn.&lt;module&gt;.push.timeoutCheck.threads | 4 | false | Threads num for checking push data timeout. If setting <module> to `data`, it works for shuffle client push data. If setting <module> to `push`, it works for Flink shuffle client push data. If setting <module> to `replicate`, it works for replicate client of worker replicating data to peer worker. | 0.3.0 |  | 
 | celeborn.&lt;role&gt;.rpc.dispatcher.threads | &lt;value of celeborn.rpc.dispatcher.threads&gt; | false | Threads number of message dispatcher event loop for roles |  |  | 
 | celeborn.io.maxDefaultNettyThreads | 64 | false | Max default netty threads | 0.3.2 |  | 
-| celeborn.network.bind.preferIpAddress | true | false | When `ture`, prefer to use IP address, otherwise FQDN. This configuration only takes effects when the bind hostname is not set explicitly, in such case, Celeborn will find the first non-loopback address to bind. | 0.3.0 |  | 
+| celeborn.network.bind.preferIpAddress | true | false | When `true`, prefer to use IP address, otherwise FQDN. This configuration only takes effects when the bind hostname is not set explicitly, in such case, Celeborn will find the first non-loopback address to bind. | 0.3.0 |  | 
 | celeborn.network.connect.timeout | 10s | false | Default socket connect timeout. | 0.2.0 |  | 
 | celeborn.network.memory.allocator.numArenas | &lt;undefined&gt; | false | Number of arenas for pooled memory allocator. Default value is Runtime.getRuntime.availableProcessors, min value is 2. | 0.3.0 |  | 
 | celeborn.network.memory.allocator.verbose.metric | false | false | Whether to enable verbose metric for pooled allocator. | 0.3.0 |  | 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix typo of `celeborn.network.bind.preferIpAddress` doc from `ture` to `true`.

### Why are the changes needed?

`celeborn.network.bind.preferIpAddress` doc has typo for `ture`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.