### PR TITLE
[CELEBORN-2242] PushMergedData RPC supports compatible with low version Server

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1527,6 +1527,10 @@ public class ShuffleClientImpl extends ShuffleClient {
           @Override
           public void onSuccess(ByteBuffer response) {
             // Compatible with lower versions of Server
+            // Workers that do not incorporate the changes from [CELEBORN-1721]
+            // return an empty payload upon success;
+            // however, clients with this patch applied will attempt to read the response content,
+            // which results in a BufferUnderflowException.
             if (response.remaining() <= 0) {
               pushState.onSuccess(hostPort);
               callback.onSuccess(ByteBuffer.wrap(new byte[] {StatusCode.SUCCESS.getValue()}));


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?

A client that supports HARD_SPLIT in PushMergedData will report the following error when accessing a lower version of the Server.

```java
java.nio.BufferUnderflowException
	at java.base/java.nio.Buffer.nextGetIndex(Buffer.java:713)
	at java.base/java.nio.DirectByteBuffer.get(DirectByteBuffer.java:334)
	at org.apache.celeborn.client.ShuffleClientImpl$5.onSuccess(ShuffleClientImpl.java:1430)
	at org.apache.celeborn.common.network.client.TransportResponseHandler.handle(TransportResponseHandler.java:373)
	at org.apache.celeborn.common.network.server.TransportChannelHandler.channelRead(TransportChannelHandler.java:158)

```

### Does this PR resolve a correctness bug?


### Does this PR introduce _any_ user-facing change?


### How was this patch tested?
local test

