### PR TITLE
[CELEBORN-2190] PartNumber field may be inconsistent in multipart upl…

### DIFF
--- a/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
+++ b/worker/src/main/scala/org/apache/celeborn/service/deploy/worker/storage/TierWriter.scala
@@ -518,14 +518,6 @@ class DfsTierWriter(
     storageManager) {
   assert(
     storageType == StorageInfo.Type.HDFS || storageType == StorageInfo.Type.OSS || storageType == StorageInfo.Type.S3)
-  flusherBufferSize = conf.workerHdfsFlusherBufferSize
-  private val flushWorkerIndex: Int = flusher.getWorkerIndex
-  val hadoopFs: FileSystem = StorageManager.hadoopFs.get(storageType)
-  var deleted = false
-  private var s3MultipartUploadHandler: MultipartUploadHandler = _
-  private var ossMultipartUploadHandler: MultipartUploadHandler = _
-  var partNumber: Int = 1
-
   this.flusherBufferSize =
     if (dfsFileInfo.isS3()) {
       conf.workerS3FlusherBufferSize
@@ -534,6 +526,12 @@ class DfsTierWriter(
     } else {
       conf.workerHdfsFlusherBufferSize
     }
+  private val flushWorkerIndex: Int = flusher.getWorkerIndex
+  val hadoopFs: FileSystem = StorageManager.hadoopFs.get(storageType)
+  var deleted = false
+  private var s3MultipartUploadHandler: MultipartUploadHandler = _
+  private var ossMultipartUploadHandler: MultipartUploadHandler = _
+  @volatile private var partNumber: Int = 1
 
   try {
     hadoopFs.create(dfsFileInfo.getDfsPath, true).close()


### PR DESCRIPTION
…oads

<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

PartNumber field may be inconsistent in multipart uploads.

### Why are the changes needed?

In the `DfsTierWriter` class, the `partNumber` field is declared as `var partNumber: Int = 1` and is incremented when generating `OssFlushTask` and `S3FlushTask`. However, this field is not thread-safe. If multiple threads call the `genFlushTask` method simultaneously, it may lead to inconsistent `partNumber` allocation.

### Does this PR resolve a correctness bug?

NO

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

CI
