### PR TITLE
[CELEBORN-2148] RemoteShuffleMaster computes number of bytes for input with memory reserved for input channels

### DIFF
--- a/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
+++ b/client-flink/common/src/main/java/org/apache/celeborn/plugin/flink/RemoteShuffleMaster.java
@@ -264,9 +264,12 @@ public class RemoteShuffleMaster implements ShuffleMaster<ShuffleDescriptor> {
     long numBytesPerPartition = conf.clientFlinkMemoryPerResultPartition();
     long numBytesForOutput = numBytesPerPartition * numResultPartitions;
 
-    int numInputGates = taskInputsOutputsDescriptor.getInputChannelNums().size();
-    long numBytesPerGate = conf.clientFlinkMemoryPerInputGate();
-    long numBytesForInput = numBytesPerGate * numInputGates;
+    int numInputChannels =
+        taskInputsOutputsDescriptor.getInputChannelNums().values().stream()
+            .mapToInt(Integer::intValue)
+            .sum();
+    long numBytesPerChannel = conf.clientFlinkMemoryPerInputChannel();
+    long numBytesForInput = numBytesPerChannel * numInputChannels;
 
     LOG.debug(
         "Announcing number of bytes {} for output and {} for input.",

--- a/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.16/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -257,8 +257,10 @@ public class RemoteShuffleMasterSuiteJ {
 
     CelebornConf celebornConf = FlinkUtils.toCelebornConf(configuration);
 
-    long numBytesPerGate = celebornConf.clientFlinkMemoryPerInputGate();
-    long expectedInput = 2 * numBytesPerGate;
+    long numBytesPerChannel = celebornConf.clientFlinkMemoryPerInputChannel();
+    long expectedInput =
+        numberOfInputGateChannels.values().stream().mapToInt(Integer::intValue).sum()
+            * numBytesPerChannel;
 
     long numBytesPerResultPartition = celebornConf.clientFlinkMemoryPerResultPartition();
     long expectedOutput = 3 * numBytesPerResultPartition;

--- a/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.17/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -269,8 +269,10 @@ public class RemoteShuffleMasterSuiteJ {
 
     CelebornConf celebornConf = FlinkUtils.toCelebornConf(configuration);
 
-    long numBytesPerGate = celebornConf.clientFlinkMemoryPerInputGate();
-    long expectedInput = 2 * numBytesPerGate;
+    long numBytesPerChannel = celebornConf.clientFlinkMemoryPerInputChannel();
+    long expectedInput =
+        numberOfInputGateChannels.values().stream().mapToInt(Integer::intValue).sum()
+            * numBytesPerChannel;
 
     long numBytesPerResultPartition = celebornConf.clientFlinkMemoryPerResultPartition();
     long expectedOutput = 3 * numBytesPerResultPartition;

--- a/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.18/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -269,8 +269,10 @@ public class RemoteShuffleMasterSuiteJ {
 
     CelebornConf celebornConf = FlinkUtils.toCelebornConf(configuration);
 
-    long numBytesPerGate = celebornConf.clientFlinkMemoryPerInputGate();
-    long expectedInput = 2 * numBytesPerGate;
+    long numBytesPerChannel = celebornConf.clientFlinkMemoryPerInputChannel();
+    long expectedInput =
+        numberOfInputGateChannels.values().stream().mapToInt(Integer::intValue).sum()
+            * numBytesPerChannel;
 
     long numBytesPerResultPartition = celebornConf.clientFlinkMemoryPerResultPartition();
     long expectedOutput = 3 * numBytesPerResultPartition;

--- a/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.19/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -269,8 +269,10 @@ public class RemoteShuffleMasterSuiteJ {
 
     CelebornConf celebornConf = FlinkUtils.toCelebornConf(configuration);
 
-    long numBytesPerGate = celebornConf.clientFlinkMemoryPerInputGate();
-    long expectedInput = 2 * numBytesPerGate;
+    long numBytesPerChannel = celebornConf.clientFlinkMemoryPerInputChannel();
+    long expectedInput =
+        numberOfInputGateChannels.values().stream().mapToInt(Integer::intValue).sum()
+            * numBytesPerChannel;
 
     long numBytesPerResultPartition = celebornConf.clientFlinkMemoryPerResultPartition();
     long expectedOutput = 3 * numBytesPerResultPartition;

--- a/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-1.20/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -272,8 +272,10 @@ public class RemoteShuffleMasterSuiteJ {
 
     CelebornConf celebornConf = FlinkUtils.toCelebornConf(configuration);
 
-    long numBytesPerGate = celebornConf.clientFlinkMemoryPerInputGate();
-    long expectedInput = 2 * numBytesPerGate;
+    long numBytesPerChannel = celebornConf.clientFlinkMemoryPerInputChannel();
+    long expectedInput =
+        numberOfInputGateChannels.values().stream().mapToInt(Integer::intValue).sum()
+            * numBytesPerChannel;
 
     long numBytesPerResultPartition = celebornConf.clientFlinkMemoryPerResultPartition();
     long expectedOutput = 3 * numBytesPerResultPartition;

--- a/client-flink/flink-2.0/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-2.0/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -272,8 +272,10 @@ public class RemoteShuffleMasterSuiteJ {
 
     CelebornConf celebornConf = FlinkUtils.toCelebornConf(configuration);
 
-    long numBytesPerGate = celebornConf.clientFlinkMemoryPerInputGate();
-    long expectedInput = 2 * numBytesPerGate;
+    long numBytesPerChannel = celebornConf.clientFlinkMemoryPerInputChannel();
+    long expectedInput =
+        numberOfInputGateChannels.values().stream().mapToInt(Integer::intValue).sum()
+            * numBytesPerChannel;
 
     long numBytesPerResultPartition = celebornConf.clientFlinkMemoryPerResultPartition();
     long expectedOutput = 3 * numBytesPerResultPartition;

--- a/client-flink/flink-2.1/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
+++ b/client-flink/flink-2.1/src/test/java/org/apache/celeborn/plugin/flink/RemoteShuffleMasterSuiteJ.java
@@ -272,8 +272,10 @@ public class RemoteShuffleMasterSuiteJ {
 
     CelebornConf celebornConf = FlinkUtils.toCelebornConf(configuration);
 
-    long numBytesPerGate = celebornConf.clientFlinkMemoryPerInputGate();
-    long expectedInput = 2 * numBytesPerGate;
+    long numBytesPerChannel = celebornConf.clientFlinkMemoryPerInputChannel();
+    long expectedInput =
+        numberOfInputGateChannels.values().stream().mapToInt(Integer::intValue).sum()
+            * numBytesPerChannel;
 
     long numBytesPerResultPartition = celebornConf.clientFlinkMemoryPerResultPartition();
     long expectedOutput = 3 * numBytesPerResultPartition;

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1469,6 +1469,7 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def testAlternative: String = get(TEST_ALTERNATIVE.key, "celeborn")
   def clientFlinkMemoryPerResultPartition: Long = get(CLIENT_MEMORY_PER_RESULT_PARTITION)
   def clientFlinkMemoryPerInputGate: Long = get(CLIENT_MEMORY_PER_INPUT_GATE)
+  def clientFlinkMemoryPerInputChannel: Long = get(CLIENT_MEMORY_PER_INPUT_CHANNEL)
   def clientFlinkNumConcurrentReading: Int = get(CLIENT_NUM_CONCURRENT_READINGS)
   def clientFlinkInputGateSupportFloatingBuffer: Boolean =
     get(CLIENT_INPUT_GATE_SUPPORT_FLOATING_BUFFER)
@@ -6023,6 +6024,14 @@ object CelebornConf extends Logging {
       .doc("Memory reserved for a input gate.")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("32m")
+
+  val CLIENT_MEMORY_PER_INPUT_CHANNEL: ConfigEntry[Long] =
+    buildConf("celeborn.client.flink.inputChannel.memory")
+      .categories("client")
+      .version("0.7.0")
+      .doc("Memory reserved for a input channel.")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("5m")
 
   val CLIENT_INPUT_GATE_SUPPORT_FLOATING_BUFFER: ConfigEntry[Boolean] =
     buildConf("celeborn.client.flink.inputGate.supportFloatingBuffer")

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -40,6 +40,7 @@ license: |
 | celeborn.client.fetch.pollChunk.wait | 500ms | false | The waiting time for shuffle client to read the empty chunk on the work side.when there are many empty chunk in the shuffle partition of a small task,the current value can be set small to avoid long waiting times and the illusion of thetask getting stuck | 0.6.1 |  | 
 | celeborn.client.fetch.timeout | 600s | false | Timeout for a task to open stream and fetch chunk. | 0.3.0 | celeborn.fetch.timeout | 
 | celeborn.client.flink.compression.enabled | true | false | Whether to compress data in Flink plugin. | 0.3.0 | remote-shuffle.job.enable-data-compression | 
+| celeborn.client.flink.inputChannel.memory | 5m | false | Memory reserved for a input channel. | 0.7.0 |  | 
 | celeborn.client.flink.inputGate.concurrentReadings | 2147483647 | false | Max concurrent reading channels for a input gate. | 0.3.0 | remote-shuffle.job.concurrent-readings-per-gate | 
 | celeborn.client.flink.inputGate.memory | 32m | false | Memory reserved for a input gate. | 0.3.0 | remote-shuffle.job.memory-per-gate | 
 | celeborn.client.flink.inputGate.supportFloatingBuffer | true | false | Whether to support floating buffer in Flink input gates. | 0.3.0 | remote-shuffle.job.support-floating-buffer-per-input-gate | 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`RemoteShuffleMaster` computes number of bytes for input with memory reserved for input channels in `computeShuffleMemorySizeForTask`.

### Why are the changes needed?

`RemoteShuffleMaster` computes number of bytes for input with memory reserved for input gates at present. `RemoteShuffleMaster` could compute input bytes with memory reserved for input channels in finer granularity, for which emory reserved is 5m that is the default threshold for spilling.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`RemoteShuffleMasterSuiteJ#testShuffleMemoryAnnouncing`