### PR TITLE
[CELEBORN-1319][FOLLOWUP] Support celeborn optimize skew partitions patch for Spark v3.5.6 and v4.0.0

### DIFF
--- a/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_2.patch
+++ b/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_2.patch
@@ -95,7 +95,7 @@ index 00000000000..5e190c512df
 +    ConfigBuilder("spark.celeborn.client.spark.stageRerun.enabled")
 +      .withAlternative("spark.celeborn.client.spark.fetch.throwsFetchFailure")
 +      .booleanConf
-+      .createWithDefault(false)
++      .createWithDefault(true)
 +
 +  private val celebornOptimizeSkewedPartitionReadEnabled = new AtomicBoolean()
 +  private val stageRerunEnabled = new AtomicBoolean()

--- a/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_3.patch
+++ b/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_3.patch
@@ -95,7 +95,7 @@ index 00000000000..5e190c512df
 +    ConfigBuilder("spark.celeborn.client.spark.stageRerun.enabled")
 +      .withAlternative("spark.celeborn.client.spark.fetch.throwsFetchFailure")
 +      .booleanConf
-+      .createWithDefault(false)
++      .createWithDefault(true)
 +
 +  private val celebornOptimizeSkewedPartitionReadEnabled = new AtomicBoolean()
 +  private val stageRerunEnabled = new AtomicBoolean()

--- a/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_4.patch
+++ b/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_4.patch
@@ -95,7 +95,7 @@ index 00000000000..5e190c512df
 +    ConfigBuilder("spark.celeborn.client.spark.stageRerun.enabled")
 +      .withAlternative("spark.celeborn.client.spark.fetch.throwsFetchFailure")
 +      .booleanConf
-+      .createWithDefault(false)
++      .createWithDefault(true)
 +
 +  private val celebornOptimizeSkewedPartitionReadEnabled = new AtomicBoolean()
 +  private val stageRerunEnabled = new AtomicBoolean()

--- a/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_5.patch
+++ b/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_5.patch
@@ -95,7 +95,7 @@ index 00000000000..5e190c512df
 +    ConfigBuilder("spark.celeborn.client.spark.stageRerun.enabled")
 +      .withAlternative("spark.celeborn.client.spark.fetch.throwsFetchFailure")
 +      .booleanConf
-+      .createWithDefault(false)
++      .createWithDefault(true)
 +
 +  private val celebornOptimizeSkewedPartitionReadEnabled = new AtomicBoolean()
 +  private val stageRerunEnabled = new AtomicBoolean()

--- a/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_5_6.patch
+++ b/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_5_6.patch
@@ -95,7 +95,7 @@ index 00000000000..5e190c512df
 +    ConfigBuilder("spark.celeborn.client.spark.stageRerun.enabled")
 +      .withAlternative("spark.celeborn.client.spark.fetch.throwsFetchFailure")
 +      .booleanConf
-+      .createWithDefault(false)
++      .createWithDefault(true)
 +
 +  private val celebornOptimizeSkewedPartitionReadEnabled = new AtomicBoolean()
 +  private val stageRerunEnabled = new AtomicBoolean()

--- a/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark4_0.patch
+++ b/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark4_0.patch
@@ -95,7 +95,7 @@ index 00000000000..5e190c512df
 +    ConfigBuilder("spark.celeborn.client.spark.stageRerun.enabled")
 +      .withAlternative("spark.celeborn.client.spark.fetch.throwsFetchFailure")
 +      .booleanConf
-+      .createWithDefault(false)
++      .createWithDefault(true)
 +
 +  private val celebornOptimizeSkewedPartitionReadEnabled = new AtomicBoolean()
 +  private val stageRerunEnabled = new AtomicBoolean()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support celeborn optimize skew partitions patch for Spark v3.5.6 and v4.0.0.

### Why are the changes needed?

There is no patch of celeborn optimize skew partitions for Spark v4.0.0. Meanwhile, Spark v3.5.6 could not apply `Celeborn-Optimize-Skew-Partitions-spark3_5.patch` because of https://github.com/apache/spark/pull/50946.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
$ git checkout v3.5.6
Previous HEAD position was fa33ea000a0 Preparing Spark release v4.0.0-rc7
HEAD is now at 303c18c7466 Preparing Spark release v3.5.6-rc1
$ git apply --check /celeborn/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark3_5_6.patch 
$ git checkout v4.0.0
Previous HEAD position was 303c18c7466 Preparing Spark release v3.5.6-rc1
HEAD is now at fa33ea000a0 Preparing Spark release v4.0.0-rc7
$ git apply --check /celeborn/assets/spark-patch/Celeborn-Optimize-Skew-Partitions-spark4_0.patch
```