### PR TITLE
[CELEBORN-2143] Create DiskFile sequentially based on createFileOrder

### DIFF
--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase1.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase1.scala
@@ -59,7 +59,7 @@ class StoragePolicyCase1 extends CelebornFunSuite {
   val mockedFlusher = mock[Flusher]
   val mockedFile = mock[File]
   when(
-    mockedStorageManager.createDiskFile(
+    mockedStorageManager.createLocalDiskFile(
       any(),
       any(),
       any(),
@@ -101,7 +101,6 @@ class StoragePolicyCase1 extends CelebornFunSuite {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(memoryHintPartitionLocation)
     when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
     val conf = new CelebornConf()
-    val flushLock = new AnyRef
     conf.set("celeborn.worker.storage.storagePolicy.createFilePolicy", "MEMORY,SSD,HDD,HDFS,OSS,S3")
     val storagePolicy = new StoragePolicy(conf, mockedStorageManager, mockedSource)
     val pendingWriters = new AtomicInteger()

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase2.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase2.scala
@@ -59,7 +59,7 @@ class StoragePolicyCase2 extends CelebornFunSuite {
   val mockedFlusher = mock[LocalFlusher]
   val mockedFile = mock[File]
   when(
-    mockedStorageManager.createDiskFile(
+    mockedStorageManager.createLocalDiskFile(
       any(),
       any(),
       any(),
@@ -100,7 +100,7 @@ class StoragePolicyCase2 extends CelebornFunSuite {
   test("test create file order case2") {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(localHintPartitionLocatioin)
     when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
-    when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
+    when(mockedStorageManager.localStorageAvailable).thenAnswer(true)
     when(mockedDiskFile.getStorageType).thenAnswer(StorageInfo.Type.HDD)
     val conf = new CelebornConf()
     conf.set("celeborn.worker.storage.storagePolicy.createFilePolicy", "SSD,HDD,HDFS,OSS,S3")

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase3.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase3.scala
@@ -59,7 +59,7 @@ class StoragePolicyCase3 extends CelebornFunSuite {
   val mockedFlusher = mock[LocalFlusher]
   val mockedFile = mock[File]
   when(
-    mockedStorageManager.createDiskFile(
+    mockedStorageManager.createLocalDiskFile(
       any(),
       any(),
       any(),
@@ -100,11 +100,10 @@ class StoragePolicyCase3 extends CelebornFunSuite {
   test("test getEvicted file case1") {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(localHintPartitionLocatioin)
     when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
-    when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
+    when(mockedStorageManager.localStorageAvailable).thenAnswer(true)
     when(mockedDiskFile.getStorageType).thenAnswer(StorageInfo.Type.SSD)
     val mockedMemoryFile = mock[LocalTierWriter]
     val conf = new CelebornConf()
-    val flushLock = new AnyRef
     val storagePolicy = new StoragePolicy(conf, mockedStorageManager, mockedSource)
     val pendingWriters = new AtomicInteger()
     val notifier = new FlushNotifier
@@ -120,11 +119,10 @@ class StoragePolicyCase3 extends CelebornFunSuite {
   test("test evict file case2") {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(memoryHintPartitionLocation)
     when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
-    when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
+    when(mockedStorageManager.localStorageAvailable).thenAnswer(true)
     when(mockedDiskFile.getStorageType).thenAnswer(StorageInfo.Type.HDD)
     val mockedMemoryFile = mock[LocalTierWriter]
     val conf = new CelebornConf()
-    val flushLock = new AnyRef
     val storagePolicy = new StoragePolicy(conf, mockedStorageManager, mockedSource)
     val pendingWriters = new AtomicInteger()
     val notifier = new FlushNotifier

--- a/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase4.scala
+++ b/worker/src/test/scala/org/apache/celeborn/service/deploy/worker/storage/storagePolicy/StoragePolicyCase4.scala
@@ -59,7 +59,7 @@ class StoragePolicyCase4 extends CelebornFunSuite {
   val mockedFlusher = mock[LocalFlusher]
   val mockedFile = mock[File]
   when(
-    mockedStorageManager.createDiskFile(
+    mockedStorageManager.createLocalDiskFile(
       any(),
       any(),
       any(),
@@ -101,7 +101,7 @@ class StoragePolicyCase4 extends CelebornFunSuite {
     when(mockedPartitionWriterContext.getPartitionLocation).thenAnswer(
       memoryDisabledHintPartitionLocation)
     when(mockedPartitionWriterContext.getPartitionType).thenAnswer(PartitionType.REDUCE)
-    when(mockedStorageManager.localOrDfsStorageAvailable).thenAnswer(true)
+    when(mockedStorageManager.localStorageAvailable).thenAnswer(true)
     when(mockedDiskFile.getStorageType).thenAnswer(StorageInfo.Type.SSD)
     val conf = new CelebornConf()
     conf.set("celeborn.worker.storage.storagePolicy.createFilePolicy", "MEMORY,SSD,HDD,HDFS,OSS,S3")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Create DiskFile sequentially based on createFileOrder

### Why are the changes needed?

1. If the PartitionLocation specifies a StorageType (such as HDFS), DfsTierWriter should be created based on that StorageType.
2. Optimize the storage strategy to create the logic for DiskFile.

### Does this PR resolve a correctness bug?

NO

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

CI