### PR TITLE
[CELEBORN-2047][FOLLOWUP] MapPartitionData should close dataChannel, indexChannel, dataInputStream and indexInputStream

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/DfsPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/DfsPartitionDataReader.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 
@@ -91,12 +90,6 @@ public class DfsPartitionDataReader extends PartitionDataReader {
   @Override
   public long position() throws IOException {
     return dataInputStream.getPos();
-  }
-
-  @Override
-  public void close() {
-    IOUtils.closeQuietly(dataInputStream);
-    IOUtils.closeQuietly(indexInputStream);
   }
 
   private void readHeaderOrIndexBuffer(

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/LocalPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/LocalPartitionDataReader.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.commons.io.IOUtils;
 
 import org.apache.celeborn.common.meta.DiskFileInfo;
 import org.apache.celeborn.common.util.Utils;
@@ -83,12 +82,6 @@ public class LocalPartitionDataReader extends PartitionDataReader {
   @Override
   public long position() throws IOException {
     return dataFileChanel.position();
-  }
-
-  @Override
-  public void close() {
-    IOUtils.closeQuietly(dataFileChanel);
-    IOUtils.closeQuietly(indexFileChannel);
   }
 
   private void readHeaderOrIndexBuffer(

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/MapPartitionDataReader.java
@@ -516,8 +516,4 @@ public class MapPartitionDataReader implements Comparable<MapPartitionDataReader
       return !isReleased && !readFinished;
     }
   }
-
-  public void close() {
-    partitionDataReader.close();
-  }
 }

--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataReader.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/storage/PartitionDataReader.java
@@ -56,8 +56,6 @@ public abstract class PartitionDataReader {
 
   public abstract long position() throws IOException;
 
-  public abstract void close();
-
   public int readBuffer(ByteBuf buffer, long dataConsumingOffset) throws IOException {
     position(dataConsumingOffset);
     int headerSize = headerBuffer.capacity();


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MapPartitionData` should close `dataChannel`, `indexChannel`, `dataInputStream` and `indexInputStream`.

Follow up #3445.

### Why are the changes needed?

`dataChannel`, `indexChannel`, `dataInputStream` and `indexInputStream` should be closed in `MapPartitionData` instead of `PartitionDataReader`.

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.