### PR TITLE
[CELEBORN-2176] Fix uncaught exception in DataPusher

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
+++ b/client/src/main/java/org/apache/celeborn/client/write/DataPusher.java
@@ -139,6 +139,9 @@ public class DataPusher {
                   } catch (InterruptedException e) {
                     logger.error("DataPusher push thread interrupted while pushing data.");
                     break;
+                  } catch (Throwable e) {
+                    logger.error("Unexpected exception occurs.", e);
+                    exceptionRef.set(new IOException(e));
                   }
                 }
               }

--- a/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/commit/ReducePartitionCommitHandler.scala
@@ -345,6 +345,11 @@ class ReducePartitionCommitHandler(
         }
       }
     }
+    if (!mapperAttemptFinishedSuccess) {
+      val another = shuffleMapperAttempts.get(shuffleId)(mapId)
+      logInfo(
+        s"Skip mapper $mapId (attempt $attemptId) for shuffle $shuffleId, another attempt $another already completed")
+    }
     (mapperAttemptFinishedSuccess, allMapperFinished)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
If DataPusher throws exception not like  CelebornIOException or IOException, do not just log it in ThreadExceptionHandler but set exception ref to avoid data lost.

### Why are the changes needed?
As described in jira, such problem will make pushthread stopped and lead to data lost.
The problem job which occurs this issue
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/6eedbf35-4ef7-4785-ae2b-7714ed86b93b" />

and the normal job which no exeception throws during pushthread working
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/c818da8b-ab58-4bf2-85c0-a7e4da958398" />



### Does this PR introduce _any_ user-facing change?
No 


### How was this patch tested?
by UT
