### PR TITLE
[CELEBORN-1258][FOLLOWUP] Introduce --show-cluster-apps-info master command to show cluster application's info

### DIFF
--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterOptions.scala
@@ -24,8 +24,15 @@ final class MasterOptions {
   @Option(names = Array("--show-masters-info"), description = Array("Show master group info"))
   private[master] var showMastersInfo: Boolean = _
 
-  @Option(names = Array("--show-cluster-apps"), description = Array("Show cluster applications"))
+  @Option(
+    names = Array("--show-cluster-apps"),
+    description = Array("Show cluster application's ids"))
   private[master] var showClusterApps: Boolean = _
+
+  @Option(
+    names = Array("--show-cluster-apps-info"),
+    description = Array("Show cluster application's info"))
+  private[master] var showClusterAppsInfo: Boolean = _
 
   @Option(names = Array("--show-cluster-shuffles"), description = Array("Show cluster shuffles"))
   private[master] var showClusterShuffles: Boolean = _

--- a/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
+++ b/cli/src/main/scala/org/apache/celeborn/cli/master/MasterSubcommandImpl.scala
@@ -33,6 +33,7 @@ class MasterSubcommandImpl extends MasterSubcommand {
   override def run(): Unit = {
     if (masterOptions.showMastersInfo) log(runShowMastersInfo)
     if (masterOptions.showClusterApps) log(runShowClusterApps)
+    if (masterOptions.showClusterAppsInfo) log(runShowClusterAppsInfo)
     if (masterOptions.showClusterShuffles) log(runShowClusterShuffles)
     if (masterOptions.excludeWorkers) log(runExcludeWorkers)
     if (masterOptions.removeExcludedWorkers) log(runRemoveExcludedWorkers)
@@ -69,6 +70,9 @@ class MasterSubcommandImpl extends MasterSubcommand {
 
   private[master] def runShowClusterApps: ApplicationsHeartbeatResponse =
     applicationApi.getApplications(commonOptions.getAuthHeader)
+
+  private[master] def runShowClusterAppsInfo: ApplicationInfoResponse =
+    applicationApi.getApplicationsInfo(commonOptions.getAuthHeader)
 
   private[master] def runShowClusterShuffles: ShufflesResponse =
     shuffleApi.getShuffles(commonOptions.getAuthHeader)

--- a/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
+++ b/cli/src/test/scala/org/apache/celeborn/cli/TestCelebornCliCommands.scala
@@ -189,6 +189,11 @@ class TestCelebornCliCommands extends CelebornFunSuite with MiniClusterFeature {
     captureOutputAndValidateResponse(args, "ApplicationsHeartbeatResponse")
   }
 
+  test("master --show-cluster-apps-info") {
+    val args = prepareMasterArgs() :+ "--show-cluster-apps-info"
+    captureOutputAndValidateResponse(args, "ApplicationInfoResponse")
+  }
+
   test("master --show-cluster-shuffles") {
     val args = prepareMasterArgs() :+ "--show-cluster-shuffles"
     captureOutputAndValidateResponse(args, "ShufflesResponse")

--- a/docs/celeborn_cli.md
+++ b/docs/celeborn_cli.md
@@ -85,8 +85,8 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
                            h3...] [--hostport=host:port] [--upsert-configs=k1:
                            v1,k2:v2,k3:v3...] [--worker-ids=w1,w2,w3...]
                            (--show-masters-info | --show-cluster-apps |
-                           --show-cluster-shuffles | --exclude-worker |
-                           --remove-excluded-worker |
+                           --show-cluster-apps-info | --show-cluster-shuffles |
+                           --exclude-worker | --remove-excluded-worker |
                            --send-worker-event=IMMEDIATELY | DECOMMISSION | 
                            DECOMMISSION_THEN_IDLE | GRACEFUL | RECOMMISSION | 
                            NONE | --show-worker-event-info |
@@ -142,7 +142,9 @@ Usage: celeborn-cli master [-hV] [--apps=appId] [--auth-header=authHeader]
       --send-worker-event=IMMEDIATELY | DECOMMISSION | DECOMMISSION_THEN_IDLE |
         GRACEFUL | RECOMMISSION | NONE
                              Send an event to a worker
-      --show-cluster-apps    Show cluster applications
+      --show-cluster-apps    Show cluster application's ids
+      --show-cluster-apps-info
+                             Show cluster application's info
       --show-cluster-shuffles
                              Show cluster shuffles
       --show-conf            Show master conf


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce `--show-cluster-apps-info` master command to show cluster application's info.

### Why are the changes needed?

#3428 introduces `/api/v1/applications/info` to list all running application's info of the cluster. Therefore, Cli should also introduce --show-cluster-apps-info master command.

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

Cli adds `--show-cluster-apps-info` master command to show cluster application's info.

### How was this patch tested?

`TestCelebornCliCommands#master --show-cluster-apps-info`