### PR TITLE
[CELEBORN-2142][FOLLOWUP][0.6] Fix failure of compilation

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
@@ -164,4 +164,8 @@ public class DiskFileInfo extends FileInfo {
   public boolean isDFS() {
     return Utils.isS3Path(filePath) || Utils.isOssPath(filePath) || Utils.isHdfsPath(filePath);
   }
+
+  public StorageInfo.Type getStorageType() {
+    return storageType;
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?

https://github.com/apache/celeborn/actions/runs/18090291003/job/51469133996

> Error:  /home/runner/work/celeborn/celeborn/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala:148: value getStorageType is not a member of org.apache.celeborn.common.meta.DiskFileInfo
Error:  /home/runner/work/celeborn/celeborn/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala:160: value getStorageType is not a member of org.apache.celeborn.common.meta.DiskFileInfo

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

