### PR TITLE
[MINOR] add makefile to do docs gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PYTHON_IMAGE ?= python:3.11-slim
+DOCKER ?= docker
+WORKDIR ?= /workspace
+PIP_CACHE ?= celeborn-pip-cache
+DOCS_OUTPUT ?= site
+DOCS_PORT ?= 8000
+DOCKER_RUN = $(DOCKER) run --rm -v $(CURDIR):$(WORKDIR) -w $(WORKDIR) -v $(PIP_CACHE):/root/.cache/pip
+
+.PHONY: help docs docs-serve docs-clean check-docker
+
+help: ## Show help for available make targets
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Targets:"
+	@grep -E '^[a-zA-Z0-9_-]+:.*##' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS=":.*##"} {printf "  %-12s %s\n", $$1, $$2}'
+
+check-docker:
+	@command -v $(DOCKER) >/dev/null 2>&1 || { echo "Docker CLI '$(DOCKER)' not found"; exit 1; }
+
+docs: check-docker ## Build the MkDocs site inside a Python 3.11 container
+	$(DOCKER_RUN) $(PYTHON_IMAGE) /bin/sh -c "pip install -r requirements.txt && mkdocs build"
+
+docs-serve: check-docker ## Run mkdocs serve inside Docker and expose DOCS_PORT
+	$(DOCKER_RUN) -p $(DOCS_PORT):$(DOCS_PORT) -it $(PYTHON_IMAGE) /bin/sh -c "pip install -r requirements.txt && mkdocs serve -a 0.0.0.0:$(DOCS_PORT)"
+
+docs-clean: ## Remove the generated site directory
+	rm -rf $(DOCS_OUTPUT)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

create a makefile to generate docs and later more targets can be added

### Why are the changes needed?

inside the makefile, it uses a python docker container to build / serve docs, so that contributors dont need to install a specific python version, venv etc. (e.g. right now the requirements.txt does not support python 3.12)


### Does this PR resolve a correctness bug?

<!-- Yes/No. (Note: If yes, committer will add `correctness` label to current pull request). -->

No

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

locally:

```
❯ make
Usage: make <target>

Targets:
  docs-clean    Remove the generated site directory
  docs-serve    Run mkdocs serve inside Docker and expose DOCS_PORT
  docs          Build the MkDocs site inside a Python 3.11 container
  help          Show help for available make targets
```


```
❯ make docs
INFO     -  DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  File "/usr/local/lib/python3.11/site-packages/mkdocs_macros/context.py", line 19, in <module>
    import pkg_resources
  File "/usr/local/lib/python3.11/site-packages/pkg_resources/__init__.py", line 98, in <module>
    warnings.warn(

INFO     -  [macros] - Macros arguments: {'module_name': 'main', 'modules': [], 'include_dir': '', 'include_yaml': [], 'j2_block_start_string': '', 'j2_block_end_string': '', 'j2_variable_start_string': '', 'j2_variable_end_string': '', 'on_undefined': 'keep', 'on_error_fail': False, 'verbose': False}
INFO     -  [macros] - Extra variables (config file): ['social']
INFO     -  [macros] - Extra filters (module): ['pretty']
INFO     -  Cleaning site directory
INFO     -  Building documentation to directory: /workspace/site
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - configuration/client.md
  - configuration/columnar-shuffle.md
  - configuration/ha.md
  - configuration/master.md
  - configuration/metrics.md
  - configuration/network-module.md
  - configuration/network.md
  - configuration/quota.md
  - configuration/worker.md
  - developers/release.md
WARNING  -  Documentation file 'developers/faulttolerant.md' contains a link to '../assets/img/revive.svg' which is not found in the documentation files.
WARNING  -  Documentation file 'developers/faulttolerant.md' contains a link to '../assets/img/batchrevive.svg' which is not found in the documentation files.
WARNING  -  Documentation file 'developers/overview.md' contains a link to '../assets/img/ess.svg' which is not found in the documentation files.
WARNING  -  Documentation file 'developers/overview.md' contains a link to '../assets/img/celeborn.svg' which is not found in the documentation files.
WARNING  -  Documentation file 'developers/shuffleclient.md' contains a link to '../assets/img/softsplit.svg' which is not found in the documentation files.
WARNING  -  Documentation file 'developers/storage.md' contains a link to '../assets/img/reducepartition.svg' which is not found in the documentation files.
WARNING  -  Documentation file 'developers/storage.md' contains a link to '../assets/img/mappartition.svg' which is not found in the documentation files.
WARNING  -  Documentation file 'developers/storage.md' contains a link to '../assets/img/multilayer.svg' which is not found in the documentation files.
WARNING  -  Documentation file 'developers/trafficcontrol.md' contains a link to '../assets/img/backpressure.svg' which is not found in the documentation files.
INFO     -  Documentation built in 1.33 seconds

~/code/apache-celeborn dev/pingz-makefile*                                                                                                                       5s apache-celeborn 14:52:43
```

`make docs-serve` locally
<img width="3222" height="1154" alt="image" src="https://github.com/user-attachments/assets/dddc02d1-fb4b-423c-be02-c433a766b5c5" />
