### PR TITLE
[CELEBORN-2032] Create reader should change to peer by taskAttemptId

### DIFF
--- a/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -97,6 +97,7 @@ class CelebornShuffleReader[K, C](
   private val stageRerunEnabled = handle.stageRerunEnabled
   private val encodedAttemptId = SparkCommonUtils.getEncodedAttemptNumber(context)
   private val pushReplicateEnabled = conf.clientPushReplicateEnabled
+  private val preferReplicaRead = context.attemptNumber % 2 == 1
 
   override def read(): Iterator[Product2[K, C]] = {
 
@@ -248,7 +249,7 @@ class CelebornShuffleReader[K, C](
         val hasReplicate = pushReplicateEnabled &&
           originLocations.asScala.exists(p => p != null && p.hasPeer)
         var locations =
-          if (context.attemptNumber % 2 == 1 && hasReplicate) {
+          if (preferReplicaRead && hasReplicate) {
             originLocations.asScala.map { p =>
               if (p != null && p.hasPeer) p.getPeer else p
             }.asJava


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the dual-replica scenario, when creating a reader, we should select the replica based on taskAttemptId. Usually, taskAttempt0 selects primary partitionLocation, task Attempt1 selects replica partitionLocation, and so on. This will provide better fault tolerance.


### Why are the changes needed?
Since https://github.com/apache/celeborn/pull/3079, we deleted the code logic which should use replica data when task attempt is odd, but if the data of primary partitionLocation is corrupted and CelebornInputStream#fillBuffer throws exception, such as decompression failure or some other exceptions, the replica prititionLocation will not be used when the task is retried. In fact, if taskAttempt1 uses the replica partitionLocation, taskAttempt1 can run successfully.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UTs.
