### PR TITLE
[CELEBORN-2245] Bump maven 3.9.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <scala.binary.version>2.12</scala.binary.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.version>3.9.9</maven.version>
+    <maven.version>3.9.12</maven.version>
 
     <flink.version>1.20.1</flink.version>
     <spark.version>3.3.4</spark.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?



### Why are the changes needed?

Avoid downloading maven every time.
```
 Version: 20260105.207.1
  Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20260105.207/images/ubuntu/Ubuntu2204-Readme.md

Maven 3.9.12
```


### Does this PR resolve a correctness bug?


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?
Current
```
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Zulu_jdk/8.0.472-8/x64
    JAVA_HOME_8_X64: /opt/hostedtoolcache/Java_Zulu_jdk/8.0.472-8/x64
exec: curl --progress-bar -L https://www.apache.org/dyn/closer.lua/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz?action=download
#=#=#                                                                         
##O#-#     
```

PR
```
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Zulu_jdk/8.0.472-8/x64
    JAVA_HOME_8_X64: /opt/hostedtoolcache/Java_Zulu_jdk/8.0.472-8/x64
Using `mvn` from path: /usr/bin/mvn
```

