### PR TITLE
[CELEBORN-2168] Bump Flink from 1.20.2 to 1.20.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1802,7 +1802,7 @@
         <module>tests/flink-it</module>
       </modules>
       <properties>
-        <flink.version>1.20.2</flink.version>
+        <flink.version>1.20.3</flink.version>
         <flink.binary.version>1.20</flink.binary.version>
         <scala.binary.version>2.12</scala.binary.version>
         <celeborn.flink.plugin.artifact>celeborn-client-flink-1.20_${scala.binary.version}</celeborn.flink.plugin.artifact>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -1192,7 +1192,7 @@ object Flink119 extends FlinkClientProjects {
 }
 
 object Flink120 extends FlinkClientProjects {
-  val flinkVersion = "1.20.2"
+  val flinkVersion = "1.20.3"
 
   // note that SBT does not allow using the period symbol (.) in project names.
   val flinkClientProjectPath = "client-flink/flink-1.20"
@@ -1242,7 +1242,7 @@ trait FlinkClientProjects {
     .aggregate(flinkCommon, flinkClient, flinkIt)
 
   // get flink major version. e.g:
-  //   1.20.2 -> 1.20
+  //   1.20.3 -> 1.20
   //   1.19.3 -> 1.19
   //   1.18.1 -> 1.18
   //   1.17.2 -> 1.17


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Flink from 1.20.2 to 1.20.3.

### Why are the changes needed?

Flink 1.20.3 has been announced to release: [Release Flink 1.20.3](https://github.com/apache/flink/releases/tag/release-1.20.3). The profile flink-1.20 could bump Flink from 1.20.2 to 1.20.3.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.