### PR TITLE
[CELEBORN-2179] Add patch of columnar shuffle for Spark 3.5.6

### DIFF
--- a/assets/spark-patch/Celeborn_Columnar_Shuffle_spark3_5.patch
+++ b/assets/spark-patch/Celeborn_Columnar_Shuffle_spark3_5.patch
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+diff --git a/core/src/main/scala/org/apache/spark/Dependency.scala b/core/src/main/scala/org/apache/spark/Dependency.scala
+index fbb92b4b4e2..a4580d94456 100644
+--- a/core/src/main/scala/org/apache/spark/Dependency.scala
++++ b/core/src/main/scala/org/apache/spark/Dependency.scala
+@@ -82,6 +82,7 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
+     val keyOrdering: Option[Ordering[K]] = None,
+     val aggregator: Option[Aggregator[K, V, C]] = None,
+     val mapSideCombine: Boolean = false,
++    var schema: AnyRef = null,
+     val shuffleWriterProcessor: ShuffleWriteProcessor = new ShuffleWriteProcessor)
+   extends Dependency[Product2[K, V]] with Logging {
+
+diff --git a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+index 91f2099ce2d..2f71f8b8c57 100644
+--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
++++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+@@ -402,6 +402,7 @@ object ShuffleExchangeExec {
+         rddWithPartitionIds,
+         new PartitionIdPassthrough(part.numPartitions),
+         serializer,
++        schema = DataTypeUtils.fromAttributes(outputAttributes),
+         shuffleWriterProcessor = createShuffleWriteProcessor(writeMetrics))
+
+     dependency


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add patch of columnar shuffle for Spark 3.5.6 with `Celeborn_Columnar_Shuffle_spark3_5.patch`.

### Why are the changes needed?

Support columnar shuffle for Spark 3.5.6.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Success build in my repo http://github.com/aagumin/spark-connect-kubernetes/blob/main/docker/Dockerfile#L29