### PR TITLE
[CELEBORN-2145] QuotaManager should respect celeborn.quota.interruptShuffle.enabled of client config

### DIFF
--- a/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
+++ b/master/src/main/java/org/apache/celeborn/service/deploy/master/clustermeta/AbstractMetaManager.java
@@ -696,4 +696,12 @@ public abstract class AbstractMetaManager implements IMetadataHandler {
     return new ImmutablePair<>(
         unhealthyCount * 1.0 / diskMap.size() >= unhealthyDiskRatioThreshold, unhealthyCount);
   }
+
+  public boolean isAppInterruptShuffleEnabled(String appId) {
+    return Boolean.parseBoolean(
+        Optional.ofNullable(applicationInfos.get(appId))
+            .map(ApplicationInfo::extraInfo)
+            .map(extraInfo -> extraInfo.get(CelebornConf.QUOTA_INTERRUPT_SHUFFLE_ENABLED().key()))
+            .orElse(CelebornConf.QUOTA_INTERRUPT_SHUFFLE_ENABLED().defaultValueString()));
+  }
 }

--- a/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
+++ b/master/src/main/scala/org/apache/celeborn/service/deploy/master/Master.scala
@@ -1177,7 +1177,6 @@ private[celeborn] class Master(
       extraInfo: JMap[String, String],
       requestId: String): Unit = {
     statusSystem.handleRegisterApplicationInfo(appId, userIdentifier, extraInfo, requestId)
-    quotaManager.registerApplicationQuotaConfig(appId, extraInfo)
     context.reply(OneWayMessageResponse)
   }
 

--- a/master/src/test/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManagerSuite.scala
+++ b/master/src/test/scala/org/apache/celeborn/service/deploy/master/quota/QuotaManagerSuite.scala
@@ -194,8 +194,8 @@ class QuotaManagerSuite extends CelebornFunSuite
           Utils.byteStringAsBytes("5G"),
           20)).asJava)
 
-    quotaManager.registerApplicationQuotaConfig("app1", extraInfo)
-    quotaManager.registerApplicationQuotaConfig("app2", extraInfo)
+    statusSystem.updateApplicationInfo("app1", user, extraInfo)
+    statusSystem.updateApplicationInfo("app2", user, extraInfo)
     addUserConsumption(user, rc)
     conf.set("celeborn.quota.cluster.diskBytesWritten", "60gb")
     configService.refreshCache()
@@ -286,8 +286,8 @@ class QuotaManagerSuite extends CelebornFunSuite
           Utils.byteStringAsBytes("2G"),
           20)).asJava)
 
-    quotaManager.registerApplicationQuotaConfig("app1", extraInfo)
-    quotaManager.registerApplicationQuotaConfig("app2", extraInfo)
+    statusSystem.updateApplicationInfo("app1", user, extraInfo)
+    statusSystem.updateApplicationInfo("app2", user, extraInfo)
     addUserConsumption(user, rc)
     conf.set("celeborn.quota.cluster.diskBytesWritten", "20gb")
     configService.refreshCache()
@@ -338,7 +338,7 @@ class QuotaManagerSuite extends CelebornFunSuite
             MIN + Math.abs(random.nextLong()) % (MAX - MIN),
             MIN + Math.abs(random.nextLong()) % (MAX - MIN),
             MIN + Math.abs(random.nextLong()) % (MAX - MIN))
-          quotaManager.registerApplicationQuotaConfig(appId, extraInfo)
+          statusSystem.updateApplicationInfo(appId, user, extraInfo)
           (appId, consumption)
       }.toMap
       val userConsumption = subResourceConsumption.values.foldRight(
@@ -390,7 +390,7 @@ class QuotaManagerSuite extends CelebornFunSuite
                 MIN + Math.abs(random.nextLong()) % (MAX - MIN),
                 MIN + Math.abs(random.nextLong()) % (MAX - MIN),
                 MIN + Math.abs(random.nextLong()) % (MAX - MIN))
-              quotaManager.registerApplicationQuotaConfig(appId, extraInfo)
+              statusSystem.updateApplicationInfo(appId, user, extraInfo)
               (appId, consumption)
           }.toMap
         } else {
@@ -398,7 +398,7 @@ class QuotaManagerSuite extends CelebornFunSuite
             index =>
               val appId = s"$user$i case2_app$index"
               val consumption = ResourceConsumption(0, 0, 0, 0)
-              quotaManager.registerApplicationQuotaConfig(appId, extraInfo)
+              statusSystem.updateApplicationInfo(appId, user, extraInfo)
               (appId, consumption)
           }.toMap
         }
@@ -495,9 +495,9 @@ class QuotaManagerSuite extends CelebornFunSuite
           0,
           0)).asJava)
 
-    quotaManager1.registerApplicationQuotaConfig("app1", extraInfo)
-    quotaManager1.registerApplicationQuotaConfig("app2", extraInfo)
-    quotaManager1.registerApplicationQuotaConfig("app3", extraInfo)
+    statusSystem1.updateApplicationInfo("app1", user, extraInfo)
+    statusSystem1.updateApplicationInfo("app2", user, extraInfo)
+    statusSystem1.updateApplicationInfo("app3", user, extraInfo)
     addUserConsumption(user, rc)
     addUserConsumption(user1, rc1)
 
@@ -613,9 +613,9 @@ class QuotaManagerSuite extends CelebornFunSuite
           0,
           0)).asJava)
 
-    quotaManager1.registerApplicationQuotaConfig("app1", extraInfo)
-    quotaManager1.registerApplicationQuotaConfig("app2", extraInfo)
-    quotaManager1.registerApplicationQuotaConfig("app3", extraInfo)
+    statusSystem1.updateApplicationInfo("app1", user1, extraInfo)
+    statusSystem1.updateApplicationInfo("app2", user1, extraInfo)
+    statusSystem1.updateApplicationInfo("app3", user2, extraInfo)
     addUserConsumption(user1, rc1)
     addUserConsumption(user2, rc2)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`QuotaManager` should respect `celeborn.quota.interruptShuffle.enabled` of client config to expire applications that enables interrupt shuffle.

### Why are the changes needed?

`QuotaManager` does not filter applications which enable interrupt shuffle at present, which causes that `QuotaManager` expires applications that unenable interrupt shuffle like high priority applications. Therefore, `QuotaManager` should respect `celeborn.quota.interruptShuffle.enabled` of client config.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`QuotaManagerSuite`