### PR TITLE
[CELEBORN-1983][FOLLOWUP] Fix fetch fail not throw due to reach spark maxTaskFailures

### DIFF
--- a/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-2/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -347,7 +347,7 @@ public class SparkUtils {
                   taskId,
                   taskInfo.attemptNumber(),
                   ti.attemptNumber());
-              return true;
+              failedTaskAttempts += 1;
             } else if (ti.successful()) {
               logger.info(
                   "StageId={} index={} taskId={} attempt={} another attempt {} is successful.",

--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -462,7 +462,7 @@ public class SparkUtils {
                   taskId,
                   taskInfo.attemptNumber(),
                   ti.attemptNumber());
-              return true;
+              failedTaskAttempts += 1;
             } else if (ti.successful()) {
               LOG.info(
                   "StageId={} index={} taskId={} attempt={} another attempt {} is successful.",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix fetch fail not throw due to reach spark maxTaskFailures.

### Why are the changes needed?
The condition `ti.attemptNumber() >= maxTaskFails - 1` may not be executed. Suppose that the current `taskAttempts` is index0, index1, index2, and index3, and that index0 and index1 have already failed while index2 and index3 are running, and the current `reportFetchFailed` is index3, then the final result will be false, while the expected result will be true.
Therefore, we should check the attemptNumber of the current task separately before the loop starts.

<img width="3558" height="608" alt="image" src="https://github.com/user-attachments/assets/2a0af3e7-912e-420e-a864-4c525d07e251" />
<img width="2332" height="814" alt="image" src="https://github.com/user-attachments/assets/bf832091-56d5-41b8-b58a-502e409d67a8" />


### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UTs.
