### PR TITLE
[CELEBORN-2212] Optimize the sorting efficiency of memoryWriters when evicting the largest memory file

### DIFF
--- a/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
+++ b/worker/src/main/java/org/apache/celeborn/service/deploy/worker/memory/MemoryManager.java
@@ -257,8 +257,9 @@ public class MemoryManager {
                 logger.info("Start evicting {} memory file infos", memoryWriters.size());
                 // always evict the largest memory file info first
                 memoryWriters.sort(
-                    Comparator.comparingLong(o -> o.getMemoryFileInfo().getFileLength()));
-                Collections.reverse(memoryWriters);
+                    Comparator.comparingLong(
+                            (PartitionDataWriter o) -> o.getMemoryFileInfo().getFileLength())
+                        .reversed());
                 for (PartitionDataWriter writer : memoryWriters) {
                   // this branch means that there is no memory pressure
                   if (!shouldEvict(aggressiveEvictModeEnabled, evictRatio)) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Optimize the sorting efficiency of memoryWriters when evicting the largest memory file.

### Why are the changes needed?

Optimize the sorting efficiency of memoryWriters when evicting the largest memory file.

### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.