### PR TITLE
[CELEBORN-2170] Refactor ByteBuffer's readToReadOnlyuffer interface

### DIFF
--- a/cpp/celeborn/memory/ByteBuffer.cpp
+++ b/cpp/celeborn/memory/ByteBuffer.cpp
@@ -77,23 +77,9 @@ std::unique_ptr<folly::IOBuf> ByteBuffer::trimBuffer(
 
 std::unique_ptr<ReadOnlyByteBuffer> ReadOnlyByteBuffer::readToReadOnlyBuffer(
     const size_t len) const {
-  std::unique_ptr<folly::IOBuf> leftData = folly::IOBuf::create(0);
-  auto cnt = 0;
-  while (cnt < len) {
-    if (this->remainingSize() == 0) {
-      break;
-    }
-    std::unique_ptr<folly::IOBuf> newBlock =
-        std::move(this->cursor_->currentBuffer()->cloneOne());
-    newBlock->pop();
-    newBlock->trimStart(this->cursor_->getPositionInCurrentBuffer());
-    if (newBlock->length() > len - cnt) {
-      newBlock->trimEnd(newBlock->length() - (len - cnt));
-    }
-    this->cursor_->skip(newBlock->length());
-    cnt += newBlock->length();
-    leftData->appendToChain(std::move(newBlock));
-  }
+  std::unique_ptr<folly::IOBuf> leftData = nullptr;
+  this->cursor_->clone(leftData, len);
+
   return createReadOnly(std::move(leftData), isBigEndian_);
 }
 } // namespace memory

--- a/cpp/celeborn/memory/tests/ByteBufferTest.cpp
+++ b/cpp/celeborn/memory/tests/ByteBufferTest.cpp
@@ -219,7 +219,14 @@ TEST(ByteBufferTest, continuousBufferRead) {
   auto ioBuf = folly::IOBuf::wrapBuffer(data.get(), size);
 
   auto readBuffer = ByteBuffer::createReadOnly(std::move(ioBuf));
+  auto readBuffer2 = readBuffer->clone();
+
   testReadData(readBuffer.get(), size);
+
+  // Test readToReadOnlyBuffer.
+  auto toReadBuffer = readBuffer2->readToReadOnlyBuffer(size);
+  EXPECT_EQ(readBuffer2->remainingSize(), 0);
+  testReadData(toReadBuffer.get(), size);
 }
 
 TEST(ByteBufferTest, segmentedBufferRead) {
@@ -248,7 +255,14 @@ TEST(ByteBufferTest, segmentedBufferRead) {
   }
 
   auto readBuffer = ByteBuffer::createReadOnly(std::move(ioBuf));
+  auto readBuffer2 = readBuffer->clone();
+
   testReadData(readBuffer.get(), size);
+
+  // Test readToReadOnlyBuffer.
+  auto toReadBuffer = readBuffer2->readToReadOnlyBuffer(size);
+  EXPECT_EQ(readBuffer2->remainingSize(), 0);
+  testReadData(toReadBuffer.get(), size);
 }
 
 TEST(ByteBufferTest, writeBufferAndRead) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR refactors ByteBuffer's readToReadOnlyBuffer interface to make it more clear and robust. UTs are updated to test this interface.

### Why are the changes needed?
To make ByteBuffer's readToReadOnlyBuffer interface more clear and robust.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Compilation and UTs.
