### PR TITLE
[CELEBORN-2016] Add cooldown time in worker shutdown

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/util/ShutdownHookManager.java
+++ b/common/src/main/java/org/apache/celeborn/common/util/ShutdownHookManager.java
@@ -147,7 +147,7 @@ public final class ShutdownHookManager {
   }
 
   static long getShutdownTimeout(CelebornConf conf) {
-    long duration = conf.workerGracefulShutdownTimeoutMs();
+    long duration = conf.workerGracefulShutdownTimeoutMs() + conf.workerShutdownCooldownTime();
     if (duration < TIMEOUT_MINIMUM) {
       duration = TIMEOUT_MINIMUM;
     }

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1262,6 +1262,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
         }).reduce(_ ++ _)
     }.orElse(Some(Map("MEMORY" -> List("SSD", "HDD", "HDFS", "S3", "OSS"))))
 
+  def workerShutdownCooldownTime: Long = get(WORKER_SHUTDOWN_COOLDOWN_TIME)
+
   // //////////////////////////////////////////////////////
   //                   Decommission                      //
   // //////////////////////////////////////////////////////
@@ -4151,6 +4153,14 @@ object CelebornConf extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("10ms")
 
+  val WORKER_SHUTDOWN_COOLDOWN_TIME: ConfigEntry[Long] =
+    buildConf("celeborn.worker.shutdown.cooldownTime")
+      .categories("worker")
+      .doc("Additional cooldown time for all shutdown operations to complete during worker decommission or graceful shutdown")
+      .version("0.6.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("5s")
+
   val WORKER_DECOMMISSION_CHECK_INTERVAL: ConfigEntry[Long] =
     buildConf("celeborn.worker.decommission.checkInterval")
       .categories("worker")
@@ -4176,14 +4186,6 @@ object CelebornConf extends Logging {
       .version("0.2.0")
       .booleanConf
       .createWithDefault(false)
-
-  val WORKER_GRACEFUL_SHUTDOWN_TIMEOUT: ConfigEntry[Long] =
-    buildConf("celeborn.worker.graceful.shutdown.timeout")
-      .categories("worker")
-      .doc("The worker's graceful shutdown timeout time.")
-      .version("0.2.0")
-      .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("600s")
 
   val WORKER_CHECK_SLOTS_FINISHED_INTERVAL: ConfigEntry[Long] =
     buildConf("celeborn.worker.graceful.shutdown.checkSlotsFinished.interval")
@@ -4230,6 +4232,15 @@ object CelebornConf extends Logging {
       .version("0.2.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("120s")
+
+  val WORKER_GRACEFUL_SHUTDOWN_TIMEOUT: ConfigEntry[Long] =
+    buildConf("celeborn.worker.graceful.shutdown.timeout")
+      .categories("worker")
+      .doc(s"The worker's graceful shutdown timeout time. This should include " +
+        s"${WORKER_CHECK_SLOTS_FINISHED_TIMEOUT.key} and ${WORKER_PARTITION_SORTER_SHUTDOWN_TIMEOUT.key}.")
+      .version("0.2.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("600s")
 
   val WORKER_PARTITION_READ_BUFFERS_MIN: ConfigEntry[Int] =
     buildConf("celeborn.worker.partition.initial.readBuffersMin")

--- a/docs/configuration/worker.md
+++ b/docs/configuration/worker.md
@@ -103,7 +103,7 @@ license: |
 | celeborn.worker.graceful.shutdown.recoverPath | &lt;tmp&gt;/recover | false | The path to store DB. | 0.2.0 |  | 
 | celeborn.worker.graceful.shutdown.saveCommittedFileInfo.interval | 5s | false | Interval for a Celeborn worker to flush committed file infos into Level DB. | 0.3.1 |  | 
 | celeborn.worker.graceful.shutdown.saveCommittedFileInfo.sync | false | false | Whether to call sync method to save committed file infos into Level DB to handle OS crash. | 0.3.1 |  | 
-| celeborn.worker.graceful.shutdown.timeout | 600s | false | The worker's graceful shutdown timeout time. | 0.2.0 |  | 
+| celeborn.worker.graceful.shutdown.timeout | 600s | false | The worker's graceful shutdown timeout time. This should include celeborn.worker.graceful.shutdown.checkSlotsFinished.timeout and celeborn.worker.graceful.shutdown.partitionSorter.shutdownTimeout. | 0.2.0 |  | 
 | celeborn.worker.http.auth.administers |  | false | A comma-separated list of users who have admin privileges, Note, when celeborn.worker.http.auth.supportedSchemes is not set, everyone is treated as administrator. | 0.6.0 |  | 
 | celeborn.worker.http.auth.basic.provider | org.apache.celeborn.common.authentication.AnonymousAuthenticationProviderImpl | false | User-defined password authentication implementation of org.apache.celeborn.common.authentication.PasswdAuthenticationProvider | 0.6.0 |  | 
 | celeborn.worker.http.auth.bearer.provider | org.apache.celeborn.common.authentication.AnonymousAuthenticationProviderImpl | false | User-defined token authentication implementation of org.apache.celeborn.common.authentication.TokenAuthenticationProvider | 0.6.0 |  | 
@@ -174,6 +174,7 @@ license: |
 | celeborn.worker.shuffle.partitionSplit.enabled | true | false | enable the partition split on worker side | 0.3.0 | celeborn.worker.partition.split.enabled | 
 | celeborn.worker.shuffle.partitionSplit.max | 2g | false | Specify the maximum partition size for splitting, and ensure that individual partition files are always smaller than this limit. | 0.3.0 |  | 
 | celeborn.worker.shuffle.partitionSplit.min | 1m | false | Min size for a partition to split | 0.3.0 | celeborn.shuffle.partitionSplit.min | 
+| celeborn.worker.shutdown.cooldownTime | 5s | false | Additional cooldown time for all shutdown operations to complete during worker decommission or graceful shutdown | 0.6.0 |  | 
 | celeborn.worker.sortPartition.indexCache.expire | 180s | false | PartitionSorter's cache item expire time. | 0.4.0 |  | 
 | celeborn.worker.sortPartition.indexCache.maxWeight | 100000 | false | PartitionSorter's cache max weight for index buffer. | 0.4.0 |  | 
 | celeborn.worker.sortPartition.prefetch.enabled | true | false | When true, partition sorter will prefetch the original partition files to page cache and reserve memory configured by `celeborn.worker.sortPartition.reservedMemoryPerPartition` to allocate a block of memory for prefetching while sorting a shuffle file off-heap with page cache for non-hdfs files. Otherwise, partition sorter seeks to position of each block and does not prefetch for non-hdfs files. | 0.5.0 |  | 

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Worker.scala
@@ -909,7 +909,7 @@ private[celeborn] class Worker(
     exitType.toUpperCase(Locale.ROOT) match {
       case "DECOMMISSION" =>
         ShutdownHookManager.get().updateTimeout(
-          conf.workerDecommissionForceExitTimeout,
+          conf.workerDecommissionForceExitTimeout + conf.workerShutdownCooldownTime,
           TimeUnit.MILLISECONDS)
         workerStatusManager.doTransition(WorkerEventType.Decommission)
       case "GRACEFUL" =>
@@ -949,7 +949,7 @@ private[celeborn] class Worker(
 
     def waitTime: Long = waitTimes * interval
 
-    while (!partitionLocationInfo.isEmpty && waitTime < timeout) {
+    while (!partitionLocationInfo.isEmpty && waitTime + interval < timeout) {
       Thread.sleep(interval)
       waitTimes += 1
       logWarning(
@@ -990,7 +990,7 @@ private[celeborn] class Worker(
 
     def waitTime: Long = waitTimes * interval
 
-    while (!storageManager.shuffleKeySet().isEmpty && waitTime < timeout) {
+    while (!storageManager.shuffleKeySet().isEmpty && waitTime + interval < timeout) {
       Thread.sleep(interval)
       waitTimes += 1
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
- Adding addition cooldown time in worker shutdown logic, which will allow all shutdown hook to execute completely.
- Minor improvement in shutdown logic.

### Why are the changes needed?

We current shutdown logic we have seen worker getting shutdown abruptly with timeout exception without completely executing the shutdown hook because of which Celeborn is –
- unable to print unreleased partition info on decommission
- not able to update sorted file DB

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
NA
