### PR TITLE
[CELEBORN-2249] Bump Spark from 3.5.7 to 3.5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1557,7 +1557,7 @@
         <lz4-java.version>1.8.0</lz4-java.version>
         <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.5.7</spark.version>
+        <spark.version>3.5.8</spark.version>
         <zstd-jni.version>1.5.5-4</zstd-jni.version>
       </properties>
     </profile>

--- a/project/CelebornBuild.scala
+++ b/project/CelebornBuild.scala
@@ -919,7 +919,7 @@ object Spark35 extends SparkClientProjects {
   val lz4JavaVersion = "1.8.0"
   val sparkProjectScalaVersion = "2.12.18"
 
-  val sparkVersion = "3.5.7"
+  val sparkVersion = "3.5.8"
   val zstdJniVersion = "1.5.5-4"
 
   override val sparkColumnarShuffleVersion: String = "3.5"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Bump Spark from 3.5.7 to 3.5.8.




### Why are the changes needed?
Spark 3.5.8 has been announced to release: [Spark 3.5.8 released](https://spark.apache.org/news/spark-3-5-8-released.html). The profile spark-3.5 could bump Spark from 3.5.7 to 3.5.8.


### Does this PR resolve a correctness bug?

No.


### Does this PR introduce _any_ user-facing change?

CI.

### How was this patch tested?

