### PR TITLE
[CELEBORN-2158] Optimize asynchronous reading of HDFS chunk offset da…

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1100,6 +1100,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
     get(CLIENT_PUSH_SENDBUFFERPOOL_CHECKEXPIREINTERVAL)
   def clientAdaptiveOptimizeSkewedPartitionReadEnabled: Boolean =
     get(CLIENT_ADAPTIVE_OPTIMIZE_SKEWED_PARTITION_READ_ENABLED)
+  def clientDfsFetchExecutorThreads: Int =
+    get(CLIENT_DFS_FETCH_EXECUTOR_THREADS)
 
   // //////////////////////////////////////////////////////
   //                   Client Shuffle                    //
@@ -6389,6 +6391,14 @@ object CelebornConf extends Logging {
         "range. Please note that this feature requires the `Celeborn-Optimize-Skew-Partitions-spark3_3.patch`. ")
       .booleanConf
       .createWithDefault(false)
+
+  val CLIENT_DFS_FETCH_EXECUTOR_THREADS: ConfigEntry[Int] =
+    buildConf("celeborn.client.dfs.fetch.executorThreads")
+      .categories("client")
+      .version("0.7.0")
+      .doc("Number of threads in the fetch executor thread pool for DFS partition reader.")
+      .intConf
+      .createWithDefault(3)
 
   //  SSL Configs
 

--- a/docs/configuration/client.md
+++ b/docs/configuration/client.md
@@ -28,6 +28,7 @@ license: |
 | celeborn.client.chunk.prefetch.enabled | false | false | Whether to enable chunk prefetch when creating CelebornInputStream. | 0.5.1 |  | 
 | celeborn.client.closeIdleConnections | true | false | Whether client will close idle connections. | 0.3.0 |  | 
 | celeborn.client.commitFiles.ignoreExcludedWorker | false | false | When true, LifecycleManager will skip workers which are in the excluded list. | 0.3.0 |  | 
+| celeborn.client.dfs.fetch.executorThreads | 3 | false | Number of threads in the fetch executor thread pool for DFS partition reader. | 0.7.0 |  | 
 | celeborn.client.eagerlyCreateInputStream.threads | 32 | false | Threads count for streamCreatorPool in CelebornShuffleReader. | 0.3.1 |  | 
 | celeborn.client.excludePeerWorkerOnFailure.enabled | true | false | When true, Celeborn will exclude partition's peer worker on failure when push data to replica failed. | 0.3.0 |  | 
 | celeborn.client.excludedWorker.expireTimeout | 180s | false | Timeout time for LifecycleManager to clear reserved excluded worker. Default to be 1.5 * `celeborn.master.heartbeat.worker.timeout` to cover worker heartbeat timeout check period | 0.3.0 | celeborn.worker.excluded.expireTimeout | 


### PR DESCRIPTION
…ta blocks

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Optimize asynchronous reading of HDFS chunk offset data blocks

### Why are the changes needed?

In FetchThread, the single-threaded sequential reading of HDFS chunkOffset affects the overall HDFS reading performance.

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

CI
