### PR TITLE
[CELEBORN-2189] Allow config worker pod terminationGracePeriodSeconds in chart

### DIFF
--- a/charts/celeborn/templates/worker/statefulset.yaml
+++ b/charts/celeborn/templates/worker/statefulset.yaml
@@ -92,7 +92,7 @@ spec:
         {{- $namespace := .Release.Namespace }}
         - >
           until {{ range until (.Values.master.replicas | int) }}
-          nslookup {{ include "celeborn.master.statefulSet.name" $ }}-{{ . }}.{{ include "celeborn.master.service.name" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local && 
+          nslookup {{ include "celeborn.master.statefulSet.name" $ }}-{{ . }}.{{ include "celeborn.master.service.name" $ }}.{{ $namespace }}.svc.{{ $.Values.cluster.name }}.local &&
           {{- end }}
           true; do
             echo "waiting for master";
@@ -176,4 +176,4 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}

--- a/charts/celeborn/tests/worker/statefulset_test.yaml
+++ b/charts/celeborn/tests/worker/statefulset_test.yaml
@@ -75,6 +75,14 @@ tests:
           path: spec.replicas
           value: 10
 
+  - it: Should use the specified terminationGracePeriodSeconds if `worker.terminationGracePeriodSeconds` is set
+    set:
+      worker.terminationGracePeriodSeconds: 70
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 70
+
   - it: Should add environment variables if `worker.env` is set
     set:
       worker:

--- a/charts/celeborn/values.yaml
+++ b/charts/celeborn/values.yaml
@@ -222,6 +222,9 @@ worker:
   # -- Number of Celeborn worker replicas to deploy, should less than node number.
   replicas: 5
 
+  # -- Value for terminationGracePeriodSeconds for worker pods
+  terminationGracePeriodSeconds: 30
+
   # -- Annotations for Celeborn worker pods.
   annotations:
     # key1: value1


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update celeborn helm chart to expose worker pod's `terminationGracePeriodSeconds` for more flexibility.

### Why are the changes needed?

The value of `terminationGracePeriodSeconds` need to expose for more flexibility.

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI. and also local

```
❯ helm unittest .

### Chart [ celeborn ] .

 PASS  Test Celeborn configmap	tests/configmap_test.yaml
 PASS  Test Celeborn role	tests/role_test.yaml
 PASS  Test Celeborn rolebinding	tests/rolebinding_test.yaml
 PASS  Test Celeborn service account	tests/serviceaccount_test.yaml

Charts:      1 passed, 1 total
Test Suites: 4 passed, 4 total
Tests:       9 passed, 9 total
Snapshot:    0 passed, 0 total
Time:        60.240792ms

```