### PR TITLE
[CELEBORN-2236] Avoiding regular expressions for DiskFileInfo storage type determination

### DIFF
--- a/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
+++ b/common/src/main/java/org/apache/celeborn/common/meta/DiskFileInfo.java
@@ -57,10 +57,15 @@ public class DiskFileInfo extends FileInfo {
       boolean partitionSplitEnabled,
       FileMeta fileMeta,
       String filePath,
+      StorageInfo.Type storageType,
       long bytesFlushed) {
     super(userIdentifier, partitionSplitEnabled, fileMeta);
     this.filePath = filePath;
-    this.storageType = StorageInfo.Type.HDD;
+    if (storageType != null) {
+      this.storageType = storageType;
+    } else {
+      this.storageType = StorageInfo.Type.HDD;
+    }
     this.bytesFlushed = bytesFlushed;
   }
 
@@ -150,19 +155,21 @@ public class DiskFileInfo extends FileInfo {
   }
 
   public boolean isHdfs() {
-    return Utils.isHdfsPath(filePath);
+    return storageType == StorageInfo.Type.HDFS;
   }
 
   public boolean isS3() {
-    return Utils.isS3Path(filePath);
+    return storageType == StorageInfo.Type.S3;
   }
 
   public boolean isOSS() {
-    return Utils.isOssPath(filePath);
+    return storageType == StorageInfo.Type.OSS;
   }
 
   public boolean isDFS() {
-    return Utils.isS3Path(filePath) || Utils.isOssPath(filePath) || Utils.isHdfsPath(filePath);
+    return storageType == StorageInfo.Type.HDFS
+        || storageType == StorageInfo.Type.S3
+        || storageType == StorageInfo.Type.OSS;
   }
 
   public StorageInfo.Type getStorageType() {

--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -661,6 +661,7 @@ message PbFileInfo {
   bool isSegmentGranularityVisible = 9;
   map<int32, int32> partitionWritingSegment = 10;
   repeated PbSegmentIndex segmentIndex = 11;
+  int32 storageType = 12;
 }
 
 message PbSegmentIndex {

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -114,11 +114,24 @@ object PbSerDeUtils {
         fileMeta.setIsWriterClosed(true)
         fileMeta
     }
+    var storageType: StorageInfo.Type = null
+    if (pbFileInfo.getStorageType == 0) {
+      if (Utils.isHdfsPath(pbFileInfo.getFilePath)) {
+        storageType = StorageInfo.Type.HDFS
+      } else if (Utils.isOssPath(pbFileInfo.getFilePath)) {
+        storageType = StorageInfo.Type.OSS
+      } else if (Utils.isS3Path(pbFileInfo.getFilePath)) {
+        storageType = StorageInfo.Type.S3
+      }
+    } else {
+      storageType = StorageInfo.typesMap.get(pbFileInfo.getStorageType)
+    }
     new DiskFileInfo(
       userIdentifier,
       pbFileInfo.getPartitionSplitEnabled,
       meta,
       pbFileInfo.getFilePath,
+      storageType,
       pbFileInfo.getBytesFlushed)
   }
 
@@ -141,6 +154,7 @@ object PbSerDeUtils {
       .setUserIdentifier(toPbUserIdentifier(fileInfo.getUserIdentifier))
       .setBytesFlushed(fileInfo.getFileLength)
       .setPartitionSplitEnabled(fileInfo.isPartitionSplitEnabled)
+      .setStorageType(fileInfo.getStorageType.getValue)
     if (fileInfo.getFileMeta.isInstanceOf[MapFileMeta]) {
       val mapFileMeta = fileInfo.getFileMeta.asInstanceOf[MapFileMeta]
       builder.setPartitionType(PartitionType.MAP.getValue)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoiding regular expressions for DiskFileInfo storage type determination.

### Why are the changes needed?

When sending a heartbeat, the Worker iterates all FileInfo objects and uses regex matching on a large number of them to check if the file is an HDFS file, thus reducing processing efficiency.

<img width="2766" height="1456" alt="image" src="https://github.com/user-attachments/assets/2dc075f6-562d-4467-a75c-4b6682ed866d" />


### Does this PR resolve a correctness bug?

No.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.