### PR TITLE
[CELEBORN-1842] Bump ap-loader version from 3.0-8 to 3.0-9

### DIFF
--- a/dev/deps/dependencies-server
+++ b/dev/deps/dependencies-server
@@ -18,7 +18,7 @@
 HikariCP/4.0.3//HikariCP-4.0.3.jar
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 aopalliance-repackaged/2.6.1//aopalliance-repackaged-2.6.1.jar
-ap-loader-all/3.0-8//ap-loader-all-3.0-8.jar
+ap-loader-all/3.0-9//ap-loader-all-3.0-9.jar
 classgraph/4.8.138//classgraph-4.8.138.jar
 commons-cli/1.5.0//commons-cli-1.5.0.jar
 commons-crypto/1.0.0//commons-crypto-1.0.0.jar

--- a/docs/developers/jvmprofiler.md
+++ b/docs/developers/jvmprofiler.md
@@ -29,7 +29,7 @@ so it is advisable that the `Worker` machines have adequate storage.
 Code profiling is currently only supported for
 
 *   Linux (x64)
-*   Linux (arm 64)
+*   Linux (arm64)
 *   Linux (musl, x64)
 *   MacOS
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <rocksdbjni.version>9.5.2</rocksdbjni.version>
     <jackson.version>2.15.3</jackson.version>
     <snappy.version>1.1.10.5</snappy.version>
-    <ap.loader.version>3.0-8</ap.loader.version>
+    <ap.loader.version>3.0-9</ap.loader.version>
     <picocli.version>4.7.6</picocli.version>
 
     <!-- Db dependencies -->

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -41,7 +41,7 @@ object Dependencies {
   val lz4JavaVersion = sparkClientProjects.map(_.lz4JavaVersion).getOrElse("1.8.0")
 
   // Dependent library versions
-  val apLoaderVersion = "3.0-8"
+  val apLoaderVersion = "3.0-9"
   val commonsCompressVersion = "1.4.1"
   val commonsCryptoVersion = "1.0.0"
   val commonsIoVersion = "2.17.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump ap-loader version from 3.0-8 to 3.0-9.

### Why are the changes needed?

ap-loader has already released v3.0-9, which should bump version from 3.0-8 for `JVMProfiler`.

Backport:

1. https://github.com/apache/spark/pull/46402
2. https://github.com/apache/spark/pull/49440

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.