### PR TITLE
[CELEBORN-2243] During the close phase of hashWriter, pushData and mergeData are sent in parallel

### DIFF
--- a/client/src/main/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -93,9 +93,6 @@ public class DummyShuffleClient extends ShuffleClient {
   }
 
   @Override
-  public void prepareForMergeData(int shuffleId, int mapId, int attemptId) throws IOException {}
-
-  @Override
   public int mergeData(
       int shuffleId,
       int mapId,

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClient.java
@@ -186,9 +186,6 @@ public abstract class ShuffleClient {
       int numPartitions)
       throws IOException;
 
-  public abstract void prepareForMergeData(int shuffleId, int mapId, int attemptId)
-      throws IOException;
-
   public abstract int mergeData(
       int shuffleId,
       int mapId,

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -1376,15 +1376,6 @@ public class ShuffleClientImpl extends ShuffleClient {
   }
 
   @Override
-  public void prepareForMergeData(int shuffleId, int mapId, int attemptId) throws IOException {
-    final String mapKey = Utils.makeMapKey(shuffleId, mapId, attemptId);
-    PushState pushState = pushStates.get(mapKey);
-    if (pushState != null) {
-      limitZeroInFlight(mapKey, pushState);
-    }
-  }
-
-  @Override
   public int mergeData(
       int shuffleId,
       int mapId,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Optimize the close process of HashBasedShuffleWriter：

BeforePR：First, synchronously wait for pushData in the dataPusher queue to complete, then send mergeData and synchronously wait.
AfterPR：During the process of sending pushData by dataPusher, mergeData is also constructed and sent simultaneously.

Optimization results: The table below shows the shuffle write time for TPCH 1TB.
| | SortBasedShuffleWriter | HashBasedShuffleWriter |
|--------|--------|--------|
| Before | 615.44W ms | 502.31W ms |
| After |  442.47W ms | 434.77W ms | 

Note: This is the result of multiple optimizations combined; 
other optimizations will be submitted as pull requests in the future.



### Why are the changes needed?
Improve performance by increasing the parallelism of pushing/merging data.

### Does this PR resolve a correctness bug?

NO

### Does this PR introduce _any_ user-facing change?

NO


### How was this patch tested?

Exists Unit Test.