### PR TITLE
[CELEBORN-1792][FOLLOWUP] Add missing break in resumeByPinnedMemory

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -597,11 +597,13 @@ public class MemoryManager {
             getNettyPinnedDirectMemory());
         resumeReplicate();
         resumePush();
+        break;
       case PUSH_PAUSED:
         logger.info(
             "Serving State is PUSH_PAUSED, but resume by lower pinned memory {}",
             getNettyPinnedDirectMemory());
         resumePush();
+        break;
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add missing break in resumeByPinnedMemory


### Why are the changes needed?
Avoid execute `resumePush` twice when resume by pinned memory from `PUSH_AND_REPLICATE_PAUSED` state.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA and cluster tests.
