### PR TITLE
[CELEBORN-2119] DfsTierWriter should close s3MultipartUploadHandler and ossMultipartUploadHandler for close resource

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
@@ -668,7 +668,14 @@ class DfsTierWriter(
   override def notifyFileCommitted(): Unit =
     storageManager.notifyFileInfoCommitted(shuffleKey, filename, dfsFileInfo)
 
-  override def closeResource(): Unit = {}
+  override def closeResource(): Unit = {
+    if (s3MultipartUploadHandler != null) {
+      s3MultipartUploadHandler.close()
+    }
+    if (ossMultipartUploadHandler != null) {
+      ossMultipartUploadHandler.close()
+    }
+  }
 
   override def cleanLocalOrDfsFiles(): Unit = {
     dfsFileInfo.deleteAllFiles(hadoopFs)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`DfsTierWriter` should close `s3MultipartUploadHandler` and `ossMultipartUploadHandler` for close resource to avoid resource leak for destroy file writer.

### Why are the changes needed?

`DfsTierWriter` does not close `s3MultipartUploadHandler` and `ossMultipartUploadHandler` in `closeResource`. 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.