### PR TITLE
[CELEBORN-2046] Specify extractionDir of AsyncProfilerLoader with celeborn.worker.jvmProfiler.localDir

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/Utils.scala
@@ -366,8 +366,6 @@ object Utils extends Logging {
     arr
   }
 
-  val isLinux: Boolean = SystemUtils.IS_OS_LINUX
-
   val isWindows: Boolean = SystemUtils.IS_OS_WINDOWS
 
   val isMac: Boolean = SystemUtils.IS_OS_MAC_OSX


### PR DESCRIPTION
### What changes were proposed in this pull request?

Specify `extractionDir` of `AsyncProfilerLoader` with `celeborn.worker.jvmProfiler.localDir`.

### Why are the changes needed?

`AsyncProfilerLoader` uses `user.home` directory to store the extracted libraries by default . When `user.home` directory is not initialized, it will cause `AsyncProfilerLoader#load` to fail. `extractionDir` of `AsyncProfilerLoader` could be specified with `celeborn.worker.jvmProfiler.localDir` to avoid failure of loading.

Backport https://github.com/apache/spark/pull/51229.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.