### PR TITLE
[CELEBORN-2123] Add log for commit file size

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriter.java
@@ -101,7 +101,11 @@ public class PartitionDataWriter implements DeviceObserver {
   }
 
   public String getFilePath() {
-    return getDiskFileInfo().getFilePath();
+    DiskFileInfo diskFileInfo = getDiskFileInfo();
+    if (diskFileInfo != null) {
+      return diskFileInfo.getFilePath();
+    }
+    return "";
   }
 
   public void incrementPendingWrites() {

--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/Controller.scala
@@ -335,17 +335,13 @@ private[deploy] class Controller(
                 waitMapPartitionRegionFinished(fileWriter, shuffleCommitTimeout)
                 val bytes = fileWriter.close()
                 if (bytes > 0L) {
+                  logDebug(
+                    s"Commit file $shuffleKey $uniqueId ${fileWriter.getFilePath} success fileSize: $bytes")
                   if (fileWriter.getStorageInfo == null) {
                     // Only HDFS can be null, means that this partition location is deleted.
                     logDebug(s"Location $uniqueId is deleted.")
                   } else {
                     val storageInfo = fileWriter.getStorageInfo
-                    val fileInfo =
-                      if (null != fileWriter.getDiskFileInfo) {
-                        fileWriter.getDiskFileInfo
-                      } else {
-                        fileWriter.getMemoryFileInfo
-                      }
                     committedStorageInfos.put(uniqueId, storageInfo)
                     if (fileWriter.getMapIdBitMap != null) {
                       committedMapIdBitMap.put(uniqueId, fileWriter.getMapIdBitMap)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add log for commit file size.

### Why are the changes needed?

Statistics on the file size information of successfully committed files enables offline analysis of file write sizes, assessment of the proportion of small files, and implementation of optimizations based on file size data.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.
