### PR TITLE
[CELEBORN-2180] Fix Invalid RequestId during RegisterApplicationInfo

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -1503,7 +1503,8 @@ object ControlMessages extends Logging {
         RegisterApplicationInfo(
           pbRegisterApplicationInfo.getAppId,
           PbSerDeUtils.fromPbUserIdentifier(pbRegisterApplicationInfo.getUserIdentifier),
-          pbRegisterApplicationInfo.getExtraInfoMap)
+          pbRegisterApplicationInfo.getExtraInfoMap,
+          pbRegisterApplicationInfo.getRequestId)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
 This PR addresses a critical bug in the deserialization logic for the RegisterApplicationInfo message.
 The change involves modifying the fromPb method in ControlMessages.scala to correctly extract the requestId from the incoming Protobuf message. Previously,  this field was ignored, leading to an invalid nil UUID on the server side.
### Why are the changes needed?
 In an HA (High Availability) deployment, all state-modifying requests must have  a valid RequestId to be processed by the Raft consensus protocol for idempotency.
 Because the RequestId was not being deserialized, the HARaftServer would reject  the RegisterApplicationInfo request with an Invalid RequestId error. This prevented clients from successfully registering their applications, rendering the cluster unusable for them. This fix ensures the RequestId is preserved, allowing applications to register correctly in HA mode.
### Does this PR introduce any user-facing change?
 No. This is a server-side bug fix that corrects behavior to be in line with expectations.
### How was this patch tested?
 The fix was validated by manually reproducing the issue and confirming that with the patch applied, the RequestId ... invalid error is resolved and applications can register successfully in an HA cluster.