### PR TITLE
[BUILD] Improve error message when bundled Maven wrapper fails

### DIFF
--- a/build/make-distribution.sh
+++ b/build/make-distribution.sh
@@ -106,16 +106,11 @@ fi
 
 export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=1g}"
 
-# Validate Maven - fallback to system mvn if bundled doesn't work
+# Validate Maven
 if ! "$MVN" --version &>/dev/null; then
-    echo -e "Warning: Maven '$MVN' not working, trying system 'mvn'..."
-    if [ `command -v mvn` ] && mvn --version &>/dev/null; then
-        MVN="mvn"
-        echo "Using system Maven: $MVN"
-    else
-        echo -e "Could not find a working Maven installation."
-        exit -1;
-    fi
+    echo -e "Could not execute Maven command: '$MVN'."
+    echo "       Use --mvn /path/to/mvn to specify an alternate Maven."
+    exit -1
 fi
 
 if [ $(command -v git) ]; then


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Update `build/make-distribution.sh` to provide a error message when the bundled Maven wrapper (`build/mvn`) is not working, guiding users to specify an alternate Maven.

<img width="784" height="282" alt="CleanShot 2025-12-16 at 10 40 45" src="https://github.com/user-attachments/assets/b60334a9-3a08-4776-b77c-2c5b453d5197" />


### Why are the changes needed?

The bundled Maven wrapper can fail silently or produce unusable output, causing build failures like:
<img width="677" height="906" alt="CleanShot 2025-12-15 at 11 00 00" src="https://github.com/user-attachments/assets/ab0497b6-6c29-4c99-9694-3701fbb3c767" />

When the bundled Maven doesn't work correctly, the script fails without any helpful message, leaving users unsure how to proceed. This change adds a `--version` check with actionable error output:

- Validates Maven works before proceeding with the build
- If validation fails, exits with a clear message explaining how to use `--mvn /path/to/mvn`

### Does this PR introduce _any_ user-facing change?

No functional change. Error messaging is improved when Maven validation fails.

### How was this patch tested?

Tested build script with broken bundled Maven, just confirm error message is displayed with instructions to specify alternate Maven path.
