### PR TITLE
[CELEBORN-1577][BUG] Quota cancel shuffle should use app shuffle id

### DIFF
--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1280,10 +1280,12 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
             case (shuffleId, _) =>
               unregisterShuffle(shuffleId)
               unregisterShuffleCallback.foreach(c => c.accept(shuffleId))
+              celebornShuffleIdToAppShuffleIdMap.remove(shuffleId)
           })
       }
     } else {
       unregisterShuffle(appShuffleId)
+      celebornShuffleIdToAppShuffleIdMap.remove(appShuffleId)
     }
   }
 
@@ -2049,9 +2051,9 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       shuffleAllocatedWorkers
         .asScala
         .keys
-        .filter { shuffleId =>
-          !commitManager.isStageEnd(shuffleId) && celebornShuffleIdToAppShuffleIdMap.contains(shuffleId)
-        }.map(celebornShuffleIdToAppShuffleIdMap.get(_))
+        .filter(!commitManager.isStageEnd(_))
+        .flatMap(shuffleId => Option(celebornShuffleIdToAppShuffleIdMap.get(shuffleId)))
+        .toSet
         .foreach(c.accept(_, reason))
 
     case _ =>

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -2054,7 +2054,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         .filter(!commitManager.isStageEnd(_))
         .flatMap(shuffleId => Option(celebornShuffleIdToAppShuffleIdMap.get(shuffleId)))
         .toSet
-        .foreach(c.accept(_, reason))
+        .foreach(shuffleId => c.accept(shuffleId, reason))
 
     case _ =>
   }

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -2054,8 +2054,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         .filter(!commitManager.isStageEnd(_))
         .flatMap(shuffleId => Option(celebornShuffleIdToAppShuffleIdMap.get(shuffleId)))
         .toSet
-        .foreach(shuffleId => c.accept(shuffleId, reason))
-
+        .foreach((shuffleId: Int) => c.accept(shuffleId, reason))
     case _ =>
   }
 

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -1262,7 +1262,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         }
       }
     }
-
+    celebornShuffleIdToAppShuffleIdMap.remove(shuffleId)
     // add shuffleKey to delay shuffle removal set
     unregisterShuffleTime.put(shuffleId, System.currentTimeMillis())
 
@@ -1280,12 +1280,10 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
             case (shuffleId, _) =>
               unregisterShuffle(shuffleId)
               unregisterShuffleCallback.foreach(c => c.accept(shuffleId))
-              celebornShuffleIdToAppShuffleIdMap.remove(shuffleId)
           })
       }
     } else {
       unregisterShuffle(appShuffleId)
-      celebornShuffleIdToAppShuffleIdMap.remove(appShuffleId)
     }
   }
 

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -109,6 +109,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
   private val shuffleIdMapping = JavaUtils.newConcurrentHashMap[
     Int,
     scala.collection.mutable.LinkedHashMap[String, (Int, Boolean)]]()
+  private val celebornShuffleIdToAppShuffleIdMap = JavaUtils.newConcurrentHashMap[Int, Int]()
   private val shuffleIdGenerator = new AtomicInteger(0)
   // app shuffle id -> whether shuffle is determinate, rerun of a indeterminate shuffle gets different result
   private val appShuffleDeterminateMap = JavaUtils.newConcurrentHashMap[Int, Boolean]();
@@ -997,6 +998,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
                 : scala.collection.mutable.LinkedHashMap[String, (Int, Boolean)] = {
               val newShuffleId = shuffleIdGenerator.getAndIncrement()
               logInfo(s"generate new shuffleId $newShuffleId for appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier")
+              celebornShuffleIdToAppShuffleIdMap.put(newShuffleId, appShuffleId)
               scala.collection.mutable.LinkedHashMap(appShuffleIdentifier -> (newShuffleId, true))
             }
           })
@@ -1053,6 +1055,7 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
                   }
                   val newShuffleId = shuffleIdGenerator.getAndIncrement()
                   logInfo(s"generate new shuffleId $newShuffleId for appShuffleId $appShuffleId appShuffleIdentifier $appShuffleIdentifier")
+                  celebornShuffleIdToAppShuffleIdMap.put(newShuffleId, appShuffleId)
                   validateCelebornShuffleIdForClean.foreach(callback =>
                     callback.accept(appShuffleIdentifier))
                   shuffleIds.put(appShuffleIdentifier, (newShuffleId, true))
@@ -2047,6 +2050,9 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
         .asScala
         .keys
         .filter(!commitManager.isStageEnd(_))
+        .filter(celebornShuffleIdToAppShuffleIdMap.contains(_))
+        .map(celebornShuffleIdToAppShuffleIdMap.get(_))
+        .toSet
         .foreach(c.accept(_, reason))
 
     case _ =>

--- a/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
+++ b/client/src/main/scala/org/apache/celeborn/client/LifecycleManager.scala
@@ -2049,10 +2049,9 @@ class LifecycleManager(val appUniqueId: String, val conf: CelebornConf) extends 
       shuffleAllocatedWorkers
         .asScala
         .keys
-        .filter(!commitManager.isStageEnd(_))
-        .filter(celebornShuffleIdToAppShuffleIdMap.contains(_))
-        .map(celebornShuffleIdToAppShuffleIdMap.get(_))
-        .toSet
+        .filter { shuffleId =>
+          !commitManager.isStageEnd(shuffleId) && celebornShuffleIdToAppShuffleIdMap.contains(shuffleId)
+        }.map(celebornShuffleIdToAppShuffleIdMap.get(_))
         .foreach(c.accept(_, reason))
 
     case _ =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  - Make sure the PR title start w/ a JIRA ticket, e.g. '[CELEBORN-XXXX] Your PR title ...'.
  - Be sure to keep the PR description updated to reflect all changes.
  - Please write your PR title to summarize what this PR proposes.
  - If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

- Added a new mapping for celebornShuffleId -> appShuffleId
- cancelAllActiveStages should passing appShuffleId not celebornShuffleId

### Why are the changes needed?

`shuffleAllocatedWorkers` worker contains celebornShuffleId, we need to use `appShuffleId` because DAGScheduler only understand app shuffle id.

### Does this PR resolve a correctness bug?

No

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

NA