### PR TITLE
[CELEBORN-2155] Avoid using duplicate diskFileInfoMap functions

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -386,12 +386,6 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
 
   private def getNextIndex = counter.getAndUpdate(counterOperator)
 
-  private val newMapFunc =
-    new java.util.function.Function[String, ConcurrentHashMap[String, DiskFileInfo]]() {
-      override def apply(key: String): ConcurrentHashMap[String, DiskFileInfo] =
-        JavaUtils.newConcurrentHashMap()
-    }
-
   private val diskFileInfoMapFunc =
     new java.util.function.Function[String, ConcurrentHashMap[String, DiskFileInfo]]() {
       override def apply(key: String): ConcurrentHashMap[String, DiskFileInfo] =
@@ -994,7 +988,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
       shuffleKey: String,
       fileName: String,
       fileInfo: DiskFileInfo): Unit = {
-    committedFileInfos.computeIfAbsent(shuffleKey, newMapFunc).put(fileName, fileInfo)
+    committedFileInfos.computeIfAbsent(shuffleKey, diskFileInfoMapFunc).put(fileName, fileInfo)
   }
 
   def getActiveShuffleSize: Long = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid using duplicate `diskFileInfoMap` functions.

### Why are the changes needed?

Avoid using duplicate `diskFileInfoMap` functions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.