### PR TITLE
[CELEBORN-2163] PushDataHandler should increment WriteDataFailCount for file writer exception of MapPartition PushData

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/PushDataHandler.scala
@@ -1243,15 +1243,17 @@ class PushDataHandler(val workerSource: WorkerSource) extends BaseMessageHandler
 
     // During worker shutdown, worker will return HARD_SPLIT for all existed partition.
     // This should before return exception to make current push request revive and retry.
+    val isPartitionSplitEnabled = fileWriter.getCurrentFileInfo.isPartitionSplitEnabled
+
     if (shutdown.get() && (messageType == Type.REGION_START || messageType ==
-        Type.PUSH_DATA_HAND_SHAKE)) {
+        Type.PUSH_DATA_HAND_SHAKE) && isPartitionSplitEnabled) {
       logInfo(s"$messageType return HARD_SPLIT for shuffle $shuffleKey since worker shutdown.")
       callback.onSuccess(ByteBuffer.wrap(Array[Byte](StatusCode.HARD_SPLIT.getValue)))
       return
     }
 
     if (checkSplit && (messageType == Type.REGION_START || messageType ==
-        Type.PUSH_DATA_HAND_SHAKE) && checkDiskFullAndSplit(
+        Type.PUSH_DATA_HAND_SHAKE) && isPartitionSplitEnabled && checkDiskFullAndSplit(
         fileWriter,
         isPrimary) == StatusCode.HARD_SPLIT) {
       workerSource.incCounter(WorkerSource.WRITE_DATA_HARD_SPLIT_COUNT)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`PushDataHandler` should increment `WriteDataFailCount` for file writer exception of MapPartition PushData.

### Why are the changes needed?

`PushDataHandler` does not increment `WriteDataFailCount` for file writer exception of MapPartition PushData, which causes that `WriteDataFailCount` metric is always zero.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.