### PR TITLE
[CELEBORN-2134] When creating a DiskFile, retrieve the storage type b…

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -1162,12 +1162,13 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
           }
           val filePath = file.getAbsolutePath
           val fileMeta = getFileMeta(partitionType, mountPoint, conf.shuffleChunkSize)
+          val storageType = diskInfos.get(mountPoint).storageType
           val diskFileInfo = new DiskFileInfo(
             userIdentifier,
             partitionSplitEnabled,
             fileMeta,
             filePath,
-            StorageInfo.Type.HDD)
+            storageType)
           logInfo(s"created file at $filePath")
           diskFileInfos.computeIfAbsent(shuffleKey, diskFileInfoMapFunc).put(
             fileName,


### PR DESCRIPTION
…ased on the mount point

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

 When creating a DiskFile, retrieve the storage type based on the mount point

### Why are the changes needed?

If the worker disk is an SSD, it should be set to the SSD type, and the storage type can be retrieved based on the mount point.

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

CI
