### PR TITLE
[CELEBORN-2153] Fix NPE problem that occurs during concurrent merge

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1333,14 +1333,16 @@ public class ShuffleClientImpl extends ShuffleClient {
       if (shouldPush) {
         limitMaxInFlight(mapKey, pushState, loc.hostAndPushPort());
         DataBatches dataBatches = pushState.takeDataBatches(addressPair);
-        doPushMergedData(
-            addressPair,
-            shuffleId,
-            mapId,
-            attemptId,
-            dataBatches.requireBatches(),
-            pushState,
-            maxReviveTimes);
+        if (dataBatches != null) {
+          doPushMergedData(
+              addressPair,
+              shuffleId,
+              mapId,
+              attemptId,
+              dataBatches.requireBatches(),
+              pushState,
+              maxReviveTimes);
+        }
       }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid NPE problems by adding non-null checks



### Why are the changes needed?
When multiple threads call pushOrMergeData, the first thread may remove the merged DataBatches from pushState and send it out. The subsequent thread will get null through the takeDataBatches method, which may cause NPE problems.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
Manual testing
