### PR TITLE
[CELEBORN-2240] Adapt to SPARK-51756 which add a new parameter `checksumValue` in `MapStatus.apply`

### DIFF
--- a/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
+++ b/client-spark/spark-3/src/main/java/org/apache/spark/shuffle/celeborn/SparkUtils.java
@@ -82,9 +82,17 @@ public class SparkUtils {
   public static final String FETCH_FAILURE_ERROR_MSG =
       "Celeborn FetchFailure appShuffleId/shuffleId: ";
 
+  private static final DynMethods.BoundMethod MAP_STATUS_APPLY_METHOD =
+      DynMethods.builder("apply")
+          // for SPARK-51756 (4.1.0) and later
+          .impl(MapStatus$.class, BlockManagerId.class, long[].class, long.class, long.class)
+          // for Spark 4.0 and earlier
+          .impl(MapStatus$.class, BlockManagerId.class, long[].class, long.class)
+          .build(MapStatus$.MODULE$);
+
   public static MapStatus createMapStatus(
       BlockManagerId loc, long[] uncompressedSizes, long mapTaskId) {
-    return MapStatus$.MODULE$.apply(loc, uncompressedSizes, mapTaskId);
+    return MAP_STATUS_APPLY_METHOD.invoke(loc, uncompressedSizes, mapTaskId, 0L);
   }
 
   private static final DynFields.UnboundField<SQLMetric> DATA_SIZE_METRIC_FIELD =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

Adapt to SPARK-51756, which changes the MapStatus API used by Celeborn.

### Why are the changes needed?

A necessary step to make Celeborn support Spark 4.1.

### Does this PR resolve a correctness bug?

<!-- Yes/No. (Note: If yes, committer will add `correctness` label to current pull request). -->

No.

### Does this PR introduce _any_ user-facing change?

Yes, it makes 

### How was this patch tested?

Have integrated with Spark 4.1 in the internal test env, and verified by some simple queries.