### PR TITLE
[CELEBORN-2183] Fix client tries to start a connection with excluded workers

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
+++ b/client/src/main/java/org/apache/celeborn/client/read/CelebornInputStream.java
@@ -467,9 +467,9 @@ public abstract class CelebornInputStream extends InputStream {
           lastException = e;
           shuffleClient.excludeFailedFetchLocation(location.hostAndFetchPort(), e);
           fetchChunkRetryCnt++;
-            if (location.hasPeer()
-                    && !isExcluded(location.getPeer())
-                    && !readSkewPartitionWithoutMapRange) {
+          if (location.hasPeer()
+              && !isExcluded(location.getPeer())
+              && !readSkewPartitionWithoutMapRange) {
             // fetchChunkRetryCnt % 2 == 0 means both replicas have been tried,
             // so sleep before next try.
             if (fetchChunkRetryCnt % 2 == 0) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Do not attempt to fetch from any worker that has already been added to fetchExcludedWorkers. Instead, try fetching from a peer worker within the same PartitionLocation.


### Why are the changes needed?
With the configuration celeborn.client.fetch.excludeWorkerOnFailure.enabled=true and celeborn.client.push.replicate.enabled=true,
when a fetch operation fails for a specific worker, that worker is added to fetchExcludedWorkers. However, subsequent attempts still try to fetch from this worker, causing repeated errors and slowing down shuffle fetch performance.
The logic should be modified so that any worker already in fetchExcludedWorkers is completely excluded from further fetch operations.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual test by debug

