### PR TITLE
[CELEBORN-2203] Set celeborn.master.internal.endpoints in the configmap

### DIFF
--- a/charts/celeborn/templates/configmap.yaml
+++ b/charts/celeborn/templates/configmap.yaml
@@ -32,6 +32,8 @@ data:
     {{- end }}
     celeborn.master.endpoints={{ $endpoints | join "," }}
 
+    celeborn.master.internal.endpoints = {{ $endpoints | join "," }}
+
     {{- range until (.Values.master.replicas | int) }}
     {{- $host := (printf "%s-%d.%s.%s.svc.%s.local" (include "celeborn.master.statefulSet.name" $) . (include "celeborn.master.service.name" $) $.Release.Namespace $.Values.cluster.name) }}
     celeborn.master.ha.node.{{ . }}.host={{ $host }}

--- a/charts/celeborn/tests/configmap_test.yaml
+++ b/charts/celeborn/tests/configmap_test.yaml
@@ -38,3 +38,9 @@ tests:
           path: data["celeborn-defaults.conf"]
       - exists:
           path: data["log4j2.xml"]
+
+  - it: Should include celeborn.master.internal.endpoints key in celeborn-defaults.conf
+    asserts:
+      - matchRegex:
+          path: data["celeborn-defaults.conf"]
+          pattern: "(?m)^\\s*celeborn\\.master\\.internal\\.endpoints\\s*=.*"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set `celeborn.master.internal.endpoints` in the configmap.

### Why are the changes needed?

The default value is `<localhost>:8097` right now, which cause that workers fail to start as it cannot connect to that port.

### Does this PR resolve a correctness bug?

<!-- Yes/No. (Note: If yes, committer will add `correctness` label to current pull request). -->

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

<img width="2732" height="1104" alt="image" src="https://github.com/user-attachments/assets/542b6554-61c1-4c7b-a7bc-718cdcd50176" />