### PR TITLE
[CELEBORN-2128] Close hadoopFs FileSystem when worker is closed

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -800,6 +800,19 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
   }
 
   def close(exitKind: Int): Unit = {
+    if (hadoopFs != null) {
+      hadoopFs.asScala.foreach {
+        case (storageType, fs) =>
+          if (fs != null) {
+            try {
+              fs.close()
+            } catch {
+              case t: Throwable =>
+                logError(s"Close $storageType FileSystem ${fs.getUri} failed.", t)
+            }
+          }
+      }
+    }
     if (db != null) {
       if (exitKind == CelebornExitKind.WORKER_GRACEFUL_SHUTDOWN) {
         try {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Close hadoopFs FileSystem when worker is closed.

### Why are the changes needed?

When the worker is closed, close the hadoopFs FileSystem to avoid resource leakage.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.