### PR TITLE
[CELEBORN-2141] MapPartitionMetaHandler should avoid multiple accesses to HDFS for writting index file

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/StoragePolicy.scala
@@ -84,11 +84,12 @@ class StoragePolicy(conf: CelebornConf, storageManager: StorageManager, source: 
           new ReducePartitionMetaHandler(partitionDataWriterContext.isRangeReadFilter, fileInfo)
         case PartitionType.MAP =>
           if (partitionDataWriterContext.isSegmentGranularityVisible) {
-            new SegmentMapPartitionMetaHandler(fileInfo.asInstanceOf[DiskFileInfo], notifier)
+            new SegmentMapPartitionMetaHandler(fileInfo.asInstanceOf[DiskFileInfo], notifier, conf)
           } else {
             new MapPartitionMetaHandler(
               fileInfo.asInstanceOf[DiskFileInfo],
-              notifier)
+              notifier,
+              conf)
           }
       }
     }

--- a/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterSuiteUtils.java
+++ b/worker/src/test/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataWriterSuiteUtils.java
@@ -65,7 +65,7 @@ public class PartitionDataWriterSuiteUtils {
     PartitionMetaHandler metaHandler = null;
     if (!reduceMeta) {
       fileInfo.replaceFileMeta(new MapFileMeta(32 * 1024, 10));
-      metaHandler = new MapPartitionMetaHandler(fileInfo, flushNotifier);
+      metaHandler = new MapPartitionMetaHandler(fileInfo, flushNotifier, new CelebornConf());
     } else {
       metaHandler = new ReducePartitionMetaHandler(conf.shuffleRangeReadFilterEnabled(), fileInfo);
     }

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/PartitionMetaHandlerSuite.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/PartitionMetaHandlerSuite.scala
@@ -24,6 +24,7 @@ import java.nio.file.Files
 import io.netty.buffer.{ByteBuf, UnpooledByteBufAllocator}
 
 import org.apache.celeborn.CelebornFunSuite
+import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.identity.UserIdentifier
 import org.apache.celeborn.common.meta.{DiskFileInfo, MapFileMeta, ReduceFileMeta}
 import org.apache.celeborn.common.protocol._
@@ -45,7 +46,7 @@ class PartitionMetaHandlerSuite extends CelebornFunSuite with MockitoHelper {
       tmpFilePath.toString,
       StorageInfo.Type.HDD)
 
-    val mapMetaHandler = new MapPartitionMetaHandler(diskFileInfo, notifier)
+    val mapMetaHandler = new MapPartitionMetaHandler(diskFileInfo, notifier, new CelebornConf())
     val pbPushDataHandShake =
       PbPushDataHandShake.newBuilder().setNumPartitions(10).setBufferSize(1024).build()
     mapMetaHandler.handleEvent(pbPushDataHandShake)
@@ -80,7 +81,7 @@ class PartitionMetaHandlerSuite extends CelebornFunSuite with MockitoHelper {
     assert(0 === start)
     assert(1024 === len)
 
-    assert(mapMetaHandler.indexChannel !== null)
+    assert(mapMetaHandler.indexFile.isLeft)
     mapMetaHandler.afterClose()
 
     val file = new File(diskFileInfo.getIndexPath)
@@ -155,7 +156,8 @@ class PartitionMetaHandlerSuite extends CelebornFunSuite with MockitoHelper {
       tmpFilePath.toString,
       StorageInfo.Type.HDD)
 
-    val mapMetaHandler = new SegmentMapPartitionMetaHandler(diskFileInfo, notifier)
+    val mapMetaHandler =
+      new SegmentMapPartitionMetaHandler(diskFileInfo, notifier, new CelebornConf())
     val pbPushDataHandShake =
       PbPushDataHandShake.newBuilder().setNumPartitions(10).setBufferSize(1024).build()
     mapMetaHandler.handleEvent(pbPushDataHandShake)
@@ -200,7 +202,7 @@ class PartitionMetaHandlerSuite extends CelebornFunSuite with MockitoHelper {
     assert(0 === start)
     assert(10240 === len)
 
-    assert(mapMetaHandler.indexChannel !== null)
+    assert(mapMetaHandler.indexFile.isLeft)
     mapMetaHandler.afterClose()
 
     val file = new File(diskFileInfo.getIndexPath)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MapPartitionMetaHandler` should avoid multiple accesses to HDFS for writting index file.

Follow up #3462.

### Why are the changes needed?

`MapPartitionMetaHandler` writes index file with multiple accesses to HDFS at present, which should avoid multiple accesses.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `PartitionMetaHandlerSuite`
- `WordCountTestWithHDFS`