### PR TITLE
[CELEBORN-2172] S3 and OSS storage select appropriate fileMeta type b…

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StorageManager.scala
@@ -1138,7 +1138,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         val s3FileInfo = new DiskFileInfo(
           userIdentifier,
           partitionSplitEnabled,
-          new ReduceFileMeta(conf.shuffleChunkSize),
+          getFileMeta(partitionType, s"s3", conf.shuffleChunkSize),
           s3FilePath,
           StorageInfo.Type.S3)
         diskFileInfos.computeIfAbsent(shuffleKey, diskFileInfoMapFunc).put(
@@ -1156,7 +1156,7 @@ final private[worker] class StorageManager(conf: CelebornConf, workerSource: Abs
         val ossFileInfo = new DiskFileInfo(
           userIdentifier,
           partitionSplitEnabled,
-          new ReduceFileMeta(conf.shuffleChunkSize),
+          getFileMeta(partitionType, s"oss", conf.shuffleChunkSize),
           ossFilePath,
           StorageInfo.Type.OSS)
         diskFileInfos.computeIfAbsent(shuffleKey, diskFileInfoMapFunc).put(


### PR DESCRIPTION
…ased on actual partition type

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

`S3` and `OSS` storage select appropriate fileMeta type based on actual partition type

### Why are the changes needed?

In the `createDiskFile` method, when handling the `S3` and `OSS` storage types, `ReduceFileMeta` is hard-coded for use regardless of whether the partition type is `MAP` or `REDUCE`. The appropriate FileMeta type is not selected based on the actual partition type, which is inconsistent with the logic for handling `local disk` and `HDFS` storage types.

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

CI
